### PR TITLE
m5stack-s3-app: address Gemini review on #51

### DIFF
--- a/embedded-poc/m5stack-s3-app/src/boot_mode.rs
+++ b/embedded-poc/m5stack-s3-app/src/boot_mode.rs
@@ -10,7 +10,6 @@
 //! for is "does cfg.toml carry credentials" — actual mode choice is
 //! now data, not code. Users in the field can flip without a host.
 
-use core::ffi::CStr;
 
 use esp_idf_svc::nvs::{EspDefaultNvsPartition, EspNvs, NvsDefault};
 
@@ -130,11 +129,4 @@ pub fn flip_and_restart(nvs: &EspNvs<NvsDefault>, current: BootMode) -> ! {
     }
     #[allow(unreachable_code)]
     loop {}
-}
-
-// Silence the unused-import warning when `boot_mode` is depended on
-// from main without exercising the CStr path (kept for future ID API).
-#[allow(dead_code)]
-fn _cstr_keepalive() -> &'static CStr {
-    c""
 }

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -13,7 +13,6 @@ use mfsk_core::core::sync::SyncCandidate;
 use mfsk_core::ft8::decode::DecodeDepth;
 use mfsk_core::ft8::decode_block::{DEFAULT_Q_THRESH, NFFT_SPEC};
 
-#[allow(unused_imports)]
 use mfsk_core::ft8::decode_block::BASIS_SCRATCH_LEN;
 use mfsk_core::msg::wsjt77::unpack77;
 use mfsk_ft8::mfsk_ft8_basis_scratch_len;

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -209,8 +209,8 @@ pub fn run_log_panel(
     // Mode label paints in the TX strip at boot. Decode mode's QSO FSM
     // will overwrite this within the first slot; WiFi mode keeps it
     // (no FSM). KEY2 long-press (2 s) flips and restarts.
-    let mode_line: heapless::String<22> = {
-        let mut s: heapless::String<22> = heapless::String::new();
+    let mode_line: heapless::String<32> = {
+        let mut s: heapless::String<32> = heapless::String::new();
         let _ = core::fmt::Write::write_fmt(
             &mut s,
             format_args!("Mode: {} hold K2→flip", mode.label()),


### PR DESCRIPTION
## Summary

Follow-up to merged #51 picking up three medium-priority Gemini code-review items that were noticed post-merge via GitHub email.

- `boot_mode.rs`: drop unused `core::ffi::CStr` import and the `_cstr_keepalive` placeholder that only existed to silence the warning.
- `decode_pipeline.rs`: remove `#[allow(unused_imports)]` on `BASIS_SCRATCH_LEN` (it is used in the runtime assertion at line 51).
- `display.rs`: bump the boot-time mode-label `heapless::String` capacity from 22 to 32. The literal `"Mode: DECODE hold K2→flip"` is 27 bytes (`→` is 3 bytes UTF-8) and was silently truncated to `"Mode: DECODE hold K2"` on the LCD.

## Test plan

- [x] `cargo check --release` clean (m5stack-s3-app)
- [x] `cargo build --release` clean
- [x] Flashed to M5Stack-S3 hardware; TX strip at boot displays full `"Mode: WiFi hold K2→flip"` (previously the `→flip` tail was cut)
- [ ] No behavior change expected for decode/QSO loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)