### PR TITLE
docs(claude): add test fixture path-hygiene convention

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,26 @@ cargo build --release --bin <bin>
     90    # capture seconds (optional, default 90)
 ```
 
+## Test fixture paths
+
+Never hardcode absolute paths like `/home/ubuntu/...` or `/Users/...`
+for test inputs. AI assistants tend to "fix" path failures by
+translating to whichever local environment they happen to run in
+(commit `119657a` flipped `/home/minoru/` → `/home/ubuntu/`), which
+just relocates the bug.
+
+- **In-repo assets**: use the `asset_path!` macro from
+  `mfsk-core/tests/common/mod.rs` (integration tests) or
+  `concat!(env!("CARGO_MANIFEST_DIR"), "/../embedded-poc/assets/<f>")`
+  (unit tests under `src/`). Vendor the file under
+  `embedded-poc/assets/` if it's not already there — the FT8 / JT9
+  reference recordings already live there.
+- **Out-of-tree user-machine assets** (e.g. the full WSJT-X tarball):
+  `option_env!("WSJTX_SAMPLES_DIR")` and skip cleanly when unset.
+- **Diagnostic output paths** (test writes a WAV for human inspection):
+  `/tmp/...` literals are fine — the human-in-the-loop step assumes a
+  known location. Don't replace these with `tempfile`.
+
 ## Memory
 
 - `~/.claude/projects/-home-minoru-src-mfsk-core/memory/` holds the


### PR DESCRIPTION
Closes #32.

## Summary
- Documents the path convention so future contributors (and AI assistants) don't reintroduce the `/home/ubuntu/...` antipattern.
- The actual JT9 unit-test path hardcoding was fixed in #36 (vendor + `CARGO_MANIFEST_DIR`-relative); FT8 integration tests were fixed in #29 with the same approach.
- `softsym.rs` `/tmp/260506_*.wav` literals are deliberately left as-is — they're **output** paths for `#[ignore]`'d diagnostic tests where a human pipes the WAV into WSJT-X. Documented as such.

## Issue #32 cleanup checklist
- [x] (1) Replace hardcoded paths in `src/jt9/*` diagnostic tests — landed in #36
- [x] (2) Document the convention in CLAUDE.md — this PR
- [ ] (3) Decide on `#[ignore]`'d `tests/{fst4,jt9}_wsjtx_samples.rs` — out of scope, those are decoder-accuracy regressions, not path hygiene (different bug class)

## Test plan
- [x] Docs-only change, no code touched
- [x] `cargo fmt --check`, `cargo clippy` n/a (no code changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)