### PR TITLE
docs(tests): update stale apon reference in ft8_qso3_apoff_recall

### DIFF
--- a/mfsk-core/tests/ft8_qso3_apoff_recall.rs
+++ b/mfsk-core/tests/ft8_qso3_apoff_recall.rs
@@ -4,9 +4,9 @@
 //!
 //! The 8-entry golden in [`WSJTX_GOLDEN`] is what WSJT-X normal mode
 //! produces with **a-priori decoding disabled** (the canonical
-//! reproducible reference). The companion AP-on regression
-//! (`ft8_qso3_apon_recall.rs`) gates a different superset and is
-//! marked `#[ignore]` until AP-list (ft8b.f90 ipass 5..8) is ported.
+//! reproducible reference). A companion AP-on regression will be
+//! added when AP-list (ft8b.f90 ipass 5..8) is ported — tracked in
+//! https://github.com/jl1nie/mfsk-core/issues/31.
 //!
 //! Run:
 //! ```sh


### PR DESCRIPTION
## Summary

Cleanup of a stale `//!` doc comment in `mfsk-core/tests/ft8_qso3_apoff_recall.rs` left over from PR #33's deletion of `ft8_qso3_apon_recall.rs`. The doc still pointed at the deleted file; replaced with a forward-link to issue #31 so the reader knows where the AP-on test will live.

No code changes — comment-only.

## Why this wasn't caught earlier

`tests/` integration test files aren't included in `cargo doc -p mfsk-core` output, so `cargo doc -D warnings` (the rustdoc CI gate + pre-commit hook) doesn't see this comment. The reference is also a literal text mention, not an intra-doc link, so no broken-link warning either.

## Related

- #31 — Port AP-list (ft8b.f90 ipass 5..8) and add real `ft8_qso3_apon_recall` test
- #33 (merged) — removed `ft8_qso3_apon_recall.rs` placeholder

https://claude.ai/code/session_01SCp366F5Bgk3sQThQKccLS

---
_Generated by [Claude Code](https://claude.ai/code/session_01SCp366F5Bgk3sQThQKccLS)_