### PR TITLE
ci: drop slow-test re-run from release.yml; add PR concurrency cancel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,16 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -D warnings
 
+# Cancel in-flight runs on the same ref when a new commit arrives
+# (typical case: a PR force-push or a fast-follow `--amend`). The
+# group key uses `head_ref` for `pull_request` events (the source
+# branch) and falls back to `ref` for `push` events on `main`. This
+# does NOT dedupe the PR-vs-post-merge pair (different refs), but it
+# does prevent run pile-ups on rapid PR iterations.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ───────────────────────────────────────────────────────────────
   # Formatting + clippy lint gate. Fast fail so the heavier matrix

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,12 +24,21 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2
 
-      # Re-run the core test suite — CI already ran on the tagged
-      # commit's push, but a tag push can arrive separately (e.g.
-      # created from the web UI). Cheap insurance against shipping
-      # broken code.
-      - name: Verify tests pass (including slow sweeps)
-        run: cargo test -p mfsk-core --features full --release -- --include-ignored
+      # Tag must be reachable from main. ci.yml has already validated
+      # every commit that landed on main (PRs gated by main
+      # protection); refusing to publish a tag that points outside
+      # main is enough to catch the "tagged a feature branch by
+      # mistake" scenario without re-running the full test suite (the
+      # 0.4.1 release added the embedded port and the slow-sweep
+      # re-run there cost ~3 min per release for zero new signal).
+      - name: Verify tag is reachable from main
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=200 origin main
+          if ! git merge-base --is-ancestor "${GITHUB_SHA}" origin/main; then
+            echo "::error::Tag commit ${GITHUB_SHA} is not an ancestor of origin/main; refusing to publish"
+            exit 1
+          fi
 
       # The tag version must match Cargo.toml's version field. Fail
       # fast if someone tags `v0.2.0` while Cargo.toml still says


### PR DESCRIPTION
## Summary

Trims duplicate CI work that surfaced during the v0.4.2 release flow.

Every release historically ran the full test suite **three times**:

1. CI on the PR (ci.yml `pull_request`)
2. CI on the merge commit landing on main (ci.yml `push: branches: [main]`)
3. release.yml \"Verify tests pass (including slow sweeps)\" on the tag push

Run #3 is pure duplicate work — the tag points at a main commit that ci.yml has already validated, and main protection prevents anything reaching main without passing CI. v0.4.1 paid ~3-4 minutes for zero new signal.

## Changes

- **release.yml**: drop the slow-sweep re-run. Replace with a cheap \"tag is reachable from main\" check that fails publish if someone tags a feature branch by mistake. Cost: ~1 second of git history fetch instead of ~3-4 min of compile + test.
- **ci.yml**: add `concurrency: cancel-in-progress` keyed on `head_ref || ref`. PR force-pushes / `--amend` no longer stack runs. The PR-vs-post-merge duplicate stays (different refs / SHAs, can't dedup without losing the README badge's main-branch run history) — that's a separate, lower-priority concern.

## Test plan

- [x] `cargo fmt --check` (pre-commit hook)
- [x] `cargo clippy --workspace --all-targets --features full -- -D warnings` (pre-commit hook)
- [ ] CI on this PR runs and passes
- [ ] Concurrency cancel observable: push another commit to this branch quickly and confirm the in-flight run is cancelled (manual check)
- [ ] Next release (whenever it ships) will validate the lighter release.yml — the \"tag is reachable from main\" check fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)