### PR TITLE
ci: escalate clippy::perf from warn to deny

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,8 +143,18 @@ jobs:
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
 
-      - name: cargo clippy -- -D warnings
-        run: cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings
+      # `-D clippy::perf` escalates the perf group from warn to deny on
+      # top of the default `-D warnings`. Catches mechanical perf
+      # antipatterns (`clippy::useless_vec`, `redundant_allocation`,
+      # `or_fun_call` allocating inside `unwrap_or`, `manual_memcpy`,
+      # etc.) as a CI gate so we don't accumulate them between Gemini
+      # reviews. main as of 2026-05-17 has 0 warnings under this group;
+      # this PR fences in that property going forward. See
+      # `~/.claude/projects/.../memory/feedback_pre_pr_self_review.md`
+      # for the human-side checklist that catches what clippy can't
+      # (e.g. `vec![0; LDPC_N]` in a hot loop — perf group misses this).
+      - name: cargo clippy -- -D warnings -D clippy::perf
+        run: cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings -D clippy::perf
 
   # ───────────────────────────────────────────────────────────────
   # Core test suite on the "full" feature set, split into parallel


### PR DESCRIPTION
## Summary

Add \`-D clippy::perf\` alongside existing \`-D warnings\` in the lint job.

Mechanical layer of the [二段構え prevention strategy](https://github.com/jl1nie/mfsk-core/pull/92#pullrequestreview-3502832022) that the 2026-05-17 Gemini-review post-mortem produced. The human-side checklist (saved as \`feedback_pre_pr_self_review\` memory) handles the patterns clippy can't see; this gate handles the ones it can.

## Verified

\`cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings -D clippy::perf\` on main: **0 warnings**. Zero-cost escalation — fence-in only, no source changes.

## What this catches (going forward)

The clippy perf group covers \~30 lints aimed at mechanical perf antipatterns:
- \`clippy::useless_vec\` (\`vec![1,2,3]\` immediately used as a slice)
- \`clippy::redundant_allocation\` (\`Rc<Box<T>>\` etc.)
- \`clippy::or_fun_call\` (allocating inside \`unwrap_or\` instead of \`unwrap_or_else\`)
- \`clippy::manual_memcpy\` (hand-rolled \`for i { dst[i] = src[i] }\`)
- \`clippy::needless_collect\` (\`.collect::<Vec<_>>().iter()\`)
- \`clippy::large_stack_arrays\`, \`clippy::large_const_arrays\`
- etc.

## What this does NOT catch

The exact patterns that triggered Gemini's #86 + #87 reviews — \`vec![0u8; LDPC_N]\` inside a hot loop where \`[0u8; LDPC_N]\` would suffice — are not in any clippy lint group. Those require the human-side checklist in the memory file. The two layers complement each other.

## Test plan

- [ ] CI green (lint job runs with the new flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)