### PR TITLE
docs: refresh ε decode_block line counts (Gemini #89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,13 +68,13 @@ Non-breaking patch. Two interleaved storylines:
 
   | file | lines | role |
   |---|---:|---|
-  | `decode_block.rs` | 416 | parent / facade |
+  | `decode_block.rs` | 423 | parent / facade |
   | `decode_block/types.rs` | 184 | audio sample + tunables |
   | `decode_block/spectrogram.rs` | 357 | `Spectrogram` + `compute_spectrogram` |
   | `decode_block/coarse_sync.rs` | 537 | Costas search + allsum |
   | `decode_block/fill_symbol_spectra.rs` | 601 | per-symbol DFT family |
-  | `decode_block/process_candidates.rs` | 1,596 | engine + facade impls |
-  | `decode_block/osd_strategy.rs` | 117 | OSD dispatch (`#63` hook) |
+  | `decode_block/process_candidates.rs` | 1,589 | engine + facade impls |
+  | `decode_block/osd_strategy.rs` | 139 | OSD dispatch (`#63` hook) |
 - **OSD scaffolding shared across ndeep=2 and ndeep=3.** New
   private `osd_setup_ldpc174_91` / `osd_npre1_pass` /
   `osd_result_from_best` helpers factor the WSJT-X-faithful setup /

--- a/docs/CLEANUP_2026_05.md
+++ b/docs/CLEANUP_2026_05.md
@@ -248,17 +248,17 @@ ROADMAP entries) stay but get a date stamp.
 
 **Done 2026-05-17 across 6 stacked PRs.** Shipped in 0.6.3.
 Final shape (from `mfsk-core/src/ft8/decode_block.rs` original
-3,517 lines → 416 line parent + 6 stage submodules):
+3,517 lines → 423 line parent + 6 stage submodules):
 
   | file | lines | role | PR |
   |---|---:|---|---|
-  | `decode_block.rs` | 416 | parent / facade | — |
+  | `decode_block.rs` | 423 | parent / facade | — |
   | `decode_block/types.rs` | 184 | audio sample + tunables | #77 |
   | `decode_block/spectrogram.rs` | 357 | `Spectrogram` + `compute_spectrogram` | #83 (re-opened #78) |
   | `decode_block/coarse_sync.rs` | 537 | Costas search + allsum | #79 |
   | `decode_block/fill_symbol_spectra.rs` | 601 | per-symbol DFT family | #80 |
-  | `decode_block/process_candidates.rs` | 1,596 | engine + facade impls | #81 |
-  | `decode_block/osd_strategy.rs` | 117 | OSD dispatch (`#63` hook) | #82 |
+  | `decode_block/process_candidates.rs` | 1,589 | engine + facade impls | #81 |
+  | `decode_block/osd_strategy.rs` | 139 | OSD dispatch (`#63` hook) | #82 |
 
 ε.6's OSD-strategy seam is now load-bearing for issue #63's
 WSJT-X-faithful OSD work (also 0.6.3).


### PR DESCRIPTION
## Summary

Address [PR #89 Gemini review](https://github.com/jl1nie/mfsk-core/pull/89). Line-count tables in CHANGELOG.md (0.6.3 entry) and docs/CLEANUP_2026_05.md (ε section) were measured at PR-creation time but several files grew during the #63 OSD follow-ups that landed in the same release. Re-measured against current main:

| file | was | now | Δ |
|---|---:|---:|---:|
| `decode_block.rs` | 416 | 423 | +7 |
| `decode_block/process_candidates.rs` | 1,596 | 1,589 | -7 |
| `decode_block/osd_strategy.rs` | 117 | 139 | +22 |

`osd_strategy.rs` grew most (#63 OSD dispatch + `OSD_HARDERRORS_MAX` rationale docstring). Other 4 entries already match.

Prose in `CLEANUP_2026_05.md` updated similarly ("416 line parent" → "423 line parent").

No behavioural change.

## Test plan

- [ ] CI green (docs-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)