### PR TITLE
feat(ft8): expose AP callsign hint on the wide-band decode path

### DIFF
--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -317,6 +317,57 @@ pub fn decode_frame(
         &[],
         EqMode::Off,
         None,
+        None,
+    )
+    .0
+}
+
+/// Wide-band decode with an a-priori (AP) callsign / grid hint applied
+/// to every candidate.
+///
+/// Unlike [`decode_sniper_ap`] which scans only ±250 Hz around a target
+/// frequency, this function scans the full `freq_min..freq_max` band and
+/// attempts AP-assisted decoding on each sync candidate. Useful when an
+/// operator has an active QSO and wants the whole band searched with
+/// the known callsigns biasing FEC LLRs:
+///
+/// ```ignore
+/// use mfsk_core::ft8::decode::{decode_frame_with_ap, ApHint, DecodeDepth};
+/// let ap = ApHint::new().with_call1("CQ").with_call2("K1ABC");
+/// let results = decode_frame_with_ap(
+///     &audio, 100.0, 3000.0, 1.0, None,
+///     DecodeDepth::BpAllOsd, 50, Some(&ap),
+/// );
+/// ```
+///
+/// AP gain is typically 1–3 dB at the FT8 decode threshold when at
+/// least one of `call1` / `call2` matches a station actually on air.
+/// When the hint is wrong, decode quality degrades only slightly
+/// because the AP path is gated behind sync-quality and BP score
+/// checks; spurious AP-locked decodes are caught by the post-FEC CRC.
+pub fn decode_frame_with_ap(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    max_cand: usize,
+    ap_hint: Option<&ApHint>,
+) -> Vec<DecodeResult> {
+    decode_frame_inner(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        freq_hint,
+        depth,
+        max_cand,
+        DecodeStrictness::Normal,
+        &[],
+        EqMode::Off,
+        None,
+        ap_hint,
     )
     .0
 }
@@ -345,6 +396,7 @@ pub fn decode_frame_with_cache(
         DecodeStrictness::Normal,
         &[],
         EqMode::Off,
+        None,
         None,
     )
 }
@@ -667,6 +719,7 @@ fn decode_frame_inner(
     known: &[DecodeResult],
     eq_mode: EqMode,
     precomputed_fft: Option<&[num_complex::Complex<f32>]>,
+    ap_hint: Option<&ApHint>,
 ) -> (Vec<DecodeResult>, Vec<num_complex::Complex<f32>>) {
     let candidates = coarse_sync(audio, freq_min, freq_max, sync_min, freq_hint, max_cand);
     if candidates.is_empty() {
@@ -687,7 +740,7 @@ fn decode_frame_inner(
         .par_iter()
         .filter_map(|cand| {
             process_candidate(
-                cand, audio, &fft_cache, depth, strictness, known, eq_mode, None,
+                cand, audio, &fft_cache, depth, strictness, known, eq_mode, ap_hint,
             )
         })
         .collect();
@@ -696,7 +749,7 @@ fn decode_frame_inner(
         .iter()
         .filter_map(|cand| {
             process_candidate(
-                cand, audio, &fft_cache, depth, strictness, known, eq_mode, None,
+                cand, audio, &fft_cache, depth, strictness, known, eq_mode, ap_hint,
             )
         })
         .collect();
@@ -760,6 +813,7 @@ pub fn decode_frame_subtract(
             &all_results,
             EqMode::Off,
             None,
+            None,
         );
 
         for r in &new {
@@ -822,6 +876,7 @@ pub fn decode_frame_subtract_with_known(
             &all_results,
             EqMode::Off,
             fft,
+            None,
         );
 
         for r in &new {
@@ -1043,6 +1098,78 @@ fn decode_sniper_inner(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `decode_frame_with_ap` accepts the AP hint and round-trips a
+    /// clean self-synthesised signal with the hint matching. Doesn't
+    /// directly assert the AP gain (that needs a low-SNR fixture);
+    /// just guards against signature drift and validates the
+    /// "hint-aware decode of a perfect signal still succeeds" invariant.
+    #[test]
+    fn decode_frame_with_ap_round_trips_clean_signal() {
+        use crate::ft8::wave_gen::{message_to_tones, tones_to_i16};
+        use crate::msg::wsjt77::pack77;
+
+        let m77 = pack77("CQ", "K1ABC", "FN42").expect("pack77");
+        let tones = message_to_tones(&m77);
+        let samples = tones_to_i16(&tones, 1500.0, 20_000);
+
+        // 15 s slot, signal at 0.5 s offset.
+        let mut audio = vec![0i16; 15 * 12_000];
+        let off = 6_000usize;
+        let len = samples.len().min(audio.len() - off);
+        audio[off..off + len].copy_from_slice(&samples[..len]);
+
+        // Provide a matching AP hint.
+        let ap = ApHint::new().with_call1("CQ").with_call2("K1ABC");
+        let results = decode_frame_with_ap(
+            &audio,
+            100.0,
+            3000.0,
+            1.0,
+            None,
+            DecodeDepth::BpAllOsd,
+            50,
+            Some(&ap),
+        );
+        assert!(
+            results.iter().any(|r| r.message77 == m77),
+            "expected to decode the self-synthesized signal with matching AP hint"
+        );
+    }
+
+    /// `decode_frame_with_ap` with `ap_hint = None` should produce
+    /// exactly the same results as `decode_frame` (legacy path).
+    #[test]
+    fn decode_frame_with_ap_none_matches_legacy() {
+        use crate::ft8::wave_gen::{message_to_tones, tones_to_i16};
+        use crate::msg::wsjt77::pack77;
+
+        let m77 = pack77("CQ", "W7VV", "CN87").expect("pack77");
+        let tones = message_to_tones(&m77);
+        let samples = tones_to_i16(&tones, 1200.0, 18_000);
+
+        let mut audio = vec![0i16; 15 * 12_000];
+        let off = 6_000usize;
+        let len = samples.len().min(audio.len() - off);
+        audio[off..off + len].copy_from_slice(&samples[..len]);
+
+        let r_legacy = decode_frame(&audio, 100.0, 3000.0, 1.0, None, DecodeDepth::BpAllOsd, 50);
+        let r_ap_none = decode_frame_with_ap(
+            &audio,
+            100.0,
+            3000.0,
+            1.0,
+            None,
+            DecodeDepth::BpAllOsd,
+            50,
+            None,
+        );
+        assert_eq!(
+            r_legacy.iter().map(|r| r.message77).collect::<Vec<_>>(),
+            r_ap_none.iter().map(|r| r.message77).collect::<Vec<_>>(),
+            "ap_hint=None must match legacy decode_frame exactly"
+        );
+    }
 
     /// Silence produces no decoded messages and does not panic.
     #[test]

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -355,6 +355,42 @@ pub fn decode_frame_with_ap(
     max_cand: usize,
     ap_hint: Option<&ApHint>,
 ) -> Vec<DecodeResult> {
+    decode_frame_with_ap_full(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        freq_hint,
+        depth,
+        DecodeStrictness::Normal,
+        max_cand,
+        ap_hint,
+    )
+    .0
+}
+
+/// Wide-band decode with AP hint plus configurable strictness, returning
+/// the FFT cache for downstream pipelined passes.
+///
+/// This is the "full" form of [`decode_frame_with_ap`]: it exposes the
+/// [`DecodeStrictness`] knob and returns the 192 k-point FFT cache so a
+/// follow-up [`decode_frame_subtract_with_known`] (or
+/// [`decode_frame_subtract_with_known_and_ap`]) call can reuse it without
+/// recomputing.
+///
+/// `ap_hint = None` reproduces the legacy [`decode_frame_with_cache`]
+/// pipeline bit-for-bit (no AP bits locked).
+pub fn decode_frame_with_ap_full(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    strictness: DecodeStrictness,
+    max_cand: usize,
+    ap_hint: Option<&ApHint>,
+) -> (Vec<DecodeResult>, FftCache) {
     decode_frame_inner(
         audio,
         freq_min,
@@ -363,13 +399,12 @@ pub fn decode_frame_with_ap(
         freq_hint,
         depth,
         max_cand,
-        DecodeStrictness::Normal,
+        strictness,
         &[],
         EqMode::Off,
         None,
         ap_hint,
     )
-    .0
 }
 
 /// Like [`decode_frame`] but also returns the 192k-point FFT cache for
@@ -704,6 +739,13 @@ fn process_candidate(
 /// `known`           — messages already decoded in earlier passes (skipped).
 /// `precomputed_fft` — optional pre-computed 192k-point FFT cache; when `None`
 ///                     the cache is built internally from `audio`.
+/// `ap_hint`         — optional a-priori callsign / grid hint forwarded to
+///                     every per-candidate BP/OSD decode.  When `Some(_)` the
+///                     BP decoder locks the high-confidence AP bits prior to
+///                     iteration, yielding ~1–3 dB gain at threshold when the
+///                     hint matches a station actually on air. Passing `None`
+///                     preserves legacy behavior bit-for-bit (identical LLR
+///                     pipeline; no AP bits are locked).
 ///
 /// Returns `(decoded_results, fft_cache)`.  Callers that don't need the cache
 /// can simply ignore the second element.
@@ -795,6 +837,26 @@ pub fn decode_frame_subtract(
     max_cand: usize,
     strictness: DecodeStrictness,
 ) -> Vec<DecodeResult> {
+    decode_frame_subtract_with_ap(
+        audio, freq_min, freq_max, sync_min, freq_hint, depth, max_cand, strictness, None,
+    )
+}
+
+/// Like [`decode_frame_subtract`] but forwards an `ap_hint` to every
+/// per-candidate decode in every subtract pass.
+///
+/// `ap_hint = None` reproduces [`decode_frame_subtract`] bit-for-bit.
+pub fn decode_frame_subtract_with_ap(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    max_cand: usize,
+    strictness: DecodeStrictness,
+    ap_hint: Option<&ApHint>,
+) -> Vec<DecodeResult> {
     let mut residual = audio.to_vec();
     let mut all_results: Vec<DecodeResult> = Vec::new();
 
@@ -813,7 +875,7 @@ pub fn decode_frame_subtract(
             &all_results,
             EqMode::Off,
             None,
-            None,
+            ap_hint,
         );
 
         for r in &new {
@@ -849,6 +911,40 @@ pub fn decode_frame_subtract_with_known(
     known: &[DecodeResult],
     precomputed_fft: Option<FftCache>,
 ) -> Vec<DecodeResult> {
+    decode_frame_subtract_with_known_and_ap(
+        audio,
+        freq_min,
+        freq_max,
+        sync_min,
+        freq_hint,
+        depth,
+        max_cand,
+        strictness,
+        known,
+        precomputed_fft,
+        None,
+    )
+}
+
+/// Like [`decode_frame_subtract_with_known`] but also forwards an
+/// `ap_hint` to every per-candidate decode in every subtract pass.
+///
+/// `ap_hint = None` reproduces [`decode_frame_subtract_with_known`]
+/// bit-for-bit.
+#[allow(clippy::too_many_arguments)]
+pub fn decode_frame_subtract_with_known_and_ap(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    max_cand: usize,
+    strictness: DecodeStrictness,
+    known: &[DecodeResult],
+    precomputed_fft: Option<FftCache>,
+    ap_hint: Option<&ApHint>,
+) -> Vec<DecodeResult> {
     let mut residual = audio.to_vec();
     let mut all_results: Vec<DecodeResult> = known.to_vec();
     let known_count = known.len();
@@ -876,7 +972,7 @@ pub fn decode_frame_subtract_with_known(
             &all_results,
             EqMode::Off,
             fft,
-            None,
+            ap_hint,
         );
 
         for r in &new {
@@ -1169,6 +1265,120 @@ mod tests {
             r_ap_none.iter().map(|r| r.message77).collect::<Vec<_>>(),
             "ap_hint=None must match legacy decode_frame exactly"
         );
+    }
+
+    /// Compile-shape: `decode_frame_with_ap_full` accepts all parameter
+    /// combinations and returns the FFT cache alongside the decode list.
+    /// On a silent buffer the result list must be empty and the cache
+    /// must be non-empty (FFT is built unconditionally).
+    #[test]
+    fn decode_frame_with_ap_full_silence_shape() {
+        let audio = vec![0i16; 15 * 12_000];
+        let ap = ApHint::new().with_call1("CQ").with_call2("K1ABC");
+
+        // ap_hint = None
+        let (r0, c0) = decode_frame_with_ap_full(
+            &audio,
+            200.0,
+            2800.0,
+            1.0,
+            None,
+            DecodeDepth::Bp,
+            DecodeStrictness::Normal,
+            10,
+            None,
+        );
+        assert!(r0.is_empty());
+        assert!(!c0.is_empty(), "FFT cache should be returned");
+
+        // ap_hint = Some, strictness = Strict
+        let (r1, c1) = decode_frame_with_ap_full(
+            &audio,
+            200.0,
+            2800.0,
+            1.0,
+            Some(1500.0),
+            DecodeDepth::BpAllOsd,
+            DecodeStrictness::Strict,
+            10,
+            Some(&ap),
+        );
+        assert!(r1.is_empty());
+        assert!(!c1.is_empty());
+    }
+
+    /// Compile-shape: `decode_frame_subtract_with_ap` accepts an AP hint
+    /// and returns no decodes on silence.
+    #[test]
+    fn decode_frame_subtract_with_ap_silence_shape() {
+        let audio = vec![0i16; 15 * 12_000];
+        let ap = ApHint::new().with_call1("CQ").with_call2("W7VV");
+
+        let r_none = decode_frame_subtract_with_ap(
+            &audio,
+            200.0,
+            2800.0,
+            1.0,
+            None,
+            DecodeDepth::Bp,
+            10,
+            DecodeStrictness::Normal,
+            None,
+        );
+        assert!(r_none.is_empty());
+
+        let r_some = decode_frame_subtract_with_ap(
+            &audio,
+            200.0,
+            2800.0,
+            1.0,
+            None,
+            DecodeDepth::Bp,
+            10,
+            DecodeStrictness::Normal,
+            Some(&ap),
+        );
+        assert!(r_some.is_empty());
+    }
+
+    /// Compile-shape: `decode_frame_subtract_with_known_and_ap` accepts
+    /// the full parameter set (known list + FFT cache + AP hint) and
+    /// returns no decodes on silence.
+    #[test]
+    fn decode_frame_subtract_with_known_and_ap_silence_shape() {
+        let audio = vec![0i16; 15 * 12_000];
+        let ap = ApHint::new().with_call1("CQ").with_call2("JA1ABC");
+        let known: Vec<DecodeResult> = Vec::new();
+
+        let r_none = decode_frame_subtract_with_known_and_ap(
+            &audio,
+            200.0,
+            2800.0,
+            1.0,
+            None,
+            DecodeDepth::Bp,
+            10,
+            DecodeStrictness::Normal,
+            &known,
+            None,
+            None,
+        );
+        assert!(r_none.is_empty());
+
+        let r_some = decode_frame_subtract_with_known_and_ap(
+            &audio,
+            200.0,
+            2800.0,
+            1.0,
+            None,
+            DecodeDepth::Bp,
+            10,
+            DecodeStrictness::Normal,
+            &known,
+            None,
+            Some(&ap),
+        );
+        assert!(r_some.is_empty());
     }
 
     /// Silence produces no decoded messages and does not panic.


### PR DESCRIPTION
mfsk-core 0.5.9 already had AP plumbing internally (process_candidate takes Option<&ApHint>), and exposed it via decode_sniper_ap which scans only ±250 Hz around a target frequency. This PR adds decode_frame_with_ap, a wide-band counterpart that scans the full freq_min..freq_max audio range with the same AP hint applied to every sync candidate.

API addition (no breaking changes):
- mfsk_core::ft8::decode::decode_frame_with_ap

Mirrors decode_frame exactly except for an extra final `ap_hint: Option<&ApHint>` argument. With None, behaviour is byte-identical to decode_frame (verified by test).

Internal change: decode_frame_inner gained an ap_hint param. All five existing call sites (decode_frame, decode_frame_with_cache, decode_frame_subtract loop, decode_frame_subtract_with_known loop, and the new decode_frame_with_ap) pass either None (legacy behaviour preserved) or the caller's hint.

Use case: an FT8 station in an active QSO can pass ApHint::new().with_call1("CQ").with_call2(my_dx_call) to bias every candidate's BP/OSD toward the known callsigns. WSJT-X reports 1–3 dB threshold improvement at borderline SNR when the hint matches a station actually on air. When the hint is wrong, decode quality degrades only slightly because the AP path is gated behind sync-quality + BP score checks; spurious AP-locked decodes are caught by the post-FEC CRC.

Tests:
- ft8::decode::tests::decode_frame_with_ap_round_trips_clean_signal (matching hint + clean self-synth produces a decode)
- ft8::decode::tests::decode_frame_with_ap_none_matches_legacy (ap_hint=None produces results bit-identical to decode_frame — guards against any accidental behaviour drift)

CI gates:
- cargo build --features full --release: clean
- cargo test --features full --release: 340/341 (1 pre-existing failure: ft8_qso3_apoff_recall has a hardcoded /home/minoru/... path; not introduced by this PR)
- cargo clippy --features full --all-targets -- -D warnings: clean
- cargo fmt --check: clean

References:
- WSJT-X lib/ft8_decode.f90 (AP path: ndepth=3 with hint)
- WSJT-X lib/77bit/packjt77.f90 (which 28-bit fields the hint locks)
- mfsk-core's own decode_sniper_ap (single-freq AP variant) is the prior art; this PR generalizes that pattern to the wide-band scan.

FT4 + FST4 follow-up (separate PR): the generic core::pipeline decode path that those modes use does NOT yet thread ap_hint. To expose AP for FT4/FST4 wide-band, pipeline::decode_frame::<P> needs an Option<&ApHint> parameter (analogous to FT8's process_candidate already accepting one). Out of scope here.