### PR TITLE
cleanup(ε.1): extract decode_block/types.rs (audio sample trait + tunables)

### DIFF
--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -38,174 +38,23 @@ use crate::core::sync::SyncCandidate;
 use crate::fec::ldpc::bp::check_crc14;
 use crate::fec::ldpc::osd::{osd_decode, osd_decode_deep};
 
-// ── Audio sample trait ──────────────────────────────────────────────────────
+// ── Submodule layout (`docs/CLEANUP_2026_05.md` ε) ──────────────────────────
+//
+// `decode_block.rs` is the parent / facade for a per-stage submodule
+// tree. ε.1 carved out `types.rs` (audio sample trait + cross-cutting
+// tunables); ε.2-6 will follow with spectrogram / coarse_sync /
+// fill_symbol_spectra / process_candidates / osd_strategy.
+mod types;
 
-/// Trait for audio sample types accepted by `decode_block`. Lets the
-/// caller hand in either `i16` (the canonical FT8 PCM) or `i8`
-/// (half-storage, ~45 dB SQNR — plenty for FT8's -24 dB threshold —
-/// useful when the slot needs to fit in scarce internal SRAM on
-/// embedded targets where PSRAM access is the bottleneck).
-///
-/// The `to_f32` implementation must produce values on the same
-/// amplitude scale as `i16` so the LLR computation downstream keeps
-/// its calibration; for `i8` we therefore multiply by 256.
-pub trait AudioSample: Copy {
-    fn to_f32(self) -> f32;
-    /// Promote to i16 range. i8 → i16 via `<<8`; i16 → i16
-    /// identity. Used by the fixed-point FFT input path.
-    fn to_i16(self) -> i16;
-}
-
-impl AudioSample for i16 {
-    #[inline]
-    fn to_f32(self) -> f32 {
-        self as f32
-    }
-    #[inline]
-    fn to_i16(self) -> i16 {
-        self
-    }
-}
-
-impl AudioSample for i8 {
-    #[inline]
-    fn to_f32(self) -> f32 {
-        // Match i16 amplitude scale (multiply by 2^8). LLR
-        // calibration (LLR_SCALE in ft8::params) thus stays
-        // valid without per-sample-type rescaling.
-        (self as i32 * 256) as f32
-    }
-    #[inline]
-    fn to_i16(self) -> i16 {
-        (self as i16) << 8
-    }
-}
-
-// ── Tunables ────────────────────────────────────────────────────────────────
-
-/// Per-symbol spectrogram FFT length. Power of two.
-///
-/// Caps differ by backend:
-/// - **fc32 (f32 path)**: 4096, limited by esp-dsp's bit-rev
-///   lookup tables shipped only at sizes 16..4096
-///   (`dsps_fft2r_bitrev_tables_fc32.c`). Requesting 8192 corrupts
-///   the rev-table array inside `dsps_fft2r_fc32_ae32_`.
-/// - **sc16 (`fixed-point` feature)**: no cap up to 32768; sc16
-///   has no rev-table dependency and generates twiddles on the fly.
-///
-/// **NFFT=3840 = 2*NSPS**, matching WSJT-X `sync8.f90`'s `NFFT1`.
-///
-/// - `tone_step_bins = TONE_SPACING_HZ / df = 6.25 / (12000/3840) = 2.0`
-///   exactly (integer), so each FT8 tone falls on a single FFT bin and
-///   the rectangular-window sidelobes do not leak onto adjacent tones.
-/// - Numerically identical scale to WSJT-X — `savg`, `sbase`, `xsig`,
-///   `xsnr2` and the Costas-correlation score can be compared bin-for-bin
-///   against WSJT-X reference output when debugging false decodes / SNR
-///   reporting (no calibration constants required).
-/// - Rectangular window throughout (no Hann); the previously needed
-///   Hann compensation, multi-bin tone sum, and Hann-coherent-gain
-///   pre-shift have all been removed.
-///
-/// Embedded (Xtensa, `fixed-point` feature) gets the same NFFT via a
-/// 256 × 15 mixed-radix wrapper around esp-dsp's radix-2 256-pt FFT
-/// (see `embedded-shared::esp_dsp_fft::MixedRadix3840Fft`). The 15-pt
-/// PFA factor is in `mfsk-core/src/core/dsp/fft_15.rs` with hardcoded
-/// 3-pt and 5-pt twiddles.
-pub const NFFT_SPEC: usize = 3840;
-
-/// Coarse-sync slide step (samples). **Quarter-symbol** (NSPS/4=480,
-/// 40 ms, 372 frames per slot) — matches WSJT-X `ft8_params.f90`
-/// `NSTEP=NSPS/4` exactly. The earlier setting NSPS/2 (=960, 184
-/// frames) had half the dt resolution and was the dominant blocker
-/// of `decode_block` parity with WSJT-X on busy slots: low-band
-/// candidates (e.g. W0RSJ @400 Hz, N1PJT @466 Hz, KD2UGC @472 Hz on
-/// qso3_busy) were either missed or the dt accuracy left BP unable
-/// to lock. The previous comment claimed halving to NSPS killed
-/// AWGN sensitivity — but that was vs NSPS, not NSPS/4 (the WSJT-X
-/// choice), which had not been benchmarked.
-// Mirrors `crate::ft8::params::NSTEP` — gated on `nstep-half` so
-// embedded targets pick the NSPS/2 (= 960) variant the embedded
-// `stage1_inc` builds spec at, instead of the WSJT-faithful NSPS/4
-// (= 480) used on host. Both consts must agree because the score
-// loop in `coarse_sync_inner` derives `m_base` from them.
-#[cfg(not(feature = "nstep-half"))]
-const NSTEP: usize = NSPS / 4;
-#[cfg(feature = "nstep-half")]
-const NSTEP: usize = NSPS / 2;
-
-/// Steps per symbol — used to map symbol-index to time-step lag.
-const NSSY: i32 = (NSPS / NSTEP) as i32;
-
-/// FT8 tone spacing (Hz).
-const TONE_SPACING_HZ: f32 = 6.25;
-
-/// Regulariser added to `mean_others` in coarse_sync's ratio metric
-/// `t / (mean_others + ε)`. On the fp path the u16 spectrogram
-/// quantises noise bins to 0; on phantom carriers where the 7
-/// non-Costas tones happen to quantise to 0 the bare ratio explodes
-/// 100-1000× over real-signal scores and buries busy-band truth in
-/// coarse_sync's top-N. ε ≈ a fraction of one u16 LSB at
-/// `FP_SPEC_SHIFT=12` keeps the ratio finite without depressing
-/// genuine weak-signal scores (AWGN -17.5 dB threshold preserved).
-///
-/// 0.5 was picked from a host sweep over real-QSO WAVs: ε ∈ {0.1,
-/// 0.25, 0.5, 1.0, 2.0} — 0.25 and 0.5 both gave 8/13 truth in
-/// top-30 on busy-band qso3 (was 4/13 with bare ratio); 0.5 had
-/// slightly tighter top ranks. ε > 1.0 starts losing borderline
-/// weak signals; ε < 0.25 leaks phantom inflation back in.
-///
-/// On the f32 path `mean_others` never quantises to 0 so ε is
-/// dwarfed by typical t0_ref values and has no measurable effect.
-const RATIO_EPS_DEFAULT: f32 = 0.5;
-fn ratio_eps() -> f32 {
-    #[cfg(feature = "std")]
-    {
-        if let Ok(s) = std::env::var("MFSK_RATIO_EPS")
-            && let Ok(v) = s.parse::<f32>()
-        {
-            return v;
-        }
-    }
-    RATIO_EPS_DEFAULT
-}
-
-/// 12 kHz fixed sample rate.
-const SAMPLE_RATE_HZ: f32 = 12_000.0;
-
-/// Slot start offset (FT8 transmits 0.5 s into the slot).
-const TX_START_OFFSET_S: f32 = 0.5;
-
-/// Coarse-sync ±lag search window (s).
-///
-/// WSJT-X uses ±2.5 s — covers operators with sloppy slot timing
-/// or slow rigs. Embedded targets running on a synced clock (NTP /
-/// GPS) live well within ±1 s; halving the lag range cuts
-/// `coarse_sync` work by ~60 % (linear in `n_lag`). If the live
-/// timing source is loose, raise this back to 2.5.
-const SYNC_LAG_S_DEFAULT: f32 = 1.0;
-fn sync_lag_s() -> f32 {
-    #[cfg(feature = "std")]
-    {
-        if let Ok(s) = std::env::var("MFSK_SYNC_LAG_S")
-            && let Ok(v) = s.parse::<f32>()
-        {
-            return v;
-        }
-    }
-    SYNC_LAG_S_DEFAULT
-}
-
-/// Same NMS α as the bench-tuned default in `mfsk-core/src/fec/ldpc/bp.rs`.
-const NMS_ALPHA: f32 = 0.75;
-
-/// `process_candidates` early-rejects cands whose full-21-symbol
-/// `sync_quality` is at or below this threshold. Matches WSJT-X
-/// `ft8b.f90:177` — `nsync ≤ 6 → bail`. Slower MCUs may raise this
-/// at the cost of a few weak-signal decodes (the previous default
-/// of 12 saved ~12-21 % stage-3 wall-clock); pass via the
-/// `q_thresh` parameter on `process_candidates_into` /
-/// `process_candidates_into_with_cs_scratch`.
-pub const DEFAULT_Q_THRESH: u32 = 6;
+// Re-export the items that were previously defined inline in this
+// file so external callers (`mfsk-ffi-ft8`, `embedded-shared`,
+// integration tests, sibling modules under `ft8/`) see the same
+// `mfsk_core::ft8::decode_block::*` paths.
+pub use types::{AudioSample, DEFAULT_Q_THRESH, NFFT_SPEC};
+use types::{
+    NMS_ALPHA, NSSY, NSTEP, SAMPLE_RATE_HZ, TONE_SPACING_HZ, TX_START_OFFSET_S, ratio_eps,
+    sync_lag_s,
+};
 
 // ── Spectrogram ─────────────────────────────────────────────────────────────
 

--- a/mfsk-core/src/ft8/decode_block/types.rs
+++ b/mfsk-core/src/ft8/decode_block/types.rs
@@ -1,0 +1,184 @@
+//! Shared types, constants, and runtime tunables for the
+//! `decode_block` pipeline.
+//!
+//! ε.1 of the `docs/CLEANUP_2026_05.md` decode_block split. Items here
+//! are the cross-cutting bits referenced by ≥2 of the per-stage
+//! submodules (spectrogram, coarse_sync, fill_symbol_spectra,
+//! process_candidates) plus the public-facade entry functions. The
+//! later ε.N PRs move per-stage code into siblings of this file under
+//! `mfsk-core/src/ft8/decode_block/`.
+//!
+//! Re-exported by the parent module (`decode_block.rs`) so external
+//! callers see the same paths (`mfsk_core::ft8::decode_block::AudioSample`,
+//! `…::NFFT_SPEC`, …) as before the move.
+
+use super::super::params::NSPS;
+
+// ── Audio sample trait ──────────────────────────────────────────────────────
+
+/// Trait for audio sample types accepted by `decode_block`. Lets the
+/// caller hand in either `i16` (the canonical FT8 PCM) or `i8`
+/// (half-storage, ~45 dB SQNR — plenty for FT8's -24 dB threshold —
+/// useful when the slot needs to fit in scarce internal SRAM on
+/// embedded targets where PSRAM access is the bottleneck).
+///
+/// The `to_f32` implementation must produce values on the same
+/// amplitude scale as `i16` so the LLR computation downstream keeps
+/// its calibration; for `i8` we therefore multiply by 256.
+pub trait AudioSample: Copy {
+    fn to_f32(self) -> f32;
+    /// Promote to i16 range. i8 → i16 via `<<8`; i16 → i16
+    /// identity. Used by the fixed-point FFT input path.
+    fn to_i16(self) -> i16;
+}
+
+impl AudioSample for i16 {
+    #[inline]
+    fn to_f32(self) -> f32 {
+        self as f32
+    }
+    #[inline]
+    fn to_i16(self) -> i16 {
+        self
+    }
+}
+
+impl AudioSample for i8 {
+    #[inline]
+    fn to_f32(self) -> f32 {
+        // Match i16 amplitude scale (multiply by 2^8). LLR
+        // calibration (LLR_SCALE in ft8::params) thus stays
+        // valid without per-sample-type rescaling.
+        (self as i32 * 256) as f32
+    }
+    #[inline]
+    fn to_i16(self) -> i16 {
+        (self as i16) << 8
+    }
+}
+
+// ── Tunables ────────────────────────────────────────────────────────────────
+
+/// Per-symbol spectrogram FFT length. Power of two.
+///
+/// Caps differ by backend:
+/// - **fc32 (f32 path)**: 4096, limited by esp-dsp's bit-rev
+///   lookup tables shipped only at sizes 16..4096
+///   (`dsps_fft2r_bitrev_tables_fc32.c`). Requesting 8192 corrupts
+///   the rev-table array inside `dsps_fft2r_fc32_ae32_`.
+/// - **sc16 (`fixed-point` feature)**: no cap up to 32768; sc16
+///   has no rev-table dependency and generates twiddles on the fly.
+///
+/// **NFFT=3840 = 2*NSPS**, matching WSJT-X `sync8.f90`'s `NFFT1`.
+///
+/// - `tone_step_bins = TONE_SPACING_HZ / df = 6.25 / (12000/3840) = 2.0`
+///   exactly (integer), so each FT8 tone falls on a single FFT bin and
+///   the rectangular-window sidelobes do not leak onto adjacent tones.
+/// - Numerically identical scale to WSJT-X — `savg`, `sbase`, `xsig`,
+///   `xsnr2` and the Costas-correlation score can be compared bin-for-bin
+///   against WSJT-X reference output when debugging false decodes / SNR
+///   reporting (no calibration constants required).
+/// - Rectangular window throughout (no Hann); the previously needed
+///   Hann compensation, multi-bin tone sum, and Hann-coherent-gain
+///   pre-shift have all been removed.
+///
+/// Embedded (Xtensa, `fixed-point` feature) gets the same NFFT via a
+/// 256 × 15 mixed-radix wrapper around esp-dsp's radix-2 256-pt FFT
+/// (see `embedded-shared::esp_dsp_fft::MixedRadix3840Fft`). The 15-pt
+/// PFA factor is in `mfsk-core/src/core/dsp/fft_15.rs` with hardcoded
+/// 3-pt and 5-pt twiddles.
+pub const NFFT_SPEC: usize = 3840;
+
+/// Coarse-sync slide step (samples). **Quarter-symbol** (NSPS/4=480,
+/// 40 ms, 372 frames per slot) — matches WSJT-X `ft8_params.f90`
+/// `NSTEP=NSPS/4` exactly. The earlier setting NSPS/2 (=960, 184
+/// frames) had half the dt resolution and was the dominant blocker
+/// of `decode_block` parity with WSJT-X on busy slots: low-band
+/// candidates (e.g. W0RSJ @400 Hz, N1PJT @466 Hz, KD2UGC @472 Hz on
+/// qso3_busy) were either missed or the dt accuracy left BP unable
+/// to lock. The previous comment claimed halving to NSPS killed
+/// AWGN sensitivity — but that was vs NSPS, not NSPS/4 (the WSJT-X
+/// choice), which had not been benchmarked.
+// Mirrors `crate::ft8::params::NSTEP` — gated on `nstep-half` so
+// embedded targets pick the NSPS/2 (= 960) variant the embedded
+// `stage1_inc` builds spec at, instead of the WSJT-faithful NSPS/4
+// (= 480) used on host. Both consts must agree because the score
+// loop in `coarse_sync_inner` derives `m_base` from them.
+#[cfg(not(feature = "nstep-half"))]
+pub(super) const NSTEP: usize = NSPS / 4;
+#[cfg(feature = "nstep-half")]
+pub(super) const NSTEP: usize = NSPS / 2;
+
+/// Steps per symbol — used to map symbol-index to time-step lag.
+pub(super) const NSSY: i32 = (NSPS / NSTEP) as i32;
+
+/// FT8 tone spacing (Hz).
+pub(super) const TONE_SPACING_HZ: f32 = 6.25;
+
+/// Regulariser added to `mean_others` in coarse_sync's ratio metric
+/// `t / (mean_others + ε)`. On the fp path the u16 spectrogram
+/// quantises noise bins to 0; on phantom carriers where the 7
+/// non-Costas tones happen to quantise to 0 the bare ratio explodes
+/// 100-1000× over real-signal scores and buries busy-band truth in
+/// coarse_sync's top-N. ε ≈ a fraction of one u16 LSB at
+/// `FP_SPEC_SHIFT=12` keeps the ratio finite without depressing
+/// genuine weak-signal scores (AWGN -17.5 dB threshold preserved).
+///
+/// 0.5 was picked from a host sweep over real-QSO WAVs: ε ∈ {0.1,
+/// 0.25, 0.5, 1.0, 2.0} — 0.25 and 0.5 both gave 8/13 truth in
+/// top-30 on busy-band qso3 (was 4/13 with bare ratio); 0.5 had
+/// slightly tighter top ranks. ε > 1.0 starts losing borderline
+/// weak signals; ε < 0.25 leaks phantom inflation back in.
+///
+/// On the f32 path `mean_others` never quantises to 0 so ε is
+/// dwarfed by typical t0_ref values and has no measurable effect.
+const RATIO_EPS_DEFAULT: f32 = 0.5;
+pub(super) fn ratio_eps() -> f32 {
+    #[cfg(feature = "std")]
+    {
+        if let Ok(s) = std::env::var("MFSK_RATIO_EPS")
+            && let Ok(v) = s.parse::<f32>()
+        {
+            return v;
+        }
+    }
+    RATIO_EPS_DEFAULT
+}
+
+/// 12 kHz fixed sample rate.
+pub(super) const SAMPLE_RATE_HZ: f32 = 12_000.0;
+
+/// Slot start offset (FT8 transmits 0.5 s into the slot).
+pub(super) const TX_START_OFFSET_S: f32 = 0.5;
+
+/// Coarse-sync ±lag search window (s).
+///
+/// WSJT-X uses ±2.5 s — covers operators with sloppy slot timing
+/// or slow rigs. Embedded targets running on a synced clock (NTP /
+/// GPS) live well within ±1 s; halving the lag range cuts
+/// `coarse_sync` work by ~60 % (linear in `n_lag`). If the live
+/// timing source is loose, raise this back to 2.5.
+const SYNC_LAG_S_DEFAULT: f32 = 1.0;
+pub(super) fn sync_lag_s() -> f32 {
+    #[cfg(feature = "std")]
+    {
+        if let Ok(s) = std::env::var("MFSK_SYNC_LAG_S")
+            && let Ok(v) = s.parse::<f32>()
+        {
+            return v;
+        }
+    }
+    SYNC_LAG_S_DEFAULT
+}
+
+/// Same NMS α as the bench-tuned default in `mfsk-core/src/fec/ldpc/bp.rs`.
+pub(super) const NMS_ALPHA: f32 = 0.75;
+
+/// `process_candidates` early-rejects cands whose full-21-symbol
+/// `sync_quality` is at or below this threshold. Matches WSJT-X
+/// `ft8b.f90:177` — `nsync ≤ 6 → bail`. Slower MCUs may raise this
+/// at the cost of a few weak-signal decodes (the previous default
+/// of 12 saved ~12-21 % stage-3 wall-clock); pass via the
+/// `q_thresh` parameter on `process_candidates_into` /
+/// `process_candidates_into_with_cs_scratch`.
+pub const DEFAULT_Q_THRESH: u32 = 6;


### PR DESCRIPTION
## Summary

First slice of the `decode_block.rs` per-stage split planned in `docs/CLEANUP_2026_05.md` ε. Moves the cross-cutting items (referenced by ≥2 of the per-stage pieces yet to be carved out) into a new `mfsk-core/src/ft8/decode_block/types.rs` submodule.

Five more PRs land in sequence — spectrogram (ε.2), coarse_sync (ε.3), fill_symbol_spectra (ε.4), process_candidates (ε.5), osd_strategy (ε.6). Each is independently reviewable and verifies the WSJT-X golden recall on `qso3_busy` before merge.

## What moves into `types.rs`

- `AudioSample` trait + impls for `i16` / `i8`
- Tunable constants: `NFFT_SPEC`, `NSTEP`, `NSSY`, `TONE_SPACING_HZ`, `SAMPLE_RATE_HZ`, `TX_START_OFFSET_S`, `SYNC_LAG_S_DEFAULT`, `NMS_ALPHA`, `DEFAULT_Q_THRESH`, `RATIO_EPS_DEFAULT`
- Runtime tunable fns: `ratio_eps()`, `sync_lag_s()`

`Spectrogram`, `SpecCell`, `FP_SPEC_SHIFT`, `CoarseAcc` stay in the parent for ε.2 — they belong with `compute_spectrogram` (the spectrogram stage submodule).

## API surface preserved

External-caller path unchanged: `mfsk_core::ft8::decode_block::*` re-exports the same public symbols (`AudioSample`, `NFFT_SPEC`, `DEFAULT_Q_THRESH`) via `pub use types::*` in the parent. Remaining ex-private items are surfaced internally with `pub(super)` + a private `use types::*` in the parent. `mfsk-ffi-ft8`, `embedded-shared`, and the m5stack apps see no change.

## Test plan

- [x] `cargo check` clean on all 4 feature cells:
  - default (`std alloc ft8 fft-rustfft`)
  - embedded ship (`alloc ft8 fft-extern fixed-point`)
  - host fixed-point bench (`std alloc ft8 fft-rustfft fixed-point`)
  - embedded with `nstep-half`
- [x] FT8 `qso3_busy` golden tests pass: WSJT-X AP-off floor, JTDX recall floor, AP-on strict-superset, AP-on subtract diag
- [x] All 7 `ft8::decode_block::tests::*` lib tests pass
- [x] `cargo clippy --features full --lib` clean
- [x] `cargo fmt --check` clean
- [x] Diff confined to `mfsk-core/src/ft8/decode_block.rs` (−168 / +17) + the new `decode_block/types.rs` (201 lines, mostly copied verbatim)

🤖 Generated with [Claude Code](https://claude.com/claude-code)