### PR TITLE
fix(ft8): i_start as i32 with WSJT-X-faithful boundary — closes #40

### DIFF
--- a/mfsk-core/src/core/llr.rs
+++ b/mfsk-core/src/core/llr.rs
@@ -78,7 +78,14 @@ pub fn descramble_info<P: super::Protocol>(info: &mut [u8]) {
 /// by 1/1000 (matching WSJT-X).
 ///
 /// `i_start` is the sample index in `cd0` of the first symbol, from fine sync.
-pub fn symbol_spectra<P: Protocol>(cd0: &[Complex<f32>], i_start: usize) -> Vec<Complex<f32>> {
+/// Signed to support candidates whose dt < -0.5 s (signal starts before the
+/// cd0 window — first sync block is partially or wholly truncated, but later
+/// blocks may still be valid). WSJT-X `ft8b.f90:155-157` boundary policy is
+/// all-or-nothing per symbol: when any of the `ds_spb` samples for a symbol
+/// would fall outside `cd0`, that symbol's window is zero-filled (rather
+/// than partially read). Per-element bounds checking lets edge symbols pull
+/// extra signal energy and shifts the LLR sign pattern away from WSJT-X.
+pub fn symbol_spectra<P: Protocol>(cd0: &[Complex<f32>], i_start: i32) -> Vec<Complex<f32>> {
     let ntones = P::NTONES as usize;
     let n_sym = P::N_SYMBOLS as usize;
     let ds_spb = (P::NSPS / P::NDOWN) as usize;
@@ -88,15 +95,18 @@ pub fn symbol_spectra<P: Protocol>(cd0: &[Complex<f32>], i_start: usize) -> Vec<
 
     let mut cs = vec![Complex::new(0.0f32, 0.0); n_sym * ntones];
     let mut buf = vec![Complex::new(0.0f32, 0.0); ds_spb];
+    let np2 = cd0.len() as i32;
 
     for k in 0..n_sym {
-        let i1 = i_start + k * ds_spb;
-        for (j, b) in buf.iter_mut().enumerate() {
-            *b = if i1 + j < cd0.len() {
-                cd0[i1 + j]
-            } else {
-                Complex::new(0.0, 0.0)
-            };
+        let i1 = i_start + (k * ds_spb) as i32;
+        if i1 >= 0 && i1 + ds_spb as i32 <= np2 {
+            for (j, b) in buf.iter_mut().enumerate() {
+                *b = cd0[(i1 as usize) + j];
+            }
+        } else {
+            for b in buf.iter_mut() {
+                *b = Complex::new(0.0, 0.0);
+            }
         }
         fft.process(&mut buf);
         for (t, bin) in buf.iter().take(ntones).enumerate() {

--- a/mfsk-core/src/core/pipeline.rs
+++ b/mfsk-core/src/core/pipeline.rs
@@ -160,11 +160,11 @@ pub fn process_candidate_basic<P: Protocol>(
     // time-only `refine_candidate` path; FT8 has its own 3-stage
     // refine wired separately in `ft8/decode.rs`.
     #[cfg(feature = "ft4")]
-    let (refined, i_start) = if P::ID == super::ProtocolId::Ft4 {
+    let (refined, i_start): (SyncCandidate, i32) = if P::ID == super::ProtocolId::Ft4 {
         let s4 = crate::ft4::refine_fine::sync4d_refine::<P>(&cd0, cand);
         let df_hz = s4.freq_hz - cand.freq_hz;
         cd0 = crate::ft4::refine_fine::freq_shift_cd0(&cd0, df_hz, ds_rate);
-        let i_start = s4.i0.max(0) as usize;
+        let i_start: i32 = s4.i0;
         let refined = SyncCandidate {
             freq_hz: s4.freq_hz,
             dt_sec: (s4.i0 as f32) / ds_rate - tx_start,
@@ -173,13 +173,13 @@ pub fn process_candidate_basic<P: Protocol>(
         (refined, i_start)
     } else {
         let refined = refine_candidate::<P>(&cd0, cand, refine_steps);
-        let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as usize;
+        let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as i32;
         (refined, i_start)
     };
     #[cfg(not(feature = "ft4"))]
-    let (refined, i_start) = {
+    let (refined, i_start): (SyncCandidate, i32) = {
         let refined = refine_candidate::<P>(&cd0, cand, refine_steps);
-        let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as usize;
+        let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as i32;
         (refined, i_start)
     };
 

--- a/mfsk-core/src/core/sync.rs
+++ b/mfsk-core/src/core/sync.rs
@@ -474,20 +474,26 @@ pub fn make_costas_ref(pattern: &[u8], ds_spb: usize) -> Vec<Vec<Complex<f32>>> 
 }
 
 /// Correlate a single Costas block starting at sample `array_start` in `cd0`.
+/// `array_start` is signed so callers can pass an `i_start` derived from a
+/// candidate with negative `dt_sec` (signal that started before the cd0
+/// window). WSJT-X `sync8d.f90:43-45` policy: if any of the `ds_spb` samples
+/// would fall outside `cd0`, the block contributes 0 (rather than partially
+/// summing).
 pub fn score_costas_block(
     cd0: &[Complex<f32>],
     csync: &[Vec<Complex<f32>>],
     ds_spb: usize,
-    array_start: usize,
+    array_start: i32,
 ) -> f32 {
-    let np2 = cd0.len();
+    let np2 = cd0.len() as i32;
     csync
         .iter()
         .enumerate()
         .map(|(k, ref_tone)| {
-            let start = array_start + k * ds_spb;
-            if start + ds_spb <= np2 {
-                cd0[start..start + ds_spb]
+            let start = array_start + (k * ds_spb) as i32;
+            if start >= 0 && start + ds_spb as i32 <= np2 {
+                let s0 = start as usize;
+                cd0[s0..s0 + ds_spb]
                     .iter()
                     .zip(ref_tone.iter())
                     .map(|(&s, &r)| s * r.conj())
@@ -501,19 +507,19 @@ pub fn score_costas_block(
 }
 
 /// Sum of Costas correlation powers across all sync blocks.
-pub fn fine_sync_power<P: Protocol>(cd0: &[Complex<f32>], i0: usize) -> f32 {
+pub fn fine_sync_power<P: Protocol>(cd0: &[Complex<f32>], i0: i32) -> f32 {
     fine_sync_power_per_block::<P>(cd0, i0).into_iter().sum()
 }
 
 /// Per-block Costas correlation powers for diagnostics and the FT8 double-sync.
-pub fn fine_sync_power_per_block<P: Protocol>(cd0: &[Complex<f32>], i0: usize) -> Vec<f32> {
+pub fn fine_sync_power_per_block<P: Protocol>(cd0: &[Complex<f32>], i0: i32) -> Vec<f32> {
     let d = SyncDims::of::<P>();
     P::SYNC_MODE
         .blocks()
         .iter()
         .map(|block| {
             let csync = make_costas_ref(block.pattern, d.ds_spb);
-            let start = i0 + block.start_symbol as usize * d.ds_spb;
+            let start = i0 + (block.start_symbol as usize * d.ds_spb) as i32;
             score_costas_block(cd0, &csync, d.ds_spb, start)
         })
         .collect()
@@ -544,22 +550,17 @@ pub fn refine_candidate<P: Protocol>(
     let nominal_i0 = ((candidate.dt_sec + P::TX_START_OFFSET_S) * d.ds_rate).round() as i32;
     let (best_i0, best_score) = (-search_steps..=search_steps)
         .map(|delta| {
-            let i0 = (nominal_i0 + delta).max(0) as usize;
+            let i0 = nominal_i0 + delta;
             let score = fine_sync_power::<P>(cd0, i0);
             (i0, score)
         })
         .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
-        .unwrap_or((0, 0.0));
+        .unwrap_or((nominal_i0, 0.0));
 
     // Parabolic sub-sample refinement around the integer peak.
-    let frac = if best_i0 >= 1 {
-        let y_neg = fine_sync_power::<P>(cd0, best_i0 - 1);
-        let y_pos = fine_sync_power::<P>(cd0, best_i0 + 1);
-        let (f, _) = parabolic_peak(y_neg, best_score, y_pos);
-        f
-    } else {
-        0.0
-    };
+    let y_neg = fine_sync_power::<P>(cd0, best_i0 - 1);
+    let y_pos = fine_sync_power::<P>(cd0, best_i0 + 1);
+    let (frac, _) = parabolic_peak(y_neg, best_score, y_pos);
 
     SyncCandidate {
         freq_hz: candidate.freq_hz,
@@ -600,28 +601,24 @@ pub fn refine_candidate_double<P: Protocol>(
 
     let best_for = |pattern: &[u8], csync: &[Vec<Complex<f32>>], block_start: u32| {
         let _ = pattern;
+        let block_off = (block_start as usize * d.ds_spb) as i32;
         let (best_i0, _) = (-search_steps..=search_steps)
             .map(|delta| {
-                let i0 = (nominal_i0 + delta).max(0) as usize;
-                let off = i0 + block_start as usize * d.ds_spb;
+                let i0 = nominal_i0 + delta;
+                let off = i0 + block_off;
                 (i0, score_costas_block(cd0, csync, d.ds_spb, off))
             })
             .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())
-            .unwrap_or((nominal_i0.max(0) as usize, 0.0));
+            .unwrap_or((nominal_i0, 0.0));
         // Parabolic sub-sample
-        let frac = if best_i0 > 0 {
-            let off_neg = (best_i0 - 1) + block_start as usize * d.ds_spb;
-            let off_0 = best_i0 + block_start as usize * d.ds_spb;
-            let off_pos = (best_i0 + 1) + block_start as usize * d.ds_spb;
-            let (f, _) = parabolic_peak(
-                score_costas_block(cd0, csync, d.ds_spb, off_neg),
-                score_costas_block(cd0, csync, d.ds_spb, off_0),
-                score_costas_block(cd0, csync, d.ds_spb, off_pos),
-            );
-            f
-        } else {
-            0.0
-        };
+        let off_neg = (best_i0 - 1) + block_off;
+        let off_0 = best_i0 + block_off;
+        let off_pos = (best_i0 + 1) + block_off;
+        let (frac, _) = parabolic_peak(
+            score_costas_block(cd0, csync, d.ds_spb, off_neg),
+            score_costas_block(cd0, csync, d.ds_spb, off_0),
+            score_costas_block(cd0, csync, d.ds_spb, off_pos),
+        );
         (best_i0, frac)
     };
 
@@ -632,7 +629,7 @@ pub fn refine_candidate_double<P: Protocol>(
     let dt_c = best_i0_c as f32 / d.ds_rate + frac_c / d.ds_rate - P::TX_START_OFFSET_S;
     let drift_dt_sec = dt_c - dt_a;
 
-    let avg_i0 = ((best_i0_a + best_i0_c) as f32 * 0.5).round() as usize;
+    let avg_i0 = ((best_i0_a + best_i0_c) as f32 * 0.5).round() as i32;
     let per_block_scores = fine_sync_power_per_block::<P>(cd0, avg_i0);
     let total: f32 = per_block_scores.iter().sum();
 

--- a/mfsk-core/src/ft4/refine_fine.rs
+++ b/mfsk-core/src/ft4/refine_fine.rs
@@ -77,13 +77,10 @@ fn score_at<P: Protocol>(
     for (start_sym, csync) in blocks_costas {
         let twiddled = twiddle_ref(csync, df_hz, ds_rate);
         let off = i0 + (*start_sym as i32) * ds_spb as i32;
-        if off < 0 {
-            // Refuse correlations that would dip into negative samples
-            // — caller's coarse pass already excluded grossly-misaligned
-            // candidates, so this is a safety floor.
-            continue;
-        }
-        total += score_costas_block(cd0, &twiddled, ds_spb, off as usize);
+        // `score_costas_block` zero-fills any block whose samples fall
+        // outside cd0 (matching WSJT-X `sync8d.f90:43-45`), so negative
+        // `off` is safe to pass through.
+        total += score_costas_block(cd0, &twiddled, ds_spb, off);
     }
     total
 }

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -487,7 +487,12 @@ fn process_candidate(
     let cand_owned = refined.clone();
     let cand: &SyncCandidate = &cand_owned;
 
-    let i_start = ((refined.dt_sec + 0.5) * 200.0).round() as usize;
+    // Signed: candidates whose actual TX started before the slot's nominal
+    // start (dt_sec < -0.5) map to negative i_start. The downstream
+    // `symbol_spectra` / `fine_sync_power_*` calls use the WSJT-X-faithful
+    // all-or-nothing per-symbol boundary check; saturating to 0 here used
+    // to silently misalign the symbol grid for negative-dt candidates.
+    let i_start = ((refined.dt_sec + 0.5) * 200.0).round() as i32;
     let cs_raw = symbol_spectra(&cd0, i_start);
     let nsync = sync_quality(&cs_raw);
     if nsync <= 6 {

--- a/mfsk-core/src/ft8/llr.rs
+++ b/mfsk-core/src/ft8/llr.rs
@@ -47,7 +47,14 @@ fn inflate_llr<T: LlrScalar>(v: Vec<T>) -> [T; LDPC_N] {
 }
 
 /// Compute 8-tone complex spectra for all 79 FT8 symbols.
-pub fn symbol_spectra(cd0: &[Complex<f32>], i_start: usize) -> Box<[[Cmplx<f32>; 8]; 79]> {
+///
+/// `i_start` is signed: candidates whose `dt_sec < -0.5` map to negative
+/// `i_start`, which the WSJT-X-faithful boundary check inside
+/// [`crate::core::llr::symbol_spectra`] handles by zero-filling out-of-bounds
+/// symbol windows. Saturating to 0 (the previous behaviour) silently
+/// misaligned the symbol grid by `|i_start|` samples and dropped real
+/// negative-dt decodes such as `qso3_busy.wav` CQ F5RXL @ -0.78 s.
+pub fn symbol_spectra(cd0: &[Complex<f32>], i_start: i32) -> Box<[[Cmplx<f32>; 8]; 79]> {
     let flat = crate::core::llr::symbol_spectra::<Ft8>(cd0, i_start);
     let mut out: Box<[[Cmplx<f32>; 8]; 79]> =
         vec![[Cmplx::<f32>::default(); 8]; 79].try_into().unwrap();

--- a/mfsk-core/src/ft8/sync.rs
+++ b/mfsk-core/src/ft8/sync.rs
@@ -57,13 +57,13 @@ pub fn compute_spectra(audio: &[i16]) -> crate::core::sync::Spectrogram {
 }
 
 #[inline]
-pub fn fine_sync_power(cd0: &[Complex<f32>], i0: usize) -> f32 {
+pub fn fine_sync_power(cd0: &[Complex<f32>], i0: i32) -> f32 {
     crate::core::sync::fine_sync_power::<Ft8>(cd0, i0)
 }
 
 /// Backwards-compatible tuple form: (array_1, array_2, array_3).
 #[inline]
-pub fn fine_sync_power_split(cd0: &[Complex<f32>], i0: usize) -> (f32, f32, f32) {
+pub fn fine_sync_power_split(cd0: &[Complex<f32>], i0: i32) -> (f32, f32, f32) {
     let scores = crate::core::sync::fine_sync_power_per_block::<Ft8>(cd0, i0);
     (
         scores.first().copied().unwrap_or(0.0),

--- a/mfsk-core/src/msg/pipeline_ap.rs
+++ b/mfsk-core/src/msg/pipeline_ap.rs
@@ -108,7 +108,7 @@ where
 
     let cd0 = downsample_cached(fft_cache, cand.freq_hz, ds_cfg);
     let refined = refine_candidate::<P>(&cd0, cand, refine_steps);
-    let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as usize;
+    let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as i32;
     let cs_raw = symbol_spectra::<P>(&cd0, i_start);
     let nsync = sync_quality::<P>(&cs_raw);
     if nsync <= sync_q_min {

--- a/mfsk-core/tests/ft4_diag_low_snr.rs
+++ b/mfsk-core/tests/ft4_diag_low_snr.rs
@@ -126,7 +126,7 @@ fn why_does_neg16db_fail() {
     for &steps in &[32i32, 48, 64] {
         let refined = refine_candidate::<Ft4>(&cd0, truth_cand, steps);
         let i0 =
-            ((refined.dt_sec + <Ft4 as FrameLayout>::TX_START_OFFSET_S) * ds_rate).round() as usize;
+            ((refined.dt_sec + <Ft4 as FrameLayout>::TX_START_OFFSET_S) * ds_rate).round() as i32;
         let cs = symbol_spectra::<Ft4>(&cd0, i0);
         let nsync = sync_quality::<Ft4>(&cs);
         eprintln!(

--- a/mfsk-core/tests/ft8_qso3_apon_recall.rs
+++ b/mfsk-core/tests/ft8_qso3_apon_recall.rs
@@ -84,21 +84,28 @@ const JTDX_AP_ON_EXTRAS: &[&str] = &[
     "K1BZM EA3CJ JN01",  // -12 dB, separate QSO context
 ];
 
-/// Hard recall floor on `JTDX_AP_ON_EXTRAS`. Currently `0` because
-/// `decode_frame_with_ap` (host wide-band path) misses the
-/// underlying coarse-sync candidates at 1196 / 244 / 472 / 2039 Hz
-/// that `decode_block` (embedded path) and JTDX both catch. AP
-/// runs in `process_candidate` only on candidates that survive
-/// coarse-sync + fine-refine, so the AP plumbing cannot recover
-/// decodes whose candidates were filtered upstream — this is a
-/// host-vs-embedded coarse-sync parity gap, not an AP-list bug,
-/// and is tracked separately as a follow-up to #31.
+/// Hard recall floor on `JTDX_AP_ON_EXTRAS`. Issue #40 (host
+/// wide-band coarse-sync candidate gap) closed the *negative-dt*
+/// half of the divergence: `process_candidate` was casting
+/// `i_start = ((refined.dt_sec + 0.5) * 200.0) as usize`, saturating
+/// to 0 for any candidate whose actual TX started before the slot's
+/// nominal start. CQ F5RXL @ -0.78 s had `i_start = -54` collapse to
+/// 0, silently misaligning the symbol grid by ~1.75 symbols and
+/// dropping the decode entirely. After the fix (i32 with WSJT-X
+/// all-or-nothing boundary check, matching
+/// `decode_block::fill_symbol_spectra_via_cd0`), single-pass host
+/// AP-off recovers 7/8 of the WSJT-X golden — same as the embedded
+/// `decode_block` path — and AP-on surfaces the F5RXL CQ via
+/// iaptype-1 blind-CQ (1/6 JTDX extras).
 ///
-/// When the parity gap closes, raise this floor toward
-/// `JTDX_AP_ON_EXTRAS.len()` and the test will start gating the
-/// fix-forward. Until then the test reports JTDX coverage as
-/// informational diagnostics.
-const JTDX_EXTRAS_HARD_FLOOR: usize = 0;
+/// The remaining 5 JTDX extras (CQ EA2BFM, K1JT HA5WA, K1BZM DK8NE,
+/// KD2UGC F6GCP, K1BZM EA3CJ) sit beneath strong neighbours on the
+/// raw spectrum and JTDX rescues them via multi-pass SIC + AP — the
+/// host equivalent is `decode_frame_subtract_with_ap`, which this
+/// test deliberately does *not* exercise (we want the apon test to
+/// gate the single-pass `decode_frame_with_ap` invariant). A
+/// separate test for the multi-pass form is the obvious follow-up.
+const JTDX_EXTRAS_HARD_FLOOR: usize = 1;
 
 /// Cap on total output. AP-on adds passes 5..12; we expect a few
 /// extra decodes but not a flood. Set generously so the test
@@ -203,19 +210,13 @@ fn qso3_apon_strict_superset_of_apoff_same_pipeline() {
     if !extras_missing.is_empty() {
         println!("  not yet caught: {:?}", extras_missing);
     }
-    // `>=` against a const that is `0` today reads as a tautology to
-    // clippy, but the const is the seam we tighten as the parity gap
-    // closes — silence the absurd-comparison lint here intentionally.
-    #[allow(clippy::absurd_extreme_comparisons)]
-    {
-        assert!(
-            extras_hit.len() >= JTDX_EXTRAS_HARD_FLOOR,
-            "JTDX AP-on coverage regressed: {}/{} below floor {}",
-            extras_hit.len(),
-            JTDX_AP_ON_EXTRAS.len(),
-            JTDX_EXTRAS_HARD_FLOOR,
-        );
-    }
+    assert!(
+        extras_hit.len() >= JTDX_EXTRAS_HARD_FLOOR,
+        "JTDX AP-on coverage regressed: {}/{} below floor {}",
+        extras_hit.len(),
+        JTDX_AP_ON_EXTRAS.len(),
+        JTDX_EXTRAS_HARD_FLOOR,
+    );
 
     // 3. Phantom ceiling — AP must not turn the decoder into a noise
     //    generator. Set generously so legitimate AP-on extras don't

--- a/mfsk-core/tests/ft8_qso3_coarse_sync_probe.rs
+++ b/mfsk-core/tests/ft8_qso3_coarse_sync_probe.rs
@@ -1,0 +1,144 @@
+//! Diagnostic probe for issue #40: list and compare candidates from both
+//! host and embedded coarse-sync pipelines on the qso3_busy.wav reference.
+//!
+//! `#[ignore]`d so it doesn't run in normal CI; invoke explicitly:
+//! ```sh
+//! cargo test --release -p mfsk-core --features full \
+//!     --test ft8_qso3_coarse_sync_probe -- --ignored --nocapture
+//! ```
+#![cfg(feature = "fft-rustfft")]
+
+use std::path::Path;
+
+use mfsk_core::core::sync::SyncCandidate;
+use mfsk_core::ft8::Ft8;
+
+#[allow(dead_code)]
+mod common;
+
+const QSO3_PATH: &str = asset_path!("qso3_busy.wav");
+
+/// Frequencies (Hz) where the WSJT-X canonical / JTDX-extras decodes sit.
+/// Sourced from `ft8_qso3_apoff_recall::WSJTX_GOLDEN` + #40 issue body.
+const PROBE_FREQS: &[(f32, &str)] = &[
+    (244.0, "K1BZM DK8NE -10 (apoff)"),
+    (400.0, "W0RSJ EA3BMU RR73"),
+    (466.0, "N1PJT HB9CQK -10"),
+    (472.0, "KD2UGC F6GCP R-23"),
+    (590.0, "K1JT HA0DU KN07"),
+    (641.0, "N1JFU EA6EE R-7"),
+    (723.0, "A92EE F5PSR -14"),
+    (1197.0, "CQ F5RXL IN94"),
+    (2039.0, "JTDX extras band"),
+];
+
+fn load_wav_i16(path: &Path) -> Vec<i16> {
+    let bytes = std::fs::read(path).expect("WAV present");
+    assert_eq!(&bytes[0..4], b"RIFF", "not a RIFF/WAV file");
+    let mut i = 12usize;
+    let (mut data_off, mut data_len) = (0usize, 0usize);
+    while i + 8 <= bytes.len() {
+        let id = &bytes[i..i + 4];
+        let len = u32::from_le_bytes(bytes[i + 4..i + 8].try_into().unwrap()) as usize;
+        i += 8;
+        if id == b"data" {
+            data_off = i;
+            data_len = len;
+        }
+        i += len;
+        if len % 2 == 1 {
+            i += 1;
+        }
+    }
+    bytes[data_off..data_off + data_len.min(bytes.len() - data_off)]
+        .chunks_exact(2)
+        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+        .collect()
+}
+
+fn print_near(label: &str, cands: &[SyncCandidate], target_hz: f32, win_hz: f32) {
+    let mut hits: Vec<&SyncCandidate> = cands
+        .iter()
+        .filter(|c| (c.freq_hz - target_hz).abs() <= win_hz)
+        .collect();
+    hits.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    if hits.is_empty() {
+        println!("    {label:<14} ∅  (no cand within ±{win_hz:.0} Hz)");
+    } else {
+        for (i, c) in hits.iter().take(5).enumerate() {
+            println!(
+                "    {label:<14} #{i}: {:>7.2} Hz  dt={:>+5.3}s  score={:.3}",
+                c.freq_hz, c.dt_sec, c.score
+            );
+        }
+    }
+}
+
+#[test]
+#[ignore]
+fn probe_coarse_sync_candidates_at_golden_freqs() {
+    let audio = load_wav_i16(Path::new(QSO3_PATH));
+
+    // Host wide-band path (used by decode_frame_with_ap).
+    let host_cands: Vec<SyncCandidate> =
+        mfsk_core::core::sync::coarse_sync::<Ft8>(&audio, 100.0, 3000.0, 1.3, None, 200);
+
+    // Embedded path (used by decode_block).
+    let spec = mfsk_core::ft8::decode_block::compute_spectrogram(&audio, 3000.0);
+    let block_cands: Vec<SyncCandidate> =
+        mfsk_core::ft8::decode_block::coarse_sync(&spec, 100.0, 3000.0, 1.3, 200);
+
+    println!(
+        "\nhost coarse_sync (Ft8): {} cands; decode_block coarse_sync: {} cands\n",
+        host_cands.len(),
+        block_cands.len()
+    );
+
+    let win = 8.0;
+    for (f, label) in PROBE_FREQS {
+        println!("  target {f:>7.1} Hz — {label}");
+        print_near("host", &host_cands, *f, win);
+        print_near("decode_block", &block_cands, *f, win);
+        println!();
+    }
+
+    // Trace the F5RXL CQ candidate through process_candidate's stages
+    // to confirm the negative-dt → usize-saturation hypothesis.
+    println!("\n  === trace 1196.88 Hz CQ F5RXL through fine refine ===");
+    let target = host_cands
+        .iter()
+        .find(|c| (c.freq_hz - 1196.88).abs() < 1.0);
+    if let Some(c) = target {
+        let (cd0, _) = mfsk_core::ft8::downsample::downsample(&audio, c.freq_hz, None);
+        let r = mfsk_core::ft8::refine_fine::fine_refine_3stage(&cd0, c.dt_sec);
+        println!(
+            "    cand:    freq={:.2}, dt={:+.3}s, score={:.3}",
+            c.freq_hz, c.dt_sec, c.score
+        );
+        println!(
+            "    refine:  delf={:+.3} Hz, refined_dt={:+.3}s, score={:.3}",
+            r.delf_hz, r.dt_sec, r.score
+        );
+        let i_signed = ((r.dt_sec + 0.5) * 200.0).round() as i32;
+        let i_usize = ((r.dt_sec + 0.5) * 200.0).round() as usize;
+        println!("    i_start: signed={i_signed}, as_usize_cast={i_usize} (saturates if neg)");
+    } else {
+        println!("    (no host candidate near 1196.88 Hz)");
+    }
+
+    // Also dump the top 30 candidates from each list, with provenance tags.
+    println!("\n  === host top-30 ===");
+    for (i, c) in host_cands.iter().take(30).enumerate() {
+        println!(
+            "    {i:>2}  {:>7.2} Hz  dt={:>+5.3}s  score={:.3}",
+            c.freq_hz, c.dt_sec, c.score
+        );
+    }
+    println!("\n  === decode_block top-30 ===");
+    for (i, c) in block_cands.iter().take(30).enumerate() {
+        println!(
+            "    {i:>2}  {:>7.2} Hz  dt={:>+5.3}s  score={:.3}",
+            c.freq_hz, c.dt_sec, c.score
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Root-cause issue #40: host `process_candidate` (and `core::pipeline` / `msg::pipeline_ap`) cast `i_start = ((refined.dt_sec + 0.5) * 200.0).round() as usize`, saturating any candidate with negative `dt_sec` to 0 and silently misaligning the symbol grid. CQ F5RXL @ 1196.88 Hz / dt=-0.77 s on `qso3_busy.wav` had its `i_start = -54` collapse to 0 → `sync_quality ≤ 6` early-return → never decoded.
- Thread `i32` through `core::llr::symbol_spectra`, `core::sync::{score_costas_block, fine_sync_power*}`, and `refine_candidate{,_double}`; use the WSJT-X all-or-nothing per-symbol boundary check that `decode_block::fill_symbol_spectra_via_cd0` was already using.
- Bumps `tests/ft8_qso3_apon_recall.rs::JTDX_EXTRAS_HARD_FLOOR` from `0` to `1` to gate the fix; adds `tests/ft8_qso3_coarse_sync_probe.rs` (`#[ignore]`d) as a permanent host-vs-embedded coarse-sync diagnostic.

Recall on `qso3_busy.wav`:

| path | before | after |
|---|---|---|
| `decode_frame_with_ap` AP-off / 8 WSJT-X golden | 5/8 | **7/8** |
| `decode_frame_with_ap` AP-on JTDX extras / 6 | 0/6 | **1/6** |
| `decode_block` JTDX 18-entry | 16/18 | 16/18 |

Host AP-off now matches `decode_block`'s recall on the same WAV. AP-on recovers CQ F5RXL via iaptype-1 blind-CQ. Embedded `decode_block` path is unaffected — it was already using the WSJT-X-faithful i32 boundary.

The remaining 5 JTDX AP-on extras (CQ EA2BFM, K1JT HA5WA, K1BZM DK8NE, KD2UGC F6GCP, K1BZM EA3CJ) are not just a multi-pass / SIC issue — `decode_frame_subtract_with_ap` produces an identical 14-decode set on this WAV, so the gap is upstream (likely candidate ranking after subtract or AP iaptype coverage). Tracked separately under ROADMAP A0' / future work.

## Test plan
- [x] `cargo test --release -p mfsk-core --features full` — all 42 test files green
- [x] `cargo test --release -p mfsk-core --features full --test ft8_qso3_apon_recall -- --nocapture` — 1/6 JTDX extras (floor 1)
- [x] `cargo test --release -p mfsk-core --features full --test ft8_qso3_apoff_recall -- --nocapture` — 7/8 WSJT-X golden
- [x] `cargo test --release -p mfsk-core --features full --test ft8_qso3_jtdx_recall -- --nocapture` — 16/18 JTDX (unchanged)
- [x] `cargo test --release -p mfsk-core --features full --test ft8_qso3_coarse_sync_probe -- --ignored --nocapture` — diagnostic still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)