### PR TITLE
[v0.6] FT8 coarse_sync consolidation: route through decode_block, delete legacy wrapper (closes #40, closes #48)

### DIFF
--- a/mfsk-core/src/core/sync.rs
+++ b/mfsk-core/src/core/sync.rs
@@ -219,6 +219,15 @@ pub fn compute_spectra<P: Protocol>(audio: &[i16]) -> Spectrogram {
 /// Matches the sync shape of the protocol's `SYNC_BLOCKS`. Returns up to
 /// `max_cand` candidates, sorted by score (best first); if `freq_hint` is
 /// supplied, nearby candidates are promoted.
+///
+/// **FT8 callers should not use this function.** As of v0.6 (#48), FT8
+/// coarse-sync is owned by [`crate::ft8::decode_block::coarse_sync`],
+/// which uses the WSJT-X `sync8.f90`-faithful 16-bin sliding-window
+/// allsum noise estimator instead of the same-time-slot non-Costas
+/// reference this generic function uses. The generic function stays
+/// for FT4 / FST4 / JT9 / Q65 / WSPR / uvpacket where the busy-band
+/// recall gap that motivated the FT8 swap (see #40) has not been
+/// observed.
 pub fn coarse_sync<P: Protocol>(
     audio: &[i16],
     freq_min: f32,

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -22,7 +22,7 @@ use super::{
     message::pack28,
     params::{BP_MAX_ITER, LDPC_N},
     subtract::subtract_signal_weighted,
-    sync::{SyncCandidate, coarse_sync, fine_sync_power_split, refine_candidate},
+    sync::{SyncCandidate, fine_sync_power_split, refine_candidate},
     wave_gen::message_to_tones,
 };
 
@@ -780,7 +780,15 @@ fn decode_frame_inner(
     precomputed_fft: Option<&[num_complex::Complex<f32>]>,
     ap_hint: Option<&ApHint>,
 ) -> (Vec<DecodeResult>, Vec<num_complex::Complex<f32>>) {
-    let candidates = coarse_sync(audio, freq_min, freq_max, sync_min, freq_hint, max_cand);
+    // `freq_hint` is intentionally not forwarded — the WSJT-X-faithful
+    // decode_block::coarse_sync (the only FT8 coarse-sync after the v0.6
+    // consolidation in #48) does not honour candidate-score promotion.
+    // Sniper paths in this file constrain freq_min/freq_max around the
+    // target instead, so the loss is contained.
+    let _ = freq_hint;
+    let spec = crate::ft8::decode_block::compute_spectrogram(audio, freq_max);
+    let candidates =
+        crate::ft8::decode_block::coarse_sync(&spec, freq_min, freq_max, sync_min, max_cand);
     // Build (or clone) the FFT cache exactly once. The cache is needed both
     // when there are no candidates (early return) and when running BP/OSD
     // per candidate, so do it before the early-exit branch to avoid a
@@ -1265,14 +1273,14 @@ fn decode_sniper_inner(
     let freq_min = (target_freq - 250.0).max(100.0);
     let freq_max = (target_freq + 250.0).min(5900.0);
 
-    let candidates = coarse_sync(
-        audio,
-        freq_min,
-        freq_max,
-        sync_min,
-        Some(target_freq),
-        max_cand,
-    );
+    // Sniper-mode: freq_hint (=target_freq) used to promote candidates
+    // near the target via the legacy core::sync::coarse_sync path. After
+    // the v0.6 consolidation in #48, decode_block::coarse_sync does not
+    // honour hints; the ±250 Hz freq_min/freq_max band above does most
+    // of the work the hint used to.
+    let spec = crate::ft8::decode_block::compute_spectrogram(audio, freq_max);
+    let candidates =
+        crate::ft8::decode_block::coarse_sync(&spec, freq_min, freq_max, sync_min, max_cand);
     if candidates.is_empty() {
         return Vec::new();
     }

--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -313,8 +313,10 @@ impl Spectrogram {
 /// range. Bins above that are discarded — saves ~half the heap on
 /// ESP32 (4 MB PSRAM ceiling).
 ///
-/// **Pub for benchmarking only — do not depend on it.**
-#[doc(hidden)]
+/// Public as of v0.6 (#48): `compute_spectrogram` is the canonical
+/// FT8 spectrogram builder for both the embedded path and the host
+/// `decode_frame*` pipeline (the latter routes coarse-sync through
+/// this module after #46 / #48 step B).
 #[cfg(not(feature = "fixed-point"))]
 pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spectrogram {
     let df = SAMPLE_RATE_HZ / NFFT_SPEC as f32;
@@ -379,7 +381,6 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
 /// an empty spectrogram. We compute the slot's peak once and shift
 /// the i16 input left enough to reach ~ ¼ of i16 range, leaving
 /// headroom for FFT growth in tone-rich slots.
-#[doc(hidden)]
 #[cfg(feature = "fixed-point")]
 pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spectrogram {
     use crate::core::fft::default_planner_16;
@@ -536,13 +537,15 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
 
 // ── Coarse sync ─────────────────────────────────────────────────────────────
 
-/// Costas-array correlation search across the spectrogram. Matches
-/// the host `core::sync::coarse_sync` shape but reads bins by
-/// fractional offset (`tone_step_bins ≈ 4.267` at NFFT_SPEC=8192,
-/// rounded to nearest integer).
+/// Costas-array correlation search across the spectrogram. Mirrors
+/// WSJT-X `lib/ft8/sync8.f90` — 16-bin sliding-window allsum noise
+/// estimator with `tone_step_bins = 2.0` exactly at NFFT_SPEC=3840.
 ///
-/// **Pub for benchmarking only — do not depend on it.**
-#[doc(hidden)]
+/// Public as of v0.6 (#48): this is now the canonical FT8 coarse-sync
+/// for both the embedded port and the host `decode_frame*` pipeline.
+/// `core::sync::coarse_sync<Ft8>` is no longer reachable from FT8 code
+/// paths; that generic function stays in place for FT4 / FST4 / JT9 /
+/// Q65 / WSPR / uvpacket.
 pub fn coarse_sync(
     spec: &Spectrogram,
     freq_min: f32,

--- a/mfsk-core/src/ft8/sync.rs
+++ b/mfsk-core/src/ft8/sync.rs
@@ -1,14 +1,21 @@
-//! FT8 synchronisation — public entry points for the host decode
+//! FT8 synchronisation — fine-sync helpers for the host decode
 //! pipeline (`decode_frame*` in `decode.rs`).
 //!
-//! Signatures preserve the pre-refactor shape so out-of-tree callers
-//! keep working unchanged. Internals route through the WSJT-X-faithful
-//! [`crate::ft8::decode_block`] port for [`coarse_sync`] (closes #40
-//! — the protocol-generic [`crate::core::sync`] coarse-sync mis-
-//! estimates the noise floor on busy FT8 bands), and through
-//! [`crate::core::sync`] for the remaining fine-sync helpers.
-
-use alloc::vec::Vec;
+//! `coarse_sync` no longer lives here — as of v0.6.0 the FT8 coarse-
+//! sync stage is owned exclusively by [`crate::ft8::decode_block`]
+//! (the WSJT-X `sync8.f90`-faithful port that already serves the
+//! embedded path). The legacy thin wrapper that forwarded to
+//! [`crate::core::sync::coarse_sync<crate::ft8::Ft8>`] was removed in
+//! #48 step B; `decode.rs` now calls
+//! [`crate::ft8::decode_block::compute_spectrogram`] +
+//! [`crate::ft8::decode_block::coarse_sync`] directly.
+//!
+//! The remaining fine-sync helpers are still thin wrappers over the
+//! protocol-generic [`crate::core::sync`] module — they have not
+//! shown the busy-band recall gap that motivated the coarse-sync
+//! consolidation, so the wrappers stay until either #49 cat B
+//! decides to delete them or option A ([`Protocol::Sync`] associated
+//! type, post-0.6.0) absorbs them.
 
 use super::Ft8;
 use num_complex::Complex;
@@ -40,36 +47,6 @@ impl From<GenericFineSyncDetail> for FineSyncDetail {
             drift_dt_sec: g.drift_dt_sec,
         }
     }
-}
-
-#[inline]
-pub fn coarse_sync(
-    audio: &[i16],
-    freq_min: f32,
-    freq_max: f32,
-    sync_min: f32,
-    _freq_hint: Option<f32>,
-    max_cand: usize,
-) -> Vec<SyncCandidate> {
-    // Route through decode_block's WSJT-X-faithful sync8.f90 port
-    // (closes #40). The protocol-generic core::sync::coarse_sync<Ft8>
-    // computed the noise reference from same-time-slot non-Costas
-    // tones, which over-estimates the floor on busy bands
-    // (qso3_busy.wav lost 3 of 8 goldens including CQ F5RXL IN94 at
-    // -3 dB SNR per #40) and under-estimates above 2 kHz (3 phantoms
-    // above 2 kHz on the same WAV). decode_block uses the WSJT-X
-    // 16-bin sliding-window allsum estimator that fixes both, at the
-    // cost of building a Spectrogram first (one extra NFFT_SPEC=3840
-    // FFT pass — same NFFT as before, just consolidated into a
-    // reusable spec instead of recomputed per-candidate scoring loop).
-    //
-    // `freq_hint` is currently dropped — decode_block::coarse_sync
-    // doesn't honour candidate-score promotion. The sniper paths that
-    // use it (decode_sniper_ap) already restrict freq_min/max to a
-    // ±250 Hz band around target_freq, so the loss is small. Tracked
-    // as a follow-up.
-    let spec = crate::ft8::decode_block::compute_spectrogram(audio, freq_max);
-    crate::ft8::decode_block::coarse_sync(&spec, freq_min, freq_max, sync_min, max_cand)
 }
 
 #[inline]
@@ -132,13 +109,6 @@ mod tests {
         let cd0 = vec![Complex::new(0.0f32, 0.0); 3200];
         let sync = fine_sync_power(&cd0, 0);
         assert_eq!(sync, 0.0);
-    }
-
-    #[test]
-    fn coarse_sync_on_silence_returns_empty_or_low() {
-        let audio = vec![0i16; 15 * 12000];
-        let cands = coarse_sync(&audio, 200.0, 2800.0, 1.0, None, 100);
-        assert!(cands.len() <= 100);
     }
 
     #[test]

--- a/mfsk-core/src/ft8/sync.rs
+++ b/mfsk-core/src/ft8/sync.rs
@@ -1,9 +1,12 @@
-//! FT8 synchronisation — thin wrapper over the protocol-generic
-//! [`crate::core::sync`] module.
+//! FT8 synchronisation — public entry points for the host decode
+//! pipeline (`decode_frame*` in `decode.rs`).
 //!
-//! The public free functions preserved here match the pre-refactor
-//! signatures so `decode`, the bench harness, and any out-of-tree callers
-//! keep working unchanged. All heavy lifting lives in `mfsk-core::sync`.
+//! Signatures preserve the pre-refactor shape so out-of-tree callers
+//! keep working unchanged. Internals route through the WSJT-X-faithful
+//! [`crate::ft8::decode_block`] port for [`coarse_sync`] (closes #40
+//! — the protocol-generic [`crate::core::sync`] coarse-sync mis-
+//! estimates the noise floor on busy FT8 bands), and through
+//! [`crate::core::sync`] for the remaining fine-sync helpers.
 
 use alloc::vec::Vec;
 
@@ -45,10 +48,28 @@ pub fn coarse_sync(
     freq_min: f32,
     freq_max: f32,
     sync_min: f32,
-    freq_hint: Option<f32>,
+    _freq_hint: Option<f32>,
     max_cand: usize,
 ) -> Vec<SyncCandidate> {
-    crate::core::sync::coarse_sync::<Ft8>(audio, freq_min, freq_max, sync_min, freq_hint, max_cand)
+    // Route through decode_block's WSJT-X-faithful sync8.f90 port
+    // (closes #40). The protocol-generic core::sync::coarse_sync<Ft8>
+    // computed the noise reference from same-time-slot non-Costas
+    // tones, which over-estimates the floor on busy bands
+    // (qso3_busy.wav lost 3 of 8 goldens including CQ F5RXL IN94 at
+    // -3 dB SNR per #40) and under-estimates above 2 kHz (3 phantoms
+    // above 2 kHz on the same WAV). decode_block uses the WSJT-X
+    // 16-bin sliding-window allsum estimator that fixes both, at the
+    // cost of building a Spectrogram first (one extra NFFT_SPEC=3840
+    // FFT pass — same NFFT as before, just consolidated into a
+    // reusable spec instead of recomputed per-candidate scoring loop).
+    //
+    // `freq_hint` is currently dropped — decode_block::coarse_sync
+    // doesn't honour candidate-score promotion. The sniper paths that
+    // use it (decode_sniper_ap) already restrict freq_min/max to a
+    // ±250 Hz band around target_freq, so the loss is small. Tracked
+    // as a follow-up.
+    let spec = crate::ft8::decode_block::compute_spectrogram(audio, freq_max);
+    crate::ft8::decode_block::coarse_sync(&spec, freq_min, freq_max, sync_min, max_cand)
 }
 
 #[inline]


### PR DESCRIPTION
**Scoped for v0.6.0 release** (per discussion in #48). This PR now contains the full v0.6.0 sync-consolidation work — both step A (coarse_sync routing, the original #40 fix) and step B (delete the `ft8::sync::coarse_sync` wrapper, inline the calls in `decode.rs`, promote `decode_block::coarse_sync` + `compute_spectrogram` to public API).

Closes #40, closes #48.

## Commits

1. **`fix(ft8): route host coarse_sync through decode_block (closes #40)`** — the minimal #40 fix. `ft8::sync::coarse_sync` body changed to call `decode_block::coarse_sync` instead of `core::sync::coarse_sync<Ft8>`.
2. **`refactor(ft8): delete sync::coarse_sync wrapper, inline decode_block calls (#48 step B)`** — wrapper removed; `decode.rs` callers inlined; `#[doc(hidden)]` removed from `decode_block::coarse_sync` + `compute_spectrogram`; doc note added to `core::sync::coarse_sync<P>`.

Squash-merge gives a single v0.6.0 commit; merge-commit keeps the two-step history if you prefer to see it.

## Why

The protocol-generic `core::sync::coarse_sync<Ft8>` estimates the noise reference from same-time-slot non-Costas tones — a single NTONES-wide window. On busy FT8 bands this over-estimates the floor (`qso3_busy.wav` lost 3 of 8 WSJT-X goldens, including the easy CQ F5RXL IN94 at -3 dB SNR), and on quiet upper bands it under-estimates (3 phantoms above 2 kHz on the same WAV).

`decode_block::coarse_sync` uses the WSJT-X 16-bin sliding-window allsum estimator from `sync8.f90` — the same noise model the embedded port was tuned against. It already gets 7/8 on `qso3_busy.wav` with `max_cand=15`, while the host wide-band gets 5/8 + 3 phantoms even at `max_cand=50`.

## Why this isn't a regression of the embedded port

The embedded port (`f118a64`, May 2) added `decode_block.rs` as a **new file** with a WSJT-X-faithful `coarse_sync` for FT8 specifically. It never modified the legacy `core::sync::coarse_sync<Ft8>` path. So `decode_frame*` has been carrying the older, less-accurate generic algorithm the whole time. PR #39 (apon recall) made this divergence visible because it's the first test that drives `decode_frame_with_ap` against a known-difficult WAV.

The fix here is a missed-opportunity backport, not a regression repair.

## v0.6.0 breaking notes (CHANGELOG fodder)

### Removed

- **`mfsk_core::ft8::sync::coarse_sync`**. Use `mfsk_core::ft8::decode_block::{compute_spectrogram, coarse_sync}` directly:
  ```rust
  // before
  let cands = mfsk_core::ft8::sync::coarse_sync(&audio, 200.0, 2800.0, 1.3, None, 50);
  // after
  let spec = mfsk_core::ft8::decode_block::compute_spectrogram(&audio, 2800.0);
  let cands = mfsk_core::ft8::decode_block::coarse_sync(&spec, 200.0, 2800.0, 1.3, 50);
  ```

### Changed (behaviour, signature unchanged)

- **`freq_hint: Option<f32>`** parameter on every `decode_frame*` and `decode_sniper*` is now silently ignored. `decode_block::coarse_sync` does not honour candidate-score promotion; sniper paths (`decode_sniper_ap`) already constrain `freq_min`/`freq_max` ±250 Hz around `target_freq`, so the loss is contained. Adding hint support to `decode_block::coarse_sync` is a follow-up.

### Improved

- **FT8 host wide-band recall** on busy bands: `qso3_busy.wav` 5/8 → 7-8/8 (CQ F5RXL IN94 -3 dB now decodes; 3 phantoms above 2 kHz eliminated).
- **`decode_block::coarse_sync` + `compute_spectrogram`** graduate from `#[doc(hidden)]` benchmark API to officially public — they are now the canonical FT8 surface for both embedded and host pipelines.

### Out of v0.6.0 scope (deferred)

- The other `ft8::sync` wrappers (`compute_spectra`, `fine_sync_power*`, `refine_candidate*`) — kept; tracked in #49 cat B for 0.7.0.
- `Protocol::Sync` associated type (option A in #48) — type-system enforcement against future drift; tracked in #48, scheduled post-0.6.0.
- `freq_hint` re-implementation in `decode_block::coarse_sync` — orthogonal to consolidation; will land as its own PR if a use case warrants it.
- Test WAV-loader consolidation (#49 cat A) — non-breaking, can land in 0.6.x patch.

## Expected test impact

- `tests/ft8_qso3_apoff_recall.rs` (8/8 baseline) — should remain 8/8.
- `tests/ft8_qso3_jtdx_recall.rs` — should remain or improve.
- `tests/ft8_qso3_apon_recall.rs` (added in #39) — `JTDX_EXTRAS_HARD_FLOOR` may now be raised toward the documented target of 6 as more candidates survive coarse-sync.
- `tests/ft8_decode_block_*` — unaffected (`decode_block` itself is unchanged; just promoted public).
- `tests/ft8_coarse_sync_concurrent.rs` — unaffected (uses `decode_block::coarse_sync` directly via the now-public path).

If the apon test starts catching more JTDX extras, the hard-floor seam needs bumping in a follow-up commit.

## Test plan

- [ ] CI matrix green
- [ ] `cargo test -p mfsk-core --features full --release -- --include-ignored` passes
- [ ] Recall on `qso3_busy.wav` via `decode_frame_with_ap`: at least 7/8

## Release plan

After this lands:

1. Bump versions: `mfsk-core` and `mfsk-ffi-ft8` to `0.5.12` → `0.6.0` in their respective `Cargo.toml`s.
2. Add CHANGELOG `## 0.6.0` section with the "Removed / Changed / Improved" notes above.
3. Tag `v0.6.0` on main → release.yml gates publish on the v0.5.13 release-pipeline machinery (#30) and ships.

https://claude.ai/code/session_01SCp366F5Bgk3sQThQKccLS