### PR TITLE
release: 0.4.3 — Q65 multi-period averaging (ionoscatter port)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## 0.4.3 — Q65 multi-period averaging (ionoscatter port)
+
+Adds the WSJT-X `iavg=1` / `iavg=2` averaged-decode path to the
+Q65 receive chain. The 0.4.2 honest-test pass left the WSJT-X
+ionoscatter reference set (`30A_Ionoscatter_6m/*.wav`) at 0/4
+decoded with an explicit `multi-period averaging not yet ported`
+docstring; this release ports it and recovers `K1JT K9AN R-16` —
+the actual exchange in the recording, decoded by averaging the 4
+slots before BP / fast-fading. Single-period EME paths
+(`60A_EME_6m`, `60D_EME_10GHz`) are unchanged.
+
+### What's new
+
+- **`mfsk_core::q65::decode_multi_period_for<P>`** + `decode_multi_period`
+  Q65-30A wrapper. Stateless API: pass `&[&[f32]]` of audio slots
+  in chronological order and an optional AP-list candidate set;
+  returns deduplicated `Vec<Q65Decode>`. Internally maintains an
+  exponential-moving-average spectrogram with time constant
+  `min(navg, 4)` (matches WSJT-X's `lib/qra/q65/q65.f90:300-304`
+  accumulator) and runs coarse sync search on the running average
+  before each candidate goes through a 3-stage decode ladder:
+  - **Stage B (AP-list)** when `ap_codewords` is supplied — averaged
+    Bessel-metric intrinsics → `Q65Codec::decode_with_codeword_list`.
+    Mirrors WSJT-X's `iavg=1` q3 path.
+  - **Stage C-fading** — averaged wide energies →
+    `intrinsics_fast_fading` BP, swept across
+    `b90·Ts ∈ {3, 8, 15} × {Gaussian, Lorentzian}`.
+  - **Stage C-plain** — averaged narrow energies → Bessel-metric BP
+    fallback.
+- Per-slot at most one decode is appended (the first stage that
+  succeeds for any candidate wins). Repeated identical messages
+  across slots are deduplicated by `(message, ±4 Hz freq)` because
+  the running EMA collapses copies of the same QSO into one
+  signal.
+
+### Verified
+
+- `tests/q65_wsjtx_samples.rs::ionoscatter_6m_full_stack_decodes_via_averaging`
+  asserts ≥1 decode across the 4-slot WSJT-X ionoscatter stack.
+  Both paths (no AP-list, K1JT/K9AN AP-list) recover
+  `K1JT K9AN R-16` at 1010 Hz / dt=0.90 s.
+- `tests/q65_wsjtx_samples.rs::ionoscatter_6m_receive_chain_runs`
+  smoke test still passes (single-period chain unchanged).
+- 6 m EME (`eme_6m_sample_yields_decode_with_ap` — 3 W7GJ exchanges
+  via plain + AP-CQ) and 10 GHz EME
+  (`q65_fast_fading::eme_10ghz_reference_decodes_with_fast_fading`
+  — 3 VK7MO/K6QPV decodes via fast-fading) untouched.
+- `cargo test --features full --release -- --include-ignored` all
+  green; clippy + fmt clean.
+
+### Implementation notes
+
+- Reuses the existing `extract_data_energies` /
+  `extract_data_energies_wide` energy extractors (private to
+  `q65::rx`), `mfsk_bessel_metric` and `intrinsics_fast_fading`
+  intrinsics builders, `Q65Codec::{decode, decode_with_codeword_list}`
+  decoders, and `super::search::coarse_search_on_spec_for<P>`. No
+  changes to `Spectrogram`, `SearchParams`, or any existing public
+  surface — the multi-period entry is an additive layer.
+- Stateless by design: real-time consumers manage the slot buffer
+  themselves. A `Q65Averager` struct + WSJT-X-style even/odd
+  parity (`iseq=0/1`) split are reasonable follow-ups but were not
+  needed to clear the WSJT-X reference set.
+- AP-list path uses the existing `standard_qso_codewords(my, his,
+  grid)` builder. When the call+grid pair is unknown, pass `None`
+  and the fading + plain BP ladder handles it.
+
 ## 0.4.2 — documentation consistency pass
 
 Patch release. No public-API changes; host builds (`--features full`)

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-core"
-version     = "0.4.2"
+version     = "0.4.3"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 description = "Pure-Rust WSJT-family decoders and synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. no_std + alloc capable with a pluggable FFT backend; ESP32-S3 PoC included."

--- a/mfsk-core/src/q65/mod.rs
+++ b/mfsk-core/src/q65/mod.rs
@@ -65,9 +65,9 @@ pub use ap_list::{MAX_AP_CODEWORDS, standard_qso_codewords};
 pub use protocol::{Q65Fec, Q65a30, Q65a60, Q65b60, Q65c60, Q65d60, Q65e60};
 pub use rx::{
     Q65Decode, decode_at, decode_at_fading_for, decode_at_for, decode_at_with_ap,
-    decode_at_with_ap_for, decode_at_with_ap_list_for, decode_scan, decode_scan_default,
-    decode_scan_fading_for, decode_scan_for, decode_scan_with_ap, decode_scan_with_ap_for,
-    decode_scan_with_ap_list_for,
+    decode_at_with_ap_for, decode_at_with_ap_list_for, decode_multi_period,
+    decode_multi_period_for, decode_scan, decode_scan_default, decode_scan_fading_for,
+    decode_scan_for, decode_scan_with_ap, decode_scan_with_ap_for, decode_scan_with_ap_list_for,
 };
 pub use search::{SearchParams, SyncCandidate, coarse_search};
 pub use sync_pattern::{Q65_DATA_POSITIONS, Q65_SYNC_BLOCKS, Q65_SYNC_POSITIONS};

--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -598,6 +598,351 @@ pub fn decode_scan_default(audio: &[f32], sample_rate: u32) -> Vec<Q65Decode> {
     )
 }
 
+// ──────────────────────────────────────────────────────────────────────────
+// Multi-period averaging — WSJT-X `iavg=1,2` parity.
+//
+// Mirrors `lib/q65_decode.f90`'s averaged decode flow: maintain an
+// EMA over the per-slot spectrogram, run coarse search on the
+// running average, and on each candidate try the AP-list / fading /
+// plain BP ladder against energies averaged across the slots seen so
+// far. Stateless (caller owns the slot buffer) — see the docstring
+// on `decode_multi_period_for` for the call shape.
+// ──────────────────────────────────────────────────────────────────────────
+
+/// Average per-symbol FFT energies (`extract_data_energies` output)
+/// element-wise across `audio_slots[..=current]` at the candidate
+/// `(start_sample, base_freq_hz)`. Returns `None` if no slot yields
+/// usable energies.
+fn averaged_data_energies<P: ModulationParams>(
+    audio_slots: &[&[f32]],
+    sample_rate: u32,
+    start_sample: usize,
+    base_freq_hz: f32,
+) -> Option<Vec<f32>> {
+    let mut accum: Option<Vec<f32>> = None;
+    let mut count = 0_usize;
+    for &audio in audio_slots {
+        let Some(e) = extract_data_energies::<P>(audio, sample_rate, start_sample, base_freq_hz)
+        else {
+            continue;
+        };
+        match accum.as_mut() {
+            Some(a) => {
+                for (slot, v) in a.iter_mut().zip(&e) {
+                    *slot += *v;
+                }
+            }
+            None => accum = Some(e),
+        }
+        count += 1;
+    }
+    let mut accum = accum?;
+    if count > 1 {
+        let inv = 1.0_f32 / count as f32;
+        for v in &mut accum {
+            *v *= inv;
+        }
+    }
+    Some(accum)
+}
+
+/// Wide-spectrogram variant of [`averaged_data_energies`] for the
+/// fast-fading metric path.
+fn averaged_data_energies_wide<P: ModulationParams>(
+    audio_slots: &[&[f32]],
+    sample_rate: u32,
+    start_sample: usize,
+    base_freq_hz: f32,
+) -> Option<Vec<f32>> {
+    let mut accum: Option<Vec<f32>> = None;
+    let mut count = 0_usize;
+    for &audio in audio_slots {
+        let Some(e) =
+            extract_data_energies_wide::<P>(audio, sample_rate, start_sample, base_freq_hz)
+        else {
+            continue;
+        };
+        match accum.as_mut() {
+            Some(a) => {
+                for (slot, v) in a.iter_mut().zip(&e) {
+                    *slot += *v;
+                }
+            }
+            None => accum = Some(e),
+        }
+        count += 1;
+    }
+    let mut accum = accum?;
+    if count > 1 {
+        let inv = 1.0_f32 / count as f32;
+        for v in &mut accum {
+            *v *= inv;
+        }
+    }
+    Some(accum)
+}
+
+/// Run the AP-list decoder against averaged narrow energies.
+fn decode_averaged_ap_list_for<P: ModulationParams>(
+    audio_slots: &[&[f32]],
+    sample_rate: u32,
+    start_sample: usize,
+    base_freq_hz: f32,
+    candidates: &[[i32; 63]],
+) -> Option<Q65Decode> {
+    use crate::core::{DecodeContext, MessageCodec};
+    use crate::msg::Q65Message;
+
+    if candidates.is_empty() {
+        return None;
+    }
+    let energies =
+        averaged_data_energies::<P>(audio_slots, sample_rate, start_sample, base_freq_hz)?;
+
+    let mut intrinsics = vec![0.0_f32; 64 * 63];
+    QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, &energies, 63, default_es_no_metric());
+
+    let codec = Q65Codec::new(&QRA15_65_64_IRR_E23);
+    let (_idx, info_syms) = codec.decode_with_codeword_list(&intrinsics, candidates)?;
+
+    let bits77 = unpack_symbols_to_bits77(&info_syms);
+    let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
+
+    Some(Q65Decode {
+        message: text,
+        freq_hz: base_freq_hz,
+        start_sample,
+        iterations: 0,
+    })
+}
+
+/// Run the fast-fading metric BP decoder against averaged wide energies.
+fn decode_averaged_fading_for<P: ModulationParams>(
+    audio_slots: &[&[f32]],
+    sample_rate: u32,
+    start_sample: usize,
+    base_freq_hz: f32,
+    b90_ts: f32,
+    model: FadingModel,
+) -> Option<Q65Decode> {
+    use crate::core::{DecodeContext, MessageCodec};
+    use crate::msg::Q65Message;
+
+    let energies =
+        averaged_data_energies_wide::<P>(audio_slots, sample_rate, start_sample, base_freq_hz)?;
+
+    let mut intrinsics = vec![0.0_f32; 64 * 63];
+    let _state = intrinsics_fast_fading(
+        &QRA15_65_64_IRR_E23,
+        &mut intrinsics,
+        &energies,
+        submode_index_from_params::<P>(),
+        b90_ts,
+        model,
+        default_es_no_metric(),
+    );
+
+    let mut codec = Q65Codec::new(&QRA15_65_64_IRR_E23);
+    let mut info_syms = [0_i32; 13];
+    let iterations = codec.decode(&intrinsics, &mut info_syms, 50).ok()?;
+
+    let bits77 = unpack_symbols_to_bits77(&info_syms);
+    let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
+
+    Some(Q65Decode {
+        message: text,
+        freq_hz: base_freq_hz,
+        start_sample,
+        iterations,
+    })
+}
+
+/// Run plain Bessel-metric BP against averaged narrow energies.
+fn decode_averaged_plain_for<P: ModulationParams>(
+    audio_slots: &[&[f32]],
+    sample_rate: u32,
+    start_sample: usize,
+    base_freq_hz: f32,
+) -> Option<Q65Decode> {
+    use crate::core::{DecodeContext, MessageCodec};
+    use crate::msg::Q65Message;
+
+    let energies =
+        averaged_data_energies::<P>(audio_slots, sample_rate, start_sample, base_freq_hz)?;
+
+    let mut intrinsics = vec![0.0_f32; 64 * 63];
+    QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, &energies, 63, default_es_no_metric());
+
+    let mut codec = Q65Codec::new(&QRA15_65_64_IRR_E23);
+    let mut info_syms = [0_i32; 13];
+    let iterations = codec.decode(&intrinsics, &mut info_syms, 50).ok()?;
+
+    let bits77 = unpack_symbols_to_bits77(&info_syms);
+    let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
+
+    Some(Q65Decode {
+        message: text,
+        freq_hz: base_freq_hz,
+        start_sample,
+        iterations,
+    })
+}
+
+/// Multi-period averaging Q65 decode for sub-mode `P`. Mirrors WSJT-X's
+/// `iavg=1`/`iavg=2` averaged-decode path from
+/// [`q65_decode.f90`](https://sourceforge.net/p/wsjt/wsjtx/ci/main/tree/lib/q65_decode.f90)
+/// — the strategy that lets ionoscatter and weak EME signals decode
+/// when single-period BP/fading cannot.
+///
+/// The function processes the slots in order, maintaining an
+/// **exponential moving average** of the per-slot spectrogram with
+/// time constant `min(navg, 4)` (`u = 1.0 / min(i+1, 4)`, matching the
+/// `lib/qra/q65/q65.f90:300-304` accumulator). At each slot the
+/// running-average spectrogram drives a coarse sync search, and for
+/// every surviving candidate a 3-stage decode ladder is tried
+/// against energies averaged across all slots seen so far:
+///
+/// 1. **AP-list** — when `ap_codewords.is_some()`. Mirrors `iavg=1`'s
+///    q3 path. Cheap relative to the rest, included when caller has a
+///    plausible call/grid pair (see [`super::ap_list::standard_qso_codewords`]).
+/// 2. **Fast-fading metric BP** — sweeps `b90·Ts ∈ {3, 8, 15}` ×
+///    `{Gaussian, Lorentzian}`. Covers the realistic ionoscatter +
+///    EME spread regimes.
+/// 3. **Plain Bessel BP** — last-resort AWGN-only fallback.
+///
+/// Returns at most one decode per slot (the first one that succeeds
+/// at any stage), deduped by `(message, ±4 Hz freq)` so a stable QSO
+/// call only counts once. Single-period decodes are *not* re-run
+/// inside this function — callers who want them should call
+/// [`decode_scan_for`] / [`decode_scan_fading_for`] separately.
+///
+/// Empty `audio_slots` returns an empty Vec.
+pub fn decode_multi_period_for<P: ModulationParams>(
+    audio_slots: &[&[f32]],
+    sample_rate: u32,
+    nominal_start_sample: usize,
+    params: &super::search::SearchParams,
+    ap_codewords: Option<&[[i32; 63]]>,
+) -> Vec<Q65Decode> {
+    use super::search::{Spectrogram, coarse_search_on_spec_for};
+
+    let mut output: Vec<Q65Decode> = Vec::new();
+    if audio_slots.is_empty() {
+        return output;
+    }
+
+    // Initialise EMA from slot 0.
+    let mut ema_spec = Spectrogram::build_for::<P>(audio_slots[0], sample_rate);
+    if ema_spec.n_time == 0 {
+        return output;
+    }
+
+    let b90_ladder = [3.0_f32, 8.0, 15.0];
+    let fading_models = [FadingModel::Gaussian, FadingModel::Lorentzian];
+
+    for (i, &audio) in audio_slots.iter().enumerate() {
+        if i > 0 {
+            let slot_spec = Spectrogram::build_for::<P>(audio, sample_rate);
+            // EMA update: weight = 1 / min(navg, 4) — matches WSJT-X's
+            // `ntc = min(navg, 4); u = 1.0/ntc` accumulator. After the
+            // 4th slot the time constant saturates, so older history
+            // decays at a fixed rate (~25%/slot).
+            if slot_spec.n_time == ema_spec.n_time
+                && slot_spec.n_freq == ema_spec.n_freq
+                && slot_spec.mags_sqr.len() == ema_spec.mags_sqr.len()
+            {
+                let weight = 1.0_f32 / ((i + 1).min(4) as f32);
+                let one_minus = 1.0 - weight;
+                for (e, s) in ema_spec.mags_sqr.iter_mut().zip(&slot_spec.mags_sqr) {
+                    *e = weight * *s + one_minus * *e;
+                }
+                ema_spec.noise_per_bin =
+                    weight * slot_spec.noise_per_bin + one_minus * ema_spec.noise_per_bin;
+            }
+            // (else: dimension mismatch, keep prior EMA — this slot
+            // still contributes to per-candidate energy averaging.)
+        }
+
+        let candidates =
+            coarse_search_on_spec_for::<P>(&ema_spec, sample_rate, nominal_start_sample, params);
+
+        let history = &audio_slots[..=i];
+        let mut slot_decode: Option<Q65Decode> = None;
+
+        'candidate_loop: for cand in candidates {
+            // Stage B — AP-list decode on averaged narrow energies.
+            if let Some(codewords) = ap_codewords
+                && let Some(d) = decode_averaged_ap_list_for::<P>(
+                    history,
+                    sample_rate,
+                    cand.start_sample,
+                    cand.freq_hz,
+                    codewords,
+                )
+            {
+                slot_decode = Some(d);
+                break 'candidate_loop;
+            }
+
+            // Stage C-fading — fast-fading metric BP, b90 × model sweep.
+            for &b90 in &b90_ladder {
+                for &model in &fading_models {
+                    if let Some(d) = decode_averaged_fading_for::<P>(
+                        history,
+                        sample_rate,
+                        cand.start_sample,
+                        cand.freq_hz,
+                        b90,
+                        model,
+                    ) {
+                        slot_decode = Some(d);
+                        break 'candidate_loop;
+                    }
+                }
+            }
+
+            // Stage C-plain — Bessel-metric BP fallback.
+            if let Some(d) = decode_averaged_plain_for::<P>(
+                history,
+                sample_rate,
+                cand.start_sample,
+                cand.freq_hz,
+            ) {
+                slot_decode = Some(d);
+                break 'candidate_loop;
+            }
+        }
+
+        if let Some(d) = slot_decode {
+            let dup = output
+                .iter()
+                .any(|prev| prev.message == d.message && (prev.freq_hz - d.freq_hz).abs() <= 4.0);
+            if !dup {
+                output.push(d);
+            }
+        }
+    }
+
+    output
+}
+
+/// Q65-30A convenience wrapper for [`decode_multi_period_for`].
+pub fn decode_multi_period(
+    audio_slots: &[&[f32]],
+    sample_rate: u32,
+    nominal_start_sample: usize,
+    params: &super::search::SearchParams,
+    ap_codewords: Option<&[[i32; 63]]>,
+) -> Vec<Q65Decode> {
+    decode_multi_period_for::<Q65a30>(
+        audio_slots,
+        sample_rate,
+        nominal_start_sample,
+        params,
+        ap_codewords,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::super::tx::synthesize_standard;

--- a/mfsk-core/tests/q65_wsjtx_samples.rs
+++ b/mfsk-core/tests/q65_wsjtx_samples.rs
@@ -22,8 +22,8 @@ use mfsk_core::fec::qra::FadingModel;
 use mfsk_core::msg::ApHint;
 use mfsk_core::q65::search::SearchParams;
 use mfsk_core::q65::{
-    Q65a30, Q65a60, decode_scan, decode_scan_fading_for, decode_scan_with_ap,
-    decode_scan_with_ap_for,
+    Q65a30, Q65a60, decode_multi_period_for, decode_scan, decode_scan_fading_for,
+    decode_scan_with_ap, decode_scan_with_ap_for,
 };
 
 /// Minimal WAV reader for WSJT-X's exact format: RIFF/WAVE header,
@@ -73,23 +73,20 @@ fn samples_dir(rel: &str) -> Option<PathBuf> {
     if dir.is_dir() { Some(dir) } else { None }
 }
 
-/// Smoke test: the Q65-30A receive chain (plain BP + AP + fast-fading
-/// metric) runs to completion against every WSJT-X ionoscatter
-/// reference recording without panicking, and the WAV reader handles
-/// the file format correctly.
+/// Smoke test: the Q65-30A *single-period* receive chain (plain BP +
+/// AP + fast-fading metric) runs to completion against every WSJT-X
+/// ionoscatter reference recording without panicking, and the WAV
+/// reader handles the file format correctly.
 ///
-/// **Decode rate is not asserted** because the WSJT-X ionoscatter
-/// sample set typically requires **multi-period averaging** — a
-/// strategy where WSJT-X stacks several adjacent slots in
-/// time-frequency before running BP / fast-fading, recovering
-/// signals that sit below any individual slot's threshold. That path
-/// is not yet ported to mfsk-core. As of 0.4.2 this port produces
-/// 0/4 decodes across plain BP / AP-CQ / fast-fading
-/// {3, 8, 15} × {Gaussian, Lorentzian}. When multi-period averaging
-/// lands, this test should be promoted to require non-zero decodes
-/// (or a sibling strict test added). Current scope: catch a panic /
-/// WAV-reader / search-params regression so the existing chain
-/// stays healthy in the meantime.
+/// **Single-period decode rate is not asserted** — these recordings
+/// sit below the single-period decode threshold (each WAV produces
+/// 0 decodes via plain / AP-CQ / fast-fading taken in isolation).
+/// The averaged-decode gate lives in
+/// `ionoscatter_6m_full_stack_decodes_via_averaging` below, which
+/// stacks the slots and recovers them via the multi-period EMA path
+/// (`decode_multi_period_for`). This test stays useful as a
+/// regression catch on the per-slot chain (panic / WAV-reader /
+/// search-params blow-up).
 #[test]
 fn ionoscatter_6m_receive_chain_runs() {
     let Some(dir) = samples_dir("30A_Ionoscatter_6m") else {
@@ -162,6 +159,116 @@ fn ionoscatter_6m_receive_chain_runs() {
     assert!(
         wav_count > 0,
         "no readable WAVs in WSJT-X Q65-30A ionoscatter sample dir"
+    );
+}
+
+/// Strict gate: stack the four ionoscatter recordings into one
+/// running EMA via [`decode_multi_period_for`] and require at least
+/// one decode total.
+///
+/// Mirrors WSJT-X's `iavg=1`/`iavg=2` averaged-decode flow from
+/// `lib/q65_decode.f90` — the path that lets weak ionoscatter
+/// signals decode when single-period BP/fading cannot. Our reduced
+/// b90 sweep `{3, 8, 15} × {Gaussian, Lorentzian}` plus plain Bessel
+/// fallback covers the realistic ionoscatter spread regime.
+///
+/// Currently no AP-list pair is supplied (the recordings are from
+/// an unknown station so we don't know plausible call/grid pairs);
+/// the fading + plain BP ladder must reach the threshold on its own.
+/// If the expected call/grid pair becomes known, pass it through
+/// [`mfsk_core::q65::standard_qso_codewords`] for the AP-list path.
+#[test]
+fn ionoscatter_6m_full_stack_decodes_via_averaging() {
+    let Some(dir) = samples_dir("30A_Ionoscatter_6m") else {
+        eprintln!("skipping: WSJT-X sample tree not found");
+        return;
+    };
+    let mut paths: Vec<_> = std::fs::read_dir(&dir)
+        .expect("read samples dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|s| s.to_str()) == Some("wav"))
+        .collect();
+    // Stable order so the EMA sees slots in chronological order.
+    paths.sort();
+    assert!(
+        !paths.is_empty(),
+        "WSJT-X Q65-30A sample dir contains no .wav files"
+    );
+
+    let audios: Vec<Vec<f32>> = paths.iter().filter_map(|p| read_wsjtx_wav(p)).collect();
+    assert!(
+        !audios.is_empty(),
+        "no readable WAVs in WSJT-X Q65-30A ionoscatter sample dir"
+    );
+    let slot_refs: Vec<&[f32]> = audios.iter().map(|v| v.as_slice()).collect();
+
+    // 15 s into the 30 s slot, ±15 s tolerance — covers the full
+    // recording so the running-EMA coarse search has the whole slot.
+    let nominal_mid = 12_000 * 15;
+    let params = SearchParams {
+        freq_min_hz: 200.0,
+        freq_max_hz: 3_000.0,
+        time_tolerance_symbols: 50,
+        score_threshold: 0.05,
+        max_candidates: 32,
+    };
+
+    let decodes_no_ap =
+        decode_multi_period_for::<Q65a30>(&slot_refs, 12_000, nominal_mid, &params, None);
+    eprintln!(
+        "[info] ionoscatter multi-period (no AP-list): {} unique decode(s) across {} slot(s)",
+        decodes_no_ap.len(),
+        slot_refs.len(),
+    );
+    for d in &decodes_no_ap {
+        eprintln!(
+            "  → freq={:.1} Hz dt={:.2} s iter={} : {}",
+            d.freq_hz,
+            d.start_sample as f32 / 12_000.0,
+            d.iterations,
+            d.message
+        );
+    }
+
+    // Try the AP-list path with K1JT / K9AN — the call pair revealed
+    // by the no-AP run above. WSJT-X normally builds this list from
+    // the user's "Watch list" or last-seen-CQ; here we hard-code the
+    // discovered pair to test the AP-list integration.
+    use mfsk_core::q65::standard_qso_codewords;
+    let ap_codewords = standard_qso_codewords("K1JT", "K9AN", "");
+    let decodes_ap = decode_multi_period_for::<Q65a30>(
+        &slot_refs,
+        12_000,
+        nominal_mid,
+        &params,
+        Some(&ap_codewords),
+    );
+    eprintln!(
+        "[info] ionoscatter multi-period (AP-list K1JT/K9AN): {} unique decode(s)",
+        decodes_ap.len(),
+    );
+    for d in &decodes_ap {
+        eprintln!(
+            "  → freq={:.1} Hz dt={:.2} s iter={} : {}",
+            d.freq_hz,
+            d.start_sample as f32 / 12_000.0,
+            d.iterations,
+            d.message
+        );
+    }
+
+    // Goal: multi-period averaging recovers the signal in at least one
+    // of the strategies. Single decode counts as success because the
+    // running-EMA collapses repeated copies of the same QSO line into
+    // one output entry — once a QSO has been recovered there's no
+    // additional information from re-recovering it.
+    assert!(
+        !decodes_no_ap.is_empty() || !decodes_ap.is_empty(),
+        "0/{} ionoscatter slots produced any decode through multi-period averaging \
+         (neither without AP-list nor with K1JT/K9AN AP-list) — regression or \
+         insufficient signal recovery in the EMA-on-spectrogram path",
+        slot_refs.len(),
     );
 }
 


### PR DESCRIPTION
## Summary

Closes the ionoscatter gap left by 0.4.2 (PR #11). Adds WSJT-X's \`iavg=1\` / \`iavg=2\` averaged-decode path to the Q65 receive chain — the strategy that lets weak ionoscatter and certain EME signals decode when single-period BP / fast-fading cannot.

**Result**: \`30A_Ionoscatter_6m/*.wav\` (4 WSJT-X reference recordings) goes from **0/4 decoded** to recovering \`K1JT K9AN R-16\` — the actual exchange in the recording.

## What's new

- **\`mfsk_core::q65::decode_multi_period_for<P>\`** + \`decode_multi_period\` Q65-30A wrapper. Stateless API:
  \`\`\`rust
  pub fn decode_multi_period_for<P: ModulationParams>(
      audio_slots: &[&[f32]],
      sample_rate: u32,
      nominal_start_sample: usize,
      params: &SearchParams,
      ap_codewords: Option<&[[i32; 63]]>,
  ) -> Vec<Q65Decode>
  \`\`\`

- **EMA on spectrogram** with time constant \`min(navg, 4)\` (matches \`lib/qra/q65/q65.f90:300-304\`). Coarse sync search runs on the running-average spectrogram, getting an SNR boost no single slot has alone.

- **3-stage decode ladder** per candidate, against energies averaged across all slots seen so far:
  1. **AP-list** — when caller provides codewords (e.g. via \`standard_qso_codewords(my, his, grid)\`). Mirrors WSJT-X's \`iavg=1\` q3 path.
  2. **Fast-fading metric BP** — sweeps \`b90·Ts ∈ {3, 8, 15} × {Gaussian, Lorentzian}\`.
  3. **Plain Bessel BP** — last-resort fallback.

- Per-slot at most one decode is appended; repeated copies of the same QSO are deduped by \`(message, ±4 Hz freq)\`.

## Verified

- New \`tests/q65_wsjtx_samples.rs::ionoscatter_6m_full_stack_decodes_via_averaging\` asserts ≥1 decode across the 4-slot stack. Both paths recover \`K1JT K9AN R-16\` at 1010 Hz / dt=0.90 s — without AP-list (37 BP iterations) and with AP-list (K1JT/K9AN, 0 iterations / template match).
- Single-period chain unchanged: \`eme_6m_sample_yields_decode_with_ap\` (3 W7GJ EME exchanges) and \`eme_10ghz_reference_decodes_with_fast_fading\` (3 VK7MO/K6QPV EME exchanges) still pass.
- \`cargo test --features full --release -- --include-ignored\` all green; clippy + fmt clean; \`cargo publish --dry-run\` clean (0.4.3).

## Implementation

Purely additive — no changes to \`Spectrogram\`, \`SearchParams\`, or any existing public surface. Reuses:

- \`extract_data_energies\` / \`extract_data_energies_wide\` (private to \`q65::rx\`)
- \`mfsk_bessel_metric\` + \`intrinsics_fast_fading\`
- \`Q65Codec::{decode, decode_with_codeword_list}\`
- \`search::coarse_search_on_spec_for<P>\` (already pub since the original Q65 port)

Stateless by design: real-time consumers manage the slot buffer caller-side. A \`Q65Averager\` struct + WSJT-X-style even/odd parity split are reasonable follow-ups but not needed to clear the WSJT-X reference set.

## Out of scope (follow-ups)

- Stateful \`Q65Averager\` struct for live receivers
- Even/odd parity split (\`iseq=0/1\`) for alternating-tx accumulators
- Browser PWA multi-WAV input UI (jl1nie/webft8 follow-up)
- Full WSJT-X b90 sweep (1..7 → 7 values vs our reduced 3-value ladder); can be extended in 1 line if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)