### PR TITLE
cleanup(β): silence compiler warnings (β.5 of cleanup plan)

### DIFF
--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -50,7 +50,6 @@ const TARGET_PEAK: i32 = (NFFT_SPEC * 2) as i32;
 const ALLSUM_FREQ_MIN: f32 = 100.0;
 const ALLSUM_FREQ_MAX: f32 = 3_000.0;
 const ALLSUM_FREQ_MID: f32 = 0.5 * (ALLSUM_FREQ_MIN + ALLSUM_FREQ_MAX);
-const ALLSUM_WIN: usize = 2 * NTONES;
 
 fn n_freq_for(max_freq_hz: f32) -> usize {
     let df = SAMPLE_RATE_HZ / NFFT_SPEC as f32;

--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -1887,7 +1887,12 @@ fn decode_block_multipass<S: AudioSample>(
 /// Hard-decision sync count (= WSJT-X `ft8b.f90:163-176` nsync) read
 /// from the pass-1 spectrogram at the result's refined (freq, dt).
 /// 21-bit upper bound (3 sync blocks × 7 Costas positions).
-#[cfg(feature = "fft-rustfft")]
+///
+/// Only the host f32 build calls this — `recompute_snr_xsnr2` /
+/// `recompute_nsync` use the `xsnr2/xbase` formulation which is
+/// f32-only (see the `#[cfg(not(feature = "fixed-point"))]` caller
+/// at line ~1877).
+#[cfg(all(feature = "fft-rustfft", not(feature = "fixed-point")))]
 fn recompute_nsync(
     result: &DecodeResult,
     spec: &Spectrogram,
@@ -2068,7 +2073,11 @@ pub fn xsnr2_db_simple(spec: &Spectrogram, result: &DecodeResult, cell_scale: f3
 /// convention) maps directly into a WSJT-X-compatible dB number.
 ///
 /// Falls back to `-24 dB` if the ratio degenerates.
-#[cfg(feature = "fft-rustfft")]
+///
+/// f32-only — fixed-point spectrograms quantise to u16, putting noise
+/// cells at zero and breaking the `log10` baseline; see the comment
+/// block at the `retain_mut` caller for the full rationale.
+#[cfg(all(feature = "fft-rustfft", not(feature = "fixed-point")))]
 fn recompute_snr_xsnr2(
     result: &DecodeResult,
     spec: &Spectrogram,
@@ -2699,6 +2708,15 @@ pub fn process_candidates_into_with_cs_scratch_tuned<S: AudioSample>(
     basis_im: &mut [i16],
     cs_scratch: &mut [[Cmplx<f32>; 8]; 79],
 ) -> Vec<DecodeResult> {
+    // Host fft-rustfft path doesn't need the basis buffers — cs is
+    // built via the cd0 32-pt FFT instead. The parameters stay in
+    // the signature so embedded callers (no fft-rustfft) get the
+    // same shape; reference them here to silence unused warnings.
+    #[cfg(feature = "fft-rustfft")]
+    {
+        let _ = &basis_re;
+        let _ = &basis_im;
+    }
     process_candidates_with_ap(
         audio,
         cands,


### PR DESCRIPTION
## Summary

β.5 of the cleanup plan in [\`docs/CLEANUP_2026_05.md\`](https://github.com/jl1nie/mfsk-core/blob/cleanup-gamma/docs/CLEANUP_2026_05.md) (depends on PR #66 for the plan document).

Clears all four compiler warnings visible under \`cargo check --features fft-rustfft,fixed-point\` — no behavioural change, golden recall holds.

## What this changes

### Tightened cfg gates (decode_block.rs)
- \`fn recompute_nsync\`, \`fn recompute_snr_xsnr2\`: gate widened from \`feature = "fft-rustfft"\` to \`all(feature = "fft-rustfft", not(feature = "fixed-point"))\`. The only caller (L1877-1878 \`retain_mut\`) is already \`#[cfg(not(feature = "fixed-point"))]\` because the xsnr2/xbase formulation needs the f32 spectrogram precision — u16 fixed-point quantisation breaks the \`log10\` baseline.

### Removed dead const (stage1_inc.rs)
- \`const ALLSUM_WIN: usize = 2 * NTONES;\` — no callers in any cfg combination. Leftover from a Phase E2 per-half allsum draft; siblings \`ALLSUM_FREQ_{MIN, MAX, MID}\` are still in use.

### Marked-intent unused parameters (decode_block.rs)
- \`process_candidates_into_with_cs_scratch_tuned\`: keeps \`basis_re\` / \`basis_im\` in the signature so embedded callers see a stable shape, but the host fft-rustfft body uses \`fill_symbol_spectra\` (cd0 path) instead of \`fill_symbol_spectra_into\` (basis path). Added explicit \`let _ = &basis_re; let _ = &basis_im;\` under the relevant cfg block so the compiler sees the intent.

## Verification

\`\`\`
cargo check -p mfsk-core --features ft8,uvpacket,fft-rustfft                  # 0 warnings
cargo check -p mfsk-core --features ft8,uvpacket,fft-rustfft,fixed-point      # 0 warnings  (was 4)
cargo check -p mfsk-core --no-default-features --features alloc,ft8,fft-rustfft  # 0 warnings
\`\`\`

Golden recall:
- \`ft8_qso3_apoff_recall\`: 16 passed
- \`ft8_qso3_jtdx_recall\`: 16 passed

## Plan continuation

Per \`docs/CLEANUP_2026_05.md\`:

| β sub-target | status |
|---|---|
| β.1 \`fft-extern\` vs \`fft-rustfft\` site audit | weekend |
| β.2 \`fixed-point\` × \`fft-rustfft\` four-cell matrix | weekend |
| β.3 \`profile-coarse\` / \`nstep-half\` | weekend |
| β.4 \`parallel\` feature audit | weekend |
| **β.5 Compiler-visible dead code** | **this PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)