### PR TITLE
fix(ft8): handle negative refined dt in host symbol_spectra (issue #40)

### DIFF
--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -502,13 +502,18 @@ fn process_candidate(
     // dt_sec = -0.78 → nominal_i0 = -56. Pre-fix: i_start = 0,
     // sync_quality = 0/1, candidate dies at the nsync gate.
     let nominal_i0 = ((refined.dt_sec + 0.5) * 200.0).round() as i32;
+    let window_len = 79 * 32; // 79 symbols * 32 samples/symbol
     let (cd0, i_start) = if nominal_i0 < 0 {
         let pad = (-nominal_i0) as usize;
-        let mut padded: alloc::vec::Vec<num_complex::Complex<f32>> =
-            alloc::vec::Vec::with_capacity(pad + cd0.len());
+        let mut padded = Vec::with_capacity(pad + cd0.len());
         padded.resize(pad, num_complex::Complex::new(0.0, 0.0));
         padded.extend_from_slice(&cd0);
         (padded, 0usize)
+    } else if (nominal_i0 as usize) + window_len > cd0.len() {
+        let mut padded = cd0;
+        let needed = (nominal_i0 as usize) + window_len;
+        padded.resize(needed, num_complex::Complex::new(0.0, 0.0));
+        (padded, nominal_i0 as usize)
     } else {
         (cd0, nominal_i0 as usize)
     };

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -487,7 +487,31 @@ fn process_candidate(
     let cand_owned = refined.clone();
     let cand: &SyncCandidate = &cand_owned;
 
-    let i_start = ((refined.dt_sec + 0.5) * 200.0).round() as usize;
+    // Compute symbol-window start in cd0 sample units (200 sps). For
+    // refined dt < -0.5 s the nominal start is negative, which the
+    // previous `as usize` cast saturated to 0 — silently reading the
+    // wrong window and emitting garbage LLRs / nsync ≈ 0. Mirror the
+    // decode_block path (decode_block.rs:1203,1228 — i32 ibest with
+    // all-or-nothing zero fill outside cd0). Implementation: when
+    // nominal_i0 < 0, prepend `|nominal_i0|` zero samples to cd0 and
+    // shift i_start to 0. Symbols that fall in the prepended region
+    // become all-zero (matches WSJT-X csymb=0 zero fill), the rest
+    // read from the original cd0 at the correct offset.
+    //
+    // Repro: qso3_busy.wav 1196 Hz F5RXL rank-7 cand has refined
+    // dt_sec = -0.78 → nominal_i0 = -56. Pre-fix: i_start = 0,
+    // sync_quality = 0/1, candidate dies at the nsync gate.
+    let nominal_i0 = ((refined.dt_sec + 0.5) * 200.0).round() as i32;
+    let (cd0, i_start) = if nominal_i0 < 0 {
+        let pad = (-nominal_i0) as usize;
+        let mut padded: alloc::vec::Vec<num_complex::Complex<f32>> =
+            alloc::vec::Vec::with_capacity(pad + cd0.len());
+        padded.resize(pad, num_complex::Complex::new(0.0, 0.0));
+        padded.extend_from_slice(&cd0);
+        (padded, 0usize)
+    } else {
+        (cd0, nominal_i0 as usize)
+    };
     let cs_raw = symbol_spectra(&cd0, i_start);
     let nsync = sync_quality(&cs_raw);
     if nsync <= 6 {

--- a/mfsk-core/tests/ft8_qso3_apon_recall.rs
+++ b/mfsk-core/tests/ft8_qso3_apon_recall.rs
@@ -98,7 +98,7 @@ const JTDX_AP_ON_EXTRAS: &[&str] = &[
 /// `JTDX_AP_ON_EXTRAS.len()` and the test will start gating the
 /// fix-forward. Until then the test reports JTDX coverage as
 /// informational diagnostics.
-const JTDX_EXTRAS_HARD_FLOOR: usize = 0;
+const JTDX_EXTRAS_HARD_FLOOR: usize = 1;
 
 /// Cap on total output. AP-on adds passes 5..12; we expect a few
 /// extra decodes but not a flood. Set generously so the test


### PR DESCRIPTION
Bisect (DOWNSTREAM_BISECT.md) traced 1196 Hz F5RXL on qso3_busy.wav (rank-7 cand, refined dt=-0.78s) to a silent integer-cast saturation in process_candidate. decode.rs:490 computed i_start as ((dt+0.5)*200).round() as usize; for refined dt<-0.5 the negative float saturated to 0, so symbol_spectra read the wrong sample window and sync_quality reported nsync=0/1, killing the candidate at the nsync<=6 gate.

Mirror the decode_block.rs:1203,1228 path (i32 ibest with all-or-nothing zero fill outside cd0). Without changing the symbol_spectra public API: when the nominal i0 is negative, prepend |i0| zero samples to the local cd0 buffer and shift i_start to 0. Symbols falling in the prepended region read as zero (matches WSJT-X csymb=0 boundary handling at ft8b.f90:155-157); both symbol_spectra and fine_sync_power_split see a consistent cd0/i_start pair.

apon_recall (mycall=K1JT, hiscall=HA0DU): extras 0/6 -> 1/6 (now decodes 'CQ F5RXL IN94'). apoff_recall: 7/8 golden, phantom set unchanged at 7 (no CRC-14 luck inflation). Full sweep (340 unit tests + integration) passes.