### PR TITLE
perf(ft8): hoist fft_cache into fill_symbol_spectra (closes #54)

### DIFF
--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -12,7 +12,7 @@ use rayon::prelude::*;
 
 pub use super::equalizer::EqMode;
 use super::{
-    downsample::{build_fft_cache, downsample},
+    downsample::build_fft_cache,
     equalizer,
     llr::sync_quality,
     message::pack28,
@@ -454,7 +454,14 @@ fn process_candidate(
     ap_hint: Option<&ApHint>,
 ) -> Option<DecodeResult> {
     let _ = strictness; // used inside try_decode via the inner
-    let (mut cd0, _) = downsample(audio, cand.freq_hz, Some(fft_cache));
+    // Use `downsample_cached` directly so the FT8 wrapper's
+    // `cache.to_vec()` clone (~3 MB) on the `Some(_)` branch is
+    // bypassed — same pattern as `fill_symbol_spectra_via_cd0`.
+    let mut cd0 = crate::core::dsp::downsample::downsample_cached(
+        fft_cache,
+        cand.freq_hz,
+        &crate::ft8::downsample::FT8_CFG,
+    );
 
     // WSJT-X 3-stage fine refinement (ft8b.f90:104-150). Validates
     // freq snap to ±0.5 Hz grid + dt to integer 200 Hz step before

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -515,6 +515,7 @@ fn process_candidate(
         refined.freq_hz,
         refined.dt_sec,
         crate::ft8::decode_block::SymMask::SyncOnly,
+        Some(fft_cache),
     );
     crate::ft8::decode_block::fill_symbol_spectra(
         &mut cs_raw,
@@ -522,6 +523,7 @@ fn process_candidate(
         refined.freq_hz,
         refined.dt_sec,
         crate::ft8::decode_block::SymMask::DataOnly,
+        Some(fft_cache),
     );
     let nsync = sync_quality(&cs_raw);
     if nsync <= 6 {

--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -1085,7 +1085,7 @@ pub fn symbol_spectra_direct<S: AudioSample>(
 ) -> Box<[[Cmplx<f32>; 8]; 79]> {
     let mut out: Box<[[Cmplx<f32>; 8]; 79]> =
         vec![[Cmplx::<f32>::default(); 8]; 79].try_into().unwrap();
-    fill_symbol_spectra(&mut out, audio, freq_hz, dt_sec, sym_mask);
+    fill_symbol_spectra(&mut out, audio, freq_hz, dt_sec, sym_mask, None);
     out
 }
 
@@ -1156,14 +1156,19 @@ pub fn fill_symbol_spectra<S: AudioSample>(
     freq_hz: f32,
     dt_sec: f32,
     mask: SymMask,
+    fft_cache: Option<&[Complex<f32>]>,
 ) {
-    fill_symbol_spectra_via_cd0(out, audio, freq_hz, dt_sec, mask);
+    fill_symbol_spectra_via_cd0(out, audio, freq_hz, dt_sec, mask, fft_cache);
 }
 
 /// Embedded fallback (no `fft-rustfft` available — Xtensa cannot run
 /// the 192k cd0 FFT). Reverts to the rectangular-window per-tone DFT
 /// for non-fixed-point builds; the fixed-point variant has its own
 /// basis-precompute path in `fill_symbol_spectra_into`.
+///
+/// The `fft_cache` parameter is accepted for API parity with the
+/// `fft-rustfft` variant but ignored — there is no 192k FFT to skip
+/// on this path.
 #[doc(hidden)]
 #[cfg(all(not(feature = "fft-rustfft"), not(feature = "fixed-point")))]
 pub fn fill_symbol_spectra<S: AudioSample>(
@@ -1172,7 +1177,9 @@ pub fn fill_symbol_spectra<S: AudioSample>(
     freq_hz: f32,
     dt_sec: f32,
     mask: SymMask,
+    fft_cache: Option<&[Complex<f32>]>,
 ) {
+    let _ = fft_cache;
     fill_symbol_spectra_generic::<f32, S>(out, audio, freq_hz, dt_sec, mask);
 }
 
@@ -1186,10 +1193,11 @@ pub fn fill_symbol_spectra<S: AudioSample>(
 ///   cs(0:7,k) = csymb(1:8) / 1e3
 /// enddo
 /// ```
-/// Per-call cost: one 192k forward FFT (~5 ms host) + one 3.2k inverse
-/// FFT + 79 × 32-pt FFT. Optimisation (cache the 192k FFT across
-/// candidates of the same slot) is left to the caller pipeline; for now
-/// the simple version is built per call.
+/// Per-call cost: 79 × 32-pt FFT + (one 192k forward FFT only if the
+/// caller did not supply `fft_cache`) + one 3.2k inverse FFT.
+/// Passing `Some(cache)` from the multipass driver (the cache built
+/// once per slot in `decode_frame_inner`) skips the 192k forward FFT
+/// per candidate — ~5 ms saved × 30+ candidates × 3 passes.
 #[cfg(feature = "fft-rustfft")]
 fn fill_symbol_spectra_via_cd0<S: AudioSample>(
     out: &mut [[Cmplx<f32>; 8]; 79],
@@ -1197,16 +1205,27 @@ fn fill_symbol_spectra_via_cd0<S: AudioSample>(
     freq_hz: f32,
     dt_sec: f32,
     mask: SymMask,
+    fft_cache: Option<&[Complex<f32>]>,
 ) {
     use rustfft::FftPlanner;
     extern crate alloc;
 
     // S → i16 conversion (no-op when S=i16 already). Per-call alloc
-    // — wasteful when cand-loop calls this 30+ times per slot, but
-    // simplifies the API. A future refactor can hoist a cached
-    // `Vec<i16>` + `fft_cache` to the multipass driver.
-    let audio_i16: alloc::vec::Vec<i16> = audio.iter().map(|s| s.to_i16()).collect();
-    let (cd0, _) = crate::ft8::downsample::downsample(&audio_i16, freq_hz, None);
+    // — still wasteful when cand-loop calls this 30+ times per slot.
+    // See #55 (perf-B) for the caller-buffer hoist. Skipped entirely
+    // when `fft_cache` is supplied (the slot-cache path doesn't need
+    // the audio bytes — only the precomputed forward FFT).
+    let cd0 = match fft_cache {
+        Some(cache) => crate::core::dsp::downsample::downsample_cached(
+            cache,
+            freq_hz,
+            &crate::ft8::downsample::FT8_CFG,
+        ),
+        None => {
+            let audio_i16: alloc::vec::Vec<i16> = audio.iter().map(|s| s.to_i16()).collect();
+            crate::ft8::downsample::downsample(&audio_i16, freq_hz, None).0
+        }
+    };
 
     // ibest in cd0 sample units (200 sps). dt_sec is offset from
     // TX_START_OFFSET_S = 0.5 s; cd0[0] corresponds to slot t=0,
@@ -1399,7 +1418,9 @@ pub fn fill_symbol_spectra<S: AudioSample>(
     freq_hz: f32,
     dt_sec: f32,
     mask: SymMask,
+    fft_cache: Option<&[Complex<f32>]>,
 ) {
+    let _ = fft_cache;
     fill_symbol_spectra_generic::<f32, S>(out, audio, freq_hz, dt_sec, mask);
 }
 
@@ -2561,7 +2582,7 @@ fn process_candidates_tuned_with_ap<S: AudioSample>(
         bp_max_iter,
         &mut cs_scratch,
         |cs, cand, mask| {
-            fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask);
+            fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask, None);
         },
         ap_hint,
         strictness,
@@ -2693,7 +2714,9 @@ pub fn process_candidates_into_with_cs_scratch_tuned<S: AudioSample>(
             #[cfg(feature = "fft-rustfft")]
             {
                 // basis_{re,im} unused on this path — borrow nothing.
-                fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask);
+                // fft_cache=None here because process_candidates_into_tuned
+                // is the embedded entry, not the slot-cache pipeline.
+                fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask, None);
             }
             // Embedded fixed-point (no fft-rustfft): keep the
             // basis-precompute + dot-product path — no 192k FFT


### PR DESCRIPTION
## Summary

Thread an `Option<&[Complex<f32>]>` fft_cache through the host candidate hot path so the 192 000-point forward FFT is built once per pass instead of once per `fill_symbol_spectra` call.

The slot-level cache was already built in `decode_frame_inner` (`decode.rs:629`) and used at `decode.rs:457`, but the two `fill_symbol_spectra` invocations inside `process_candidate` (lines 512, 519) discarded it and rebuilt. Across ~30 candidates × 3 SIC passes × 2 spectra each = ~180 calls per slot, that was ~180 redundant 192k FFTs.

Bonus: the FT8 `downsample(_, Some(cache))` wrapper used to clone the cache on return (`cache.to_vec()`, ~3 MB) just for tuple symmetry — every caller threw the clone away. Switched to `downsample_cached(...)` (no clone) when a cache is supplied.

## Measurement

`ft8_qso3_apon_recall`, release, 3 runs each:

| | run 1 | run 2 | run 3 | avg |
|---|---|---|---|---|
| before | 14.69 s | 14.59 s | 14.61 s | **14.63 s** |
| after | 13.04 s | 13.06 s | 13.03 s | **13.04 s** |
| Δ | | | | **−1.59 s (−11 %)** |

## API change

The `#[doc(hidden)]` public `fill_symbol_spectra` (all 3 cfg variants) gains a trailing `fft_cache: Option<&[Complex<f32>]>` parameter. The function carries a `**Pub for benchmarking only — do not depend on it.**` disclaimer, so this is not a semver-breaking change.

## Test plan

- [x] `cargo check --tests --features ft8,jt9,uvpacket,fft-rustfft` clean
- [x] Full test suite: 250+ tests across all integration test files pass, no regressions
- [x] `ft8_qso3_apon_recall` (17 tests) pass with 11 % wall-clock improvement
- [x] `ft8_qso3_apoff_recall` golden floor pass

Closes #54. Companion follow-ups: #55 (perf-B), #56 (perf-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)