### PR TITLE
feat(decode): expose DecodeDepth + DecodeStrictness on ft4 + fst4

### DIFF
--- a/mfsk-core/src/fst4/decode.rs
+++ b/mfsk-core/src/fst4/decode.rs
@@ -116,6 +116,32 @@ pub fn decode_frame_with_cache(
     sync_min: f32,
     max_cand: usize,
 ) -> (Vec<DecodeResult>, FftCache) {
+    decode_frame_with_cache_and_options(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        DecodeDepth::BpAllOsd,
+        DecodeStrictness::Normal,
+        max_cand,
+    )
+}
+
+/// Same as [`decode_frame_with_cache`] but with explicit `depth` +
+/// `strictness` knobs (see [`decode_frame_with_options`]).
+///
+/// Added per Gemini's review on PR #21 (Tier 1.3) so callers driving
+/// pipelined SIC / narrow-band rescan can match the Fast / Normal /
+/// Deep menu without going through the legacy hardcoded shim.
+pub fn decode_frame_with_cache_and_options(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    depth: DecodeDepth,
+    strictness: DecodeStrictness,
+    max_cand: usize,
+) -> (Vec<DecodeResult>, FftCache) {
     pipeline::decode_frame::<Fst4s60>(
         audio,
         &FST4_60A_DOWNSAMPLE,
@@ -123,9 +149,9 @@ pub fn decode_frame_with_cache(
         freq_max,
         sync_min,
         None,
-        DecodeDepth::BpAllOsd,
+        depth,
         max_cand,
-        DecodeStrictness::Normal,
+        strictness,
         EqMode::Off,
         REFINE_STEPS,
         SYNC_Q_MIN,
@@ -197,6 +223,24 @@ mod tests {
             ] {
                 let _ =
                     decode_frame_with_options(&empty, 100.0, 3000.0, 0.8, None, depth, strict, 5);
+            }
+        }
+    }
+
+    /// Compile-time check that `decode_frame_with_cache_and_options`
+    /// accepts every combination of `DecodeDepth` × `DecodeStrictness`.
+    #[test]
+    fn decode_frame_with_cache_and_options_accepts_all_param_combos() {
+        let empty = vec![0i16; 12 * 60 * 1000]; // 60 s of silence
+        for &depth in &[DecodeDepth::Bp, DecodeDepth::BpAll, DecodeDepth::BpAllOsd] {
+            for &strict in &[
+                DecodeStrictness::Strict,
+                DecodeStrictness::Normal,
+                DecodeStrictness::Deep,
+            ] {
+                let _ = decode_frame_with_cache_and_options(
+                    &empty, 100.0, 3000.0, 0.8, depth, strict, 5,
+                );
             }
         }
     }

--- a/mfsk-core/src/fst4/decode.rs
+++ b/mfsk-core/src/fst4/decode.rs
@@ -51,16 +51,54 @@ pub fn decode_frame(
     sync_min: f32,
     max_cand: usize,
 ) -> Vec<DecodeResult> {
+    decode_frame_with_options(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        None,
+        DecodeDepth::BpAllOsd,
+        DecodeStrictness::Normal,
+        max_cand,
+    )
+}
+
+/// Decode one FST4-60A slot with explicit `depth` + `strictness` knobs.
+///
+/// Mirrors [`crate::ft4::decode::decode_frame_with_options`] and
+/// [`crate::ft8::decode::decode_frame`]'s `depth` parameter. Adds the
+/// `strictness` axis (which the public shim hardcodes to
+/// [`DecodeStrictness::Normal`]). Useful for matching WSJT-X's
+/// Fast / Normal / Deep menu in downstream applications:
+///
+/// | WSJT-X menu | depth        | strictness |
+/// |---|---|---|
+/// | Fast        | `Bp`         | `Strict`   |
+/// | Normal      | `BpAll`      | `Normal`   |
+/// | Deep        | `BpAllOsd`   | `Deep`     |
+///
+/// `freq_hint`: when `Some(f)`, narrows the coarse-sync to candidates
+/// near `f`. Pass `None` for full-band scan.
+pub fn decode_frame_with_options(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    strictness: DecodeStrictness,
+    max_cand: usize,
+) -> Vec<DecodeResult> {
     pipeline::decode_frame::<Fst4s60>(
         audio,
         &FST4_60A_DOWNSAMPLE,
         freq_min,
         freq_max,
         sync_min,
-        /*freq_hint*/ None,
-        DecodeDepth::BpAllOsd,
+        freq_hint,
+        depth,
         max_cand,
-        DecodeStrictness::Normal,
+        strictness,
         EqMode::Off,
         REFINE_STEPS,
         SYNC_Q_MIN,
@@ -141,5 +179,25 @@ mod tests {
             "expected to recover 'JA1ABC PM95', got {:?}",
             texts
         );
+    }
+
+    /// Compile-time check that `decode_frame_with_options` accepts every
+    /// combination of `DecodeDepth` × `DecodeStrictness`. No actual
+    /// decoding happens — empty audio returns no candidates fast — but
+    /// this guards against future signature drift breaking downstream
+    /// callers that do parameterised dispatch.
+    #[test]
+    fn decode_frame_with_options_accepts_all_param_combos() {
+        let empty = vec![0i16; 12 * 60 * 1000]; // 60 s of silence
+        for &depth in &[DecodeDepth::Bp, DecodeDepth::BpAll, DecodeDepth::BpAllOsd] {
+            for &strict in &[
+                DecodeStrictness::Strict,
+                DecodeStrictness::Normal,
+                DecodeStrictness::Deep,
+            ] {
+                let _ =
+                    decode_frame_with_options(&empty, 100.0, 3000.0, 0.8, None, depth, strict, 5);
+            }
+        }
     }
 }

--- a/mfsk-core/src/ft4/decode.rs
+++ b/mfsk-core/src/ft4/decode.rs
@@ -63,16 +63,54 @@ pub fn decode_frame(
     sync_min: f32,
     max_cand: usize,
 ) -> Vec<DecodeResult> {
+    decode_frame_with_options(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        None,
+        DecodeDepth::BpAllOsd,
+        DecodeStrictness::Normal,
+        max_cand,
+    )
+}
+
+/// Decode one FT4 slot with explicit `depth` + `strictness` knobs.
+///
+/// Mirrors [`crate::ft8::decode::decode_frame`]'s `depth` parameter and
+/// adds the `strictness` axis (which FT8's public shim hardcodes to
+/// [`DecodeStrictness::Normal`]). Useful for matching WSJT-X's
+/// Fast / Normal / Deep menu in downstream applications:
+///
+/// | WSJT-X menu | depth        | strictness |
+/// |---|---|---|
+/// | Fast        | `Bp`         | `Strict`   |
+/// | Normal      | `BpAll`      | `Normal`   |
+/// | Deep        | `BpAllOsd`   | `Deep`     |
+///
+/// `freq_hint` is the same as in `ft8::decode::decode_frame`: when
+/// `Some(f)`, narrows the coarse-sync to candidates near `f` ± a few Hz.
+/// Pass `None` for full-band scan.
+pub fn decode_frame_with_options(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    strictness: DecodeStrictness,
+    max_cand: usize,
+) -> Vec<DecodeResult> {
     pipeline::decode_frame::<Ft4>(
         audio,
         &FT4_DOWNSAMPLE,
         freq_min,
         freq_max,
         sync_min,
-        None,
-        DecodeDepth::BpAllOsd,
+        freq_hint,
+        depth,
         max_cand,
-        DecodeStrictness::Normal,
+        strictness,
         EqMode::Off,
         REFINE_STEPS,
         SYNC_Q_MIN,
@@ -162,4 +200,28 @@ pub fn decode_sniper_ap(
         SYNC_Q_MIN / 2,
         ap_hint,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time check that `decode_frame_with_options` accepts every
+    /// combination of `DecodeDepth` × `DecodeStrictness`. No actual
+    /// decoding happens — empty audio returns no candidates fast — but
+    /// this guards against future signature drift.
+    #[test]
+    fn decode_frame_with_options_accepts_all_param_combos() {
+        let empty = vec![0i16; 12 * 7500]; // 7.5 s of silence at 12 kHz
+        for &depth in &[DecodeDepth::Bp, DecodeDepth::BpAll, DecodeDepth::BpAllOsd] {
+            for &strict in &[
+                DecodeStrictness::Strict,
+                DecodeStrictness::Normal,
+                DecodeStrictness::Deep,
+            ] {
+                let _ =
+                    decode_frame_with_options(&empty, 100.0, 3000.0, 1.0, None, depth, strict, 5);
+            }
+        }
+    }
 }

--- a/mfsk-core/src/ft4/decode.rs
+++ b/mfsk-core/src/ft4/decode.rs
@@ -126,6 +126,32 @@ pub fn decode_frame_with_cache(
     sync_min: f32,
     max_cand: usize,
 ) -> (Vec<DecodeResult>, FftCache) {
+    decode_frame_with_cache_and_options(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        DecodeDepth::BpAllOsd,
+        DecodeStrictness::Normal,
+        max_cand,
+    )
+}
+
+/// Same as [`decode_frame_with_cache`] but with explicit `depth` +
+/// `strictness` knobs (see [`decode_frame_with_options`]).
+///
+/// Added per Gemini's review on PR #21 (Tier 1.3) so callers driving
+/// pipelined subtraction can match the Fast / Normal / Deep menu
+/// without going through the legacy hardcoded shim.
+pub fn decode_frame_with_cache_and_options(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    depth: DecodeDepth,
+    strictness: DecodeStrictness,
+    max_cand: usize,
+) -> (Vec<DecodeResult>, FftCache) {
     pipeline::decode_frame::<Ft4>(
         audio,
         &FT4_DOWNSAMPLE,
@@ -133,9 +159,9 @@ pub fn decode_frame_with_cache(
         freq_max,
         sync_min,
         None,
-        DecodeDepth::BpAllOsd,
+        depth,
         max_cand,
-        DecodeStrictness::Normal,
+        strictness,
         EqMode::Off,
         REFINE_STEPS,
         SYNC_Q_MIN,
@@ -150,6 +176,32 @@ pub fn decode_frame_subtract(
     sync_min: f32,
     max_cand: usize,
 ) -> Vec<DecodeResult> {
+    decode_frame_subtract_with_options(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        DecodeDepth::BpAllOsd,
+        DecodeStrictness::Normal,
+        max_cand,
+    )
+}
+
+/// Same as [`decode_frame_subtract`] but with explicit `depth` +
+/// `strictness` knobs (see [`decode_frame_with_options`]).
+///
+/// Added per Gemini's review on PR #21 (Tier 1.3) so SIC callers can
+/// match the Fast / Normal / Deep menu without going through the
+/// legacy hardcoded shim.
+pub fn decode_frame_subtract_with_options(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    depth: DecodeDepth,
+    strictness: DecodeStrictness,
+    max_cand: usize,
+) -> Vec<DecodeResult> {
     pipeline::decode_frame_subtract::<Ft4>(
         audio,
         &FT4_DOWNSAMPLE,
@@ -158,9 +210,9 @@ pub fn decode_frame_subtract(
         freq_max,
         sync_min,
         None,
-        DecodeDepth::BpAllOsd,
+        depth,
         max_cand,
-        DecodeStrictness::Normal,
+        strictness,
         REFINE_STEPS,
         SYNC_Q_MIN,
     )
@@ -172,6 +224,32 @@ pub fn decode_frame_subtract(
 pub fn decode_sniper_ap(
     audio: &[i16],
     target_freq: f32,
+    max_cand: usize,
+    eq_mode: EqMode,
+    ap_hint: Option<&ApHint>,
+) -> Vec<DecodeResult> {
+    decode_sniper_ap_with_options(
+        audio,
+        target_freq,
+        DecodeDepth::BpAllOsd,
+        DecodeStrictness::Normal,
+        max_cand,
+        eq_mode,
+        ap_hint,
+    )
+}
+
+/// Same as [`decode_sniper_ap`] but with explicit `depth` +
+/// `strictness` knobs (see [`decode_frame_with_options`]).
+///
+/// Added per Gemini's review on PR #21 (Tier 1.3) so sniper + AP
+/// callers can match the Fast / Normal / Deep menu without going
+/// through the legacy hardcoded shim.
+pub fn decode_sniper_ap_with_options(
+    audio: &[i16],
+    target_freq: f32,
+    depth: DecodeDepth,
+    strictness: DecodeStrictness,
     max_cand: usize,
     eq_mode: EqMode,
     ap_hint: Option<&ApHint>,
@@ -190,9 +268,9 @@ pub fn decode_sniper_ap(
         // can recover signals whose coarse-sync score wouldn't qualify for
         // a bare decode — we still need candidates to attempt the lock on.
         0.5,
-        DecodeDepth::BpAllOsd,
+        depth,
         max_cand,
-        DecodeStrictness::Normal,
+        strictness,
         eq_mode,
         REFINE_STEPS,
         // Halve the sync-quality gate for AP: locked bits carry the
@@ -221,6 +299,66 @@ mod tests {
             ] {
                 let _ =
                     decode_frame_with_options(&empty, 100.0, 3000.0, 1.0, None, depth, strict, 5);
+            }
+        }
+    }
+
+    /// Compile-time check that `decode_frame_with_cache_and_options`
+    /// accepts every combination of `DecodeDepth` × `DecodeStrictness`.
+    #[test]
+    fn decode_frame_with_cache_and_options_accepts_all_param_combos() {
+        let empty = vec![0i16; 12 * 7500];
+        for &depth in &[DecodeDepth::Bp, DecodeDepth::BpAll, DecodeDepth::BpAllOsd] {
+            for &strict in &[
+                DecodeStrictness::Strict,
+                DecodeStrictness::Normal,
+                DecodeStrictness::Deep,
+            ] {
+                let _ = decode_frame_with_cache_and_options(
+                    &empty, 100.0, 3000.0, 1.0, depth, strict, 5,
+                );
+            }
+        }
+    }
+
+    /// Compile-time check that `decode_frame_subtract_with_options`
+    /// accepts every combination of `DecodeDepth` × `DecodeStrictness`.
+    #[test]
+    fn decode_frame_subtract_with_options_accepts_all_param_combos() {
+        let empty = vec![0i16; 12 * 7500];
+        for &depth in &[DecodeDepth::Bp, DecodeDepth::BpAll, DecodeDepth::BpAllOsd] {
+            for &strict in &[
+                DecodeStrictness::Strict,
+                DecodeStrictness::Normal,
+                DecodeStrictness::Deep,
+            ] {
+                let _ = decode_frame_subtract_with_options(
+                    &empty, 100.0, 3000.0, 1.0, depth, strict, 5,
+                );
+            }
+        }
+    }
+
+    /// Compile-time check that `decode_sniper_ap_with_options` accepts
+    /// every combination of `DecodeDepth` × `DecodeStrictness`.
+    #[test]
+    fn decode_sniper_ap_with_options_accepts_all_param_combos() {
+        let empty = vec![0i16; 12 * 7500];
+        for &depth in &[DecodeDepth::Bp, DecodeDepth::BpAll, DecodeDepth::BpAllOsd] {
+            for &strict in &[
+                DecodeStrictness::Strict,
+                DecodeStrictness::Normal,
+                DecodeStrictness::Deep,
+            ] {
+                let _ = decode_sniper_ap_with_options(
+                    &empty,
+                    1500.0,
+                    depth,
+                    strict,
+                    5,
+                    EqMode::Off,
+                    None,
+                );
             }
         }
     }


### PR DESCRIPTION
FT4 and FST4-60A's public `decode_frame` shims hardcoded DecodeDepth::BpAllOsd + DecodeStrictness::Normal. Their internal generic pipeline already accepted both as parameters; this PR surfaces them via new `decode_frame_with_options` entry points that mirror FT8's existing `decode_frame(audio, ..., depth, max_cand)` signature shape.

Public API additions (no breaking changes):
- `mfsk_core::ft4::decode::decode_frame_with_options`
- `mfsk_core::fst4::decode::decode_frame_with_options`

Both take (audio, freq_min, freq_max, sync_min, freq_hint, depth, strictness, max_cand). The legacy `decode_frame(audio, freq_min, freq_max, sync_min, max_cand)` becomes a shim using BpAllOsd + Normal — unchanged behaviour for existing callers.

Mirror to WSJT-X's Decode menu:

  | WSJT-X    | depth      | strictness |
  |-----------|------------|------------|
  | Fast      | Bp         | Strict     |
  | Normal    | BpAll      | Normal     |
  | Deep      | BpAllOsd   | Deep       |

Tests:
- ft4::decode::tests::decode_frame_with_options_accepts_all_param_combos
- fst4::decode::tests::decode_frame_with_options_accepts_all_param_combos Both iterate every depth × strictness combination (3×3 = 9) on a silent buffer to guard against future signature drift.

Why ft4 + fst4 only:
- FT8 already exposes `depth` on its public API; nothing to add.
- JT9, JT65, Q65, WSPR use Fano / Reed-Solomon / QRA decoders that don't share the LDPC + OSD axis. Their tunables (Fano max stack, KV iteration cap, etc.) need a separate enum to be honest. Will follow up in a separate PR.

CI gates:
- cargo build --features full --release: clean
- cargo test --features full --release: 338/339 (1 pre-existing failure: ft8_qso3_apoff_recall.rs has a hardcoded /home/minoru/... path; not introduced by this PR)
- cargo clippy --features full --all-targets -- -D warnings: clean
- cargo fmt --check: clean

References:
- WSJT-X lib/ft8_decode.f90 (depth = ndepth in WSJT-X parlance)
- WSJT-X lib/fst4_decode.f90 (same)
- DecodeStrictness:Strict OSD calibration matches WSJT-X aggressive decoding off (ndepth=1).