### PR TITLE
cleanup(δ): documentation sync — ROADMAP refresh + AP-hint terminology + CLAUDE.md consolidation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ carries its own Quick example:
 - [`mfsk_core::q65`](https://docs.rs/mfsk-core/latest/mfsk_core/q65/)
   — `decode_scan_default` (Q65-30A); generic `decode_scan_for<P>`
   for any wired sub-mode including the Q65-60A‥E EME variants;
-  `decode_scan_with_ap` / `decode_scan_with_ap_for<P>` for AP-biased
+  `decode_scan_with_ap` / `decode_scan_with_ap_for<P>` for AP-hint
   decoding (~2 dB threshold gain when call signs are known); and
   `decode_scan_fading_for<P>` for the fast-fading metric (Gaussian
   / Lorentzian channel models) that recovers 5–8 dB on Doppler-spread
@@ -332,7 +332,11 @@ the 0.5.x baseline. M5Stack Core2 (LX6) on the same WAV ~2.8 s. See
 for the integration contract, runtime BP / `nstep-half` tuning knobs,
 and the structural recall ceiling (no `fine_refine_pass1` on Xtensa
 without 192k FFT — investigated and deferred);
-`embedded-poc/m5stack-{s3,core2}/` are the working example binaries.
+`embedded-poc/m5stack-s3-app/` is the production FT8 controller
+crate (LCD UI + QSO FSM + WiFi-UDP log streaming);
+`embedded-poc/m5stack-{s3,core2}/` are compute-bench crates kept
+for performance regression tracking (Core2 fold-in into the S3
+dual-core pipeline is tracked in [#61](https://github.com/jl1nie/mfsk-core/issues/61)).
 
 Host AP-on multipass recall on the same WAV is materially higher.
 After 0.6.2's host pipeline catch-up (cs-source unification +

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,8 +1,13 @@
 # Roadmap (post-0.6.2)
 
-## v0.6.2 status (in flight, 2026-05-10)
+## v0.6.2 status (shipped, 2026-05-10)
 
-Cumulative `v0.6.0` + `v0.6.1` + `v0.6.2` shipped as one release.
+Cumulative `v0.6.0` + `v0.6.1` + `v0.6.2` shipped as one release via PR #50
+(commit `ba067fd`, crates.io `mfsk-core@0.6.2` / `mfsk-ffi-ft8@0.6.2`).
+The 2026-05-13 post-merge sweep (`#53`, `#60`, `#62`, `#66`, `#67`, `#68`,
+`#69`) closed the documentation / dead-code follow-ups against this bundle
+without bumping the crate version. See `docs/CLEANUP_2026_05.md` for the
+γ/β/δ/ε cleanup plan that drove that sweep.
 Headline numbers (all on `qso3_busy.wav`):
 
 - Host AP-off recall: **7/8** WSJT-X golden, **16/18** JTDX golden
@@ -56,7 +61,42 @@ i16-throughout FIR refine path or a streaming chunk-processing
 refactor lands. Both are out of scope for a 0.6.x patch — defer
 to a 0.7.x design pass.
 
-### Open follow-ups for 0.6.x patches and 0.7.0
+### Open follow-ups
+
+Currently open GitHub issues (state:open as of 2026-05-14):
+
+- **#23** — FST4-60A golden lockdown (host); FST4-15 / FST4W
+  stretch. Carried forward from the post-0.5.12 "Phase A1".
+- **#24** — JT65B golden lockdown + erasure-metadata path.
+  Carried forward from the post-0.5.12 "Phase A2".
+- **#25** — MSK144 decode path. Community-contribution invitation;
+  not on the 3-month roadmap.
+- **#58** — coalesce redundant `compute_llr` between Step 3 (OSD)
+  and Step 4 (AP) in `decode_block`. Low-priority host perf.
+- **#61** — fold `m5stack-core2` into the S3 dual-core pipeline
+  and retire the Core2 crate. Weekend hardware bring-up
+  (2026-05-17/18) per `docs/CLEANUP_2026_05.md` (ε prerequisite).
+- **#63** — WSJT-X-faithful OSD `npre1` precoding for host
+  `BpAllOsd`; reduces false positives. Deprioritised — see PR #62
+  for the design note documenting the current parity gap.
+- **#64** — hoist `fft_cache` through host `decode_block_multipass`
+  (perf follow-up to #60, which landed the single-pass hoist).
+- **#65** — share `cd0` between SyncOnly + DataOnly
+  `fill_symbol_spectra` calls (host perf nice-to-have).
+
+Carry-overs from the post-0.5.12 plan that have since closed:
+
+- **A0** (`#40` host wide-band coarse-sync gap) — closed by v0.6.0.
+- **A0'** (`decode_block_with_ap` embedded reach) — landed in
+  v0.6.1 as Step 4 of `process_one_candidate_inner`. The
+  `decode_block_with_ap` symmetric public entry exists but the
+  5 missing JTDX-extras on `qso3_busy.wav` sit upstream of AP
+  (host coarse-sync surfaces them only with `subtract_signal_lpf`
+  multipass — a host-side win, not embedded). No new issue filed
+  yet; revisit when an embedded-only WAV surfaces where the gap is
+  post-coarse-sync.
+
+Architectural notes that did not graduate to issues:
 
 - **#48 option A** — `Protocol::Sync` associated type for
   type-system enforcement against future protocol-sync drift.
@@ -66,20 +106,12 @@ to a 0.7.x design pass.
   bound. Subsumed structurally by Phase 4 dispatch in v0.6.0; the
   doc note ("FT8 should not use this") is the practical backstop
   until #48 option A lands.
-- **#23 / #24 / #25** (FST4 / JT65 / MSK144 lockdowns), and
-  m5stack-s3-app Phase B (QSO FSM + TX picker UI integration)
-  remain on the original roadmap; v0.6.x did not touch them.
-- **Embedded fine_refine** — new tracking issue to file: design
-  i16-throughout streaming FIR cd0 path so that `fine_refine_pass1`
-  can run on S3 within slot budget without a PSRAM round-trip per
-  candidate.
-- **A0'** = `decode_block_with_ap` reachable from the embedded
-  bench — landed as Step 4 in `process_one_candidate_inner` in
-  0.6.1; the 5 missing JTDX-extras on `qso3_busy.wav` still sit
-  upstream of AP (host coarse-sync surfaces them only with
-  `subtract_signal_lpf` multipass — a host-side win, not embedded).
-  Revisit when an embedded-only WAV surfaces where the gap is
-  post-coarse-sync.
+- **Embedded fine_refine** — design i16-throughout streaming FIR
+  cd0 path so `fine_refine_pass1` can run on S3 within slot budget
+  without a PSRAM round-trip per candidate. No issue filed yet;
+  prerequisite is the ε `decode_block` restructure (see
+  `docs/CLEANUP_2026_05.md`) so the seam exists to hook a
+  streaming alternative onto.
 
 ## v0.6.0 status (shipped, 2026-05-09)
 
@@ -98,379 +130,114 @@ Bundled refactor + AP iaptype 2 release. Closes:
 - **#49 cat C** (`#[doc(hidden)]` graduation for items embedded
   consumers + FFI already depend on).
 
-A0 / A0' from the earlier roadmap are the carry-overs:
+A0 / A0' (host coarse-sync gap and `decode_block_with_ap`) from the
+earlier roadmap were the carry-overs at the time of the v0.6.0 cut;
+the master Open follow-ups list above (under v0.6.2 status) supersedes
+this section.
 
-- **A0** = #40 — closed by v0.6.0.
-- **A0'** = `decode_block_with_ap` — **deferred**. The 5 missing
-  JTDX-extras on `qso3_busy.wav` sit upstream of AP (host coarse-sync
-  doesn't surface the candidates at -18 dB), so adding an embedded AP
-  loop now would ship code without measurable user-visible improvement
-  on the reference WAV. Revisit when a WAV surfaces where the gap is
-  actually post-coarse-sync, or when the embedded port grows operator
-  context (m5stack-s3-app Phase 4). New issue to file when that day
-  comes.
+## Cleanup 2026-05
 
-Open follow-ups for 0.6.x patches and 0.7.0:
+`docs/CLEANUP_2026_05.md` tracks a four-stage post-0.6.2 tidy-up
+(γ scaffolding → β feature/cfg → δ docs sync → ε `decode_block.rs`
+restructure). Status as of 2026-05-14:
 
-- **#48 option A** — `Protocol::Sync` associated type for type-system
-  enforcement against future protocol-sync drift. Scoped out of v0.6.0
-  (8 protocols + 2 macros + embedded feature matrix; benefit is
-  speculative for non-FT8 protocols). Tracked separately.
-- **#49 cat D** — `core::sync::coarse_sync<P>` `NotFt8` marker bound.
-  Subsumed structurally by Phase 4 dispatch in v0.6.0; the doc note
-  ("FT8 should not use this") is the practical backstop until #48
-  option A lands.
-- **#23 / #24** (FST4 / JT65 golden lockdowns), **#25** (MSK144), and
-  Phase B (m5stack-s3-app) remain on the original roadmap; v0.6.0 did
-  not touch them.
+- **γ** Done 2026-05-13 (PR #66). Retired
+  `embedded-poc/m5stack-{core2,s3}/src/bin/rx_skeleton.rs`.
+- **β** Done 2026-05-13 (PR #67 + #69). Compiler-visible dead code
+  cleared; `Cmplx` unified with `num_complex::Complex` via type
+  alias (−5 `unsafe` cast wrappers); cfg-matrix audit confirms
+  every fixed-point × fft-{rustfft,extern} cell builds clean.
+- **δ** Documentation sync — current sweep.
+- **ε** `decode_block.rs` restructure into a `decode_block/`
+  submodule directory + OSD strategy seam for `#63` precoding.
+  Week-scale; intentionally sequenced after the weekend hardware
+  bring-up for `#61` (Core2 → S3 unification) so the two refactors
+  do not collide.
 
 # Roadmap (legacy, written for post-0.5.12)
 
-## Context
+Most of the post-0.5.12 plan landed in the 0.6.x bundle (PR #50,
+shipped 2026-05-10) or is now tracked under a GitHub issue. The
+sections below survive as historical context plus quick file-path
+hints; the live worklist is the **Open follow-ups** section above.
 
-0.5.12 closed FT8 AP-list issue #31 (iaptype-1 / blind-CQ pass added,
-`ft8_qso3_apon_recall` regression test landed) and bundled three
-0.5.11-shipping correctness fixes — most critically #26 (FT8 phase-2
-SIC was running on un-subtracted residual; weak signals masked by
-known strong ones stayed masked). Also re-locked JT9 recall at 7/7
-after JTDX cross-check expanded the original 5-entry golden, and
-restored FT4 GFSK BT=1.0 / NFILT=1400 to WSJT-X parity (#27, #28).
+## Phase A — Host protocol golden lockdowns
 
-Three threads of work — confirmed with the user — for the next 3-month
-horizon:
+- **A0** (`#40` host coarse-sync gap) and **A0'** (`decode_block_with_ap`)
+  closed in v0.6.0 / v0.6.1 respectively.
+- **A1** FST4-60A (`#23`) — `tests/fst4_wsjtx_samples.rs` is `#[ignore]`d
+  with "decode_frame returns 0 messages"; root-cause line-walk of
+  `WSJT-X/lib/fst4_decode.f90` against `mfsk-core/src/fst4/decode.rs`
+  still pending. Probe template:
+  `mfsk-core/src/jt9/decode.rs::gate_diag::probe_missing_goldens`.
+- **A2** JT65 (`#24`) — current implementation is JT65A; WSJT-X
+  ships JT65B samples. Add a `Jt65b` ZST mirroring the Q65 sub-mode
+  generic pattern (`Q65a30`, `Q65a60`, ...) and lock recall against
+  `samples/JT65/JT65B/*.wav` via a new
+  `tests/jt65b_wsjtx_samples.rs` harness.
+- **A3** FST4-15 / FST4W — `#23` "stretch", deferred indefinitely
+  (no user demand; FST4-60A is the dominant terrestrial sub-mode).
 
-1. **Close the AP-on value loop** — issue #40 (host coarse-sync
-   candidate gap) blocks the just-shipped AP iaptype-1 from surfacing
-   any of the 6 JTDX-confirmed AP-on extras on `qso3_busy.wav`. Until
-   #40 closes the AP work has no measurable real-WAV effect.
-2. Lock the remaining host-side protocol goldens (FST4 #23, JT65 #24)
-   using the same WSJT-X-source-faithful methodology that closed JT9.
-3. Take `embedded-poc/m5stack-s3-app` from its current state (LCD-rendered
-   WAV-fed FT8 demo; Phase 0/0.5/3 done) to a complete mountain-top FT8
-   QSO transceiver controller (Phase 1/2/4/5/6 + TX keying).
+## Phase B — m5stack-s3-app
 
-User-confirmed scope decisions:
-- **MSK144 (#25)** stays open as community-contribution invitation — NOT
-  on this roadmap. The unique correlator + meteor-burst loop are too far
-  from the FT/JT/Q-family pipeline to fit the 3-month plan honestly.
-- **Embedded fixed-point pipeline** stays FT8-only. No FT4/JT9 embedded
-  ports in scope; mountain-top app will be FT8-only.
-- **m5stack-s3-app MVP target** = full QSO transceiver (RX + TX + CI-V +
-  QSO FSM + ADIF), not just an RX spotter. Phased delivery: v0.6 = RX
-  spotter useful in field, v0.7 = full QSO controller.
+Per `embedded-poc/m5stack-s3-app/CLAUDE.md` (and the Phase 0..6
+markers in module doc-comments), current state as of 2026-05-13:
 
-## Phase A — Host AP value loop + protocol golden lockdowns
+- **Phase 0 / 0.5 / 3** — Done. LCD bring-up, WAV-fed pipeline,
+  4-region UI (status / waterfall / decoded list / TX strip).
+- **Phase 4** — QSO FSM dry-run done (auto-CQ visible on LCD,
+  `qso.rs` ~360 lines, 8 host-side unit tests). No TX audio
+  synthesis yet (parked behind Phase 1 UAC per user judgement —
+  speaker output is a stopgap, real path is USB UAC OUT to the
+  radio).
+- **Phase 0.6 / 0.7** — Done. WiFi UDP log streaming (UART /
+  LCD / UDP fanout) + USB-CDC freeze fix (`println!` gated on
+  `usb_serial_jtag_is_connected`) + runtime boot-mode selector
+  (NVS + KEY2 long-press) for WiFi / decoder coexistence.
+- **Phase 1 UAC** — Pending. `uac.rs` is still a doc placeholder;
+  port `espressif/esp_usb_audio` via `esp-idf-svc` bindings,
+  drain a 12 kHz sample ring into `decode_pipeline.rs`. 48 → 12
+  kHz resample reuses the Q32 linear resampler from
+  `mfsk-ffi-ft8/src/stream.rs`.
+- **Phase 2 BLE CI-V** — Pending. `civ.rs` comment-only stub;
+  uncomment `esp32-nimble` in `Cargo.toml`, implement central
+  pairing with the IC-705 BLE service + K7MDL2 framing.
+- **Phase 5 ADIF / Phase 6 buttons** — Pending. `flash_log.rs`
+  (littlefs mount / rotate / dump), `adif.rs` (append-only
+  `/qso.adi`), `buttons.rs` (GPIO 11/12 IRQ + Monitor/Cursor/
+  QSO-prep/Menu mode FSM).
+- **TX keying** — Pending. Pair with Phase 2 (`civ::set_ptt`)
+  and Phase 1 (TX audio synth to UAC OUT endpoint).
 
-### A0. Host coarse-sync candidate gap (#40) — small / medium, **highest priority**
-
-The FT8 AP iaptype-1 pass landed in 0.5.12 (#31, PR #39) but currently
-catches **0/6** of the JTDX-confirmed AP-on extras on `qso3_busy.wav`.
-Root cause is upstream of AP: `decode_frame_with_ap` (host wide-band)
-misses the underlying coarse-sync candidates at 1196 / 244 / 472 / 2039
-Hz that `decode_block` (embedded path) and JTDX both pick up, so the
-AP loop in `process_candidate` has nothing to rescue. Until A0 closes,
-the 0.5.12 AP work has no measurable real-WAV effect — that's why this
-sits ahead of A1/A2.
-
-Approach: bisect what makes the two host pipelines diverge on the same
-WAV at the same `sync_min`. Likely suspects (in rough priority):
-
-- `coarse_sync` algorithm differences: `src/ft8/sync.rs` (host) vs
-  `decode_block.rs` per-tone DFT path. Compare candidate count, score
-  thresholding, NMS behaviour.
-- `refine_fine::refine_fine_3stage` (host-only) — WSJT-X-faithful 3-stage
-  filter intentionally rejects birdie phantoms above 2 kHz; the gate
-  may be cutting real signals too. `decode.rs:464–486` is the call site.
-- `nsync ≤ 6` early-return in `process_candidate` (`decode.rs:493`)
-  vs whatever the embedded path uses at the same stage.
-
-Tools to reuse:
-- `tests/ft8_qso3_apon_recall.rs` — already has the AP-on / AP-off
-  diff harness. Add a third pass that prints all coarse_sync candidates
-  pre-`process_candidate` with their scores so the divergence is visible.
-- `JTDX_EXTRAS_HARD_FLOOR` constant (currently `0`) is the seam: each
-  candidate the host starts catching, raise the floor toward 6.
-
-Estimate: 3-7 days of investigation. Outcome: floor at 6 (matching JTDX
-recall on this WAV), or root-cause documented as deliberate divergence
-with separate on-air WAV showing the host-path advantage.
-
-### A0'. `decode_block_with_ap` for embedded — medium, follow-on
-
-Host AP work doesn't help mountain-top runs until embedded gets AP
-too. `decode_block.rs:2376` currently passes `None` to `bp_decode`.
-Symmetric port of the host pass-5..12 multi-pass loop into the
-embedded pow-of-2 FFT pipeline. Shape mirrors `decode_frame_with_ap` →
-`process_candidate`, but without the rustfft dependency. Files:
-
-- `mfsk-core/src/ft8/decode_block.rs` — add `decode_block_with_ap` /
-  `_with_ap_options` paralleling `decode_frame_with_ap` /
-  `decode_frame_with_ap_full`.
-- `mfsk-core/tests/ft8_qso3_apon_recall.rs` — add a sibling
-  `decode_block_with_ap` arm so the same WAV regression covers both
-  paths.
-- New issue to file (not yet open).
-
-Estimate: 1 week after A0 (depends on understanding the coarse-sync
-divergence first — A0 may inform the embedded port).
-
-### A1. FST4-60A golden (#23) — small / medium
-
-`tests/fst4_wsjtx_samples.rs` already exists but is `#[ignore]`d with
-"decode_frame returns 0 messages". This is **not** "add a harness" — it's
-"debug why our fst4 decode produces 0 results on the WSJT-X reference",
-the same flavour as the JT9 work that just closed.
-
-Approach: line-walk `WSJT-X/lib/fst4_decode.f90` + `lib/fst4sim.f90`
-against `mfsk-core/src/fst4/decode.rs`. The LDPC(240, 101) + Costas-8
-sync layout is shared with FT8 / WSPR and well-tested, so the divergence
-is almost certainly in soft-symbol extraction or the sync-quality gate.
-
-Tools to reuse:
-- The probe pattern from `mfsk-core/src/jt9/decode.rs::gate_diag::
-  probe_missing_goldens` (sweep frequencies in 0.5 Hz steps, print
-  per-stage scores) — port to fst4.
-- Sample at `/home/ubuntu/src/WSJT-X/samples/FST4+FST4W/210115_0058.wav`.
-
-Estimate: 3-5 days. Outcome: `tests/fst4_wsjtx_samples.rs` passes with
-recall locked, `#[ignore]` removed.
-
-### A2. JT65 golden (#24) — medium
-
-Sample mismatch discovered during exploration: WSJT-X ships **JT65B**
-samples (`samples/JT65/JT65B/*.wav`, 8 files) but our implementation is
-**JT65A**. Recommended path: add JT65B sub-mode and lock recall against
-WSJT-X-distributed material. Reasons:
-
-- The `mfsk-core::jt65::rx::demodulate_aligned` + `decode_at_with_erasures`
-  + `Rs63_12::decode_jt65_erasures` chain is sub-mode-agnostic — JT65A vs
-  JT65B differs only in NSPS / tone-spacing constants and `T_SLOT_S`.
-- This mirrors the Q65 sub-mode generic pattern (`Q65a30`, `Q65a60`,
-  `Q65b60`, …) that already works in the codebase.
-- Locking against on-disk WSJT-X samples is genuine regression coverage,
-  not a synth-only gate.
-
-Files to add/touch:
-- `mfsk-core/src/jt65/mod.rs` — new `Jt65b` ZST alongside the existing
-  Jt65A module-as-protocol arrangement; reuse the `decode_scan_for<P>` /
-  `decode_at_for<P>` generic shape that Q65 uses.
-- `mfsk-core/src/jt65/rx.rs` — confirm tone-spacing parameter is generic
-  over the protocol ZST; refactor if hard-coded.
-- `mfsk-core/tests/jt65b_wsjtx_samples.rs` — new harness mirroring
-  `tests/jt9_wsjtx_samples.rs` (which has the most recent / best
-  template).
-- `README.md` recall table — add JT65B line.
-- Close #24.
-
-Estimate: 1-2 weeks. Probe-debug iteration likely needed for the
-low-SNR samples; the `decode_at_with_erasures` path is already complete
-on JT65A so the soft-decision RS work doesn't repeat.
-
-### A3. FST4-15 / FST4W (deferred)
-
-FST4-15 and FST4W are tracked in #23 as "stretch". Deferred — no user
-demand surfaced, FST4-60A is the dominant terrestrial sub-mode. Issue
-remains open as a placeholder.
-
-## Phase B — m5stack-s3-app: WAV-fed demo → full QSO transceiver
-
-The app source already uses `Phase 0..6` markers in module doc-comments.
-Phases below pick up those markers in an order chosen so each delivers
-something field-deployable rather than "everything-or-nothing".
-
-### B1. Phase 1 — Live UAC audio input (~2 weeks)
-
-Replace the WAV-loop in `decode_pipeline.rs::wav_simulator_thread` with
-USB Audio Class host capture from a transceiver (IC-705, FT-991A, …).
-
-- `embedded-poc/m5stack-s3-app/src/uac.rs` — currently 16-line stub. Port
-  the espressif `usb_host_uac` recipe to Rust via `esp-idf-svc` bindings.
-- `decode_pipeline.rs` — drain a UAC sample ring at 12 kHz instead of
-  looping WAV bytes.
-- 48 kHz (typical radio rate) → 12 kHz resampler: re-use the Q32
-  fixed-point linear resampler already shipped in
-  `mfsk-ffi-ft8/src/stream.rs`. Either link via `mfsk-ffi-ft8` C API
-  from the s3-app, or vendor the same algorithm directly into a small
-  Rust module — choose at implementation time based on link footprint.
-- `audio.rs::AUDIO_GATE` already supports muting playback during decode
-  stress peaks — reuse.
-
-Verifies: real S3 connected to IC-705 USB-OTG, tune 14.074 MHz, see live
-FT8 decode lines in the LCD scroll panel.
-
-### B2. Phases 5 + 6 — Persistent log + button input (~1 week)
-
-Make the app useful as a "spotter that records what it heard" before any
-TX automation lands.
-
-- `flash_log.rs::LittleFsLog` — finish the three TODOs (mount VFS, write
-  + rotate, dump). 45-line existing skeleton.
-- `adif.rs` — append-only `/littlefs/qso.adi` with WSJT-X-compatible
-  record format. Currently a 8-line placeholder.
-- `buttons.rs` — wire GPIO 11/12 interrupts (pins are in `board.rs`) to
-  an event queue. State-machine modes: Monitor → Cursor (select callsign
-  in list) → QSO-prep (preview reply) → Menu (config). 13-line stub
-  today.
-
-After B2: v0.6 ship-ready as field RX spotter. Push tag, release.yml
-publishes the m5stack-s3-app binary alongside the existing
-`mfsk-ffi-ft8-*-esp32s3-xtensa.tar.gz` (see C3 below).
-
-### B3. Phase 2 — BLE CI-V transport (~2 weeks)
-
-- `civ.rs` — comment-only 26-line stub today. Uncomment the
-  `esp32-nimble` dependency in `Cargo.toml`. Implement BLE central
-  pairing with the IC-705 BLE service + the K7MDL2 protocol framing.
-- UART fallback for non-BLE radios: USB-OTG pins are already defined
-  (GPIO 19/20 in `board.rs`).
-- API surface: `CivClient::{connect, read_freq, set_freq, set_mode,
-  set_ptt}`.
-
-### B4. Phase 4 + TX keying — QSO FSM + audio modulation (~3 weeks)
-
-Hardest single block. Turns the spotter into a transceiver controller.
-
-- `qso.rs::QsoManager` — currently 51-line type skeleton. Implement the
-  IDLE → CALLING → REPORT → FINAL → DONE state machine with retry
-  counters + timeout transitions, mirroring WSJT-X
-  `lib/genft8.f90`'s auto-sequencer.
-- TX audio modulation: feed `mfsk_core::ft8::wave_gen::tones_to_i16`
-  output through I2S DAC → audio cable to radio mic input. Sample-rate
-  match (12 kHz → 48 kHz I2S DAC clock) via simple repeat-N + linear
-  interp.
-- TX timing: hold PTT via `civ.rs::set_ptt(true)`, play 13 s of audio
-  synced to slot boundary (`time_sync.rs` already publishes UTC), release
-  PTT. Slot boundary detection: re-use `time_sync.rs`'s median-DT
-  estimate when no GPS PPS / NTP is available.
-- Callsign hash table: reuse `mfsk_core::msg::CallsignHashTable`.
-
-Post-B4: v0.7 ships. The "leave the laptop at home" goal is realised.
+Sequencing not committed beyond "Phase 1 UAC next".
+`mfsk-ffi-ft8/src/stream.rs::mfsk_ft8_stream_*` and
+`embedded-shared` resampler API are the seams.
 
 ## Phase C — Quality / infra
 
-### C1. Embedded CI cross-build (~2 days)
+- **C1** Embedded CI cross-build — still pending. `xtensa-esp32-espidf`
+  / `xtensa-esp32s3-espidf` targets only build at release time today.
+  The cleanup-2026-05 ε restructure (`decode_block` split) is a soft
+  prerequisite so the embedded build does not have to re-validate a
+  3500-line file on every PR.
+- **C2** Reproducible release builds — `esp-rs/xtensa-toolchain@v1.5`
+  is pinned, but the `+esp` Rust version inside the action still
+  floats. Pin or capture in the artifact.
+- **C3** m5stack-s3-app release artifact — `release.yml` builds
+  `libmfsk_ft8.a` only; add a job emitting a flashable
+  `espflash save-image` for the s3-app once Phase 1 UAC stabilises.
 
-The 0.5.10 release fail-and-hotfix-to-0.5.11 cycle this morning came
-from `f32::round` missing under `no_std`. The Xtensa build runs only at
-release-time today, so the regression was caught post-tag. Add a
-`feature-matrix-embedded` job to `.github/workflows/ci.yml`:
+## Quick file-path index
 
-- `--target xtensa-esp32-espidf --no-default-features --features
-  embedded-fixed-point,embedded-runtime` (mfsk-ffi-ft8)
-- `--target xtensa-esp32s3-espidf` ditto
-- Runs on every PR, not just tag-push.
-
-The release.yml binary-build steps can stay as the artifact-emitting
-counterpart — same compile invocation, different post-build action.
-
-### C2. Reproducible release builds (~1 day)
-
-Pin the `+esp` toolchain version in `.github/workflows/release.yml`'s
-`esp-rs/xtensa-toolchain@v1.5` step so artifacts are deterministic
-across release runs (currently floats on whatever `+esp` version the
-action vendors).
-
-### C3. m5stack-s3-app artifact in release.yml (deferred to v0.6)
-
-Add a release.yml job that builds the s3-app binary + packages a
-flashable image (`espflash save-image` output) so v0.6 release
-artifacts include a one-step install for the field-deployable
-spotter.
-
-## Sequencing (3-month horizon)
-
-```
-Now           +1m           +2m           +3m
- │             │             │             │
- A0 host coarse-sync gap ┐   │             │
- (3-7d, blocking 0.5.12  │   │             │
-  AP work value)         │   │             │
-                         │   │             │
- A0' decode_block_with_ap│   │             │
- (~1w, after A0)         │   │             │
-         │               │   │             │
-         A1 FST4─┐   A2 JT65──┐             │
-         (3-5d)  │   (1-2w)   │             │
-                 │            │             │
- B1 UAC live audio ───────────┼             │
- (~2w, in parallel with A)    │             │
-                 │            │             │
-                 B2 log+buttons┐            │
-                 (~1w)         │            │
-                              v0.6          │
-                               │            │
-                               B3 CI-V (~2w) ┐
-                               │             │
-                               │             B4 QSO+TX (~3w) ┐
-                               │             │             v0.7
- C1 embedded-CI                │             │             │
- (in parallel, ~2d)            │             │             │
-                               │             │             │
- C2 reproducible release (~1d, opportunistic)
- C3 s3-app artifact (with v0.6)
-```
-
-A0 sits at the front because the AP iaptype-1 pass shipped in 0.5.12
-has no measurable effect on real WAVs until it closes. A1 + A2 in
-Phase A are independent of Phase B and can run in parallel when
-there's host-side context-switching headroom.
-
-## Verification per phase
-
-- **A0 host coarse-sync gap**: `cargo test --release -p mfsk-core
-  --features full --test ft8_qso3_apon_recall -- --nocapture` ⇒
-  `JTDX AP-on extras: 6/6 hit`, then raise `JTDX_EXTRAS_HARD_FLOOR`
-  to 6. Bonus: the AP-off baseline of `decode_frame_with_ap` matches
-  `decode_block`'s 7/8 against the WSJT-X canonical golden.
-- **A0' embedded AP**: `cargo test --release -p mfsk-core --features
-  full --test ft8_qso3_apon_recall` (with the new
-  `decode_block_with_ap` arm enabled) ⇒ same JTDX extras coverage on
-  the embedded path. Optionally re-flash M5Stack S3 with a slot
-  containing operator-context QSO and visually confirm AP rescues.
-- **A1 FST4-60A**: `cargo test --release -p mfsk-core --features full
-  --test fst4_wsjtx_samples` (no `--ignored`, the test stops being
-  ignored) ⇒ recall locked.
-- **A2 JT65B**: `cargo test --release -p mfsk-core --features full
-  --test jt65b_wsjtx_samples` ⇒ recall locked. README table updated.
-- **B1 UAC**: real S3 connected to IC-705 via USB-OTG, tune 14.074 MHz
-  during a live FT8 window, decode lines appear on LCD scroll within
-  one slot of activation.
-- **B2 v0.6**: power-cycle test — boot S3, decode for 10 minutes, power
-  off, power on, ADIF file from before persists; button cycles modes.
-- **B3 CI-V**: S3 reads IC-705 freq via BLE, writes a new freq, radio
-  responds.
-- **B4 v0.7**: two-station test — S3 calling CQ, WSJT-X on PC replies;
-  S3 auto-sends report, QSO completes through 73; ADIF entry written
-  with correct callsign / RPRT / time.
-- **C1**: PR with intentional `no_std` regression (e.g. `f32::round`
-  without `num_traits::Float` import) is caught by ci.yml before merge.
-
-## Critical file paths
-
-Host-side (Phase A):
-- `mfsk-core/src/ft8/sync.rs` + `mfsk-core/src/ft8/decode_block.rs`
-  (A0 — coarse-sync algorithm comparison)
-- `mfsk-core/src/ft8/refine_fine.rs` (A0 — phantom-filter gate audit)
-- `mfsk-core/tests/ft8_qso3_apon_recall.rs::JTDX_EXTRAS_HARD_FLOOR`
-  (A0 progress seam — grow toward 6 as candidates start surviving)
-- `mfsk-core/src/ft8/decode.rs::process_candidate` (A0' — port the
-  multi-pass AP loop into the embedded `decode_block_*` family)
-- `mfsk-core/tests/fst4_wsjtx_samples.rs` (existing, `#[ignore]`d)
-- `mfsk-core/src/fst4/decode.rs` ⇔ `WSJT-X/lib/fst4_decode.f90`
-- `mfsk-core/src/jt65/{mod,rx,decode}.rs` ⇔ `WSJT-X/lib/jt65_decode.f90`
-- `mfsk-core/src/jt9/decode.rs::gate_diag::probe_missing_goldens`
-  (template for FST4 / JT65 / FT8-coarse-sync probe patterns)
-
-Embedded app (Phase B):
-- `embedded-poc/m5stack-s3-app/src/{uac,civ,adif,qso,buttons,flash_log}.rs`
-  (each is currently stub or skeleton)
-- `embedded-poc/m5stack-s3-app/src/decode_pipeline.rs` (replace WAV-loop
-  source for B1)
-- `embedded-poc/m5stack-s3-app/src/{audio,time_sync,display}.rs`
-  (already-functional, will be reused / extended)
-- `mfsk-ffi-ft8/src/stream.rs` (Q32 resampler reuse for B1)
-
-Infra (Phase C):
-- `.github/workflows/ci.yml` (add embedded matrix job)
-- `.github/workflows/release.yml` (pin esp toolchain, add s3-app
-  artifact)
+- Host FT8 reference: `mfsk-core/src/ft8/decode_block.rs` (canonical
+  coarse-sync + per-candidate inner), `mfsk-core/src/ft8/decode.rs`
+  (host `decode_frame*` family + `refine_fine` gate).
+- Probe templates: `mfsk-core/src/jt9/decode.rs::gate_diag::probe_missing_goldens`.
+- Protocol-specific: `mfsk-core/src/fst4/decode.rs` ⇔
+  `WSJT-X/lib/fst4_decode.f90`; `mfsk-core/src/jt65/{mod,rx,decode}.rs`
+  ⇔ `WSJT-X/lib/jt65_decode.f90`.
+- Embedded app: `embedded-poc/m5stack-s3-app/src/{uac,civ,adif,qso,buttons,flash_log}.rs`
+  (current state per the section above);
+  `embedded-poc/m5stack-s3-app/src/decode_pipeline.rs` (Phase 1
+  UAC integration site).
+- Infra: `.github/workflows/{ci,release}.yml`.

--- a/embedded-poc/CLAUDE.md
+++ b/embedded-poc/CLAUDE.md
@@ -77,9 +77,11 @@ is what the user types under tee / piped redirection.
 - **wrong toolchain (`error: toolchain 'esp' is not installed`)**
   — reinstall via `espup install`. Don't try to use stable Rust here.
 - **`tlsf_malloc` heap corruption mid-sweep** — known bug when
-  `decode_block` is called directly (see memory
-  `project_decode_block_embedded.md` item 2). Production
-  bench main.rs replicates the D pattern manually.
+  `decode_block` is called directly from a long-running bench
+  loop; allocator state gets corrupted partway through. Production
+  bench `main.rs` works around it by inlining the per-iteration
+  steps (the "D pattern") instead of calling `decode_block` as a
+  single function.
 - **"Segment … has not changed, skipping write"** — re-flashing
   the same ELF finishes in ~5 s but the chip still runs the
   previous binary. Touch a source file (e.g. bump a `log::info!`

--- a/embedded-poc/CLAUDE.md
+++ b/embedded-poc/CLAUDE.md
@@ -1,0 +1,110 @@
+# embedded-poc — agent notes (shared)
+
+Cross-board workflow for the ESP32 Xtensa crates under
+`embedded-poc/`. Per-crate `CLAUDE.md` files cover board-specific
+overrides (target triple, port, PSRAM mode) and point at this file
+for the shared setup / debug list. The repo-root `CLAUDE.md` covers
+flash-and-capture conventions (`scripts/flash-monitor.sh`,
+`logs/` layout) that apply to every embedded crate here.
+
+## One-time setup (already done on this machine)
+
+- `~/.rustup/toolchains/esp/` — Xtensa-fork Rust toolchain installed
+  via [`espup`](https://github.com/esp-rs/espup). Selected
+  automatically per crate by `rust-toolchain.toml`
+  (`channel = "esp"`). Covers both `xtensa-esp32-espidf` (LX6) and
+  `xtensa-esp32s3-espidf` (LX7).
+- `~/.espressif/` — esp-idf checkout / tools managed by `embuild`
+  (downloaded on first build into `.embuild/` inside each crate).
+- `~/export-esp.sh` — sets `PATH` and `LIBCLANG_PATH` for the
+  Xtensa toolchain. **Must be sourced** before any cargo invocation,
+  otherwise `bindgen` fails to find clang and the Xtensa GCC
+  binutils aren't on PATH.
+- `~/.cargo/bin/espflash` — flasher (espflash 4.x).
+
+## Build + flash + monitor (shared template)
+
+The per-crate `CLAUDE.md` files override the target triple and bin
+name; the three-step workflow itself is identical:
+
+```sh
+# 1. Source the cross-dev env (PATH + LIBCLANG_PATH).
+source ~/export-esp.sh
+
+# 2. Build for the crate's target triple.
+cd embedded-poc/<crate>
+cargo build --release
+
+# 3. Flash and capture, via the wrapper that gets the espflash
+#    reset flags right (avoids dropping S3 USB-OTG boards into
+#    DOWNLOAD mode on the second flash).
+../scripts/flash-monitor.sh \
+    target/<triple>/release/<bin> \
+    logs/<bin>_<tag>_$(date +%Y-%m-%d).log \
+    90    # capture seconds (optional, default 90)
+```
+
+`cargo run --release` works the same when the runner in
+`.cargo/config.toml` is set up and the shell is interactive
+(espflash auto-detects a single port). The explicit 3-step form
+is what the user types under tee / piped redirection.
+
+## LX6 (Core2) vs LX7 (S3) — comparison table
+
+| | M5Stack Core2 (LX6) | M5StickS3 / S3-app (LX7) |
+|---|---|---|
+| Target triple | `xtensa-esp32-espidf` | `xtensa-esp32s3-espidf` |
+| Bench bin | `mfsk-core-m5stack-core2` | `mfsk-core-m5stack-s3` |
+| Production app | (none — Core2 fold-in is `#61`) | `m5stack-s3-app` (FT8 controller) |
+| PSRAM mode | (default) | Octal (`CONFIG_SPIRAM_MODE_OCT=y`, ~80 MB/s); Quad on M5Stamp S3 — set `_MODE_QUAD=y` |
+| Internal DRAM | ~280 KB usable | ~512 KB |
+| Port enumeration | `/dev/ttyACM0` | `/dev/ttyACM0` (USB-Serial-JTAG, native S3); `/dev/ttyUSB0` (CP210x bridge on some boards) |
+| SIMD | None | PIE (auto-picked by `esp-dsp` at build); no hand-written intrinsics |
+| `release.opt-level` | `1` | `1` (shared Xtensa-Rust LLVM regression on `s`/`z` with f32-select patterns — `core::pipeline` ships an arithmetic-form workaround) |
+| `SPIRAM_MALLOC_ALWAYSINTERNAL` | n/a | `4096` (mandatory for dual-core; `16384` drains internal DRAM with cs Box × 2 workers → tlsf corruption) |
+
+## Trouble we've already debugged (cross-board)
+
+- **`espflash::no_serial`** — device not connected, or
+  `/dev/tty*` permission denied (user not in `dialout`).
+- **`espflash::dialoguer_error: not a terminal`** — espflash
+  auto-detected multiple ports and tried to prompt; pass `--port`
+  explicitly, or use `scripts/flash-monitor.sh` which forwards
+  `--port` automatically.
+- **bindgen / `unable to find libclang`** — forgot to source
+  `~/export-esp.sh`. `LIBCLANG_PATH` must point at the bundled
+  esp-clang (not system clang).
+- **wrong toolchain (`error: toolchain 'esp' is not installed`)**
+  — reinstall via `espup install`. Don't try to use stable Rust here.
+- **`tlsf_malloc` heap corruption mid-sweep** — known bug when
+  `decode_block` is called directly (see memory
+  `project_decode_block_embedded.md` item 2). Production
+  bench main.rs replicates the D pattern manually.
+- **"Segment … has not changed, skipping write"** — re-flashing
+  the same ELF finishes in ~5 s but the chip still runs the
+  previous binary. Touch a source file (e.g. bump a `log::info!`
+  line) to force a real rewrite; expect ~15-25 s for a real
+  factory-partition write. See repo-root CLAUDE.md for full
+  context on this and the `--before no-reset` flag that
+  `scripts/flash-monitor.sh` passes.
+
+## Crates under `embedded-poc/`
+
+- **`m5stack-core2/`** — Core2 LX6 compute bench. Decoder-only,
+  no UI. Fold-in into the S3 dual-core pipeline is tracked under
+  `#61`; weekend hardware bring-up.
+- **`m5stack-s3/`** — S3 LX7 compute bench. Decoder-only,
+  WAV-fed `rx_wavsim` is the primary driver.
+- **`m5stack-s3-app/`** — production FT8 controller (LCD UI +
+  QSO FSM + WiFi UDP log streaming + ES8311 audio + planned UAC).
+- **`embedded-shared/`** — `no_std` crate shared between the
+  bench / app crates. Streaming pipeline, dual-core dispatch,
+  resamplers, BASIS scratch helpers.
+- **`idf-component/`** — esp-idf component shim that wraps
+  `mfsk-ffi-ft8` so C-only ESP-IDF projects can pull the FT8
+  decoder in without writing Rust glue.
+- **`scripts/`** — `flash-monitor.sh`, `udp-log-listen.sh`.
+  Both actively used; see repo-root CLAUDE.md for why.
+- **`assets/`** — vendored WSJT-X reference WAVs used by host
+  integration tests (`asset_path!` macro) and by the embedded
+  WAV-feed bench.

--- a/embedded-poc/embedded-shared/CLAUDE.md
+++ b/embedded-poc/embedded-shared/CLAUDE.md
@@ -1,0 +1,28 @@
+# embedded-shared — agent notes
+
+`no_std` crate factored out of the bench / app crates under
+`embedded-poc/`. Currently holds:
+
+- streaming-pipeline scaffolding (per-half stage1 incremental
+  FFT feed, dispatch helpers),
+- 48 kHz / 16 kHz → 12 kHz Q32 linear resamplers reused across
+  WAV-sim, UAC, and FFI streaming surfaces,
+- `BASIS` scratch placement helpers (heap-allocated since Phase
+  0.7a, see commit `6e8f934`),
+- `compute_bench` glue that drives `decode_block` against
+  canned WAV inputs for the bench crates.
+
+See [`embedded-poc/CLAUDE.md`](../CLAUDE.md) for the shared
+toolchain setup (same `esp` toolchain, same `~/export-esp.sh`
+gate; targets `xtensa-esp32-espidf` and `xtensa-esp32s3-espidf`
+in turn depending on which downstream crate is building).
+
+## Crate-specific notes
+
+- **`no_std + alloc`** — same constraints as the downstream
+  bench / app crates. Do not pull `std`-only deps.
+- **Streaming API** is the seam the m5stack-s3-app Phase 1 UAC
+  port hooks into; see `docs/ROADMAP.md` Phase B and the
+  `mfsk_ft8_stream_*` ABI in `mfsk-ffi-ft8/src/stream.rs`.
+- **Diagnostics**: `compute_bench` writes per-half timing to
+  the logger configured by the downstream crate.

--- a/embedded-poc/m5stack-core2/CLAUDE.md
+++ b/embedded-poc/m5stack-core2/CLAUDE.md
@@ -20,9 +20,10 @@ overrides.
 ## Crate-specific gotchas
 
 - **`tlsf_malloc` heap corruption mid-sweep** — `decode_block`
-  called directly trips a known TLSF heap bug; production main.rs
-  replicates the D pattern manually. Background in memory
-  `project_decode_block_embedded.md` item 2.
+  called directly from a long-running bench loop trips a known
+  TLSF heap bug. Production `main.rs` works around it by inlining
+  the per-iteration steps (the "D pattern") instead of calling
+  `decode_block` as a single function.
 - **`release.opt-level`** must stay `1`. `s` / `z` trigger an
   Xtensa-Rust LLVM regression on f32-select patterns; see the
   arithmetic-form workaround in `mfsk-core::core::pipeline` (FT4 SIC).

--- a/embedded-poc/m5stack-core2/CLAUDE.md
+++ b/embedded-poc/m5stack-core2/CLAUDE.md
@@ -1,78 +1,36 @@
 # m5stack-core2 — agent build/flash notes
 
-Quick-reference for the ESP32 cross-dev workflow this PoC uses. Forgetting
-any of these has cost real time before; check this list before invoking
-anything.
+ESP32 Core2 (Xtensa LX6) compute bench. See
+[`embedded-poc/CLAUDE.md`](../CLAUDE.md) for the shared
+toolchain setup, flash-and-capture template, and cross-board
+debug list — this file only covers the crate-specific
+overrides.
 
-## One-time setup (already done on this machine)
+## Crate-specific knobs
 
-- `~/.rustup/toolchains/esp/` — Xtensa-fork Rust toolchain installed via
-  [`espup`](https://github.com/esp-rs/espup). Selected automatically for
-  this crate by `rust-toolchain.toml` (`channel = "esp"`).
-- `~/.espressif/` — esp-idf checkout / tools managed by `embuild`
-  (downloaded on first build into `.embuild/` inside the crate).
-- `~/export-esp.sh` — sets `PATH` and `LIBCLANG_PATH` for the Xtensa
-  toolchain. **Must be sourced** before any cargo invocation in this
-  crate, otherwise `bindgen` fails to find clang and the Xtensa GCC
-  binutils aren't on PATH.
-- `~/.cargo/bin/espflash` — flasher.
+- **Target triple**: `xtensa-esp32-espidf`.
+- **Bin name**: `mfsk-core-m5stack-core2`.
+- **`.cargo/config.toml` runner**: `espflash flash --monitor`, so
+  `cargo run --release` flashes and opens the serial monitor on
+  an interactive TTY. For tee / pipe captures use
+  `../scripts/flash-monitor.sh` as documented in the shared file.
+- **Port**: M5Stack Core2 enumerates as `/dev/ttyACM0`. Pass
+  `--port /dev/ttyACM0` explicitly so espflash never prompts.
 
-## Build + flash + monitor
+## Crate-specific gotchas
 
-The user's actual workflow has three steps, kept separate so each can
-be re-run independently. Do **not** collapse them into `cargo run`
-under a non-interactive shell — espflash's runner mode prompts for
-disambiguation when multiple ports exist and fails with "not a
-terminal" under `tee`/pipe redirection.
+- **`tlsf_malloc` heap corruption mid-sweep** — `decode_block`
+  called directly trips a known TLSF heap bug; production main.rs
+  replicates the D pattern manually. Background in memory
+  `project_decode_block_embedded.md` item 2.
+- **`release.opt-level`** must stay `1`. `s` / `z` trigger an
+  Xtensa-Rust LLVM regression on f32-select patterns; see the
+  arithmetic-form workaround in `mfsk-core::core::pipeline` (FT4 SIC).
 
-```sh
-# 1. Source the cross-dev env (PATH + LIBCLANG_PATH).
-source ~/export-esp.sh
+## Status (2026-05-14)
 
-# 2. Build for xtensa-esp32-espidf. ~30 s clean release; ~3 s incremental.
-cd embedded-poc/m5stack-core2
-cargo build --release
-
-# 3. Flash and open the serial monitor. M5Stack Core2 enumerates as
-#    /dev/ttyACM0; pass --port explicitly so espflash never prompts.
-espflash flash --monitor --port /dev/ttyACM0 \
-    target/xtensa-esp32-espidf/release/mfsk-core-m5stack-core2
-```
-
-`cargo run --release` does work the same when run from an interactive
-TTY (the `runner` in `.cargo/config.toml` invokes `espflash flash
---monitor`), but the explicit-3-step form is more robust under
-automation / piped tees and matches what the user types.
-
-## Capturing logs
-
-Pipe espflash output to `logs/<descriptive>.log` to keep the on-device
-sweep results — the bench logs every per-stage timing and per-message
-SNR over UART, and we compare across runs (`grep -E 'WAV|stage|truth'`
-across files).
-
-```sh
-espflash flash --monitor --port /dev/ttyACM0 \
-    target/xtensa-esp32-espidf/release/mfsk-core-m5stack-core2 \
-    | tee logs/realqso_<config>_$(date +%Y-%m-%d).log
-```
-
-The serial monitor only exits on Ctrl-C; for long sweeps the user
-typically lets the bench finish (logged "Sweep complete. Idling.")
-then interrupts.
-
-## Trouble we've already debugged
-
-- **`espflash::no_serial`** — device not connected, or `/dev/ttyACM0`
-  permission denied (user not in `dialout`).
-- **`espflash::dialoguer_error: not a terminal`** — espflash auto-
-  detected multiple ports and tried to prompt; pass `--port` explicitly.
-- **bindgen / `unable to find libclang`** — forgot to source
-  `~/export-esp.sh`. `LIBCLANG_PATH` must point at the bundled
-  esp-clang (not system clang).
-- **wrong toolchain (`error: toolchain 'esp' is not installed`)** —
-  reinstall via `espup install`. Don't try to use stable Rust here.
-- **`tlsf_malloc` heap corruption mid-sweep** — known bug when
-  `decode_block` is called directly (see memory
-  `project_decode_block_embedded.md` item 2). Production main.rs
-  replicates the D pattern manually.
+Bench-only crate; the live-RX scaffold (`rx_skeleton.rs`) was
+retired in PR #66 (γ stage of `docs/CLEANUP_2026_05.md`). Core2
+fold-in into the S3 dual-core pipeline is tracked under
+[`#61`](https://github.com/jl1nie/mfsk-core/issues/61) — weekend
+hardware bring-up.

--- a/embedded-poc/m5stack-core2/Cargo.toml
+++ b/embedded-poc/m5stack-core2/Cargo.toml
@@ -23,8 +23,8 @@ harness = false
 [profile.release]
 # `opt-level = 1` mirrors the ESP32-S3 PoC: same Xtensa-Rust LLVM
 # regression at opt-level "s"/"z" with f32-select patterns. The
-# `qsb_partial_gain` workaround in mfsk-core dodges the trigger but
-# keeping opt-level low keeps the ELF debuggable.
+# arithmetic-form workaround in `mfsk-core::core::pipeline` (FT4 SIC)
+# dodges the trigger but keeping opt-level low keeps the ELF debuggable.
 opt-level = 1
 
 [profile.dev]

--- a/embedded-poc/m5stack-s3-app/CLAUDE.md
+++ b/embedded-poc/m5stack-s3-app/CLAUDE.md
@@ -1,0 +1,47 @@
+# m5stack-s3-app — agent notes
+
+Production FT8 controller for M5StickS3 — LCD UI, QSO FSM,
+WiFi UDP log streaming, ES8311 audio, planned USB UAC + BLE
+CI-V to IC-705. The repo-root `CLAUDE.md` is authoritative
+for flash-and-capture conventions (`scripts/flash-monitor.sh`,
+USB-CDC freeze caveats); see also
+[`embedded-poc/CLAUDE.md`](../CLAUDE.md) for the shared
+Xtensa-LX7 toolchain notes and the LX6/LX7 comparison table.
+
+## Crate-specific knobs
+
+- **Target triple**: `xtensa-esp32s3-espidf`.
+- **`opt-level = 1`** — same LX7 LLVM regression as the sibling
+  `m5stack-s3` bench crate.
+- **Partitions**: factory 3 MB + littlefs 1 MB. CSV path is
+  derived from `CARGO_MANIFEST_DIR` (see commit `a03d9e7`).
+- **sdkconfig**: BT NimBLE central + USB host stack enabled +
+  Octal PSRAM. `SPIRAM_MALLOC_ALWAYSINTERNAL = 4096` (same as
+  sibling crate; required for dual-core).
+
+## Crate-specific gotchas
+
+- **USB-CDC host disconnect freezes the FanoutLogger** —
+  `println!` to USB-Serial-JTAG VFS blocks indefinitely after
+  the host releases the CDC endpoint. Gate on
+  `usb_serial_jtag_is_connected()`; see commit `8b46f4e` for
+  the fix and `project_m5stick_s3_app.md` memory for the
+  validation procedure.
+- **`cfg.toml` (WiFi creds) is gitignored** — `cfg-sample.toml`
+  is the committed template (wifikey2 convention).
+- **WiFi UDP log sink target**: aterm-class APs drop subnet
+  broadcast between stations; default `pc_ip = "auto"` may
+  silently fail. Switch to unicast PC IP if heartbeat doesn't
+  arrive.
+- **WSL2 PC listener** needs a Hyper-V firewall rule for inbound
+  UDP 9999 (mirrored-mode default blocks it); see
+  `project_m5stick_s3_app.md` memory for the exact PowerShell
+  invocation.
+
+## Status (2026-05-14)
+
+Phase 0 / 0.5 / 3 / 4 / 0.6 / 0.7 shipped on `main`. Next is
+Phase 1 (USB UAC host capture from IC-705); after that
+Phase 2 (BLE CI-V), Phase 5 (ADIF), Phase 6 (buttons), and
+TX keying close the v0.7 transceiver-controller goal. See
+`docs/ROADMAP.md` Phase B for the full phasing.

--- a/embedded-poc/m5stack-s3-app/CLAUDE.md
+++ b/embedded-poc/m5stack-s3-app/CLAUDE.md
@@ -25,8 +25,7 @@ Xtensa-LX7 toolchain notes and the LX6/LX7 comparison table.
   `println!` to USB-Serial-JTAG VFS blocks indefinitely after
   the host releases the CDC endpoint. Gate on
   `usb_serial_jtag_is_connected()`; see commit `8b46f4e` for
-  the fix and `project_m5stick_s3_app.md` memory for the
-  validation procedure.
+  the fix.
 - **`cfg.toml` (WiFi creds) is gitignored** — `cfg-sample.toml`
   is the committed template (wifikey2 convention).
 - **WiFi UDP log sink target**: aterm-class APs drop subnet
@@ -34,9 +33,9 @@ Xtensa-LX7 toolchain notes and the LX6/LX7 comparison table.
   silently fail. Switch to unicast PC IP if heartbeat doesn't
   arrive.
 - **WSL2 PC listener** needs a Hyper-V firewall rule for inbound
-  UDP 9999 (mirrored-mode default blocks it); see
-  `project_m5stick_s3_app.md` memory for the exact PowerShell
-  invocation.
+  UDP 9999 (mirrored-mode default blocks it). The exact
+  `New-NetFirewallHyperVRule` invocation is captured in the
+  Phase 0.6 commit log (search `git log --grep "Phase 0.6"`).
 
 ## Status (2026-05-14)
 

--- a/embedded-poc/m5stack-s3/CLAUDE.md
+++ b/embedded-poc/m5stack-s3/CLAUDE.md
@@ -1,86 +1,39 @@
 # m5stack-s3 — agent build/flash notes
 
-ESP32-S3 (LX7) クロス開発ワークフロー。m5stack-core2 (LX6) 用 CLAUDE.md
-の S3 版 — toolchain や流儀は同じで、target / port / PSRAM mode のみ差分。
-issue #15 Phase 2 baseline 取得を主目的に作成 (2026-05-04)。
+M5StickS3 / ESP32-S3 (Xtensa LX7) compute bench. See
+[`embedded-poc/CLAUDE.md`](../CLAUDE.md) for the shared
+toolchain setup, flash-and-capture template, cross-board
+debug list, and the LX6 vs LX7 comparison table — this file
+only covers the crate-specific overrides.
 
-## One-time setup (already done on this machine)
+## Crate-specific knobs
 
-- `~/.rustup/toolchains/esp/` — Xtensa-fork Rust toolchain installed via
-  [`espup`](https://github.com/esp-rs/espup). Selected automatically for
-  this crate by `rust-toolchain.toml` (`channel = "esp"`)。LX7 ターゲット
-  `xtensa-esp32s3-espidf` も同じ esp toolchain が rustc/std を提供する。
-- `~/.espressif/` — esp-idf checkout / tools managed by `embuild`
-  (downloaded on first build into `.embuild/` inside the crate).
-- `~/export-esp.sh` — sets `PATH` and `LIBCLANG_PATH` for the Xtensa
-  toolchain. **Must be sourced** before any cargo invocation in this
-  crate, otherwise `bindgen` fails to find clang and the Xtensa GCC
-  binutils aren't on PATH.
-- `~/.cargo/bin/espflash` — flasher.
+- **Target triple**: `xtensa-esp32s3-espidf`.
+- **Bin name**: `mfsk-core-m5stack-s3` (with `rx_wavsim` as the
+  primary streaming-pipeline driver bin).
+- **Port**: S3 dev kits enumerate as `/dev/ttyACM0` (USB-Serial-JTAG,
+  native S3) or `/dev/ttyUSB0` (CP210x bridge on some M5Stack S3
+  modules). Confirm with `dmesg | tail` after plugging in.
+- **PSRAM mode**: Octal (`CONFIG_SPIRAM_MODE_OCT=y`, ~80 MB/s) by
+  default; Quad PSRAM boards (M5Stamp S3 etc.) switch to
+  `_MODE_QUAD=y`.
+- **`SPIRAM_MALLOC_ALWAYSINTERNAL = 4096`** is mandatory for
+  dual-core dispatch. Bumping to `16384` puts both workers'
+  `cs Box` (5 KB × 15 × 2) in internal DRAM and drains it →
+  TLSF corruption → Guru Meditation.
 
-## Build + flash + monitor
+## Crate-specific gotchas
 
-```sh
-# 1. Source the cross-dev env (PATH + LIBCLANG_PATH).
-source ~/export-esp.sh
+- **dual-core dispatch + Phase E2 race** — historical LX6 issue
+  carried over. `rx_wavsim` runs **sequential per-half on
+  main**; the dispatch path is ported but not wired by default.
+- **`release.opt-level`** must stay `1` (shared LLVM regression
+  with Core2).
+- **`tlsf_malloc` heap corruption** — same `decode_block`-direct-
+  call bug as LX6; main.rs replicates the D pattern manually.
 
-# 2. Build for xtensa-esp32s3-espidf. ~30 s clean release; ~3 s incremental.
-cd embedded-poc/m5stack-s3
-cargo build --release
+## Status (2026-05-14)
 
-# 3. Flash and open the serial monitor. S3 dev kits typically enumerate
-#    as /dev/ttyACM0 (USB-Serial-JTAG, native S3) or /dev/ttyUSB0
-#    (CP210x bridge on M5Stack S3 modules). Confirm with `dmesg | tail`
-#    after plugging in, then pass --port explicitly.
-espflash flash --monitor --port /dev/ttyACM0 \
-    target/xtensa-esp32s3-espidf/release/mfsk-core-m5stack-s3
-```
-
-`cargo run --release` も interactive TTY なら同じく動く (`.cargo/config.toml`
-の `runner` が `espflash flash --monitor`)。tee/pipe redirection をかける
-場合のみ 3-step に分ける。
-
-## Capturing logs
-
-```sh
-espflash flash --monitor --port /dev/ttyACM0 \
-    target/xtensa-esp32s3-espidf/release/mfsk-core-m5stack-s3 \
-    | tee logs/<descriptive>_$(date +%Y-%m-%d).log
-```
-
-Phase 2 baseline は `logs/s3_baseline_<date>.log` /
-`logs/s3_baseline_llr_i8_<date>.log` のように命名。
-
-## LX6 との差分メモ
-
-- **PSRAM mode**: S3 は Octal (`CONFIG_SPIRAM_MODE_OCT=y`、~80 MB/s)。
-  Quad PSRAM の S3 ボード (M5Stamp S3 等) を使う場合は `_MODE_QUAD=y`
-  に切替。
-- **内蔵 SRAM**: S3 ~512 KB DRAM (vs LX6 ~280 KB usable)。issue #15
-  Phase 5 で stage 3 per-cand workspace を内蔵 pin する余地。
-- **PIE SIMD**: S3 LX7 のみ。esp-dsp が S3 ビルド時に自動選択する
-  ので、stage1 FFT / stage3 DFT は素のリビルドだけで速くなる見込み。
-  手書き intrinsics は追求しない (issue #15 前提結論 1)。
-- **dual_core dispatch + Phase E2 race**: LX6 で未解決のまま deferred
-  (`project_decode_block_embedded.md` 参照)。S3 でも同じ症状が出る
-  可能性が高いので、`rx_wavsim` は **sequential per-half on main** を
-  そのまま継承して信頼運用。dispatch 経路は port するが配線しない。
-- **opt-level**: m5stack-core2 と同じく `release.opt-level = 1`。
-  `qsb_partial_gain` workaround は mfsk-core 側で入っているので "s"/"z"
-  も技術的には通るはずだが、S3 で初めて build するときは 1 で安全側に。
-
-## Trouble we've already debugged (LX6 から継承)
-
-- **`espflash::no_serial`** — device not connected, or port permission
-  denied (user not in `dialout`)。
-- **`espflash::dialoguer_error: not a terminal`** — pass `--port` explicitly.
-- **bindgen / `unable to find libclang`** — forgot to source
-  `~/export-esp.sh`. `LIBCLANG_PATH` must point at the bundled
-  esp-clang (not system clang).
-- **`tlsf_malloc` heap corruption mid-sweep** — `decode_block` を
-  main.rs から直接呼ぶと再現する既知バグ (memory
-  `project_decode_block_embedded.md` item 2)。Production main.rs は
-  D pattern を手で reproduce して回避。
-- **dual-core 化で `SPIRAM_MALLOC_ALWAYSINTERNAL=4096` が必須** —
-  16384 だと両 worker の cs Box (5KB×15×2) が内蔵 DRAM 行きで枯渇 →
-  tlsf 破壊 → Guru Meditation。S3 でも継承して 4096 のまま。
+Bench-only crate; the live-RX scaffold (`rx_skeleton.rs`) was
+retired in PR #66 (γ stage of `docs/CLEANUP_2026_05.md`). Live
+RX + UI development lives in `embedded-poc/m5stack-s3-app/`.

--- a/embedded-poc/m5stack-s3/Cargo.toml
+++ b/embedded-poc/m5stack-s3/Cargo.toml
@@ -27,8 +27,8 @@ harness = false
 [profile.release]
 # `opt-level = 1` mirrors the ESP32-S3 PoC: same Xtensa-Rust LLVM
 # regression at opt-level "s"/"z" with f32-select patterns. The
-# `qsb_partial_gain` workaround in mfsk-core dodges the trigger but
-# keeping opt-level low keeps the ELF debuggable.
+# arithmetic-form workaround in `mfsk-core::core::pipeline` (FT4 SIC)
+# dodges the trigger but keeping opt-level low keeps the ELF debuggable.
 opt-level = 1
 
 [profile.dev]

--- a/mfsk-core/src/core/pipeline.rs
+++ b/mfsk-core/src/core/pipeline.rs
@@ -542,8 +542,9 @@ pub fn decode_frame_subtract<P: Protocol>(
             // `if cond { 0.5 } else { 1.0 }` to dodge an Xtensa Rust
             // 1.95.0.0 LLVM instruction-selection SIGSEGV on the
             // `[2 x float] [1.0, 0.5]` constant pool the select form
-            // generates. See `crate::ft8::decode::qsb_partial_gain`
-            // for the same workaround applied to the FT8 SIC path.
+            // generates. The FT8 SIC path used the same workaround
+            // until 0.6.2 retired `qsb_partial_gain` along with
+            // `subtract_signal_weighted`.
             let qsb = (r.sync_cv > 0.3) as u32 as f32;
             let gain = 1.0 - 0.5 * qsb;
             // `r.info` is post-descramble (FT4 only); re-apply the rvec

--- a/mfsk-core/src/core/pipeline.rs
+++ b/mfsk-core/src/core/pipeline.rs
@@ -543,8 +543,9 @@ pub fn decode_frame_subtract<P: Protocol>(
             // 1.95.0.0 LLVM instruction-selection SIGSEGV on the
             // `[2 x float] [1.0, 0.5]` constant pool the select form
             // generates. The FT8 SIC path used the same workaround
-            // until 0.6.2 retired `qsb_partial_gain` along with
-            // `subtract_signal_weighted`.
+            // until 0.6.2 retired the FT8 implementation of
+            // `qsb_partial_gain` and `subtract_signal_weighted` (the
+            // FT4 versions are still live in this generic pipeline).
             let qsb = (r.sync_cv > 0.3) as u32 as f32;
             let gain = 1.0 - 0.5 * qsb;
             // `r.info` is post-descramble (FT4 only); re-apply the rvec

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -1411,7 +1411,7 @@ mod tests {
         audio[off..off + n_sig].copy_from_slice(&buf[..n_sig]);
 
         // Phase 1: decode A. We need a real DecodeResult (with proper sync_cv,
-        // freq_hz, dt_sec) so subtract_signal_weighted can reconstruct A.
+        // freq_hz, dt_sec) so the SIC path can reconstruct A.
         let phase1 = decode_frame(&audio, 200.0, 2800.0, 1.0, None, DecodeDepth::BpAllOsd, 50);
         let known_results: Vec<DecodeResult> = phase1
             .iter()

--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -513,7 +513,7 @@ pub fn decode_scan_for<P: ModulationParams>(
     decode_scan_inner::<P>(audio, sample_rate, nominal_start_sample, params, None)
 }
 
-/// AP-biased version of [`decode_scan_for`]. Same coarse search; each
+/// AP-hint variant of [`decode_scan_for`]. Same coarse search; each
 /// candidate is decoded with the AP hint applied, which lifts the
 /// effective decode threshold by 2–4 dB on Q65-30A and is essential
 /// for EME on 6 m and above.

--- a/mfsk-ffi/include/mfsk.h
+++ b/mfsk-ffi/include/mfsk.h
@@ -452,7 +452,7 @@ enum MfskStatus mfsk_q65_decode(enum MfskQ65SubMode submode,
                                 struct MfskMessageList *out);
 
 /**
- * AP-biased Q65 scan-and-decode. Up to four optional hints
+ * AP-hint Q65 scan-and-decode. Up to four optional hints
  * (`call1`, `call2`, `grid`, `report`) — each may be NULL when
  * unknown. Lifts the effective decode threshold by ~2 dB when the
  * supplied hints are correct.

--- a/mfsk-ffi/src/lib.rs
+++ b/mfsk-ffi/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! Q65 has six sub-modes (Q65-30A for terrestrial, Q65-60A‥60E for
 //! the EME band lineup) and four decoder strategies (AWGN Bessel,
-//! AP-biased BP, fast-fading metric, AP-list template matching).
+//! AP-hint BP, fast-fading metric, AP-list template matching).
 //! The simple `mfsk_decoder_new(MFSK_PROTOCOL_Q65A30)` path covers
 //! the most common terrestrial Q65 case; the dedicated
 //! `mfsk_q65_*` function family exposes every sub-mode and every
@@ -1109,7 +1109,7 @@ pub unsafe extern "C" fn mfsk_q65_decode(
     MfskStatus::Ok
 }
 
-/// AP-biased Q65 scan-and-decode. Up to four optional hints
+/// AP-hint Q65 scan-and-decode. Up to four optional hints
 /// (`call1`, `call2`, `grid`, `report`) — each may be NULL when
 /// unknown. Lifts the effective decode threshold by ~2 dB when the
 /// supplied hints are correct.


### PR DESCRIPTION
## Summary

δ stage of the four-stage cleanup tracked in `docs/CLEANUP_2026_05.md`
(γ + β shipped in PR #66 / #67 / #69 on 2026-05-13).

- **δ.1 ROADMAP**: 0.6.2 marked shipped (PR #50, 2026-05-10); Open
  follow-ups rebuilt against the live issue set
  (#23/#24/#25/#58/#61/#63/#64/#65); new "Cleanup 2026-05" pointer
  section. Legacy post-0.5.12 section compressed — A0 (#40) and A0'
  (`decode_block_with_ap`) shipped in v0.6.0 / v0.6.1; Phase B
  rewritten against the current `m5stack-s3-app` phase log
  (Phase 0/0.5/3/4/0.6/0.7 done, Phase 1 UAC next); Sequencing
  diagram + per-phase Verification block dropped (the issue tracker
  is the live worklist). `docs/ROADMAP.md`: 508 → 243 lines.
- **δ.2 root README**: `embedded-poc/` pointer rewritten — call out
  `m5stack-s3-app/` as the production crate and
  `m5stack-{s3,core2}/` as compute benches (Core2 fold-in tracked
  under #61).
- **δ.3 AP-hint terminology**: five remaining "AP-biased" sites
  (mfsk-core q65/rx.rs, mfsk-ffi src/lib.rs ×2, mfsk-ffi include/mfsk.h,
  README.md) updated to "AP-hint", matching the convention PR #53
  established for `LIBRARY.{md,ja.md}`. Workspace grep returns zero
  hits.
- **δ.4 embedded CLAUDE.md**: new shared `embedded-poc/CLAUDE.md`
  (110 lines, one-time setup + build-flash-monitor template + LX6/LX7
  table + cross-board debug list). Per-crate trimmed to
  crate-specific overrides only — `m5stack-core2/CLAUDE.md` 78 → 36
  lines, `m5stack-s3/CLAUDE.md` 86 → 39 lines. New stubs for the two
  crates that lacked one: `m5stack-s3-app/CLAUDE.md` (47 lines) and
  `embedded-shared/CLAUDE.md` (28 lines). All per-crate < 50 lines.
- **δ.5 retired-API references**: workspace grep for the post-0.6.2
  removed symbols. Broken cross-refs fixed in
  `mfsk-core/src/core/pipeline.rs` (`qsb_partial_gain` back-reference
  date-stamped as historical), `mfsk-core/src/ft8/decode.rs` (test
  comment naming a removed function), and the embedded
  `Cargo.toml` / CLAUDE.md comments (LLVM workaround now points at
  the live site in `core::pipeline` FT4 SIC). Remaining grep hits
  are intentional historical notes already date-stamped to 0.6.2,
  plus the FT4 crate's own `subtract_signal_weighted` (different
  module, still in use).

## Acceptance (per `docs/CLEANUP_2026_05.md` δ)

- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --features full -p mfsk-core`
  + `-p mfsk-ffi`: clean (no broken intra-doc cross-references).
- Workspace grep for `AP-biased\|AP biased\|AP-bias` outside
  `CLEANUP_2026_05.md`: zero hits.
- Each per-crate embedded `CLAUDE.md` is under 50 lines (36 / 39 /
  47 / 28).

Pre-commit hook (`fmt`, `clippy --workspace --all-targets --features
full -- -D warnings`, `rustdoc -D warnings`) passed locally.

## Diff stat

```
 README.md                              |   8 +-
 docs/ROADMAP.md                        | 543 ++++++++++------------------
 embedded-poc/CLAUDE.md                 | 110 ++++++ (new)
 embedded-poc/m5stack-core2/CLAUDE.md   | 110 +++----
 embedded-poc/m5stack-core2/Cargo.toml  |   4 +-
 embedded-poc/m5stack-s3/CLAUDE.md      | 121 +++-----
 embedded-poc/m5stack-s3/Cargo.toml     |   4 +-
 embedded-poc/m5stack-s3-app/CLAUDE.md  |  47 ++ (new)
 embedded-poc/embedded-shared/CLAUDE.md |  28 ++ (new)
 mfsk-core/src/core/pipeline.rs         |   5 +-
 mfsk-core/src/ft8/decode.rs            |   2 +-
 mfsk-core/src/q65/rx.rs                |   2 +-
 mfsk-ffi/include/mfsk.h                |   2 +-
 mfsk-ffi/src/lib.rs                    |   4 +-
 14 files changed, 429 insertions(+), 561 deletions(-)
```

## Test plan

- [ ] CI `cargo test -p mfsk-core --features full --release -- --include-ignored`
- [ ] CI 13-cell feature matrix
- [ ] CI rustdoc `-D warnings`
- [ ] Skim the refreshed `docs/ROADMAP.md` Open follow-ups against
      the live `gh issue list --state open` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)