### PR TITLE
release: 0.4.2 — documentation consistency pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,10 @@ jobs:
           - "wspr"
           - "jt9"
           - "jt65"
+          - "q65"
+          - "uvpacket"
+          - "embedded-tx"  # no_std + alloc TX preset (host-side compile only)
+          - "embedded-rx"  # no_std + alloc RX preset (pulls fft-extern)
           - "full"
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,81 @@
 # Changelog
 
+## 0.4.2 — documentation consistency pass
+
+Patch release. No public-API changes; host builds (`--features full`)
+are byte-identical to 0.4.1. Brings the README, crate docs, mfsk-ffi
+README and `docs/LIBRARY.{md,ja.md}` back in line with the 0.4.x
+reality (embedded port, Q65 family, registry semantics).
+
+### Documentation
+
+- README, lib.rs feature table and CHANGELOG updated to reflect the
+  full feature surface: `fft-rustfft` / `fft-extern` /
+  `embedded-tx` / `embedded-rx` / `esp32s3` are now listed, the
+  example `Cargo.toml` snippet uses `version = "0.4"`, and the
+  `Status` section references the embedded port instead of the
+  retired 0.3.x baseline.
+- `docs/LIBRARY.md` §4 (and the Japanese mirror) gain a single
+  receive-pipeline data-flow diagram covering the
+  `samples → coarse_sync → refine → symbol_spectra → equalize_local
+  → compute_llr → P::Fec::decode_soft → P::Msg::unpack` chain, plus
+  a paragraph spelling out *why* there is no `Demodulator` /
+  `Receiver` trait (the path is realised as free functions generic
+  over `P: Protocol` so monomorphisation produces per-protocol code
+  identical to a hand-written decoder).
+- `FecCodec` trait docstring (`mfsk-core/src/core/protocol.rs`) now
+  has a "Symbol granularity" section: the trait surface is bit-level
+  by contract, non-binary codes (Q65 QRA over GF(2⁶), JT65 RS over
+  GF(2⁶)) pack/unpack symbols inside their own `encode`, and
+  `Q65Fec::decode_soft` returns `None` by design — the real Q65
+  decode runs symbol-level via `crate::fec::qra::Q65Codec` from
+  `crate::q65::rx::decode_at_for`.
+- README adds a "Static set of protocols" callout: `PROTOCOLS` is
+  fixed at compile time by Cargo features; there is no runtime
+  `register_protocol()` API by design (every wired ZST is verified
+  by `tests/protocol_invariants.rs` and that guarantee can't be
+  extended to types unknown at compile time).
+- `mfsk-ffi/README.md` protocol table gains the missing Q65 row
+  plus the dedicated `mfsk_q65_decode{,_with_ap,_fading,_with_ap_list}`
+  + `mfsk_encode_q65` ABI entries that 0.2.0 already shipped.
+
+### Tests
+
+- `tests/protocol_invariants.rs` cross-protocol asserts tightened:
+  - `every_wired_protocol_has_a_unique_protocol_id` now derives the
+    expected distinct-id count imperatively from the active feature
+    flags, so the `unique.len() == expected` assertion is meaningful
+    under any feature combination — not just `--features full`
+    where it was previously gated.
+  - `registry_entries_match_zst_trait_constants` now asserts that
+    the count of verified entries equals `PROTOCOLS.len()`. Adding a
+    new ZST + registry entry but forgetting the matching `check!`
+    line trips this count cross-check instead of silently passing,
+    and uvpacket sub-modes are now covered by their own `check!`
+    lines.
+  - Module doc updated to call out that the per-protocol invariant
+    tests are feature-gated, so `cargo test --features full` is
+    required for full eleven-ZST coverage.
+- `mfsk-core/src/lib.rs` "Trait surface verification" section now
+  reports the actual ~25 invariants split across modulation /
+  frame-layout / codec layers (was "17") and notes the default
+  `cargo test` only exercises FT8 + FT4.
+
+### crates.io metadata
+
+- `mfsk-core/Cargo.toml` `description` rewritten to mention the
+  embedded-port story (`no_std + alloc`, pluggable FFT, ESP32-S3
+  PoC) so the crates.io listing card matches the README.
+- `categories` extended with `embedded` and `no-std` (now 5 of 5
+  slots used).
+
+### CI
+
+- `feature-matrix` job adds `q65`, `uvpacket`, `embedded-tx` and
+  `embedded-rx` rows. The embedded entries build the library
+  no_std + alloc on the Linux host; the standalone `embedded-poc/`
+  Xtensa binaries remain excluded from CI (PoC scope).
+
 ## 0.4.1 — embedded port (no_std + alloc, FFT trait, ESP32-S3 PoC)
 
 Adds an embedded-target port without breaking the existing host

--- a/README.md
+++ b/README.md
@@ -68,9 +68,15 @@ Adding a new protocol is a trait impl on a ZST, not a cross-cutting
 refactor: FST4-60A joined the crate post-hoc without changing any
 shared pipeline code.
 
+The receive path is a chain of free functions in `core::sync` →
+`core::llr` → `core::equalize` → `core::pipeline` (each generic
+over `P: Protocol`), not a `Demodulator` / `Receiver` trait. See
+[`docs/LIBRARY.md` §4](https://github.com/jl1nie/mfsk-core/blob/main/docs/LIBRARY.md#4-shared-primitives-core)
+for the data-flow diagram.
+
 ```toml
 [dependencies]
-mfsk-core = { version = "0.3", features = ["ft8", "ft4"] }
+mfsk-core = { version = "0.4", features = ["ft8", "ft4"] }
 ```
 
 ## Attribution
@@ -99,6 +105,24 @@ License matches upstream: **GPL-3.0-or-later**.
 | JT65       | 60 s   | Reed-Solomon(63, 12) GF(2⁶)       | 72 bit  | 63 distributed slots   | `jt65`  |
 | Q65-30A    | 30 s   | QRA(15, 65) GF(2⁶) + CRC-12       | 77 bit  | 22 distributed slots   | `q65`   |
 | Q65-60A‥E  | 60 s   | (same QRA codec)                  | 77 bit  | (same sync layout)     | `q65`   |
+
+Seven protocol families, eleven wired ZSTs in the registry: Q65 contributes one
+30-s sub-mode (Q65-30A) plus five 60-s EME sub-modes (Q65-60A‥E) that share
+the FEC, message codec and sync layout but differ in NSPS / tone spacing.
+[`PROTOCOLS`](https://docs.rs/mfsk-core/latest/mfsk_core/static.PROTOCOLS.html)
+exposes one entry per wired ZST; `uvpacket` (when enabled) adds four
+more for its rate ladder.
+
+### Static set of protocols
+
+`PROTOCOLS` is a `const` slice — the set of supported protocols is
+fixed at compile time by Cargo features. There is no runtime
+`register_protocol()` API by design: every wired ZST is verified by
+`tests/protocol_invariants.rs` to satisfy the trait surface, and that
+guarantee can't be extended to types unknown at compile time. UI /
+FFI consumers should iterate `PROTOCOLS` (or filter via `by_id` /
+`by_name`) at startup; if you need a new protocol, add the ZST + a
+`protocol_meta!` line and rebuild.
 
 ### Applied example: `uvpacket`
 
@@ -154,6 +178,11 @@ characterisation.
 | `parallel`    | ✓       | Rayon-parallel candidate processing          |
 | `osd-deep`    |         | OSD-3 fallback on AP decodes (extra CPU)     |
 | `eq-fallback` |         | Non-EQ fallback inside `EqMode::Adaptive`    |
+| `fft-rustfft` | ✓       | Default host FFT backend (`rustfft`, requires `std`) |
+| `fft-extern`  |         | Pluggable FFT trait — caller binary supplies an `FftPlanner` impl (esp-dsp on ESP32-S3, CMSIS-DSP on RP2350, …) |
+| `embedded-tx` |         | `no_std + alloc` TX-only preset (FT8 + FT4 + WSPR, no FFT backend pulled in) |
+| `embedded-rx` |         | `no_std + alloc` RX preset (FT8 + FT4 + WSPR + `fft-extern`) |
+| `esp32s3`     |         | Alias for `embedded-rx` — used by `embedded-poc/esp32s3/` |
 
 ## Quick example
 
@@ -243,17 +272,26 @@ reference:
 
 ## Status
 
-`0.3.x` — API is deliberately not frozen. Breaking changes follow
-cargo-style minor bumps (`0.3 → 0.4`). Algorithm correctness is
-covered by ~330 tests across the workspace, including end-to-end
-synth → decode roundtrips for every protocol, an AWGN sensitivity
-sweep that confirms Q65-30A hits its WSJT-X-published −24 dB
-threshold, an AP-vs-plain comparison that shows the expected ~2 dB
-gain from a-priori call sign information, an AP-list (template
-matching) comparison that decodes 6/6 frames at SNR −25 dB where
-plain BP fails 0/6, a real 6 m EME recording (W7GJ exchanges from
-the WSJT-X reference set), and a real 10 GHz EME recording that
-the fast-fading metric is required to decode. The trait surface
-itself is pinned by `tests/protocol_invariants.rs` — a single
-generic `<P: Protocol>` checker run across every wired ZST so a
-new protocol gets structural validation without bespoke glue.
+`0.4.x` — API is deliberately not frozen. Breaking changes follow
+cargo-style minor bumps (`0.4 → 0.5`). 0.4.1 added the embedded
+port: `no_std + alloc` builds work end-to-end, the FFT backend is
+pluggable through a trait (`fft-rustfft` for host, `fft-extern` for
+embedded targets that bring their own FFT — esp-dsp, CMSIS-DSP),
+caller-buffer TX APIs (`*_into` variants, `*_OUTPUT_LEN` constants)
+let callers preallocate, and a working ESP32-S3 PoC lives at
+`embedded-poc/esp32s3/`.
+
+Algorithm correctness is covered by the workspace test suite,
+including end-to-end synth → decode roundtrips for every protocol,
+an AWGN sensitivity sweep that confirms Q65-30A hits its
+WSJT-X-published −24 dB threshold, an AP-vs-plain comparison that
+shows the expected ~2 dB gain from a-priori call sign information,
+an AP-list (template matching) comparison that decodes 6/6 frames at
+SNR −25 dB where plain BP fails 0/6, a real 6 m EME recording (W7GJ
+exchanges from the WSJT-X reference set), and a real 10 GHz EME
+recording that the fast-fading metric is required to decode. The
+trait surface itself is pinned by `tests/protocol_invariants.rs` —
+a single generic `<P: Protocol>` checker run across every wired ZST
+so a new protocol gets structural validation without bespoke glue.
+Run with `--features full` for the eleven-ZST coverage; the default
+features (`ft8`, `ft4`) only exercise the two default protocols.

--- a/docs/LIBRARY.ja.md
+++ b/docs/LIBRARY.ja.md
@@ -184,6 +184,22 @@ mfsk_core
 ワークスペースの兄弟クレート `mfsk-ffi` が同じクレートの上に C ABI
 共有ライブラリ (`libmfsk.{so,a,dylib}` + `mfsk.h`) を構築する。
 
+#### `FecCodec` はシンボル粒度から独立
+
+`FecCodec` trait の表面 (`core/protocol.rs`) は **bit** で語る:
+`&[u8]` info / codeword、`&[f32]` bit-LLR、`K`・`N` も bit 単位。
+上記の 4 系統の FEC のうち 2 系統 — JT65 の Reed-Solomon over
+GF(2⁶) と Q65 の QRA over GF(2⁶) — は非二進符号で、bit 単位の
+trait API を満たすために `encode` の中で bit ↔ シンボル変換を
+内製している。それぞれの本来のシンボル単位デコードは
+`decode_soft` の外側に置かれていて、`Q65Fec::decode_soft` は仕様
+として `None` を返し、実際の Q65 デコードは GF(64) 確率ベクトル上の
+非二進 BP として `fec::qra::Q65Codec` で実行され、エントリポイントは
+`q65::rx::decode_at_for` になっている。`K` / `N` を bit で数えて
+おくことで、二進・非二進どちらの符号にも
+`FecCodec::N ≤ N_DATA × BITS_PER_SYMBOL` という横断的不変条件
+(§7.2) が同じ式で成り立つ。
+
 ## 2. Protocol トレイト階層
 
 対応するすべてのモードは、3 つの合成可能な trait を実装する
@@ -428,6 +444,52 @@ C ABI には同 4 戦略が `mfsk_q65_decode`、`mfsk_q65_decode_with_ap`、
 6 sub-mode のいずれにもアクセス可能。
 
 ## 4. 共有プリミティブ (`core`)
+
+### 受信パイプライン概観
+
+任意の wired プロトコルにおける受信フロー全体 — 生オーディオ
+サンプルから復号メッセージ文字列まで — は、以下に挙げる `core`
+サブモジュール内のフリー関数群を `P: Protocol` でパラメタライズ
+して鎖状に呼び出した形になっている:
+
+```text
+┌─────────┐  coarse_sync   ┌──────────────┐  refine_candidate  ┌──────────┐
+│ samples │ ─────────────▶ │  candidates  │ ─────────────────▶ │ candidate│
+│ i16/f32 │  (FFT/Costas)  │ (f, dt, snr) │   (fine sync)      │ refined  │
+└─────────┘                └──────────────┘                    └────┬─────┘
+                                                                    │  symbol_spectra
+                                                                    ▼
+                  ┌─────────────┐  compute_llr  ┌──────────────┐  equalize_local
+                  │   LLR vec   │ ◀───────────  │     cs[]     │ ◀──────────┐
+                  │  (4 vars)   │   (per WSJT)  │   Complex    │ (per-tone  │
+                  └──────┬──────┘               │  per-symbol  │  Wiener)   │
+                         │                      └──────────────┘            │
+                         │  P::Fec::decode_soft  (LDPC BP / Fano / RS /     │
+                         │                        QRA-symbol-level)         │
+                         ▼                                                  │
+                  ┌─────────────┐                                           │
+                  │ info bits   │                                           │
+                  └──────┬──────┘                                           │
+                         │  P::Msg::unpack                                  │
+                         ▼                                                  │
+                  ┌─────────────┐                                           │
+                  │ message txt │ ──── (subtract for next iter) ────────────┘
+                  └─────────────┘
+```
+
+`Demodulator` や `Receiver` という trait はない。受信経路は
+`core::sync` / `core::llr` / `core::equalize` / `core::pipeline` の
+フリー関数群として実現され、それぞれ `P: Protocol` で generic に
+なっている。Monomorphization により、手書きのプロトコル別デコーダ
+と同等のコードが生成されつつ、各プロトコルに n-method な受信
+trait の実装を強制しないで済む。Soft demap は
+`core::llr::compute_llr<P>` で、`Protocol::demap()` メソッドではなく
+フリー関数になっているのは、スペクトル抽出 (`symbol_spectra`)・
+WSJT 式 4 バリアント LLR (a/b/c/d)・equalizer がデータとして
+組み合わさるためで、trait 合成では表現が冗長になる。Sync /
+equalize / pipeline ドライバも同じスタイルで、プロトコル型を
+パラメータとして受け取り `P` の関連定数 (`NTONES`、`NSPS`、
+`SYNC_MODE` など) を直接参照する。
 
 ### DSP (`mfsk_core::core::dsp`)
 

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -195,6 +195,21 @@ The `mfsk-ffi` sibling crate in this workspace builds a C ABI
 shared library (`libmfsk.{so,a,dylib}` + `mfsk.h`) on top of the
 same crate.
 
+#### `FecCodec` is symbol-agnostic
+
+The `FecCodec` trait surface (`core/protocol.rs`) speaks in **bits**:
+`&[u8]` info / codeword, `&[f32]` bit-LLRs, `K` and `N` counted in
+bits. The four FEC families above include two non-binary codes —
+Reed-Solomon over GF(2⁶) for JT65 and QRA over GF(2⁶) for Q65 — which
+implement the bit-level trait by packing / unpacking bits ↔ symbols
+inside their own `encode`. Their natural symbol-level decode lives
+outside `decode_soft`: `Q65Fec::decode_soft` returns `None` by design,
+and the real Q65 decode runs over GF(64) probability vectors via
+`fec::qra::Q65Codec` from `q65::rx::decode_at_for`. Counting `K` /
+`N` in bits keeps the cross-protocol invariant
+`FecCodec::N ≤ N_DATA × BITS_PER_SYMBOL` meaningful for both binary
+and non-binary codes — see §7.2.
+
 ## 2. Protocol trait hierarchy
 
 Every supported mode is described by a zero-sized type that
@@ -454,6 +469,51 @@ and `mfsk_q65_decode_with_ap_list`, each taking a `MfskQ65SubMode`
 parameter so any of the six sub-modes is reachable from C/C++/Kotlin.
 
 ## 4. Shared primitives (`core`)
+
+### Receive pipeline at a glance
+
+The complete receive flow for any wired protocol — from raw audio
+samples to decoded message text — is a chain of free functions in
+the `core` submodules below, parameterised by `P: Protocol`:
+
+```text
+┌─────────┐  coarse_sync   ┌──────────────┐  refine_candidate  ┌──────────┐
+│ samples │ ─────────────▶ │  candidates  │ ─────────────────▶ │ candidate│
+│ i16/f32 │  (FFT/Costas)  │ (f, dt, snr) │   (fine sync)      │ refined  │
+└─────────┘                └──────────────┘                    └────┬─────┘
+                                                                    │  symbol_spectra
+                                                                    ▼
+                  ┌─────────────┐  compute_llr  ┌──────────────┐  equalize_local
+                  │   LLR vec   │ ◀───────────  │     cs[]     │ ◀──────────┐
+                  │  (4 vars)   │   (per WSJT)  │   Complex    │ (per-tone  │
+                  └──────┬──────┘               │  per-symbol  │  Wiener)   │
+                         │                      └──────────────┘            │
+                         │  P::Fec::decode_soft  (LDPC BP / Fano / RS /     │
+                         │                        QRA-symbol-level)         │
+                         ▼                                                  │
+                  ┌─────────────┐                                           │
+                  │ info bits   │                                           │
+                  └──────┬──────┘                                           │
+                         │  P::Msg::unpack                                  │
+                         ▼                                                  │
+                  ┌─────────────┐                                           │
+                  │ message txt │ ──── (subtract for next iter) ────────────┘
+                  └─────────────┘
+```
+
+There is no `Demodulator` or `Receiver` trait. The receive path is
+realised as free functions in `core::sync`, `core::llr`,
+`core::equalize`, `core::pipeline`, each generic over `P: Protocol`.
+Monomorphisation produces per-protocol code identical to a hand-
+written decoder, without forcing every protocol to implement an
+n-method receive interface. `core::llr::compute_llr<P>` is the soft
+demapper: it lives as a free fn rather than a `Protocol::demap()`
+method because the spectral extraction (`symbol_spectra`), the four
+WSJT-style LLR variants (a/b/c/d) and the equaliser feed into it as
+data, not as trait composition. The same pattern applies to sync,
+equalisation and the pipeline driver — all of them take the
+protocol type as a parameter and read `P`'s associated constants
+(`NTONES`, `NSPS`, `SYNC_MODE`, …) directly.
 
 ### DSP (`mfsk_core::core::dsp`)
 

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name        = "mfsk-core"
-version     = "0.4.1"
+version     = "0.4.2"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
-description = "Pure-Rust library for WSJT-family digital amateur-radio modes (FT8/FT4/FST4/WSPR/JT9/JT65/Q65): protocol traits, DSP, FEC codecs, message codecs, decoders and synthesisers — unified behind a zero-cost generic abstraction."
+description = "Pure-Rust WSJT-family decoders and synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. no_std + alloc capable with a pluggable FFT backend; ESP32-S3 PoC included."
 repository  = "https://github.com/jl1nie/mfsk-core"
 readme      = "../README.md"
 keywords    = ["wsjt", "ft8", "q65", "amateur-radio", "dsp"]
-categories  = ["science", "encoding", "multimedia::audio"]
+categories  = ["science", "encoding", "multimedia::audio", "embedded", "no-std"]
 
 [features]
 default      = ["std", "ft8", "ft4", "parallel", "fft-rustfft"]

--- a/mfsk-core/src/core/protocol.rs
+++ b/mfsk-core/src/core/protocol.rs
@@ -276,8 +276,26 @@ pub struct FecResult {
 /// Implementors MUST be `Default`-constructible so generic pipeline code can
 /// obtain an instance via `P::Fec::default()` without plumbing state.
 /// Stateless codecs (matrices in `const` / `static`) are the common case.
+///
+/// # Symbol granularity
+///
+/// The trait surface speaks in **bits**: `&[u8]` info / codeword, `&[f32]`
+/// bit-LLRs, `K` and `N` counted in bits. Non-binary codes (Q65's QRA over
+/// GF(2⁶), JT65's RS over GF(2⁶)) implement this surface by packing /
+/// unpacking bits ↔ symbols inside their own `encode`, and by using a
+/// private symbol-level decode path that lives outside `decode_soft`. In
+/// particular [`crate::q65::Q65Fec::decode_soft`] returns `None` by design —
+/// the real Q65 decode runs over GF(64) probability vectors via
+/// [`crate::fec::qra::Q65Codec`] and is invoked from
+/// [`crate::q65::rx::decode_at_for`], not through this trait.
+///
+/// Counting `K` / `N` in bits keeps the cross-protocol invariant
+/// `FecCodec::N ≤ N_DATA × BITS_PER_SYMBOL` (pinned in
+/// `tests/protocol_invariants.rs::assert_codec_consistency`) meaningful for
+/// both binary (LDPC, conv) and non-binary (RS, QRA) codes.
 pub trait FecCodec: Default + 'static {
-    /// Codeword length.
+    /// Codeword length, in **bits** (regardless of the underlying symbol
+    /// alphabet — see "Symbol granularity" above).
     const N: usize;
 
     /// Information-bit length.
@@ -285,12 +303,17 @@ pub trait FecCodec: Default + 'static {
 
     /// Systematic encode: `info.len() == K`, `codeword.len() == N`. The first
     /// `K` bits of `codeword` must equal `info` (systematic form).
+    /// Non-binary codes pack bits into their native symbols internally.
     fn encode(&self, info: &[u8], codeword: &mut [u8]);
 
     /// Soft-decision decode from log-likelihood ratios.
     ///
     /// `llr.len() == N`. On success returns the `K` information bits plus
     /// decoder statistics. On failure returns `None`.
+    ///
+    /// Non-binary codes whose natural decode operates on symbol-level
+    /// probability vectors (Q65) MAY return `None` unconditionally and
+    /// expose their real decode through a protocol-specific entry point.
     fn decode_soft(&self, llr: &[f32], opts: &FecOpts) -> Option<FecResult>;
 }
 

--- a/mfsk-core/src/lib.rs
+++ b/mfsk-core/src/lib.rs
@@ -120,10 +120,15 @@
 //! | `jt9`         |          | JT9 (60 s, 9-FSK, conv r=½ K=32 + Fano)      |
 //! | `jt65`        |          | JT65 (60 s, 65-FSK, RS(63,12))               |
 //! | `q65`         |          | Q65-30A + Q65-60A‥E (65-FSK, QRA(15,65) GF(64)) |
-//! | `full`        |          | Aggregate of all seven protocols             |
+//! | `full`        |          | Aggregate of all seven protocols + uvpacket + packet-bytes |
 //! | `parallel`    | yes      | Rayon-parallel candidate processing          |
 //! | `osd-deep`    |          | OSD-3 fallback on AP decodes (extra CPU)     |
 //! | `eq-fallback` |          | Non-EQ fallback inside `EqMode::Adaptive`    |
+//! | `fft-rustfft` | yes      | Default host FFT backend (`rustfft`, requires `std`) |
+//! | `fft-extern`  |          | Pluggable FFT trait — caller binary supplies an `FftPlanner` impl |
+//! | `embedded-tx` |          | `no_std + alloc` TX-only preset (FT8 + FT4 + WSPR) |
+//! | `embedded-rx` |          | `no_std + alloc` RX preset (FT8 + FT4 + WSPR + `fft-extern`) |
+//! | `esp32s3`     |          | Alias for `embedded-rx` (used by `embedded-poc/esp32s3/`) |
 //!
 //! ## Runtime registry
 //!
@@ -153,16 +158,26 @@
 //! `tests/protocol_invariants.rs` runs a single generic
 //! `assert_protocol_invariants::<P: Protocol>` over every wired ZST
 //! (FT8 / FT4 / FST4 / WSPR / JT9 / JT65 plus all six Q65 sub-modes
-//! — 11 in total). It pins 17 trait-level invariants:
-//! `2^BITS_PER_SYMBOL ≤ NTONES`, `SYMBOL_DT × 12000 == NSPS`,
-//! `N_SYMBOLS == N_DATA + N_SYNC`, sync-mode self-consistency,
-//! `FecCodec::K ≥ MessageCodec::PAYLOAD_BITS`, and so on. Adding a
-//! new `Protocol` impl is a one-line registry edit + a one-line
-//! test invocation; the same generic body proves the new ZST's
-//! constants are internally consistent without any per-protocol
-//! glue. Drift between trait doc and implementation is caught
-//! mechanically — the work that landed Q65 surfaced one such
-//! discrepancy in `GRAY_MAP` and fixed it in the same pass.
+//! — 11 in total; uvpacket adds four more under `--features uvpacket`).
+//! It pins ~25 trait-level invariants split across three layers:
+//! modulation (`2^BITS_PER_SYMBOL ≤ NTONES`, `SYMBOL_DT × 12000 ==
+//! NSPS`, GRAY_MAP coverage and uniqueness, GFSK / tone-spacing
+//! positivity), frame layout (`N_SYMBOLS == N_DATA + N_SYNC`, sync
+//! pattern in-range, `T_SLOT_S > 0`), and codec consistency
+//! (`FecCodec::K ≥ MessageCodec::PAYLOAD_BITS`, `FecCodec::N ≤
+//! N_DATA × BITS_PER_SYMBOL`). Adding a new `Protocol` impl is a
+//! one-line registry edit + a one-line test invocation; the same
+//! generic body proves the new ZST's constants are internally
+//! consistent without any per-protocol glue. Drift between trait
+//! doc and implementation is caught mechanically — the work that
+//! landed Q65 surfaced one such discrepancy in `GRAY_MAP` and fixed
+//! it in the same pass.
+//!
+//! The default features (`ft8`, `ft4`) only exercise the two default
+//! protocols; run `cargo test --features full` (or enable a specific
+//! protocol feature) to cover the rest. The registry size and
+//! `ProtocolId` uniqueness checks adapt to whatever feature
+//! combination is active.
 //!
 //! ## Library stack
 //!

--- a/mfsk-core/tests/protocol_invariants.rs
+++ b/mfsk-core/tests/protocol_invariants.rs
@@ -20,6 +20,17 @@
 //! 3. **Documents the trait contract by example**: the assertions
 //!    in this file are the source-of-truth for what "a valid Q65
 //!    sub-mode looks like at the trait level".
+//!
+//! ## Feature coverage
+//!
+//! Each per-protocol test is gated on its protocol feature, so the
+//! default `cargo test` (features `ft8`, `ft4`) only exercises FT8
+//! and FT4 invariants. Run `cargo test --features full --test
+//! protocol_invariants` to validate every wired ZST (the seven WSJT
+//! protocols + four uvpacket sub-modes), or pass an individual
+//! protocol feature to scope the run. The registry-size and
+//! ProtocolId-uniqueness checks adapt to whatever feature
+//! combination is active so they're always meaningful.
 
 use mfsk_core::{
     FecCodec, FrameLayout, MessageCodec, ModulationParams, PROTOCOLS, Protocol, ProtocolId,
@@ -414,11 +425,18 @@ fn registry_entries_match_zst_trait_constants() {
     // its ZST through `assert_meta_matches_trait`. The lookup
     // happens by name (the user-facing handle), so a name typo or
     // a wrong-type macro arg in `registry.rs` is caught here.
-
+    //
+    // After the per-name checks we assert that the *count* of
+    // verified entries equals `PROTOCOLS.len()`. Adding a registry
+    // entry but forgetting the matching `check!` line trips that
+    // count assertion — without it, missing entries would be a
+    // silent gap.
+    let mut checked = 0usize;
     macro_rules! check {
         ($name:literal, $ty:ty) => {{
             let meta = by_name($name).unwrap_or_else(|| panic!("registry missing entry {}", $name));
             assert_meta_matches_trait::<$ty>(meta);
+            checked += 1;
         }};
     }
 
@@ -443,6 +461,21 @@ fn registry_entries_match_zst_trait_constants() {
         check!("Q65-60D", Q65d60);
         check!("Q65-60E", Q65e60);
     }
+    #[cfg(feature = "uvpacket")]
+    {
+        check!("UvRobust", UvRobust);
+        check!("UvStandard", UvStandard);
+        check!("UvUltraRobust", UvUltraRobust);
+        check!("UvExpress", UvExpress);
+    }
+
+    assert_eq!(
+        checked,
+        PROTOCOLS.len(),
+        "registry has {} entries but only {checked} were verified by name; \
+         a `check!` line is missing for some PROTOCOLS entry",
+        PROTOCOLS.len(),
+    );
 }
 
 #[test]
@@ -543,32 +576,60 @@ fn every_wired_protocol_has_a_unique_protocol_id() {
     }
 
     // Distinct protocol families must have distinct IDs.
-    let _unique: Vec<ProtocolId> = {
+    let unique: Vec<ProtocolId> = {
         let mut v: Vec<ProtocolId> = ids.iter().map(|(_, id)| *id).collect();
         v.sort_by_key(|id| *id as u8);
         v.dedup();
         v
     };
 
-    // Q65 + uvpacket each contribute multiple ZSTs but one ID; assert
-    // the dedupe count matches the number of distinct families.
-    #[cfg(all(
-        feature = "ft8",
-        feature = "ft4",
-        feature = "fst4",
-        feature = "wspr",
-        feature = "jt9",
-        feature = "jt65",
-        feature = "q65",
-        feature = "uvpacket"
-    ))]
+    // Expected count of distinct ProtocolId families under the active
+    // feature combination. Q65 contributes one id (6 ZSTs share it);
+    // uvpacket contributes one id (4 ZSTs share it). Every other
+    // wired protocol is one family = one id. Computed imperatively
+    // mirroring `registry_size_matches_wired_protocols` so the check
+    // adapts to any --features combo, not just `--features full`.
+    #[allow(unused_mut)]
+    let mut expected_distinct = 0usize;
+    #[cfg(feature = "ft8")]
+    {
+        expected_distinct += 1;
+    }
+    #[cfg(feature = "ft4")]
+    {
+        expected_distinct += 1;
+    }
+    #[cfg(feature = "fst4")]
+    {
+        expected_distinct += 1;
+    }
+    #[cfg(feature = "wspr")]
+    {
+        expected_distinct += 1;
+    }
+    #[cfg(feature = "jt9")]
+    {
+        expected_distinct += 1;
+    }
+    #[cfg(feature = "jt65")]
+    {
+        expected_distinct += 1;
+    }
+    #[cfg(feature = "q65")]
+    {
+        expected_distinct += 1;
+    }
+    #[cfg(feature = "uvpacket")]
+    {
+        expected_distinct += 1;
+    }
     assert_eq!(
-        _unique.len(),
-        8,
-        "expected 8 distinct ProtocolId values \
-         (FT8, FT4, FST4, WSPR, JT9, JT65, Q65, UvPacket), \
-         got {:?} from {ids:?}",
-        _unique
+        unique.len(),
+        expected_distinct,
+        "distinct ProtocolId count {} != expected {expected_distinct} \
+         under the active feature set; got {:?} from {ids:?}",
+        unique.len(),
+        unique,
     );
 
     // Each ID is a known variant (this is a static guarantee from the enum,

--- a/mfsk-ffi/README.md
+++ b/mfsk-ffi/README.md
@@ -96,7 +96,7 @@ int main() {
 ```
 
 The runnable version lives at `examples/cpp_smoke/main.cpp`; it exercises
-all six protocols + multi-threaded decode stress tests. Build and run
+the wired protocols + multi-threaded decode stress tests. Build and run
 with:
 
 ```
@@ -118,6 +118,11 @@ bash examples/cpp_smoke/build.sh
 | `mfsk_encode_wspr`         | Synthesise a Type-1 WSPR message (`call grid power_dbm`).         |
 | `mfsk_encode_jt9`          | Synthesise a standard JT9 message.                                |
 | `mfsk_encode_jt65`         | Synthesise a standard JT65 message.                               |
+| `mfsk_encode_q65`          | Synthesise a Q65 message (sub-mode selected via `MfskQ65SubMode`). |
+| `mfsk_q65_decode`          | Q65 plain BP decode (basic strategy).                             |
+| `mfsk_q65_decode_with_ap`  | Q65 BP decode with a-priori call-sign / grid hints (~2 dB gain).  |
+| `mfsk_q65_decode_fading`   | Q65 fast-fading metric (Gaussian / Lorentzian) for high-Doppler EME. |
+| `mfsk_q65_decode_with_ap_list` | Q65 AP-list (template-matching) decode (~3 dB gain when call pair is known). |
 | `mfsk_samples_free`        | Release the `f32` buffer returned by an encode.                   |
 | `mfsk_last_error`          | Thread-local last-error string (UTF-8, NUL-terminated).           |
 | `mfsk_version`             | Library version (major << 16 \| minor << 8 \| patch).             |
@@ -169,6 +174,17 @@ decoding:
 | `MFSK_PROTOCOL_WSPR`        | 120 s       | 1 440 000 samples @ 12 kHz   |
 | `MFSK_PROTOCOL_JT9`         | 60 s        | 720 000 samples @ 12 kHz     |
 | `MFSK_PROTOCOL_JT65`        | 60 s        | 720 000 samples @ 12 kHz     |
+| `MFSK_PROTOCOL_Q65A30`      | 30 s        | 360 000 samples @ 12 kHz     |
+
+The Q65 family adds five more 60-s EME sub-modes (Q65-60A‥E,
+×1/×2/×4/×8/×16 tone spacing) reachable through the dedicated
+`mfsk_q65_*` function family with a `MfskQ65SubMode` parameter
+rather than through `mfsk_decoder_new`. Use `mfsk_q65_decode` for
+the basic AWGN strategy, `mfsk_q65_decode_with_ap` for a-priori
+call-sign hints (~2 dB gain), `mfsk_q65_decode_fading` for the
+fast-fading metric required at 5.7 / 10 / 24 GHz EME, and
+`mfsk_q65_decode_with_ap_list` for BP-free AP-list template
+matching (~3 dB gain when the call pair is known up-front).
 
 Non-12 kHz input is resampled internally (linear interpolation).
 Sample rates from 8 000 Hz up to at least 96 000 Hz work.


### PR DESCRIPTION
## Summary

Patch release. No public-API changes; host builds (`--features full`) are byte-identical to 0.4.1.

- README, lib.rs feature table and CHANGELOG aligned with the 0.4.x surface (`fft-rustfft` / `fft-extern` / `embedded-tx` / `embedded-rx` / `esp32s3` listed; 0.3.x Status section retired). Cargo example pinned to "0.4".
- `docs/LIBRARY.{md,ja.md}` §4 gain a single receive-pipeline data-flow diagram and a paragraph on why there is no `Demodulator` / `Receiver` trait (the path is realised as free fns generic over `P: Protocol`).
- `FecCodec` trait docstring grows a "Symbol granularity" section covering Q65's GF(2⁶) bit↔symbol packing and `Q65Fec::decode_soft` returning `None` by design.
- README adds a "Static set of protocols" callout (`PROTOCOLS` is fixed at compile time; no `register_protocol()` runtime API).
- `mfsk-ffi/README.md` protocol table gains the missing Q65 row + `mfsk_q65_decode{,_with_ap,_fading,_with_ap_list}` ABI entries.
- `tests/protocol_invariants.rs`: ProtocolId-uniqueness assert now derives expected count imperatively from the active feature flags so it's meaningful under any `--features` combo (was `cfg(all(...))`-gated and dead under default features); `registry_entries_match_zst_trait_constants` asserts `checked == PROTOCOLS.len()` so a missing `check!` line trips the count cross-check; uvpacket sub-modes covered by their own `check!` lines.
- `mfsk-core/Cargo.toml`: `description` rewritten to mention the embedded-port story; `categories` extended with `embedded` + `no-std`.
- `ci.yml` feature-matrix adds `q65`, `uvpacket`, `embedded-tx`, `embedded-rx` rows (host-side lib build only; `embedded-poc/` Xtensa binaries remain excluded from CI).

## Test plan

- [x] `cargo test --features full --test protocol_invariants` (12/12)
- [x] `cargo test --features full --lib` (262/262)
- [x] `cargo test --doc -p mfsk-core --features full` (13/13)
- [x] `cargo doc --features full --no-deps` (RUSTDOCFLAGS=-D warnings)
- [x] `cargo clippy --workspace --all-targets --features full -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo publish --dry-run --features full`
- [x] Negative test: `check!` 行を1本コメントアウトすると `registry has 16 entries but only 15 were verified` で count cross-check が発火
- [x] Negative test: `expected_distinct = 1usize` (inflated) で default features 下でも `distinct ProtocolId count 2 != expected 3` で発火
- [ ] CI `feature-matrix` 全行 (default + ft8 + ft4 + fst4 + wspr + jt9 + jt65 + q65 + uvpacket + embedded-tx + embedded-rx + full) が green
- [ ] CI `publish-dry-run` job green
- [ ] After merge: tag `v0.4.2` triggers `release.yml` → publishes to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)