### PR TITLE
cleanup(ε.6): lift OSD dispatch into decode_block/osd_strategy.rs (#63 hook)

### DIFF
--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -21,11 +21,18 @@
 // ── Submodule layout (`docs/CLEANUP_2026_05.md` ε) ──────────────────────────
 //
 // `decode_block.rs` is the parent / facade for a per-stage submodule
-// tree. ε.1 carved out `types.rs`; ε.2 carved `spectrogram.rs`; ε.3
-// carved `coarse_sync.rs`; ε.4 carved `fill_symbol_spectra.rs`; ε.5
-// carved `process_candidates.rs`. ε.6 will follow with osd_strategy.
+// tree carved out by `docs/CLEANUP_2026_05.md` ε:
+//   ε.1 types  · ε.2 spectrogram  · ε.3 coarse_sync
+//   ε.4 fill_symbol_spectra  · ε.5 process_candidates
+//   ε.6 osd_strategy (the WSJT-X-faithful precoding hook for #63)
+//
+// `process_candidates` and `osd_strategy` are siblings; the rest of
+// the tree is stage-shaped (spectrogram → coarse_sync →
+// fill_symbol_spectra → per-candidate processing). The parent file
+// owns only module declarations + re-exports + tests.
 mod coarse_sync;
 mod fill_symbol_spectra;
+mod osd_strategy;
 mod process_candidates;
 mod spectrogram;
 mod types;

--- a/mfsk-core/src/ft8/decode_block/osd_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/osd_strategy.rs
@@ -1,0 +1,117 @@
+//! OSD fallback strategy — Step 3 of the per-candidate decode
+//! staircase.
+//!
+//! Runs only when Steps 1–2 (BP staircase) fail and the caller asks
+//! for `BpAllOsd` depth at sufficient `sync_quality`. Computes a
+//! fresh f32 LLR bundle for the candidate (OSD operates on f32
+//! regardless of the embedded fixed-point `LlrT`), then walks the
+//! four LLR variants (a/b/c/d) through `osd_decode` (ndeep=2) or
+//! `osd_decode_deep(_, 3, _)` for high-q candidates, applying the
+//! WSJT-X-faithful `nharderrors > 36` cycle gate to weed out
+//! high-error CRC-luck codewords.
+//!
+//! ε.6 of the `docs/CLEANUP_2026_05.md` `decode_block` split. This
+//! is the deliberate hook point for issue **#63** — the
+//! WSJT-X-faithful `nord=1 + npre1=1` precoding patch — so that
+//! restoring strict WSJT-X behaviour does not require touching
+//! `process_one_candidate_inner` or any other stage. Replace the
+//! `osd_decode` / `osd_decode_deep` call below with a precoding
+//! variant; everything else stays put.
+//!
+//! **WSJT-X-faithfulness deviation (#63 context).** `ft8b.f90` always
+//! calls `osd174_91(..., norder=2, ...)` for FT8, which dispatches to
+//! `nord=1 + npre1=1` — order-1 MRB search **plus** a precoding rule
+//! (test error patterns derived from G matrix columns;
+//! `osd174_91.f90:230-289`). mfsk-core has no precoding implementation
+//! yet; the bumped `ndeep` here was chosen as a simpler stand-in.
+//! Whether pattern-count compensation actually covers the
+//! structurally-distinct patterns WSJT-X's precoding generates is an
+//! open question.
+
+use alloc::vec;
+
+use super::super::decode::DecodeDepth;
+use super::super::params::LDPC_N;
+use super::process_candidates::WSJTX_NHARDERRORS_MAX;
+use crate::core::scalar::Cmplx;
+use crate::fec::ldpc::bp::{BpResult, check_crc14};
+use crate::fec::ldpc::osd::{osd_decode, osd_decode_deep};
+
+/// Pass-ID range emitted by the OSD fallback (`14..=17` mirrors the
+/// llr-variant order `a/b/c/d` — see the post-0.6.1 pass-ID layout
+/// documented inline below). Exposed so `process_one_candidate_inner`
+/// can size its pass-tracking buffers without re-declaring magic
+/// numbers.
+pub(super) const PASS_ID_OSD_A: u8 = 14;
+
+/// Try the OSD staircase for a candidate whose BP staircase didn't
+/// converge. Returns `Some((bp_result, pass_id))` on the first
+/// accepted CRC-pass codeword, `None` otherwise.
+///
+/// Gates internally on `depth = BpAllOsd` and `q >= 12` so the caller
+/// can invoke unconditionally — keeps the per-candidate staircase in
+/// `process_one_candidate_inner` straightforward (`accepted = accepted
+/// .or_else(|| osd_strategy::try_fallback(...))`).
+pub(super) fn try_fallback(
+    cs_scratch: &[[Cmplx<f32>; 8]; 79],
+    depth: DecodeDepth,
+    q: u32,
+) -> Option<(BpResult, u8)> {
+    if !matches!(depth, DecodeDepth::BpAllOsd) || q < 12 {
+        return None;
+    }
+
+    // OSD operates on `&[f32]` directly — independent of the embedded
+    // `LlrT` choice — so we compute a fresh f32 LLR bundle here. Only
+    // fires when Steps 1+2 BP failed and `q >= 12`, so the extra
+    // compute_llr is cheap relative to the OSD work itself.
+    let llr_full_f32: super::super::llr::LlrSet<f32> = super::super::llr::compute_llr(cs_scratch);
+
+    // Pass-ID space (post-0.6.1): BP variants 0..3, AP iaptypes
+    // 5..12 (mirroring WSJT-X ipass 5..12), host OSD-Deep 13,
+    // embedded OSD a/b/c/d 14/15/16/17. The +10 shift on OSD
+    // frees 5..12 for the AP loop being plumbed into the same
+    // per-candidate function in 0.6.1.
+    for (llr, pid) in [
+        (&llr_full_f32.llra, PASS_ID_OSD_A),
+        (&llr_full_f32.llrb, PASS_ID_OSD_A + 1),
+        (&llr_full_f32.llrc, PASS_ID_OSD_A + 2),
+        (&llr_full_f32.llrd, PASS_ID_OSD_A + 3),
+    ] {
+        // OSD depth dispatch — mfsk-core terminology.
+        //
+        // `osd_decode_deep(_, N, _)` tries MRB error patterns of
+        // weight 0..=N (inclusive). `osd_decode` is a thin wrapper for
+        // `osd_decode_generic(_, 2, _, _)` (ndeep=2). The ndeep=2/3
+        // split has been the design since f118a64.
+        //
+        // **Hook point for #63.** Replace this branch with the
+        // WSJT-X-faithful `nord=1 + npre1=1` precoding variant; the
+        // rest of the strategy stays intact.
+        let osd = if q >= 18 {
+            osd_decode_deep(llr, 3, Some(check_crc14))
+        } else {
+            osd_decode(llr)
+        };
+        if let Some(osd) = osd {
+            // Mirror the BP-variant `nharderrors > 36` cycle gate
+            // (ft8b.f90:422) on the OSD path. WSJT-X's OSD itself
+            // returns CRC-pass codewords with negated `nhardmin` on
+            // CRC fail (osd174_91:290), but we apply the same upper
+            // bound to the hard-error count so high-error CRC-luck
+            // codewords don't pass through OSD either.
+            if osd.hard_errors > WSJTX_NHARDERRORS_MAX {
+                continue;
+            }
+            let bp = BpResult {
+                message77: osd.message77,
+                info: osd.info,
+                codeword: vec![0u8; LDPC_N],
+                hard_errors: osd.hard_errors,
+                iterations: 0,
+            };
+            return Some((bp, pid));
+        }
+    }
+    None
+}

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -17,7 +17,6 @@
 //! ε.5 of the `docs/CLEANUP_2026_05.md` `decode_block` split.
 
 use alloc::boxed::Box;
-use alloc::vec;
 use alloc::vec::Vec;
 
 #[cfg(not(feature = "std"))]
@@ -38,7 +37,8 @@ use super::types::{
 use crate::core::scalar::{Cmplx, ComplexSpec};
 use crate::core::sync::SyncCandidate;
 use crate::fec::ldpc::bp::check_crc14;
-use crate::fec::ldpc::osd::{osd_decode, osd_decode_deep};
+#[cfg(feature = "fft-rustfft")]
+use crate::fec::ldpc::osd::osd_decode_deep;
 
 #[cfg(all(feature = "fixed-point", not(feature = "fft-rustfft")))]
 use super::fill_symbol_spectra::fill_symbol_spectra_into;
@@ -1258,7 +1258,7 @@ where
 /// WSJT-X-faithful nharderrors gate (ft8b.f90:422). High hard-error
 /// CRC-pass decodes are the dominant phantom source on busy bands;
 /// reject above this and fall through to the next BP variant.
-const WSJTX_NHARDERRORS_MAX: u32 = 36;
+pub(super) const WSJTX_NHARDERRORS_MAX: u32 = 36;
 
 /// Per-candidate decode core — runs the LLR-staircase, OSD fallback,
 /// and AP iaptype loop on a *fully-filled* `cs_scratch`. Shared
@@ -1376,69 +1376,11 @@ pub(in crate::ft8) fn process_one_candidate_inner(
     }
 
     // Step 3: OSD fallback (sync_quality gated; only for BpAllOsd).
-    // OSD operates on `&[f32]` directly — independent of the
-    // `LlrT` choice — so we compute a fresh f32 LLR bundle here.
-    // Only fires when Steps 1+2 BP failed and `q >= 12`, so the
-    // extra compute_llr is cheap relative to the OSD work itself.
-    if accepted.is_none() && matches!(depth, DecodeDepth::BpAllOsd) && q >= 12 {
-        let llr_full_f32: super::super::llr::LlrSet<f32> =
-            super::super::llr::compute_llr(cs_scratch);
-        // Pass-ID space (post-0.6.1): BP variants 0..3, AP iaptypes
-        // 5..12 (mirroring WSJT-X ipass 5..12), host OSD-Deep 13,
-        // embedded OSD a/b/c/d 14/15/16/17. The +10 shift on OSD
-        // frees 5..12 for the AP loop being plumbed into this same
-        // function in 0.6.1 (decode_block_with_ap path).
-        for (llr, pid) in [
-            (&llr_full_f32.llra, 14u8),
-            (&llr_full_f32.llrb, 15),
-            (&llr_full_f32.llrc, 16),
-            (&llr_full_f32.llrd, 17),
-        ] {
-            // OSD depth dispatch — mfsk-core terminology.
-            //
-            // `osd_decode_deep(_, N, _)` tries MRB error patterns of
-            // weight 0..=N (inclusive). `osd_decode` is a thin wrapper for
-            // `osd_decode_generic(_, 2, _, _)` (ndeep=2). The
-            // ndeep=2/3 split has been the design since f118a64.
-            //
-            // **WSJT-X-faithfulness deviation (see #63).** ft8b.f90
-            // always calls `osd174_91(..., norder=2, ...)` for FT8,
-            // which dispatches to `nord=1 + npre1=1` — order-1 MRB
-            // search **plus** a precoding rule (test error patterns
-            // derived from G matrix columns; osd174_91.f90:230-289).
-            // mfsk-core has no precoding implementation; the bumped
-            // ndeep here was chosen as a simpler stand-in. Whether
-            // pattern-count compensation actually covers the
-            // structurally-distinct patterns WSJT-X's precoding
-            // generates is an open question. #63 tracks restoring
-            // strict WSJT-X behaviour (nord=1 + npre1).
-            let osd = if q >= 18 {
-                osd_decode_deep(llr, 3, Some(check_crc14))
-            } else {
-                osd_decode(llr)
-            };
-            if let Some(osd) = osd {
-                // Mirror the BP-variant `nharderrors > 36` cycle
-                // gate (ft8b.f90:422) on the OSD path. WSJT-X's
-                // OSD itself returns CRC-pass codewords with
-                // negated `nhardmin` on CRC fail (osd174_91:290),
-                // but we apply the same upper bound to the
-                // hard-error count so high-error CRC-luck
-                // codewords don't pass through OSD either.
-                if osd.hard_errors > WSJTX_NHARDERRORS_MAX {
-                    continue;
-                }
-                let bp = crate::fec::ldpc::bp::BpResult {
-                    message77: osd.message77,
-                    info: osd.info,
-                    codeword: vec![0u8; LDPC_N],
-                    hard_errors: osd.hard_errors,
-                    iterations: 0,
-                };
-                accepted = Some((bp, pid));
-                break;
-            }
-        }
+    // The actual dispatch — including the WSJT-X-faithfulness
+    // deviation #63 tracks restoring — lives in `super::osd_strategy`
+    // so #63 can patch it without touching the rest of this function.
+    if accepted.is_none() {
+        accepted = super::osd_strategy::try_fallback(cs_scratch, depth, q);
     }
 
     // Step 4: AP iaptype loop (host f32 only; gated on fft-rustfft).
@@ -1557,7 +1499,7 @@ pub(in crate::ft8) fn process_one_candidate_inner(
                     let bp = crate::fec::ldpc::bp::BpResult {
                         message77: osd.message77,
                         info: osd.info,
-                        codeword: vec![0u8; LDPC_N],
+                        codeword: alloc::vec![0u8; LDPC_N],
                         hard_errors: osd.hard_errors,
                         iterations: 0,
                     };


### PR DESCRIPTION
## Summary

Final slice of the `decode_block.rs` per-stage split — the load-bearing structural payoff of ε. **Stacked on #81 (ε.5)** — merge order: #77 → #78 → #79 → #80 → #81 → this.

Lifts the OSD-fallback block out of `process_one_candidate_inner` (now in `process_candidates.rs`) into a dedicated `osd_strategy` submodule with a single `try_fallback(cs_scratch, depth, q) → Option<(BpResult, u8)>` entry. The caller becomes a 3-line `accepted.is_none()` check:

```rust
if accepted.is_none() {
    accepted = super::osd_strategy::try_fallback(cs_scratch, depth, q);
}
```

`try_fallback` itself owns the `BpAllOsd + q ≥ 12` gating, the fresh f32 LLR compute, the a/b/c/d variant walk, the q-conditional `osd_decode` / `osd_decode_deep` depth switch, the `nharderrors > 36` cycle gate, and the BpResult assembly — same behaviour as the pre-ε.6 inline block, just relocated.

## The #63 hook

This is the deliberate hook point for issue **#63** — WSJT-X-faithful `nord=1 + npre1=1` precoding. With the OSD dispatch in its own module, restoring strict WSJT-X behaviour means patching `osd_strategy::try_fallback` alone — `process_one_candidate_inner`, the multipass driver, and every other stage stay untouched. The module docstring and an inline comment in `try_fallback` mark the hook explicitly.

## Other cleanups in this PR

- `WSJTX_NHARDERRORS_MAX` in `process_candidates.rs` bumped from private to `pub(super)` so `osd_strategy` can read it
- `osd_decode_deep` import in `process_candidates.rs` cfg-gated to `feature = "fft-rustfft"` (only the AP iaptype loop uses it post-lift); `osd_decode` import dropped entirely (only used by the lifted block)
- `alloc::vec` macro import dropped in favour of fully-qualified `alloc::vec!`; matches the pattern the rest of the file already uses and avoids "unused import" warnings under embedded ship where the only bare `vec!` callsite was the lifted OSD block

## Test plan

- [x] `cargo check` clean on all 4 feature cells, no warnings
- [x] FT8 `qso3_busy` golden tests pass (WSJT-X AP-off floor, JTDX recall floor, AP-on strict-superset, AP-on subtract diag)
- [x] All 7 `ft8::decode_block::tests::*` lib tests pass
- [x] `cargo clippy --features full --lib` clean, `cargo fmt --check` clean, `cargo doc --features full --no-deps` clean
- [x] Diff: `process_candidates.rs` −66 / +7, `decode_block.rs` +13 / −7 (mod decl + comment refresh), new `osd_strategy.rs` +117

## Final ε shape

Started at 3,517-line monolith. Final tree:

| file | lines | role |
|---|---|---|
| `decode_block.rs` | 423 | parent / facade |
| `decode_block/types.rs` | 184 | audio sample + tunables |
| `decode_block/spectrogram.rs` | 357 | Spectrogram + compute_spectrogram |
| `decode_block/coarse_sync.rs` | 537 | Costas search + allsum helpers |
| `decode_block/fill_symbol_spectra.rs` | 601 | per-symbol DFT family |
| `decode_block/process_candidates.rs` | 1538 | engine + facade impls |
| `decode_block/osd_strategy.rs` | 117 | OSD dispatch (#63 hook) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)