### PR TITLE
tests + docs: address Gemini sweep on past PRs

### DIFF
--- a/docs/LIBRARY.ja.md
+++ b/docs/LIBRARY.ja.md
@@ -170,7 +170,7 @@ mfsk_core
 ├── jt65/             JT65 ZST + decode (+ 消失対応 RS)
 └── q65/              Q65 ファミリ — 6 sub-mode ZST + decode + synth
     ├── protocol.rs     q65_submode! マクロ (Q65a30..Q65e60 ZST 生成)
-    ├── rx.rs           4 つのデコード戦略 (AWGN / AP / fast-fading / AP-list)
+    ├── rx.rs           4 つのデコード戦略 (AWGN / AP-hint / fast-fading / AP-list)
     ├── ap_list.rs      standard_qso_codewords — full AP-list 候補生成
     ├── tx.rs           65-FSK 合成器 (sub-mode 対応)
     ├── search.rs       22 シンボル Costas-block coarse 検索

--- a/docs/LIBRARY.ja.md
+++ b/docs/LIBRARY.ja.md
@@ -121,7 +121,7 @@ Q65 は WSPR では試されなかった軸で trait 面を試す材料になっ
    生成するため、sub-mode ごとのコード重複は無い。
 4. **4 つの並列なデコード戦略**: 同一 FEC フレームに対し正当に
    選び得る受信経路が 4 通り存在するのは Q65 が初めて — plain AWGN
-   BP、AP-biased BP、fast-fading metric、AP-list テンプレート照合。
+   BP、AP-hint BP、fast-fading metric、AP-list テンプレート照合。
    §3 で詳述する。各戦略は sub-mode ZST に対して generic な
    別個のエントリポイント関数として共存し、内部の FEC と
    メッセージコーデックは共有する。
@@ -400,7 +400,7 @@ generic である。
 | 状況                                                  | 戦略                       | エントリポイント                                              | 閾値ゲイン       |
 |-------------------------------------------------------|----------------------------|---------------------------------------------------------------|------------------|
 | デフォルト — チャネル特性 / メッセージ未知            | AWGN Bessel + BP           | `decode_at_for<P>` / `decode_scan_for<P>`                     | 基準             |
-| コールサイン or レポート既知、地上波チャネル          | AP-biased BP               | `decode_at_with_ap_for<P>` / `decode_scan_with_ap_for<P>`     | ~2 dB            |
+| コールサイン or レポート既知、地上波チャネル          | AP-hint BP               | `decode_at_with_ap_for<P>` / `decode_scan_with_ap_for<P>`     | ~2 dB            |
 | ドップラー拡散チャネル (≥10 Hz、microwave EME)        | Fast-fading metric + BP    | `decode_at_fading_for<P>` / `decode_scan_fading_for<P>`       | 拡散時 5–8 dB    |
 | コールペア既知、QSO 文脈無し、地上波                  | AP-list テンプレート照合   | `decode_at_with_ap_list_for<P>` / `decode_scan_with_ap_list_for<P>` | ~3 dB |
 
@@ -408,7 +408,7 @@ generic である。
 Bessel-I0 metric で確率ベクトル化し、QRA 符号上で非二進 belief
 propagation を実行する。加法ガウスノイズに近いチャネルで安全に動く。
 
-**AP-biased BP** は BP 開始前に既知の情報ビット位置で intrinsic
+**AP-hint BP** は BP 開始前に既知の情報ビット位置で intrinsic
 確率ベクトルをクランプする。正しい hint は BP の収束点を真値側に
 寄せ、誤った hint は誤デコードよりも収束失敗を引き起こす傾向が
 ある (CRC が残りを捕捉する)。`mfsk_core::msg::ApHint` の builder
@@ -854,7 +854,7 @@ MfskStatus        mfsk_encode_q65(MfskQ65SubMode submode,
 MfskStatus        mfsk_q65_decode(MfskQ65SubMode, ...);              // AWGN
 MfskStatus        mfsk_q65_decode_with_ap(MfskQ65SubMode, ...,
                                   const char* ap_call1, ap_call2,
-                                  ap_grid, ap_report, ...);          // AP-biased BP
+                                  ap_grid, ap_report, ...);          // AP-hint BP
 MfskStatus        mfsk_q65_decode_fading(MfskQ65SubMode, ...,
                                   float b90_ts,
                                   MfskQ65FadingModel, ...);          // fast-fading
@@ -971,7 +971,7 @@ repeat-accumulate 符号で、Walsh-Hadamard メッセージにより確率
 実送信する。実装した 6 sub-mode は同じ FEC + 同期配置 + 77 bit
 メッセージを共有し、`NSPS` (30 s vs 60 s スロット) と
 トーン間隔 (×1, ×2, ×4, ×8, ×16) のみが異なる。§3 の 4 つの
-並列デコード戦略 (AWGN BP, AP-biased BP, fast-fading metric,
+並列デコード戦略 (AWGN BP, AP-hint BP, fast-fading metric,
 AP-list テンプレート照合) はすべて同じ QRA codec を利用する。
 
 ### 10.1 スコープ境界: 応用例としての `uvpacket`
@@ -1013,7 +1013,7 @@ uvpacket が汎用 TX/RX パイプラインを bypass するため、
 テスト** を同時に出荷しました:
 
 - **Q65 ファミリ拡張 — *positive* probe**。trait 表面を非バイナリ
-  符号 (QRA over GF(2⁶)) と 4 並列デコード戦略 (AWGN / AP /
+  符号 (QRA over GF(2⁶)) と 4 並列デコード戦略 (AWGN / AP-hint /
   fast-fading / AP-list) まで押し広げて、形が崩れないことを確認
   した。`Protocol` / `ModulationParams` / `FrameLayout` /
   `FecCodec` / `MessageCodec` の各層が、1 つのマクロから生やした

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -180,7 +180,7 @@ mfsk_core
 ├── jt65/             JT65 ZST + decode (+ erasure-aware RS)
 └── q65/              Q65 family — 6 sub-mode ZSTs + decode + synth
     ├── protocol.rs     q65_submode! macro emitting Q65a30 .. Q65e60 ZSTs
-    ├── rx.rs           4 decoder strategies (AWGN / AP / fast-fading / AP-list)
+    ├── rx.rs           4 decoder strategies (AWGN / AP-hint / fast-fading / AP-list)
     ├── ap_list.rs      standard_qso_codewords — full AP-list candidate generator
     ├── tx.rs           65-FSK synthesiser (sub-mode-aware)
     ├── search.rs       coarse 22-symbol Costas-block search

--- a/docs/LIBRARY.md
+++ b/docs/LIBRARY.md
@@ -128,7 +128,7 @@ exercise:
 4. **Four parallel decoder strategies** — Q65 is the first protocol
    in the library where the receiver chain has multiple legitimate
    paths through the same FEC. They are listed in §3:
-   plain AWGN BP, AP-biased BP, fast-fading metric, and AP-list
+   plain AWGN BP, AP-hint BP, fast-fading metric, and AP-list
    template matching. Each is a distinct entry-point function
    generic over the sub-mode ZST; the underlying FEC and message
    codec are shared.
@@ -418,7 +418,7 @@ sub-mode ZST.
 | When                                               | Strategy                  | Entry point                                                   | Threshold gain |
 |----------------------------------------------------|---------------------------|---------------------------------------------------------------|----------------|
 | Default — unknown channel, unknown content         | AWGN Bessel + BP          | `decode_at_for<P>` / `decode_scan_for<P>`                     | baseline       |
-| Known callsign(s) or report, terrestrial channel   | AP-biased BP              | `decode_at_with_ap_for<P>` / `decode_scan_with_ap_for<P>`     | ~2 dB          |
+| Known callsign(s) or report, terrestrial channel   | AP-hint BP              | `decode_at_with_ap_for<P>` / `decode_scan_with_ap_for<P>`     | ~2 dB          |
 | Doppler-spread channel (microwave EME, ≥10 Hz spread) | Fast-fading metric + BP | `decode_at_fading_for<P>` / `decode_scan_fading_for<P>`       | 5–8 dB on spread channels |
 | Known call pair, no QSO context, terrestrial       | AP-list template matching | `decode_at_with_ap_list_for<P>` / `decode_scan_with_ap_list_for<P>` | ~3 dB          |
 
@@ -427,7 +427,7 @@ become probability vectors via the Bessel-I0 metric, then non-binary
 belief propagation runs on the QRA code. Falls back gracefully on
 any channel reasonably close to additive Gaussian noise.
 
-**AP-biased BP** clamps the intrinsic probability vectors at known
+**AP-hint BP** clamps the intrinsic probability vectors at known
 information-bit positions before BP. A correct hint shifts the BP
 fixed-point closer to the truth; a wrong hint typically fails to
 converge rather than misdecoding (the CRC catches what's left).
@@ -987,7 +987,7 @@ channel symbols actually transmitted. Six wired sub-modes share
 the same FEC + sync layout + 77-bit message; only `NSPS`
 (30-s vs 60-s slot) and tone spacing (×1, ×2, ×4, ×8, ×16) differ
 between them. The four parallel decoder strategies introduced in
-§3 (AWGN BP, AP-biased BP, fast-fading metric, AP-list template
+§3 (AWGN BP, AP-hint BP, fast-fading metric, AP-list template
 matching) all share the same QRA codec under the hood.
 
 ### 10.1 Scope boundary: `uvpacket` as an applied example
@@ -1031,7 +1031,7 @@ trait abstractions, in opposite directions:
 
 - **Q65 family expansion — *positive* probe.** Pushed the trait
   surface to a non-binary code (QRA over GF(2⁶)) and four parallel
-  decoder strategies (AWGN / AP / fast-fading / AP-list) without
+  decoder strategies (AWGN / AP-hint / fast-fading / AP-list) without
   bending the trait shape. The `Protocol` / `ModulationParams` /
   `FrameLayout` / `FecCodec` / `MessageCodec` layers carried
   through unchanged for six sub-modes generated from one macro.

--- a/mfsk-core/src/jt9/rx.rs
+++ b/mfsk-core/src/jt9/rx.rs
@@ -330,9 +330,6 @@ fn freq_sweep_1224hz() {
         env!("CARGO_MANIFEST_DIR"),
         "/../embedded-poc/assets/130418_1742.wav"
     ));
-    if !path.exists() {
-        return;
-    }
     let bytes = std::fs::read(path).unwrap();
     let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
     let audio: Vec<f32> = bytes[44..44 + dl]
@@ -371,9 +368,6 @@ fn wide_freq_time_sweep() {
         env!("CARGO_MANIFEST_DIR"),
         "/../embedded-poc/assets/130418_1742.wav"
     ));
-    if !path.exists() {
-        return;
-    }
     let bytes = std::fs::read(path).unwrap();
     let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
     let audio: Vec<f32> = bytes[44..44 + dl]

--- a/mfsk-core/src/jt9/rx.rs
+++ b/mfsk-core/src/jt9/rx.rs
@@ -215,9 +215,6 @@ mod diag_tests {
             env!("CARGO_MANIFEST_DIR"),
             "/../embedded-poc/assets/130418_1742.wav"
         ));
-        if !path.exists() {
-            return;
-        }
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let data = &bytes[44..44 + dl];
@@ -264,10 +261,6 @@ mod diag_tests {
             env!("CARGO_MANIFEST_DIR"),
             "/../embedded-poc/assets/130418_1742.wav"
         ));
-        if !path.exists() {
-            eprintln!("WAV not found");
-            return;
-        }
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let audio: Vec<f32> = bytes[44..44 + dl]

--- a/mfsk-core/tests/jt9_wsjtx_samples.rs
+++ b/mfsk-core/tests/jt9_wsjtx_samples.rs
@@ -1,31 +1,24 @@
 //! JT9 real-world signal validation against the WSJT-X sample
-//! recording shipped under `WSJT-X/samples/JT9/130418_1742.wav`
+//! recording vendored under `embedded-poc/assets/130418_1742.wav`
 //! (12 kHz mono PCM-16, 60 s — one full JT9 slot).
-//!
-//! Skipped when the WSJT-X tree is not present at the expected
-//! sibling path.
 //!
 //! Counterpart to `q65_wsjtx_samples.rs` and `ft4_wsjtx_samples.rs`.
 
 #![cfg(all(feature = "jt9", any(feature = "fft-rustfft", feature = "fft-extern")))]
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use mfsk_core::jt9::decode_scan;
 use mfsk_core::jt9::search::SearchParams;
 
 #[allow(dead_code)]
 mod common;
-use common::load_wav_f32_opt as read_wsjtx_wav_f32;
+use common::load_wav_f32 as read_wsjtx_wav_f32;
 
-fn sample_path() -> Option<PathBuf> {
-    let manifest = std::env::var("CARGO_MANIFEST_DIR").ok()?;
-    let p = Path::new(&manifest)
-        .join("../embedded-poc/assets/130418_1742.wav")
-        .canonicalize()
-        .ok()?;
-    if p.is_file() { Some(p) } else { None }
-}
+const SAMPLE_PATH: &str = concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../embedded-poc/assets/130418_1742.wav"
+);
 
 struct Golden {
     msg: &'static str,
@@ -91,15 +84,7 @@ const DT_TOL_SEC: f32 = 0.5; // ≈ 1 symbol; covers ⅛-sym lag grid + slot-off
 // to bring the 1505 Hz signal inside the search band.
 #[test]
 fn jt9_wsjtx_sample_recall_vs_golden() {
-    let Some(path) = sample_path() else {
-        eprintln!(
-            "skipping: vendored JT9 sample not found at \
-             embedded-poc/assets/130418_1742.wav"
-        );
-        return;
-    };
-
-    let audio = read_wsjtx_wav_f32(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let audio = read_wsjtx_wav_f32(Path::new(SAMPLE_PATH));
 
     // Default SearchParams is 1400..1600 Hz which excludes every
     // golden tone (1119..1346 Hz). Widen the band; everything else


### PR DESCRIPTION
## Summary

Sweep of historical Gemini code-review comments on merged PRs #3–#50. Most HIGH/MED items were already resolved by the 0.5 → 0.6 refactoring (sync consolidation, per-candidate inner unification, FT4 BT fix via #27, known-signal subtraction via #26). This PR cleans up the six items that survived:

- **`tests/jt9_wsjtx_samples.rs`** — drop the `sample_path()` Option indirection and the silent `return;` fallback. The WAV is vendored at `embedded-poc/assets/130418_1742.wav`; silent skip undermined the "CI gates regression" intent of #38. Now hard-fails via `load_wav_f32`. (Gemini #38 HIGH + MED)
- **`src/jt9/rx.rs`** — remove dead `if !path.exists() { return; }` / `eprintln + return` guards in three `#[ignore]` diagnostic tests. `fs::read(path).unwrap()` on the next line already gives a clear panic on missing assets. (Gemini #36 ×3 MED)
- **`docs/LIBRARY.{md,ja.md}`** — "AWGN / AP / fast-fading / AP-list" → "AWGN / AP-hint / ..." for consistency with `UVPACKET.{md,ja.md}`. (Gemini #9 ×2 MED)

## Outstanding items (issues to be filed)

- **perf-A**: hoist `fft_cache` into `fill_symbol_spectra_via_cd0` (Gemini #14 HIGH-derived)
- **perf-B**: caller-buffer `audio_i16` in same function (#14)
- **perf-C**: m5stack-core2 embedded `fill_symbol_spectra_into` migration (#14 MED)
- **D-1**: redundant `compute_llr` at `decode_block.rs:2918` + `:2976` (#50 MED)
- **D-2**: OSD depth-2 fallback regression check vs WSJT-X `osd174_91` (#50 MED)
- **H**: m5stack-core2 `static mut BASIS_*` heap migration aligned with PR #51 (#14 MED)

## Test plan

- [x] `cargo check -p mfsk-core --tests --features ft8,jt9,uvpacket,fft-rustfft` clean
- [x] `cargo test ... --test jt9_wsjtx_samples jt9_wsjtx_sample_recall_vs_golden` → `ok. 1 passed`
- [ ] `#[ignore]` diagnostic tests in `src/jt9/rx.rs` — not run by default; verified pattern change only

🤖 Generated with [Claude Code](https://claude.com/claude-code)