### PR TITLE
test(q65): make WSJT-X ionoscatter test honest about the gap

### DIFF
--- a/mfsk-core/tests/q65_wsjtx_samples.rs
+++ b/mfsk-core/tests/q65_wsjtx_samples.rs
@@ -18,9 +18,13 @@ use std::fs::File;
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
+use mfsk_core::fec::qra::FadingModel;
 use mfsk_core::msg::ApHint;
 use mfsk_core::q65::search::SearchParams;
-use mfsk_core::q65::{Q65a60, decode_scan, decode_scan_with_ap, decode_scan_with_ap_for};
+use mfsk_core::q65::{
+    Q65a30, Q65a60, decode_scan, decode_scan_fading_for, decode_scan_with_ap,
+    decode_scan_with_ap_for,
+};
 
 /// Minimal WAV reader for WSJT-X's exact format: RIFF/WAVE header,
 /// `fmt ` chunk = PCM (1 channel, 12 kHz, 16-bit), `data` chunk =
@@ -69,8 +73,25 @@ fn samples_dir(rel: &str) -> Option<PathBuf> {
     if dir.is_dir() { Some(dir) } else { None }
 }
 
+/// Smoke test: the Q65-30A receive chain (plain BP + AP + fast-fading
+/// metric) runs to completion against every WSJT-X ionoscatter
+/// reference recording without panicking, and the WAV reader handles
+/// the file format correctly.
+///
+/// **Decode rate is not asserted** because the WSJT-X ionoscatter
+/// sample set typically requires **multi-period averaging** — a
+/// strategy where WSJT-X stacks several adjacent slots in
+/// time-frequency before running BP / fast-fading, recovering
+/// signals that sit below any individual slot's threshold. That path
+/// is not yet ported to mfsk-core. As of 0.4.2 this port produces
+/// 0/4 decodes across plain BP / AP-CQ / fast-fading
+/// {3, 8, 15} × {Gaussian, Lorentzian}. When multi-period averaging
+/// lands, this test should be promoted to require non-zero decodes
+/// (or a sibling strict test added). Current scope: catch a panic /
+/// WAV-reader / search-params regression so the existing chain
+/// stays healthy in the meantime.
 #[test]
-fn ionoscatter_6m_samples_yield_some_decode() {
+fn ionoscatter_6m_receive_chain_runs() {
     let Some(dir) = samples_dir("30A_Ionoscatter_6m") else {
         eprintln!(
             "skipping: WSJT-X sample tree not found at ../../WSJT-X/samples/Q65/30A_Ionoscatter_6m/"
@@ -89,11 +110,7 @@ fn ionoscatter_6m_samples_yield_some_decode() {
         "WSJT-X Q65-30A sample dir contains no .wav files"
     );
 
-    // Wide search params: the signal in a real recording can start
-    // anywhere in the slot, not just at the nominal +1 s offset.
     // ±50 symbols × 0.3 s/sym ≈ ±15 s around the slot midpoint.
-    let mut total = 0usize;
-    let mut decoded_at_least_one = 0usize;
     let nominal_mid = 12_000 * 15; // 15 s into the 30 s slot
     let params = SearchParams {
         freq_min_hz: 200.0,
@@ -103,14 +120,7 @@ fn ionoscatter_6m_samples_yield_some_decode() {
         max_candidates: 32,
     };
 
-    // Try a few common AP guesses on each recording. Without knowing
-    // the actual exchange, "CQ" is the most common starting hint
-    // (most ionoscatter signals are calling CQ).
-    let hints = [
-        ("plain", ApHint::new()),
-        ("CQ", ApHint::new().with_call1("CQ")),
-    ];
-
+    let mut wav_count = 0usize;
     for path in &entries {
         let audio = match read_wsjtx_wav(path) {
             Some(a) => a,
@@ -119,42 +129,39 @@ fn ionoscatter_6m_samples_yield_some_decode() {
                 continue;
             }
         };
-        total += 1;
-        let mut hit = false;
-        for (label, hint) in &hints {
-            let decodes = if hint.has_info() {
-                decode_scan_with_ap(&audio, 12_000, nominal_mid, &params, hint)
-            } else {
-                decode_scan(&audio, 12_000, nominal_mid, &params)
-            };
-            let names: Vec<String> = decodes.iter().map(|d| d.message.clone()).collect();
-            println!(
-                "{} [{label}]: {} decode(s) → {names:?}",
-                path.file_name().unwrap().to_string_lossy(),
-                decodes.len()
-            );
-            if !decodes.is_empty() {
-                hit = true;
-            }
-        }
-        if hit {
-            decoded_at_least_one += 1;
-        }
-    }
+        wav_count += 1;
 
-    // Real-world ionoscatter signals exhibit Doppler spread, multi-
-    // path fading, and may sit close to the noise floor. Q65's
-    // fast-fading metric in WSJT-X helps with that; that path is
-    // not yet ported here, so we do NOT insist on any specific
-    // decode rate. The test runs to validate that:
-    //   - .wav reading succeeds,
-    //   - decode_scan runs to completion without crashing on real
-    //     audio,
-    //   - the printed table can be inspected to track real-world
-    //     fidelity as the receiver evolves.
-    eprintln!(
-        "[info] {decoded_at_least_one}/{total} WSJT-X Q65-30A ionoscatter recordings \
-         produced at least one decode (fast-fading path not yet ported)"
+        // Three receive paths must all complete without panic. Decode
+        // counts are reported but not asserted — see this test's
+        // docstring for why ionoscatter is currently a known gap.
+        let plain = decode_scan(&audio, 12_000, nominal_mid, &params);
+        let cq = decode_scan_with_ap(
+            &audio,
+            12_000,
+            nominal_mid,
+            &params,
+            &ApHint::new().with_call1("CQ"),
+        );
+        let fading = decode_scan_fading_for::<Q65a30>(
+            &audio,
+            12_000,
+            nominal_mid,
+            &params,
+            8.0,
+            FadingModel::Gaussian,
+            None,
+        );
+        eprintln!(
+            "{}: plain={} cq={} fading_b90=8={}",
+            path.file_name().unwrap().to_string_lossy(),
+            plain.len(),
+            cq.len(),
+            fading.len(),
+        );
+    }
+    assert!(
+        wav_count > 0,
+        "no readable WAVs in WSJT-X Q65-30A ionoscatter sample dir"
     );
 }
 


### PR DESCRIPTION
## Summary

Surfaced during DCC-pitch verification: \`ionoscatter_6m_samples_yield_some_decode\` reported 0/4 decodes against the WSJT-X Q65-30A reference set (\`30A_Ionoscatter_6m/*.wav\`) and **silently passed** — no assertion on the decode count, just an \`[info]\` line trailing \"fast-fading path not yet ported\". The receive chain was being exercised but never validated, contradicting the 0.4.2 doc cleanup's claim of real-world Q65 verification.

## Investigation

The full sweep — plain BP, AP-CQ, fast-fading B90·Ts ∈ {3, 8, 15} × {Gaussian, Lorentzian} — returns 0 decodes on every recording. The other Q65 reference paths still produce real decodes with real assertions:

- \`eme_6m_sample_yields_decode_with_ap\` — W7GJ exchanges via AP (3 decodes)
- \`q65_fast_fading::eme_10ghz_reference_decodes_with_fast_fading\` — VK7MO ↔ K6QPV via fast-fading (3 decodes, B90Ts=15 / Gaussian)

The likely missing piece is **multi-period averaging**: WSJT-X's ionoscatter strategy stacks several adjacent slots in time-frequency before running BP / fast-fading, recovering signals that sit below any individual slot's threshold. Single-slot decode (which is all the test was doing) doesn't recover them. AP-list template matching (\`decode_at_with_ap_list_for\`) was also not exercised.

## Fix

Rename to \`ionoscatter_6m_receive_chain_runs\` and document honestly:

- Smoke test that exercises plain BP + AP-CQ + fast-fading paths against every reference WAV, asserts only that the chain runs to completion without panic / WAV-reader / search-params crash.
- Docstring records the actual decode rate (0/4 as of 0.4.2), names the suspected missing path (multi-period averaging), and notes the promotion path (when averaging lands, this test should require non-zero decodes or a sibling strict test should be added).

Default \`cargo test\` and \`cargo test -- --include-ignored\` both green. No phantom \`#[ignore]\` strict test that would fail under the CI's \`--include-ignored\` invocation.

## Honest scope going forward

For the 0.4.x line:
- ✅ 6 m EME (W7GJ) decodes via AP — verified
- ✅ 10 GHz EME (VK7MO/K6QPV) decodes via fast-fading metric — verified
- ⚠️ 6 m ionoscatter (4 reference WAVs) — **0/4 decoded**, known gap until multi-period averaging is ported

DCC paper / Hackaday narrative should treat ionoscatter as future work, not as a verified path.

## Test plan

- [x] \`cargo test --features full --test q65_wsjtx_samples --release\` — 2 pass
- [x] \`cargo test --features full --test q65_wsjtx_samples --release -- --include-ignored\` — 2 pass
- [x] \`cargo fmt --check\` + \`cargo clippy -- -D warnings\` (pre-commit hook)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)