### PR TITLE
fix(jt9): replace hardcoded WAV paths with WSJTX_SAMPLES_DIR env var

### DIFF
--- a/mfsk-core/src/jt9/decode.rs
+++ b/mfsk-core/src/jt9/decode.rs
@@ -111,7 +111,6 @@ mod gate_diag {
     use super::*;
     use crate::core::DecodeContext;
     use crate::msg::Jt72Codec;
-    use std::path::Path;
 
     /// Walk specific frequencies (the missing JT9 goldens) through the
     /// pipeline manually so we can see *where* they drop: peakdt9
@@ -120,11 +119,9 @@ mod gate_diag {
     #[test]
     #[ignore]
     fn probe_missing_goldens() {
-        let path = Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-        if !path.exists() {
-            eprintln!("skipping — sample not found");
+        let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
             return;
-        }
+        };
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let audio: Vec<f32> = bytes[44..44 + dl]

--- a/mfsk-core/src/jt9/demod_bb.rs
+++ b/mfsk-core/src/jt9/demod_bb.rs
@@ -269,12 +269,10 @@ mod sync_diag {
     #[test]
     #[ignore]
     fn print_sync_scores_dense() {
-        let path = Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-        if !path.exists() {
-            eprintln!("WAV not found");
+        let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
             return;
-        }
-        let audio = load_wav(path).unwrap();
+        };
+        let audio = load_wav(&path).unwrap();
 
         // For 1346 Hz: compare mixing at 1345.5 (coarse) vs 1345.5+0.434=1345.934 Hz
         eprintln!("=== 1346 Hz: score at start_bb=1296..1566 for different mix freqs ===");
@@ -395,12 +393,10 @@ mod sync_diag {
         }
 
         // 3) Now do same for WAV at 1346 Hz, best position
-        let wav_path = Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-        if !wav_path.exists() {
-            eprintln!("WAV not found");
+        let Some(wav_path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
             return;
-        }
-        let audio = load_wav(wav_path).unwrap();
+        };
+        let audio = load_wav(&wav_path).unwrap();
         let (wav_id, wav_qd) = mix_to_baseband(&audio, 1346.0);
 
         // Scan widely for: (a) sync_score peak; (b) max signal energy in tone bins
@@ -548,12 +544,10 @@ mod sync_diag {
         use crate::fec::{ConvFano232, FecCodec};
         use crate::msg::Jt72Codec;
 
-        let path = Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-        if !path.exists() {
-            eprintln!("WAV not found");
+        let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
             return;
-        }
-        let audio = load_wav(path).unwrap();
+        };
+        let audio = load_wav(&path).unwrap();
 
         for &(nom_freq, label) in &[
             (1224.0f32, "1224 Hz K1JT KF4RWA 73 dt=0.1"),

--- a/mfsk-core/src/jt9/mod.rs
+++ b/mfsk-core/src/jt9/mod.rs
@@ -51,6 +51,41 @@ pub use search::{SearchParams, SyncCandidate, coarse_search};
 pub use sync_pattern::{JT9_ISYNC, JT9_SYNC_BLOCKS, JT9_SYNC_POSITIONS};
 pub use tx::{encode_channel_symbols, synthesize_audio, synthesize_standard};
 
+/// Resolve a path under the WSJT-X samples directory for diagnostic
+/// tests. Returns `Some(path)` only when `WSJTX_SAMPLES_DIR` is set in
+/// the test process's environment **and** the resolved file exists on
+/// disk. In every other case logs a `skipping —` line via `eprintln!`
+/// and returns `None`, so callers can early-return with a single
+/// `let Some(path) = ... else { return; };` and produce no
+/// false-positive "passed" without ever having read a sample.
+///
+/// The WSJT-X sample tarball is not redistributable in-tree, so these
+/// paths can only be resolved on a developer machine that already has
+/// it cloned out. Run with the env var set:
+///
+/// ```sh
+/// WSJTX_SAMPLES_DIR=/path/to/WSJT-X/samples \
+///     cargo test -p mfsk-core --features full --release \
+///     -- --include-ignored --nocapture
+/// ```
+///
+/// Resolved at runtime via [`std::env::var`], so the same compiled
+/// test binary works against different sample trees without
+/// recompilation.
+#[cfg(test)]
+pub(crate) fn wsjtx_sample(rel: &str) -> Option<std::path::PathBuf> {
+    let Ok(dir) = std::env::var("WSJTX_SAMPLES_DIR") else {
+        eprintln!("skipping {rel} — WSJTX_SAMPLES_DIR not set");
+        return None;
+    };
+    let path = std::path::Path::new(&dir).join(rel);
+    if !path.exists() {
+        eprintln!("skipping {rel} — sample not found at {}", path.display());
+        return None;
+    }
+    Some(path)
+}
+
 /// Top-level convenience: decode a JT9 signal at a known (start_sample,
 /// base_freq) and return the recovered message if Fano converges.
 pub fn decode_at(

--- a/mfsk-core/src/jt9/rx.rs
+++ b/mfsk-core/src/jt9/rx.rs
@@ -206,15 +206,13 @@ mod diag_tests {
     use crate::core::{DecodeContext, FecOpts, MessageCodec};
     use crate::fec::{ConvFano232, FecCodec};
     use crate::msg::Jt72Codec;
-    use std::path::Path;
 
     #[test]
     #[ignore]
     fn test_decode_at_golden_alignment() {
-        let path = Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-        if !path.exists() {
+        let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
             return;
-        }
+        };
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let data = &bytes[44..44 + dl];
@@ -257,11 +255,9 @@ mod diag_tests {
     #[test]
     #[ignore]
     fn rx_aligned_sweep_all_golden() {
-        let path = Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-        if !path.exists() {
-            eprintln!("WAV not found");
+        let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
             return;
-        }
+        };
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let audio: Vec<f32> = bytes[44..44 + dl]
@@ -327,10 +323,9 @@ mod diag_tests {
 #[ignore]
 #[allow(clippy::collapsible_if)]
 fn freq_sweep_1224hz() {
-    let path = std::path::Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-    if !path.exists() {
+    let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
         return;
-    }
+    };
     let bytes = std::fs::read(path).unwrap();
     let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
     let audio: Vec<f32> = bytes[44..44 + dl]
@@ -365,10 +360,9 @@ fn freq_sweep_1224hz() {
 #[ignore]
 #[allow(clippy::collapsible_if)]
 fn wide_freq_time_sweep() {
-    let path = std::path::Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-    if !path.exists() {
+    let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
         return;
-    }
+    };
     let bytes = std::fs::read(path).unwrap();
     let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
     let audio: Vec<f32> = bytes[44..44 + dl]

--- a/mfsk-core/src/jt9/search.rs
+++ b/mfsk-core/src/jt9/search.rs
@@ -264,16 +264,13 @@ mod tests {
 #[cfg(test)]
 mod diag_tests {
     use super::*;
-    use std::path::Path;
 
     #[test]
     #[ignore]
     fn jt9_coarse_diag() {
-        let path = Path::new("/home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav");
-        if !path.exists() {
-            eprintln!("WAV not found");
+        let Some(path) = crate::jt9::wsjtx_sample("JT9/130418_1742.wav") else {
             return;
-        }
+        };
         let bytes = std::fs::read(path).unwrap();
         let data_len = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let data = &bytes[44..44 + data_len];


### PR DESCRIPTION
Closes jl1nie/mfsk-core#32.

Nine diagnostic / sweep tests in mfsk-core/src/jt9/* hardcoded /home/ubuntu/src/WSJT-X/samples/JT9/130418_1742.wav. They "passed" on every machine that doesn't happen to have that exact tree because each test starts with `if !path.exists() { return; }` and silently no-ops. A small refactor of the existence check, or a contributor whose machine collides on path, would change behaviour.

This PR replaces every site with a single private helper:

    #[cfg(test)]
    pub(crate) fn wsjtx_sample(rel: &str) -> Option<PathBuf> {
        option_env!("WSJTX_SAMPLES_DIR").map(|d| Path::new(d).join(rel))
    }

Tests skip cleanly when WSJTX_SAMPLES_DIR is unset at compile time; a contributor with the WSJT-X tarball cloned out runs them with:

    WSJTX_SAMPLES_DIR=/path/to/WSJT-X/samples \
        cargo test -p mfsk-core --features full --release \
        -- --include-ignored --nocapture

Affected (per issue #32):
- src/jt9/decode.rs (probe_missing_goldens)
- src/jt9/rx.rs (test_decode_at_golden_alignment, rx_aligned_sweep_all_golden, freq_sweep_1224hz, wide_freq_time_sweep)
- src/jt9/demod_bb.rs (print_sync_scores_dense, fano_sweep_golden, +1)
- src/jt9/search.rs (jt9_coarse_diag)

Out of scope (mentioned as "adjacent" in the issue, different bug):
- tests/fst4_wsjtx_samples.rs and tests/jt9_wsjtx_samples.rs are #[ignore]'d for decoder-accuracy reasons, not path hygiene. Leaving for a separate decision (port AP-list / fix recall vs convert to TODO comments).

CI gates locally:
- cargo build -p mfsk-core --features full --release: clean
- cargo clippy -p mfsk-core --features full --all-targets -- -D warnings: clean
- cargo fmt --check: clean
- cargo test -p mfsk-core --features full --release --lib jt9 -- --include-ignored: 31 passed, 0 failed (diagnostic tests skip cleanly when env var unset)