### PR TITLE
docs(roadmap): add #72/#73/#74 to Open follow-ups

### DIFF
--- a/docs/CLEANUP_2026_05.md
+++ b/docs/CLEANUP_2026_05.md
@@ -277,6 +277,347 @@ Acceptance for ε:
   unchanged.
 - Build size unchanged within ±2 KB on the embedded preset.
 
+### ε.0 — Pre-flight survey (2026-05-14)
+
+Investigation snapshot used to derive the split below. Re-verify
+before code lands if anything in `decode_block.rs` shifts between
+now and ε start.
+
+**Current section map of `mfsk-core/src/ft8/decode_block.rs`**
+(3517 lines on `docs/roadmap-add-72-74` @ commit `27425cf`):
+
+| Lines        | Block                                                                  | Notes                                                                                                  |
+|--------------|------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------|
+| 21-50        | crate imports                                                          | Forward-deps on `super::decode::{ApHint, DecodeDepth, DecodeResult, DecodeStrictness}`                 |
+| 52-112       | `AudioSample` trait + `i16`/`i8` impls                                 | Public utility, no stage affinity                                                                      |
+| 114-214      | Constants + runtime tunables (`NFFT_SPEC`, `NSTEP`, `RATIO_EPS`, `SYNC_LAG_S`, `NMS_ALPHA`, `DEFAULT_Q_THRESH`, `LlrT` alias) | Shared across all stages; `nstep-half` cfg lives here                                                  |
+| 217-322      | `Spectrogram` struct + impls (host f32 / embedded i16 variants)        | Public; crosses every stage boundary                                                                   |
+| 324-548      | `compute_spectrogram` (host + embedded cfg-split)                      | **Stage A**, pub                                                                                       |
+| 553-1077     | `coarse_sync` family + `fill_coarse_allsum` + `coarse_sync_inner`      | **Stage B**, pub for {`coarse_sync`, `coarse_sync_with_allsum`, `coarse_allsum_len`, `precompute_coarse_allsum`, `precompute_coarse_allsum_into`} |
+| 1079-1645    | symbol-spectra family (`symbol_spectra_direct{,_into}`, `SymMask`, all `fill_symbol_spectra{,_generic,_into,_into_generic}` cfg-split, `BASIS_SCRATCH_LEN`) | **Stage C**, `#[doc(hidden)] pub` — used by `decode.rs` + `embedded-shared`                            |
+| 1647-1893    | Public entry points (`decode_block{,_tuned,_with_ap,_with_ap_tuned}`) + `decode_block_multipass` (host f32 path) | Façade — kept at parent module                                                                         |
+| 1895-2154    | `recompute_nsync`, `xsnr2_db_simple`, `recompute_snr_xsnr2`            | SNR helpers — wedged into the `decode_block_multipass` body in source order                            |
+| 2131-2210    | Embedded `decode_block_multipass` + `fine_refine_pass1` (cfg-split)    | Embedded path                                                                                          |
+| 2213-2286    | `decode_block_into{,_tuned}` (fixed-point)                             | Façade — kept at parent module                                                                         |
+| 2288-2434    | `pass1_limit`, `RefinedCandidate`, `refine_candidates{,_into,_with}`   | **Stage D**, pub for `RefinedCandidate` + `refine_candidates_into`                                     |
+| 2443-2477    | `sync_quality_block0` + `LlrT` cfg alias                               | Shared helper                                                                                          |
+| 2495-2532    | `bp_step_select` (host / embedded cfg-split)                           | Shared helper                                                                                          |
+| 2534-2837    | `process_candidates*` family (8 entry points)                          | **Stage E**, `#[doc(hidden)] pub` — `process_candidates_into_with_cs_scratch_tuned` is the embedded API |
+| 2862-3171    | `process_one_candidate_inner` (Step 1 BP llra → Step 2 BP llrd/b/c → **Step 3 OSD** → Step 4 AP iaptype loop) | Per-candidate inner. **OSD seam target.**                                                              |
+| 3173-end     | `#[cfg(test)] mod tests`                                               | Inline unit tests                                                                                      |
+
+**External callers of `decode_block::*` (must stay reachable):**
+
+- `mfsk-core/src/ft8/decode.rs` — `compute_spectrogram`,
+  `coarse_sync`, `fill_symbol_spectra`, `SymMask`.
+- `mfsk-core/src/ft8/baseline.rs` — `Spectrogram`.
+- `mfsk-core/src/core/sync.rs`, `mfsk-core/src/ft8/{sync,llr}.rs`
+  — doc-link references only (no `use`).
+- `mfsk-core/tests/*` — `decode_block`, `DEFAULT_Q_THRESH`,
+  `precompute_coarse_allsum`, `coarse_sync_with_allsum`,
+  `compute_spectrogram`, `BASIS_SCRATCH_LEN`.
+- `embedded-poc/embedded-shared/src/{dual_core,pipeline,stage1_inc,apps/*}.rs`
+  — `coarse_sync`, `coarse_sync_with_allsum`,
+  `process_candidates_into_with_cs_scratch_tuned`,
+  `refine_candidates_into`, `RefinedCandidate`, `Spectrogram`,
+  `BASIS_SCRATCH_LEN`, `NFFT_SPEC`, `compute_spectrogram`,
+  `DEFAULT_Q_THRESH`.
+- `embedded-poc/m5stack-{core2,s3,s3-app}/*` — `BASIS_SCRATCH_LEN`,
+  `DEFAULT_Q_THRESH`, `NFFT_SPEC`, `xsnr2_db_simple`.
+
+Implication: nothing on the external-caller list can change its
+fully-qualified path. The parent `decode_block.rs` must
+`pub use` every item above so call sites stay byte-identical.
+
+### ε.1 — File layout (committed)
+
+Edition 2018+ module layout (no `mod.rs`); parent stays as
+`mfsk-core/src/ft8/decode_block.rs`, submodules live under
+`mfsk-core/src/ft8/decode_block/`:
+
+| File                                       | Approx. lines | Contains                                                                                                    |
+|--------------------------------------------|--------------:|-------------------------------------------------------------------------------------------------------------|
+| `decode_block.rs` (parent / façade)        |       ~700    | `use` re-exports, public entry points (`decode_block{,_tuned,_with_ap,_with_ap_tuned,_into,_into_tuned}`), `decode_block_multipass` (host f32 + embedded cfg-split), `#[cfg(test)] mod tests` |
+| `decode_block/params.rs`                   |       ~100    | All constants + `nstep-half` cfg + `LlrT` cfg alias + runtime tunables (`ratio_eps`, `sync_lag_s`, `pass1_limit`) |
+| `decode_block/audio_sample.rs`             |        ~60    | `AudioSample` trait + `i16` / `i8` impls                                                                    |
+| `decode_block/spectrogram.rs`              |       ~270    | `Spectrogram` struct + impls + `compute_spectrogram` (cfg-split host/embedded)                              |
+| `decode_block/coarse_sync.rs`              |       ~530    | Stage B family (`coarse_sync`, `coarse_sync_with_allsum`, `coarse_allsum_len`, `precompute_coarse_allsum{,_into}`, `fill_coarse_allsum`, `coarse_sync_inner`) |
+| `decode_block/fill_symbol_spectra.rs`      |       ~570    | Stage C family — every `symbol_spectra_*` and `fill_symbol_spectra*` cfg variant + `SymMask` + `BASIS_SCRATCH_LEN` + `fill_symbol_spectra_via_cd0` |
+| `decode_block/refine_candidates.rs`        |       ~200    | Stage D family + `RefinedCandidate` + `sync_quality_block0` + `fine_refine_pass1` (cfg-split)               |
+| `decode_block/snr.rs`                      |       ~190    | `xsnr2_db_simple`, `recompute_nsync`, `recompute_snr_xsnr2` (host f32 only)                                 |
+| `decode_block/process_candidates.rs`       |       ~310    | Stage E family (8 entry points) + `bp_step_select` + `WSJTX_NHARDERRORS_MAX` + the internal `process_candidates_tuned_with_ap` / `process_candidates_with_ap` drivers |
+| `decode_block/process_one.rs`              |       ~250    | `process_one_candidate_inner` with **Step 3 swapped for `osd_strategy::decode`** (see ε.2)                  |
+| `decode_block/osd_strategy.rs`             |        ~80    | OSD seam — see ε.2                                                                                          |
+
+Estimated total: ~3260 lines vs current 3517. The ~250-line drop
+comes from import dedup + dropping the `#[cfg(feature = "...")]`
+duplication where the cfg-split body collapses to one cfg-gated
+file. **It is fine if this number ends up larger** — the
+acceptance bar is parity, not LOC reduction.
+
+Inside the parent file, the **only** items are:
+
+```rust
+mod audio_sample;
+mod coarse_sync;
+mod fill_symbol_spectra;
+mod osd_strategy;
+mod params;
+mod process_candidates;
+mod process_one;
+mod refine_candidates;
+mod snr;
+mod spectrogram;
+
+pub use audio_sample::AudioSample;
+pub use coarse_sync::{
+    coarse_allsum_len, coarse_sync, coarse_sync_with_allsum,
+    precompute_coarse_allsum, precompute_coarse_allsum_into,
+};
+pub use fill_symbol_spectra::{
+    fill_symbol_spectra, fill_symbol_spectra_generic, fill_symbol_spectra_into,
+    fill_symbol_spectra_into_generic, symbol_spectra_direct, symbol_spectra_direct_into,
+    BASIS_SCRATCH_LEN, SymMask,
+};
+pub use params::{DEFAULT_Q_THRESH, NFFT_SPEC};
+pub use process_candidates::{
+    process_candidates, process_candidates_into, process_candidates_into_tuned,
+    process_candidates_into_with_cs_scratch, process_candidates_into_with_cs_scratch_tuned,
+    process_candidates_tuned,
+};
+pub use refine_candidates::{refine_candidates_into, sync_quality_block0, RefinedCandidate};
+pub use snr::xsnr2_db_simple;
+pub use spectrogram::{compute_spectrogram, Spectrogram};
+
+// Façade entry points (definitions, not re-exports — see ε.3
+// for why these stay at the parent file).
+pub fn decode_block<S: AudioSample>(...) -> Vec<DecodeResult> { ... }
+// ... decode_block_tuned, decode_block_with_ap, decode_block_with_ap_tuned,
+//     decode_block_into, decode_block_into_tuned, decode_block_multipass (private),
+//     #[cfg(test)] mod tests
+```
+
+### ε.2 — OSD strategy seam (the seam #63 hooks)
+
+Current shape — `process_one_candidate_inner` Step 3
+(`decode_block.rs:2958-3016`):
+
+```rust
+if accepted.is_none() && matches!(depth, DecodeDepth::BpAllOsd) && q >= 12 {
+    let llr_full_f32: LlrSet<f32> = compute_llr(cs_scratch);
+    for (llr, pid) in [(&llra, 14u8), (&llrb, 15), (&llrc, 16), (&llrd, 17)] {
+        let osd = if q >= 18 {
+            osd_decode_deep(llr, 3, Some(check_crc14))    // ndeep=3
+        } else {
+            osd_decode(llr)                                // ndeep=2
+        };
+        if let Some(osd) = osd { /* accept with pid */ }
+    }
+}
+```
+
+Why this is the right seam: PR #62 documented that WSJT-X
+`osd174_91.f90:230-289` always calls `nord=1 + npre1=1` —
+order-1 MRB **plus** precoding patterns derived from `G`-matrix
+columns — and mfsk-core has no precoding implementation. The
+ndeep-2/3 dispatch above is the local stand-in. #63 is the
+issue to swap this for the strict path; ε's contribution is
+to widen the door so #63 doesn't have to touch
+`process_one_candidate_inner` again.
+
+Proposed `decode_block/osd_strategy.rs` interface:
+
+```rust
+//! OSD fallback strategy seam (Step 3 of process_one_candidate_inner).
+//!
+//! Two implementations:
+//! - [`HostDeepDispatch`] (current behaviour): ndeep=2 when q<18,
+//!   ndeep=3 when q≥18, applied to all four llra/b/c/d.
+//! - [`WsjtxFaithful`] (#63 placeholder): `nord=1 + npre1=1` —
+//!   not yet implemented; ε ships only the trait.
+
+use crate::fec::ldpc::bp::BpResult;
+use crate::fec::ldpc::osd::{osd_decode, osd_decode_deep};
+use crate::ft8::llr::LlrSet;
+use crate::ft8::params::LDPC_N;
+
+/// Result of an OSD attempt — same shape `process_one_candidate_inner`
+/// stuffs into its `accepted` slot, including the pass-ID byte so the
+/// caller doesn't have to remember the 14/15/16/17 mapping.
+pub struct OsdHit {
+    pub bp: BpResult,
+    pub pass_id: u8,
+}
+
+/// Step 3 trait. `try_decode` runs over the four LLR variants
+/// in `llr_set` and returns the first acceptance, or `None`.
+///
+/// `q` is the symbol-level sync quality (`sync_quality` value
+/// after stage 3 refill, range 0..=21) — implementations may
+/// use it to dispatch between cheap and deep search.
+pub trait OsdStrategy {
+    fn try_decode(&self, llr_set: &LlrSet<f32>, q: u32) -> Option<OsdHit>;
+}
+
+/// Current behaviour (matches v0.6.2). ndeep=2/3 split on q,
+/// applied to all four llra/b/c/d. Pass-ID 14/15/16/17.
+pub struct HostDeepDispatch;
+
+impl OsdStrategy for HostDeepDispatch { /* extracted from Step 3 */ }
+
+/// #63 target. **Stub only** in ε — returns `None`. The actual
+/// `nord=1 + npre1=1` implementation lands when #63 is picked up;
+/// keeping the type here means the trait surface stops moving
+/// before that work begins.
+#[cfg(feature = "fft-rustfft")]
+pub struct WsjtxFaithful;
+
+#[cfg(feature = "fft-rustfft")]
+impl OsdStrategy for WsjtxFaithful {
+    fn try_decode(&self, _llr_set: &LlrSet<f32>, _q: u32) -> Option<OsdHit> {
+        None  // #63 fills this in
+    }
+}
+
+/// Default for the current `process_one_candidate_inner` call site.
+/// `WsjtxFaithful` is opt-in via a runtime knob in #63.
+pub fn default_strategy() -> &'static dyn OsdStrategy {
+    &HostDeepDispatch
+}
+```
+
+`process_one_candidate_inner` Step 3 becomes:
+
+```rust
+if accepted.is_none() && matches!(depth, DecodeDepth::BpAllOsd) && q >= 12 {
+    let llr_full_f32 = compute_llr(cs_scratch);
+    if let Some(hit) = osd_strategy::default_strategy().try_decode(&llr_full_f32, q) {
+        accepted = Some((hit.bp, hit.pass_id));
+    }
+}
+```
+
+Design constraints honoured:
+
+- **No behavioural change in ε.** `default_strategy()` returns
+  `HostDeepDispatch`, which is bit-identical to the inline
+  Step 3 code (same LLR set, same dispatch, same pass-IDs).
+  Golden recall holds by construction.
+- **Static dispatch is fine.** The trait stays object-safe and
+  uses `&dyn` here because there is exactly one call site and
+  swapping at runtime (per #63) is the future flexibility we
+  want. If profiling shows the vtable matters we can switch to
+  a generic later — but Step 3 only fires when q≥12 + BP
+  failed, so it's a cold path.
+- **No new `pub` surface.** `osd_strategy` is `pub(crate)` from
+  the parent `decode_block`; #63 will decide whether to
+  re-export the trait when it ships its runtime knob.
+
+### ε.3 — Why the façade entry points stay at the parent file
+
+`decode_block`, `decode_block_tuned`, `decode_block_with_ap{,_tuned}`,
+`decode_block_into{,_tuned}`, and the private
+`decode_block_multipass` form one coherent unit that wires every
+stage together. Moving them into a submodule (e.g.
+`decode_block/entry.rs`) would force a `pub use` chain through the
+parent for every public entry, which is exactly the kind of
+re-export ceremony Rust 2018+ inline modules let us avoid.
+Keeping them at the parent also keeps `#[cfg(test)] mod tests`
+co-located with the only function the tests actually call into.
+
+### ε.4 — Submodule visibility map
+
+The split rule: **submodules expose to siblings via `pub(super)`
+where re-exports aren't needed**, and the parent uses `pub use`
+only for items the external caller survey above flagged.
+
+| Submodule item                                                                                                                                                                              | Visibility            | Reason                                                  |
+|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------|---------------------------------------------------------|
+| `Spectrogram`, `compute_spectrogram`, `coarse_sync*`, `precompute_coarse_allsum*`, `coarse_allsum_len`, `fill_symbol_spectra*`, `symbol_spectra_direct*`, `SymMask`, `BASIS_SCRATCH_LEN`, `RefinedCandidate`, `refine_candidates_into`, `sync_quality_block0`, `process_candidates*` family, `xsnr2_db_simple`, `AudioSample`, `NFFT_SPEC`, `DEFAULT_Q_THRESH` | `pub` (re-exported)   | On external-caller survey list                          |
+| `fill_coarse_allsum`, `coarse_sync_inner`, `fill_symbol_spectra_via_cd0`, `refine_candidates_with`, `pass1_limit`, `bp_step_select`, `WSJTX_NHARDERRORS_MAX`                                 | `pub(super)`          | Only called from sibling modules; never pub             |
+| `recompute_nsync`, `recompute_snr_xsnr2`                                                                                                                                                    | `pub(super)`          | Only called from `decode_block_multipass`               |
+| `process_candidates_tuned_with_ap`, `process_candidates_with_ap`                                                                                                                            | `pub(super)`          | Only called from sibling `process_candidates::*`        |
+| `osd_strategy::OsdStrategy`, `osd_strategy::HostDeepDispatch`, `osd_strategy::default_strategy`                                                                                              | `pub(super)`          | Used by `process_one`; not re-exported until #63        |
+| `process_one_candidate_inner`                                                                                                                                                               | `pub(super)`          | Already `pub(super)` today; stays the same              |
+| `params::LlrT`, `params::ratio_eps`, `params::sync_lag_s`                                                                                                                                   | `pub(super)`          | Shared scalar / runtime tunables                        |
+
+**`pub`-but-`#[doc(hidden)]` items kept verbatim:** every
+`#[doc(hidden)]` entry in the survey continues to be
+`#[doc(hidden)] pub` after ε. We are not relitigating which
+items deserve to be in the documented surface — that is a
+separate decision (#72 / #74 follow-ups). ε is mechanical.
+
+**Items that could become `pub(crate)` later but stay `pub`
+for ε:** `symbol_spectra_direct`, `symbol_spectra_direct_into`,
+`process_candidates`, `process_candidates_tuned` — the external
+caller survey did not surface a non-`decode_block.rs` user, but
+they are part of the historically-stable surface that
+`#[doc(hidden)] pub` exists to keep cheap. Re-classify under #72.
+
+### ε.5 — Sequenced execution plan
+
+Designed so each step is a self-contained PR that compiles + tests
+green on its own. Numbered steps map to commit boundaries; the
+whole sequence is one Issue + one PR thread.
+
+0. **ε.0 (this section)** — design doc ratified. **Already
+   shipped in the δ docs sync sweep.** No code touched.
+1. **ε.1** — Move `params`, `audio_sample`, `spectrogram` into
+   submodules. Smallest, most independent piece; touches no
+   logic. Updates `pub use` chain at parent. CI: `cargo check`
+   on every feature row of the cfg matrix, `cargo test`,
+   `cargo test --features fixed-point`, Core2 +
+   S3 `cargo build --release` (no flash needed).
+2. **ε.2** — Extract `coarse_sync`. Largest single move
+   (~530 lines) but logically isolated. Same CI gates.
+3. **ε.3** — Extract `fill_symbol_spectra`. Big cfg matrix
+   here (fft-rustfft × fixed-point × generic-Sc); careful that
+   every `#[cfg(...)]` arm still has a path through.
+4. **ε.4** — Extract `refine_candidates` + `snr`.
+5. **ε.5** — Extract `process_candidates` (the 8-entry-point
+   family) and the `bp_step_select` helper.
+6. **ε.6** — Extract `process_one` (split out
+   `process_one_candidate_inner`).
+7. **ε.7** — Land `osd_strategy.rs` with `HostDeepDispatch` as
+   the only inhabitant; refactor Step 3 to dispatch through it.
+   **Golden recall must be byte-identical** before and after
+   (qso3_busy AP-off 7/8, AP-on 5/6 extras; full reference
+   suite). This is the step that creates the seam #63 will
+   later fill with `WsjtxFaithful`.
+8. **ε.8** — Pub-map tighten (the items currently `pub` only
+   because they were reached cross-module — re-classify per
+   §ε.4). Coordinate with #72 if that lands first.
+
+`ε.2`-`ε.7` are each one-day moves; the full sequence is
+estimated at 5-6 working days plus regression runs. **Each
+step must hold:**
+
+- `cargo test` green on host (default feature set).
+- `cargo test --features fixed-point` green.
+- `cargo check --no-default-features --features <every-row>`
+  green across the cfg matrix (`fft-rustfft` × `fixed-point` ×
+  `nstep-half`).
+- Core2 + S3 `cargo build --release` green.
+- WSJT-X reference recall: qso3_busy AP-off ≥ 7/8 host, no
+  regression in JTDX-extras count, embedded recall unchanged.
+- Build-size delta < ±2 KB on the embedded preset
+  (`embedded-poc/m5stack-s3` release).
+
+### ε.6 — Pre-flight checklist for the implementer
+
+Before starting ε.1 in code:
+
+- [ ] Confirm `#61` (Core2 → S3 fold-in) is either merged or on
+  a branch that won't conflict with `decode_block/` directory
+  creation.
+- [ ] Branch from `main` not the active δ branch.
+- [ ] Snapshot `cargo test` baseline output to `logs/epsilon-baseline.txt`
+  so each step can diff against it.
+- [ ] Snapshot Core2 + S3 build-size baselines
+  (`ls -l target/.../release/*.elf`) for the ±2 KB acceptance check.
+- [ ] Open one tracking Issue ("ε decode_block.rs restructure"); each
+  step in §ε.5 is one commit on a single PR off that issue.
+
 ## Out of scope for this cleanup
 
 - Implementing #61 (Core2→S3 unification) — wait for weekend

--- a/docs/CORE2_FOLD_IN.md
+++ b/docs/CORE2_FOLD_IN.md
@@ -1,0 +1,347 @@
+# Core2 fold-in into the production controller (issue #61)
+
+**Status (2026-05-15):** plan ratified, ready for Phase 1 (lib
+extraction). Phases 3-5 are the weekend hardware bring-up window
+(2026-05-17/18). ε `decode_block` restructure (`docs/CLEANUP_2026_05.md`)
+is intentionally sequenced **after** Phase 5 so the two refactors do
+not collide.
+
+## Context
+
+The embedded port currently maintains two parallel decode bench crates
+(`embedded-poc/m5stack-core2`, `embedded-poc/m5stack-s3`) plus the
+production controller (`embedded-poc/m5stack-s3-app`). The bench shims
+already collapsed into `embedded-poc/embedded-shared/src/apps/` — the
+remaining duplication is **infrastructure** (Cargo.toml, sdkconfig,
+`.cargo/config.toml`, partitions) and **board peripheral glue** that
+exists only in S3 shape under `m5stack-s3-app/`. The LX6 path has no
+in-tree LCD / PMIC / button / audio driver; the old `rx_skeleton.rs`
+PDM scaffold was pseudocode only and was retired in PR #66.
+
+Goal: bring Core2 (LX6) onto the same production-shape codebase as the
+S3 controller so the LX6 board is a first-class decode target rather
+than a separate bench crate. Tracked under
+[#61](https://github.com/jl1nie/mfsk-core/issues/61).
+
+## Architectural constraint that shapes the plan
+
+Issue #61 lists as a **non-goal**: *"Single-binary that flashes to
+either board without a target switch — the toolchain still picks
+`xtensa-esp32-espidf` vs `xtensa-esp32s3-espidf` at compile time."*
+
+Empirically this is **forced** by `esp-idf-sys`:
+
+- `.cargo/config.toml` `target = "..."` is per-invocation, not
+  per-feature; Cargo cannot feature-gate the default target.
+- `[package.metadata.esp-idf-sys].esp_idf_sdkconfig_defaults` is a
+  build-script-time literal — it cannot select among sdkconfig files
+  via feature flags.
+- The MCU env var (`MCU=esp32` vs `MCU=esp32s3`) routed through
+  `.cargo/config.toml` is similarly per-crate.
+
+Therefore the unified codebase **must** be a **library crate** that two
+**thin binary crates** depend on:
+
+```
+embedded-poc/
+├── mfsk-app-shared/        ← [lib] crate, holds the production-shape code
+├── m5stack-s3-app/         ← [bin] shim, target = xtensa-esp32s3-espidf
+└── m5stack-core2-app/      ← [bin] shim, target = xtensa-esp32-espidf  (new)
+```
+
+This honours #61's "no single-binary" non-goal while collapsing the
+real duplication (board glue + production logic). Per-shim
+`Cargo.toml` + `sdkconfig.defaults` is ~70 lines of config;
+`mfsk-app-shared` is what holds the 20-file production codebase.
+
+## Critical files to touch
+
+Library extraction (Phase 1):
+
+- All 20 files under `embedded-poc/m5stack-s3-app/src/` move to
+  `embedded-poc/mfsk-app-shared/src/`. Module tree preserved; only
+  the `main.rs` entry function becomes `pub fn run<B: Board>() -> !`.
+- `embedded-poc/m5stack-s3-app/src/main.rs` shrinks to ~10 lines
+  (link patches + `mfsk_app_shared::run::<board::BoardS3>()`).
+- `embedded-poc/m5stack-s3-app/Cargo.toml` adds `mfsk-app-shared`
+  path dep, drops the body deps that move into the library.
+
+Board trait (Phase 2):
+
+- New `mfsk-app-shared/src/board.rs` defines the `Board` trait.
+  Replaces the current `m5stack-s3-app/src/board.rs` constants-only
+  file. Modules that take board-specific types as parameters today
+  (display.rs, pmic.rs, audio.rs, buttons.rs) become generic over `B`.
+- New `mfsk-app-shared/src/boards/s3.rs` — `BoardS3 impl Board` plus
+  the S3-specific ST7789P3 / M5PM1 / ES8311 init that currently lives
+  inline in display.rs / pmic.rs / audio.rs.
+- New `mfsk-app-shared/src/boards/core2.rs` — `BoardCore2 impl Board`
+  (Phase 3 fills this in).
+
+Core2 board impl (Phase 3):
+
+- `mfsk-app-shared/src/boards/core2/lcd.rs` — ILI9342C init via
+  `mipidsi` crate (already supports both ST7789 and ILI9342C — same
+  pattern as the existing S3 display driver).
+- `mfsk-app-shared/src/boards/core2/pmic_axp192.rs` — AXP192 init
+  (I2C 0x34): LCD backlight rail, LDO2/LDO3 power gates, button
+  charge state.
+- `mfsk-app-shared/src/boards/core2/audio_pdm.rs` — SPM1423 PDM mic
+  capture (GPIO0 = SCK, GPIO34 = DIN, mono 16 kHz → 12 kHz
+  resampler already lives in `embedded-shared::wav_sim`-style Q32
+  linear). New code; rx_skeleton's pseudocode is a starting outline
+  only.
+- `mfsk-app-shared/src/boards/core2/buttons.rs` — BtnA / BtnB / BtnC
+  GPIO39/38/37 polling (mirror existing buttons.rs shape).
+
+Core2 binary crate (Phase 4):
+
+- `embedded-poc/m5stack-core2-app/Cargo.toml` — references
+  `mfsk-app-shared` via path, target = xtensa-esp32-espidf,
+  QUAD PSRAM features.
+- `embedded-poc/m5stack-core2-app/.cargo/config.toml` — runner
+  espflash, port `/dev/ttyACM0`.
+- `embedded-poc/m5stack-core2-app/sdkconfig.defaults` — Core2-tuned
+  (QUAD PSRAM, no BT, optional WiFi).
+- `embedded-poc/m5stack-core2-app/partitions.csv` — Core2 16MB
+  flash layout (factory 3MB + littlefs 1MB matching s3-app).
+- `embedded-poc/m5stack-core2-app/src/main.rs` — 10 lines, calls
+  `mfsk_app_shared::run::<BoardCore2>()`.
+
+Hardware bring-up + retire (Phase 5):
+
+- `git rm -r embedded-poc/m5stack-core2/` — old LX6 bench crate.
+- Defer `embedded-poc/m5stack-s3/` (S3 bench) retirement — separate
+  decision; not blocking #61.
+
+Docs + workspace (Phase 6):
+
+- Add `embedded-poc/m5stack-core2-app/CLAUDE.md`,
+  `embedded-poc/mfsk-app-shared/CLAUDE.md`.
+- Update `embedded-poc/CLAUDE.md` "Crates under embedded-poc" list.
+- Update `docs/ROADMAP.md` Open follow-ups: mark #61 closed; remove
+  the "weekend hardware bring-up" footnote on ε scheduling.
+
+## Reused infrastructure (do not re-build)
+
+- `embedded-shared::dual_core` — already board-agnostic. Both
+  `BoardS3` and `BoardCore2` route through this for the
+  pass2_split / stage3_split work. Commit `15913aa` already proved
+  dual-core decode_block runs on Core2 LX6.
+- `embedded-shared::wav_sim` — Q32 16/48 → 12 kHz resampler used by
+  both bench and PDM-driven capture.
+- `embedded-shared::stage1_inc` — incremental stage-1 spectrogram,
+  no cfg-gating needed.
+- `embedded-shared::internal_pool` — `.bss`-resident cs scratch,
+  works on both DRAM sizes (Core2 ~280 KB usable vs S3 ~512 KB).
+- `mfsk-core::ft8::decode_block` — the LX6 vs LX7 difference is the
+  `fixed-point-bp` asm dot product (LX6-gated already) and the
+  `fft-extern` planner (works on both via `esp-dsp`). No mfsk-core
+  changes needed.
+- `mipidsi` crate (already in s3-app deps) supports ILI9342C in
+  addition to ST7789P3 — no new display crate dependency.
+
+## Implementation phases
+
+Each phase is one PR off the same tracking issue. Phases 1-2 are
+mechanical refactors that ship before the weekend; phases 3-5 land
+during the weekend hardware window.
+
+### Phase 1 — Extract `mfsk-app-shared` library (1 day)
+
+Pure code move with a `pub fn run` entry. The S3 build must remain
+byte-identical (same final ELF size ± alignment).
+
+1. Create `embedded-poc/mfsk-app-shared/` with `[lib]` Cargo.toml.
+2. Move all 20 source files from `m5stack-s3-app/src/` (except
+   `main.rs`) into `mfsk-app-shared/src/`.
+3. Convert `mod` declarations: what was `mod adif;` in `main.rs`
+   becomes `pub mod adif;` in `mfsk-app-shared/src/lib.rs`.
+4. Expose `pub fn run() -> !` matching the current `main` body.
+5. Shrink `m5stack-s3-app/src/main.rs` to a 10-line shim.
+6. Update `m5stack-s3-app/Cargo.toml` — add
+   `mfsk-app-shared = { path = "../mfsk-app-shared" }`, drop now-
+   library-owned deps.
+
+Acceptance: `cargo build --release` green on m5stack-s3-app, S3 app
+boots and decodes identically to commit `27425cf` baseline.
+
+### Phase 2 — Introduce `Board` trait + extract `BoardS3` (2 days)
+
+Type-level seam so a second board impl plugs in cleanly.
+
+1. Define `mfsk-app-shared/src/board.rs`:
+   ```rust
+   pub trait Board {
+       // Pinout
+       const LCD_WIDTH: u16;
+       const LCD_HEIGHT: u16;
+       const I2C_BUS: u8;
+       // ...
+       // Init seams
+       fn init_pmic(i2c: &mut I2cDriver) -> Result<()>;
+       fn init_lcd(spi: SpiHandle, pins: LcdPins) -> Result<LcdSurface>;
+       fn init_audio_capture(...) -> Result<AudioCaptureHandle>;
+       fn poll_buttons() -> ButtonEvents;
+       // Identifier for log lines
+       const NAME: &'static str;
+   }
+   ```
+2. Move existing S3-specific init from `display.rs` / `pmic.rs` /
+   `audio.rs` / `buttons.rs` / `board.rs` into
+   `mfsk-app-shared/src/boards/s3.rs` as `BoardS3` impl.
+3. Make `display.rs` / `audio.rs` / `pmic.rs` / `buttons.rs` generic
+   over `B: Board` (or rename — module structure can stay).
+4. `lib.rs::run<B: Board>()` plumbs the board through to call sites.
+5. Update m5stack-s3-app shim to `run::<BoardS3>()`.
+
+Acceptance: S3 build green, S3 boot + decode unchanged. Recall on
+qso3_busy reference WAV must not regress. ELF size delta < ±2 KB.
+
+### Phase 3 — Implement `BoardCore2` (3-4 days)
+
+Port the missing LX6 peripheral glue. Drives the bulk of new code.
+
+1. **AXP192 PMIC** (`boards/core2/pmic_axp192.rs`) — I2C 0x34:
+   - LDO2 = LCD logic (3.3 V), LDO3 = LCD backlight (2.8 V),
+     DC-DC1 = ESP main rail. Power-on sequence + button charge
+     state register.
+   - Reference: M5Unified `power_axp192.cpp` minimum subset.
+2. **ILI9342C LCD** (`boards/core2/lcd.rs`) — SPI:
+   - SCK = GPIO18, MOSI = GPIO23, MISO = GPIO38, CS = GPIO5,
+     DC = GPIO15, RST = (AXP192-controlled).
+   - Use `mipidsi::Builder::new(ILI9342CRgb565::default(), di)`.
+3. **PDM mic** (`boards/core2/audio_pdm.rs`) — I2S0 PDM mode:
+   - CLK = GPIO0, DIN = GPIO34, mono, 16 kHz, 16-bit.
+   - Use `esp-idf-hal::i2s::I2sDriver` PDM RX config; downsample to
+     12 kHz with the existing `wav_sim`-style Q32 linear resampler.
+   - Reference: M5Unified `audio_class.cpp` PDM init; SPM1423
+     datasheet.
+4. **Buttons** (`boards/core2/buttons.rs`) — BtnA = GPIO39,
+   BtnB = GPIO38, BtnC = GPIO37, all active-low. Mirror the s3
+   poll shape.
+5. **MPU6886 IMU** — out of scope for #61. Stub `Board::imu()` to
+   `None` for Core2; revisit if/when the controller UI uses motion.
+
+Acceptance: `cargo check --target=xtensa-esp32-espidf` green from a
+stub `m5stack-core2-app` Cargo.toml. No hardware flash yet.
+
+### Phase 4 — Create `m5stack-core2-app` binary crate (0.5 day)
+
+Pure config wiring. The actual code is already in mfsk-app-shared.
+
+1. `embedded-poc/m5stack-core2-app/Cargo.toml` — `[bin]` only, deps
+   = mfsk-app-shared + log + esp-idf-svc (matched to s3-app
+   version).
+2. `.cargo/config.toml` — target `xtensa-esp32-espidf`, runner
+   `espflash flash --monitor --before no-reset --after no-reset`,
+   `MCU=esp32` env.
+3. `sdkconfig.defaults` — QUAD PSRAM, BT off, WiFi optional,
+   `SPIRAM_MALLOC_ALWAYSINTERNAL = 4096` (same dual-core threshold
+   as S3), partition table custom.
+4. `partitions.csv` — factory 3MB + littlefs 1MB layout matching
+   s3-app.
+5. `src/main.rs` — 10 lines:
+   ```rust
+   fn main() -> ! {
+       esp_idf_svc::sys::link_patches();
+       mfsk_app_shared::run::<mfsk_app_shared::boards::BoardCore2>()
+   }
+   ```
+6. `build.rs` — same partition-CSV-path-from-`CARGO_MANIFEST_DIR`
+   shim as commit `6b8ca96`.
+
+Acceptance: `cargo build --release` green for Core2 target on host
+(no flash yet).
+
+### Phase 5 — Hardware bring-up + retire old crate (weekend window)
+
+1. Source `~/export-esp.sh`, build, flash to real Core2 hardware
+   via `embedded-poc/scripts/flash-monitor.sh`.
+2. Boot, confirm: AXP192 power-up message → LCD shows boot banner →
+   PDM mic captures audio → dual-core decode pipeline produces
+   decodes for the same qso3_busy WAV input the bench used.
+3. Bench parity: confirm Core2 dual-core hits its current
+   `~3.22 s/slot` baseline (commit `15913aa`). Capture log to
+   `embedded-poc/m5stack-core2-app/logs/core2_fold_in_2026-05-1X.log`.
+4. S3 regression: re-flash s3-app + qso3_busy reference, confirm
+   recall ≥ baseline (7 total per memory `project_release_0_6_x`).
+5. `git rm -r embedded-poc/m5stack-core2/` — old bench crate
+   retired.
+6. Update workspace `Cargo.toml` member list.
+
+### Phase 6 — Docs + workspace sync (0.5 day)
+
+1. New `embedded-poc/m5stack-core2-app/CLAUDE.md` — crate-specific
+   build/flash overrides (mirror s3-app/CLAUDE.md structure;
+   USB-OTG note becomes "no USB-OTG on LX6 stock board").
+2. New `embedded-poc/mfsk-app-shared/CLAUDE.md` — library crate
+   notes (board trait, sub-module map).
+3. Update `embedded-poc/CLAUDE.md` "Crates under embedded-poc"
+   section.
+4. Update `docs/ROADMAP.md` Open follow-ups: mark #61 closed;
+   remove the "weekend hardware bring-up" footnote on ε scheduling
+   (its prerequisite is now satisfied).
+5. Memory note via `project_esp32_port.md` — record dual-core LX6
+   under unified-app structure with new fold-in numbers.
+
+## Out of scope for #61
+
+- LX6-LX7 SIMD parity (asm dot product stays LX6-gated, per #61).
+- LCD UI feature parity — Core2 UI may start as log-only panel.
+  Full QSO UI port to ILI9342C is a follow-up.
+- MPU6886 IMU support on Core2.
+- WiFi-mode polish on Core2 — boots and connects, but UDP-log
+  binding behaviour on QUAD PSRAM untested.
+- Retiring `embedded-poc/m5stack-s3/` (S3 bench crate) — separate
+  decision once we confirm s3-app covers all bench needs.
+
+## Risks + mitigations
+
+- **mipidsi ILI9342C parity**: the crate's ILI9342C driver may
+  diverge from M5Stack's stock orientation / colour-order tuning.
+  Plan B is a hand-written init sequence (~30 lines, port from
+  M5Unified `Panel_M5Stack.cpp`).
+- **PDM clock stability**: SPM1423 has been known to produce a
+  ~50 ppm offset that breaks slot alignment. If it surfaces, use
+  the same NTP slot-boundary anchor s3-app already uses
+  (`time_sync.rs`) — already board-agnostic.
+- **TLSF heap fragmentation on Core2**: known LX6 bug (see
+  `embedded-poc/m5stack-core2/CLAUDE.md`). The s3-app D-pattern
+  workaround already lives in shared code paths, so this risk is
+  inherited not new.
+- **QUAD vs Octal PSRAM throughput**: dual-core on LX6 QUAD
+  measured ~3.22 s in `15913aa`. Acceptance is "no regression from
+  that baseline" — not S3 parity.
+
+## Verification (end-to-end)
+
+After Phase 5 lands:
+
+```sh
+# S3 app — no regression (baseline = current main)
+source ~/export-esp.sh
+cd embedded-poc/m5stack-s3-app
+cargo build --release
+../scripts/flash-monitor.sh \
+    target/xtensa-esp32s3-espidf/release/m5stack-s3-app \
+    logs/s3_post_core2_fold_$(date +%Y-%m-%d).log \
+    120
+# Expect: boot OK, qso3_busy decode = 7 hits, no recall drop
+
+# Core2 app — fold-in works
+cd ../m5stack-core2-app
+cargo build --release
+../scripts/flash-monitor.sh \
+    target/xtensa-esp32-espidf/release/m5stack-core2-app \
+    logs/core2_fold_in_$(date +%Y-%m-%d).log \
+    120
+# Expect: AXP192 power-up, LCD banner, PDM capture, dual-core
+#         decode pipeline ≤ 3.5 s/slot on qso3_busy
+
+# Host parity (no behavioural changes from this PR)
+cd ../../mfsk-core
+cargo test                                  # default features
+cargo test --features fixed-point          # embedded LLR parity
+cargo test --test ft8_qso3_apoff_recall    # WSJT-X golden
+```

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -83,6 +83,17 @@ Currently open GitHub issues (state:open as of 2026-05-14):
   (perf follow-up to #60, which landed the single-pass hoist).
 - **#65** — share `cd0` between SyncOnly + DataOnly
   `fill_symbol_spectra` calls (host perf nice-to-have).
+- **#72** — `DecodeStrictness` duplicate definition + uncalibrated
+  `core::pipeline` copy for FT4/FST4 (either tighten the public
+  API or honour the *"can re-tune later"* promise). Schedule
+  after ε.7 pub-map tighten.
+- **#73** — `EqMode::Adaptive` has collapsed into `EqMode::Local`
+  in the AP-list path; restore the non-EQ fallback or drop the
+  variant. Schedule after ε.
+- **#74** — `DecodeDepth::Bp` (cheapest staircase) has no known
+  in-tree caller beyond smoke tests; survey downstream C consumers
+  before retiring. Schedule after ε.5 (which already touches the
+  LLR / BP / OSD staircase).
 
 Carry-overs from the post-0.5.12 plan that have since closed:
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -74,8 +74,12 @@ Currently open GitHub issues (state:open as of 2026-05-14):
 - **#58** — coalesce redundant `compute_llr` between Step 3 (OSD)
   and Step 4 (AP) in `decode_block`. Low-priority host perf.
 - **#61** — fold `m5stack-core2` into the S3 dual-core pipeline
-  and retire the Core2 crate. Weekend hardware bring-up
-  (2026-05-17/18) per `docs/CLEANUP_2026_05.md` (ε prerequisite).
+  and retire the Core2 crate. Implementation plan ratified
+  2026-05-15 — see `docs/CORE2_FOLD_IN.md`. Phases 1-2 (lib
+  extraction + `Board` trait) can land before the weekend;
+  phases 3-5 (LX6 board impl + hardware bring-up) are the
+  2026-05-17/18 window. ε prerequisite per
+  `docs/CLEANUP_2026_05.md`.
 - **#63** — WSJT-X-faithful OSD `npre1` precoding for host
   `BpAllOsd`; reduces false positives. Deprioritised — see PR #62
   for the design note documenting the current parity gap.
@@ -150,7 +154,7 @@ this section.
 
 `docs/CLEANUP_2026_05.md` tracks a four-stage post-0.6.2 tidy-up
 (γ scaffolding → β feature/cfg → δ docs sync → ε `decode_block.rs`
-restructure). Status as of 2026-05-14:
+restructure). Status as of 2026-05-15:
 
 - **γ** Done 2026-05-13 (PR #66). Retired
   `embedded-poc/m5stack-{core2,s3}/src/bin/rx_skeleton.rs`.
@@ -158,11 +162,15 @@ restructure). Status as of 2026-05-14:
   cleared; `Cmplx` unified with `num_complex::Complex` via type
   alias (−5 `unsafe` cast wrappers); cfg-matrix audit confirms
   every fixed-point × fft-{rustfft,extern} cell builds clean.
-- **δ** Documentation sync — current sweep.
+- **δ** Documentation sync done 2026-05-15. Latest pass added the
+  ε detailed design (`docs/CLEANUP_2026_05.md` §ε.0-ε.6) and the
+  Core2 fold-in implementation plan (`docs/CORE2_FOLD_IN.md`).
 - **ε** `decode_block.rs` restructure into a `decode_block/`
   submodule directory + OSD strategy seam for `#63` precoding.
-  Week-scale; intentionally sequenced after the weekend hardware
-  bring-up for `#61` (Core2 → S3 unification) so the two refactors
+  Detailed design ratified 2026-05-14 (`docs/CLEANUP_2026_05.md`
+  §ε.0-ε.6). Week-scale; intentionally sequenced after the
+  weekend hardware bring-up for `#61` (Core2 → S3 unification,
+  plan in `docs/CORE2_FOLD_IN.md`) so the two refactors
   do not collide.
 
 # Roadmap (legacy, written for post-0.5.12)


### PR DESCRIPTION
## Summary

Adds the three YAGNI-adjacent cleanup issues filed today
(2026-05-14) to the ROADMAP Open follow-ups list. Each one
already documents its own ε-first scheduling in the issue body;
the ROADMAP line repeats it so the next reader doesn't pick the
work up out of order.

- **#72** — \`DecodeStrictness\` duplicate definition + uncalibrated
  \`core::pipeline\` copy for FT4 / FST4 (either tighten the
  public API or honour the *\"can re-tune later\"* promise).
- **#73** — \`EqMode::Adaptive\` has collapsed into \`EqMode::Local\`
  in the AP-list path; restore the non-EQ fallback or drop the
  variant.
- **#74** — \`DecodeDepth::Bp\` (cheapest staircase) has no known
  in-tree caller beyond smoke tests; survey downstream C
  consumers before retiring.

## Test plan

- [x] pre-commit hook (\`fmt\` + \`clippy --workspace --all-targets
      --features full -- -D warnings\` + \`rustdoc -D warnings\`)
- [ ] CI green (docs-only change, no behavioural risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)