### PR TITLE
feat(s3-app): wire espressif/usb_host_uac 1.4.0 component + bindings

### DIFF
--- a/embedded-poc/bindings.h
+++ b/embedded-poc/bindings.h
@@ -3,3 +3,11 @@
 #if defined(ESP_IDF_COMP_ESPRESSIF__ESP_DSP_ENABLED)
 #include "esp_dsp.h"
 #endif
+
+// USB UAC host driver — only m5stack-s3-app pulls this component in
+// (Core2 has no USB-OTG host). Guarded on the component-manager
+// macro so Core2 builds don't try to include a header that isn't on
+// the include path.
+#if defined(ESP_IDF_COMP_ESPRESSIF__USB_HOST_UAC_ENABLED)
+#include "usb/uac_host.h"
+#endif

--- a/embedded-poc/m5stack-s3-app/Cargo.toml
+++ b/embedded-poc/m5stack-s3-app/Cargo.toml
@@ -85,3 +85,15 @@ esp_idf_sdkconfig_defaults = ["sdkconfig.defaults", "sdkconfig.gen.defaults"]
 remote_component = { name = "espressif/esp-dsp", version = "^1.4" }
 bindings_header = "../bindings.h"
 bindings_module = "esp_dsp"
+
+# Phase 1: UAC host capture from IC-705. 1.4.0 で ESP32-S3 + PSRAM 構成
+# 対応 + driver task の任意コア配置が確定 (旧版は PSRAM 有効時に driver
+# task stack が壊れる既知問題があった)。bindings_module = "uac" で
+# `esp_idf_sys::uac::*` に `uac_host_install` / `uac_host_device_open` /
+# `uac_host_device_start` / `uac_host_device_read` などが生える。
+# reference example は esp-usb 上流の
+# `host/class/uac/usb_host_uac/examples/audio_player/main/main.c`。
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/usb_host_uac", version = "^1.4" }
+bindings_header = "../bindings.h"
+bindings_module = "uac"

--- a/embedded-poc/m5stack-s3-app/components_esp32s3.lock
+++ b/embedded-poc/m5stack-s3-app/components_esp32s3.lock
@@ -1,4 +1,14 @@
 dependencies:
+  espressif/cmake_utilities:
+    component_hash: 351350613ceafba240b761b4ea991e0f231ac7a9f59a9ee901f751bddc0bb18f
+    dependencies:
+    - name: idf
+      require: private
+      version: '>=4.1'
+    source:
+      registry_url: https://components.espressif.com
+      type: service
+    version: 0.5.3
   espressif/esp-dsp:
     component_hash: c1832a2020342144d0de7940f73184584f182b3e9aa53180ee86c84ce7ff14dc
     dependencies:
@@ -9,12 +19,41 @@ dependencies:
       registry_url: https://components.espressif.com/
       type: service
     version: 1.8.1
+  espressif/usb_host_uac:
+    component_hash: 329ee15599a523e279e34751304396d5482d5081c10df14cb5fdaa121323fa02
+    dependencies:
+    - name: espressif/cmake_utilities
+      registry_url: https://components.espressif.com
+      require: private
+      version: 0.5.*
+    - name: idf
+      require: private
+      version: '>=5.0'
+    - name: espressif/usb
+      registry_url: https://components.espressif.com
+      require: public
+      rules:
+      - if: idf_version >=6.0
+      - if: target not in ["linux"]
+      version: ^1.0.0
+    source:
+      registry_url: https://components.espressif.com/
+      type: service
+    targets:
+    - esp32s2
+    - esp32s3
+    - esp32s31
+    - esp32p4
+    - esp32h4
+    - linux
+    version: 1.4.0
   idf:
     source:
       type: idf
     version: 5.5.3
 direct_dependencies:
 - espressif/esp-dsp
-manifest_hash: dcb6777ebbd882ef694f10772d4eee72fde25082f70145f202c77448f436eac5
+- espressif/usb_host_uac
+manifest_hash: 2c0a5c6345c67283a820fe16718bdc893591c4e9e2a7298c80f76e7d78f01617
 target: esp32s3
 version: 2.0.0

--- a/embedded-poc/m5stack-s3-app/sdkconfig.defaults
+++ b/embedded-poc/m5stack-s3-app/sdkconfig.defaults
@@ -51,9 +51,18 @@ CONFIG_LWIP_TCP_ENABLED=y
 CONFIG_LWIP_UDP_ENABLED=y
 
 # ── USB Host (UAC capture) ───────────────────────────────────────────
-# Phase 1 で有効化 (recipe.c port 時)。Phase 0.6 では DRAM 節約のため
-# 無効化 — WiFi STA + decode_pipeline が同時に動く余地を確保。
-CONFIG_USB_HOST_ENABLED=n
+# Phase 1: IC-705 audio capture via espressif/usb_host_uac 1.4.x
+# (managed component pulled in via Cargo.toml extra_components). Host
+# stack を常時 link し、runtime には `BootMode::Uac` でのみ
+# `uac_host_install()` を呼ぶ。Host driver は ~20-30 KB DRAM を常時
+# 消費する (BootMode::Decode/Wifi でも) が、boot-time mode dispatch
+# で機能切り替えする方が field UX として簡潔。
+#
+# 注意: USB host を install すると USB-Serial-JTAG endpoint が
+# auto-detach され、`println!` 系の console は USB 経路から消える。
+# `BootMode::Uac` では WiFi STA + UDP log を必ず up させること
+# (main.rs dispatch arm 側で強制)。
+CONFIG_USB_HOST_ENABLED=y
 
 # ── PSRAM (Octal 8 MB) ────────────────────────────────────────────────
 CONFIG_SPIRAM=y

--- a/embedded-poc/m5stack-s3-app/src/uac.rs
+++ b/embedded-poc/m5stack-s3-app/src/uac.rs
@@ -1,16 +1,51 @@
-//! USB Audio Class host capture (Phase 1).
+//! USB Audio Class host capture — Phase 1 skeleton.
 //!
 //! IC-705 を ESP32-S3 USB-OTG host で UAC class device として認識し、
-//! isochronous IN endpoint から 16 kHz mono i16 を吸い上げて
-//! `mfsk_ft8_stream_push_i16` (12 kHz リサンプル経由) に流す。
+//! isochronous IN endpoint から音声を吸い上げて decode pipeline に流す
+//! 経路。本ファイルは Phase 1 の **component 取り込み + bindings
+//! sanity check** のみ。実装本体は #30 (host install + hot-plug) と
+//! それ以降の todo で順に積む。
 //!
-//! 実装メモ:
-//! - 参照: espressif/esp_usb_audio (recipe.c) — Rust から `unsafe extern "C"`
-//!   で叩く薄いラッパーを書く。
-//! - サンプリング: IC-705 USB Audio は 48 kHz / 16 kHz が選べる。電力と
-//!   帯域の都合で 16 kHz を選択し、`embedded_shared` の linear resampler
-//!   I16→12k で 12 kHz に揃える。
-//! - 検証: PC で 1500 Hz tone を IC-705 に注入 → S3 側で `peek_latest`
-//!   → FFT magnitude が 1500 Hz に立つことを USB-CDC log で確認。
+//! ## 接続方式 (確定済)
 //!
-//! Phase 0 ではプレースホルダのみ。
+//! - Component: `espressif/usb_host_uac@^1.4` を `Cargo.toml` の
+//!   `extra_components` 経由で managed component として取得。
+//!   bindings は `esp_idf_sys::uac::*` に生成 (Cargo.toml の
+//!   `bindings_module = "uac"`)。
+//! - IC-705 USB Audio は **固定 48 kHz / stereo / 16-bit** (16 kHz は
+//!   selectable ではない)。S3 側で stereo → mono (L ch 抽出 / R ch 破棄)
+//!   + 48 kHz → 12 kHz の 4:1 decimation を `embedded_shared` 経由で行う。
+//! - Reference example は esp-usb 上流の
+//!   `host/class/uac/usb_host_uac/examples/audio_player/main/main.c`。
+//!   そこの init 順序 (`usb_host_install` → `uac_host_install` →
+//!   `RX_CONNECTED` 通知で `uac_host_device_open` →
+//!   `uac_host_device_start`) をそのまま Rust に移植する想定。
+//!
+//! ## OTG 排他
+//!
+//! `usb_host_install()` を呼んだ瞬間に USB-Serial-JTAG endpoint が
+//! detach されるため、`BootMode::Uac` では WiFi STA + UDP log を必ず
+//! 起動させる (`main.rs` dispatch arm で強制)。
+//!
+//! ## 進捗
+//!
+//! - [x] managed component + bindings (#29, このファイル)
+//! - [ ] host install + hot-plug callback (#30)
+//! - [ ] iso IN streaming (#31)
+//! - [ ] 48 kHz stereo → 12 kHz mono resampler + ringbuf → decode (#32)
+//! - [ ] verification on hardware (#33-#34)
+//! - [ ] disconnect/reconnect polish (#35)
+
+/// Component / binding sanity check. Compile-only assertion that
+/// `esp_idf_svc::sys::uac::*` resolves — if `cargo check --release`
+/// succeeds with this referenced, we know the managed component is on
+/// the include path and bindgen generated the expected symbols. The
+/// `sys` re-export comes from `esp-idf-svc` (we don't pull `esp-idf-sys`
+/// as a direct dep — it's transitive via svc/hal).
+///
+/// Not called from `main.rs` yet; pulled into the build only via the
+/// `_BINDINGS_PRESENT` constant so the linker can DCE it once real
+/// entry points land in #30+.
+#[allow(dead_code)]
+const _BINDINGS_PRESENT: usize =
+    core::mem::size_of::<esp_idf_svc::sys::uac::uac_host_driver_config_t>();


### PR DESCRIPTION
## Summary

Phase 1 UAC step 1 of 7: pull `espressif/usb_host_uac@^1.4` as a managed component, generate Rust bindings under `esp_idf_svc::sys::uac::*`, flip `CONFIG_USB_HOST_ENABLED=y`. **No runtime behaviour change** — `uac.rs` contains only a `size_of::<uac_host_driver_config_t>()` compile-time sanity check until #30 wires the actual host install.

## Files

- `embedded-poc/m5stack-s3-app/Cargo.toml` — second `extra_components` block for `espressif/usb_host_uac`.
- `embedded-poc/bindings.h` — guarded `#include "usb/uac_host.h"` (only m5stack-s3-app pulls this component in; Core2 has no USB-OTG host).
- `embedded-poc/m5stack-s3-app/sdkconfig.defaults` — `CONFIG_USB_HOST_ENABLED=n` → `=y` with comment explaining the link-time vs runtime trade-off.
- `embedded-poc/m5stack-s3-app/components_esp32s3.lock` — auto-regenerated by IDF Component Manager (pulls `usb_host_uac@1.4.0` + `cmake_utilities@0.5.3`).
- `embedded-poc/m5stack-s3-app/src/uac.rs` — placeholder rewritten with the correct IC-705 sample-rate (48 kHz stereo / 16-bit fixed, not the 16 kHz the old doc claimed), progress checklist, and the compile-time sanity-check constant.

## Component choice

`espressif/usb_host_uac@^1.4` (latest 1.4.0, 2026-05-06). Why pin to 1.4:
- 1.4.0 fixes a PSRAM-enabled-build driver-task crash that bit pre-1.3.2 builds. M5StickS3 is Octal PSRAM so this is load-bearing.
- 1.4.0 allows the UAC driver task to run on `tskNO_AFFINITY`.
- 1.3.3 introduced forced `bInterval=1` for iso IN (IC-705 already uses bInterval=1 — fine).

## Build trade-off

`CONFIG_USB_HOST_ENABLED=y` is link-time → host stack consumes ~20-30 KB DRAM in every `BootMode` (Decode + Wifi included), not just Uac. Acceptable on the 512 KB-internal-DRAM S3. Runtime `uac_host_install()` will still gate on `BootMode::Uac` so USB-Serial-JTAG console survives in non-UAC modes.

## Verified

`source ~/export-esp.sh && cargo check --release` from `embedded-poc/m5stack-s3-app/`:
- Bindings generated under `pub mod uac { ... }` in `bindings.rs`.
- All key entry points present: `uac_host_install`, `_uninstall`, `_handle_events`, `_device_open(_with_vid_pid)`, `_close`, `_get_device_info`, `_get_device_alt_param`, `_device_start`, `_suspend`, `_resume`, `_stop`, `_device_read`, `_device_write`.
- All key structs/types present: `uac_host_driver_config_t`, `uac_host_device_config_t`, `uac_host_stream_config_t`, `uac_host_dev_info_t`, `uac_host_dev_alt_param_t`, callbacks (`uac_host_driver_event_cb_t`, `uac_host_device_event_cb_t`).

## Next

- #30 — USB host install + hot-plug callback (real `uac_host_install` call gated on `BootMode::Uac`).

## Test plan

- [ ] CI green (host-only build; no embedded matrix entry yet).
- [ ] User runs `cargo check --release` on the s3-app crate locally after merge — confirms the lockfile + bindings reproduce on a fresh checkout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)