### PR TITLE
perf(osd): hoist scratch + reuse codeword + O(1) npre2 insert (Gemini #86, #87)

### DIFF
--- a/mfsk-core/src/fec/ldpc/osd.rs
+++ b/mfsk-core/src/fec/ldpc/osd.rs
@@ -1013,8 +1013,12 @@ fn build_npre2_table(setup: &OsdSetup, ntau: usize) -> OsdNpre2Table {
     let mut row_keys = [0u16; LDPC_K];
     for i in 0..k {
         let mut rk: u16 = 0;
+        // Hoist `i * n + k` out of the j loop — Gemini PR #96 minor
+        // perf nit. `g` is row-major LDPC_K × LDPC_N, row i parity
+        // section starts at `row_base + k`.
+        let row_base = i * n;
         for j in 0..ntau {
-            if setup.g[i * n + (k + j)] != 0 {
+            if setup.g[row_base + k + j] != 0 {
                 rk |= 1u16 << (ntau - 1 - j);
             }
         }

--- a/mfsk-core/src/fec/ldpc/osd.rs
+++ b/mfsk-core/src/fec/ldpc/osd.rs
@@ -791,21 +791,28 @@ fn osd_setup_ldpc174_91(llr: &[f32; LDPC_N]) -> Option<OsdSetup> {
     })
 }
 
-/// Un-permute a candidate codeword and CRC-verify it. Returns the
-/// unpermuted full codeword + its first-`K` info slice, or `None` if
-/// CRC fails.
-fn try_candidate_ldpc174_91(perm: &[usize], cp: &[u8]) -> Option<(Vec<u8>, Vec<u8>)> {
-    let n = LDPC_N;
-    let k = LDPC_K;
-    let mut c = vec![0u8; n];
-    for col in 0..n {
-        c[perm[col]] = cp[col];
+/// Un-permute a candidate codeword into the caller-provided
+/// `c_unperm` scratch buffer and CRC-verify it. Returns the
+/// unpermuted full codeword + its first-`K` info slice as fresh
+/// `Vec`s on CRC pass, or `None` if CRC fails (no allocation on
+/// the fail path).
+///
+/// Caller provides the scratch buffer so it can be reused across
+/// the ~4186 invocations a single OSD candidate triggers — heap
+/// churn on each call was the dominant per-candidate cost before
+/// this refactor (Gemini PR #86 review).
+fn try_candidate_ldpc174_91(
+    perm: &[usize],
+    cp: &[u8],
+    c_unperm: &mut [u8; LDPC_N],
+) -> Option<(Vec<u8>, Vec<u8>)> {
+    for col in 0..LDPC_N {
+        c_unperm[perm[col]] = cp[col];
     }
-    let decoded = c[..k].to_vec();
-    if !check_crc14(&decoded) {
+    if !check_crc14(&c_unperm[..LDPC_K]) {
         return None;
     }
-    Some((decoded, c))
+    Some((c_unperm[..LDPC_K].to_vec(), c_unperm.to_vec()))
 }
 
 /// Run the WSJT-X `nord=1 + npre1=1` pass against the given
@@ -824,6 +831,19 @@ fn osd_npre1_pass(setup: &OsdSetup, best: &mut OsdBest, ntheta: u32) {
     let k = LDPC_K;
     let nt = NPRE1_PARITY_WINDOW.min(n - k);
 
+    // Fixed-size scratch buffers: hoist allocations out of the per-
+    // candidate hot loop (Gemini PR #87 review). `LDPC_N` / `LDPC_K`
+    // are `const`, so `[T; N]` lives on the stack with no allocator
+    // round-trip.
+    let mut ce_iflag = [0u8; LDPC_N];
+    let mut e2sub = [0u8; LDPC_N - LDPC_K];
+    let mut e2 = [0u8; LDPC_N - LDPC_K];
+    let mut ce_pair = [0u8; LDPC_N];
+    // Caller-provided buffer for try_candidate_ldpc174_91 — shared
+    // across every CRC try in this pass (Gemini PR #86 review,
+    // ~4186 calls/candidate previously each allocating their own Vec).
+    let mut c_unperm = [0u8; LDPC_N];
+
     // Order-0 baseline.
     {
         let mut wd = 0.0f32;
@@ -833,16 +853,12 @@ fn osd_npre1_pass(setup: &OsdSetup, best: &mut OsdBest, ntheta: u32) {
             }
         }
         if wd < best.dd
-            && let Some((d, cw)) = try_candidate_ldpc174_91(&setup.perm, &setup.c_perm)
+            && let Some((d, cw)) =
+                try_candidate_ldpc174_91(&setup.perm, &setup.c_perm, &mut c_unperm)
         {
             best.maybe_update(d, cw, wd);
         }
     }
-
-    let mut ce_iflag = vec![0u8; n];
-    let mut e2sub = vec![0u8; n - k];
-    let mut e2 = vec![0u8; n - k];
-    let mut ce_pair = vec![0u8; n];
 
     for iflag in (0..k).rev() {
         ce_iflag.copy_from_slice(&setup.c_perm);
@@ -870,7 +886,8 @@ fn osd_npre1_pass(setup: &OsdSetup, best: &mut OsdBest, ntheta: u32) {
             }
             let dd = d1 + parity_wd;
             if dd < best.dd
-                && let Some((d, cw)) = try_candidate_ldpc174_91(&setup.perm, &ce_iflag)
+                && let Some((d, cw)) =
+                    try_candidate_ldpc174_91(&setup.perm, &ce_iflag, &mut c_unperm)
             {
                 best.maybe_update(d, cw, dd);
             }
@@ -902,7 +919,8 @@ fn osd_npre1_pass(setup: &OsdSetup, best: &mut OsdBest, ntheta: u32) {
             }
             let dd = d1 + setup.absrx_perm[n1] + parity_wd_pair;
             if dd < best.dd
-                && let Some((d, cw)) = try_candidate_ldpc174_91(&setup.perm, &ce_pair)
+                && let Some((d, cw)) =
+                    try_candidate_ldpc174_91(&setup.perm, &ce_pair, &mut c_unperm)
             {
                 best.maybe_update(d, cw, dd);
             }
@@ -936,19 +954,18 @@ impl OsdNpre2Table {
         }
     }
 
+    /// Head insertion: O(1) per insert. The previous implementation
+    /// traversed the chain to find the tail (O(L) per insert), which
+    /// dominated `build_npre2_table` for keys with long chains. To
+    /// keep WSJT-X iteration order under `iter_pairs`, the build loop
+    /// in [`build_npre2_table`] inserts entries in **reverse** of the
+    /// original tail-insert order — head-insert then naturally yields
+    /// the same traversal sequence. (Gemini PR #87 review.)
     fn insert(&mut self, key: usize, i1: u8, i2: u8) {
         let idx = self.pairs.len() as i32;
         self.pairs.push((i1, i2));
-        self.next.push(-1);
-        if self.fp[key] == -1 {
-            self.fp[key] = idx;
-        } else {
-            let mut cur = self.fp[key] as usize;
-            while self.next[cur] != -1 {
-                cur = self.next[cur] as usize;
-            }
-            self.next[cur] = idx;
-        }
+        self.next.push(self.fp[key]);
+        self.fp[key] = idx;
     }
 
     /// Iterate over `(i1, i2)` pairs registered at `key`, in
@@ -968,23 +985,45 @@ impl OsdNpre2Table {
 }
 
 /// Build the [`OsdNpre2Table`] for `ntau`-bit XOR of all C(K, 2)
-/// MRB column pairs. Insertion order matches WSJT-X
-/// (`i1` from K-1 down to 0, `i2` from `i1-1` down to 0) so the
-/// chain traversal in [`OsdNpre2Table::iter_pairs`] yields candidates
-/// in the same sequence WSJT-X explores them.
+/// MRB column pairs.
+///
+/// Two perf optimisations vs the WSJT-X-faithful tail-insert / reverse-
+/// loop reference (Gemini PR #87 review):
+///
+/// 1. **row_keys pre-compute.** Each row's `ntau`-bit parity key is
+///    independent of the pairing inner loop. Hoist the per-row bit
+///    pack into a `LDPC_K`-length scratch (~1.4 KB on the stack for
+///    ntau=14 → `u16`), reducing the inner-loop work from O(K² · ntau)
+///    to O(K · ntau + K²). `ntau <= 14` per WSJT-X constraints — fits
+///    in `u16` with one bit to spare.
+///
+/// 2. **Forward loops paired with head-insert in
+///    [`OsdNpre2Table::insert`].** The original reverse outer/inner +
+///    tail-insert yielded a specific iteration order under
+///    [`OsdNpre2Table::iter_pairs`]. Forward outer/inner + head-insert
+///    yields the *same* order (head-insert reverses, forward loop
+///    reverses again — net no change), so candidates surface in the
+///    same sequence WSJT-X explores them. Preserves any tie-break
+///    parity with the reference implementation.
 fn build_npre2_table(setup: &OsdSetup, ntau: usize) -> OsdNpre2Table {
     let n = LDPC_N;
     let k = LDPC_K;
     let mut table = OsdNpre2Table::new(ntau);
-    for i1 in (0..k).rev() {
-        for i2 in (0..i1).rev() {
-            let mut key: usize = 0;
-            for j in 0..ntau {
-                let bit = setup.g[i1 * n + (k + j)] ^ setup.g[i2 * n + (k + j)];
-                if bit != 0 {
-                    key |= 1 << (ntau - 1 - j);
-                }
+
+    let mut row_keys = [0u16; LDPC_K];
+    for i in 0..k {
+        let mut rk: u16 = 0;
+        for j in 0..ntau {
+            if setup.g[i * n + (k + j)] != 0 {
+                rk |= 1u16 << (ntau - 1 - j);
             }
+        }
+        row_keys[i] = rk;
+    }
+
+    for i1 in 0..k {
+        for i2 in 0..i1 {
+            let key = (row_keys[i1] ^ row_keys[i2]) as usize;
             table.insert(key, i1 as u8, i2 as u8);
         }
     }
@@ -1009,9 +1048,13 @@ fn osd_npre2_pass(setup: &OsdSetup, best: &mut OsdBest, ntau: usize) {
     let k = LDPC_K;
     let table = build_npre2_table(setup, ntau);
 
-    let mut ce_misub = vec![0u8; n];
-    let mut e2sub = vec![0u8; n - k];
-    let mut ce_test = vec![0u8; n];
+    // Same fixed-size scratch + caller-provided unperm buffer pattern
+    // as `osd_npre1_pass` — see that function's hoist for rationale
+    // (Gemini PR #86 / #87 review).
+    let mut ce_misub = [0u8; LDPC_N];
+    let mut e2sub = [0u8; LDPC_N - LDPC_K];
+    let mut ce_test = [0u8; LDPC_N];
+    let mut c_unperm = [0u8; LDPC_N];
 
     for iflag in (0..k).rev() {
         ce_misub.copy_from_slice(&setup.c_perm);
@@ -1061,7 +1104,8 @@ fn osd_npre2_pass(setup: &OsdSetup, best: &mut OsdBest, ntau: usize) {
                     }
                 }
                 if dd < best.dd
-                    && let Some((d, cw)) = try_candidate_ldpc174_91(&setup.perm, &ce_test)
+                    && let Some((d, cw)) =
+                        try_candidate_ldpc174_91(&setup.perm, &ce_test, &mut c_unperm)
                 {
                     best.maybe_update(d, cw, dd);
                 }

--- a/mfsk-core/src/ft8/decode_block/osd_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/osd_strategy.rs
@@ -17,10 +17,7 @@
 //! dispatch table, replacing the previous mfsk-core-specific
 //! brute-force ndeep=2/3 split (`osd_decode` / `osd_decode_deep`).
 
-use alloc::vec;
-
 use super::super::decode::DecodeDepth;
-use super::super::params::LDPC_N;
 use crate::core::scalar::Cmplx;
 use crate::fec::ldpc::bp::BpResult;
 use crate::fec::ldpc::osd::{osd_decode_npre1, osd_decode_npre1_npre2};
@@ -125,10 +122,14 @@ pub(super) fn try_fallback(
             if osd.hard_errors > OSD_HARDERRORS_MAX {
                 continue;
             }
+            // Reuse `osd.codeword` instead of allocating a fresh
+            // zero vec — `OsdResult` already carries the actual
+            // decoded codeword bits, which the previous `vec![0; N]`
+            // dropped on the floor (Gemini PR #86 review).
             let bp = BpResult {
                 message77: osd.message77,
                 info: osd.info,
-                codeword: vec![0u8; LDPC_N],
+                codeword: osd.codeword,
                 hard_errors: osd.hard_errors,
                 iterations: 0,
             };

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1547,10 +1547,15 @@ pub(in crate::ft8) fn process_one_candidate_inner(
                     && let Some(osd) = osd_decode_deep(&llr_ap, 2, Some(check_crc14))
                     && validate(osd.message77, osd.hard_errors)
                 {
+                    // Reuse `osd.codeword` — `OsdResult` already
+                    // carries the decoded bits; the previous
+                    // `vec![0; LDPC_N]` was both wasteful and dropped
+                    // the real codeword on the floor (Gemini PR #86
+                    // review).
                     let bp = crate::fec::ldpc::bp::BpResult {
                         message77: osd.message77,
                         info: osd.info,
-                        codeword: alloc::vec![0u8; LDPC_N],
+                        codeword: osd.codeword,
                         hard_errors: osd.hard_errors,
                         iterations: 0,
                     };


### PR DESCRIPTION
## Summary

Address 5 perf items from the Gemini reviews on PR #86 and #87. All changes are perf-only — no algorithmic deviation from WSJT-X-faithful reference, recall floors preserved.

### Changes

1. **`try_candidate_ldpc174_91` caller-provided scratch buffer** (#86 high) — previously allocated `vec![0u8; LDPC_N]` on every call (~4186/candidate). Now takes `&mut [u8; LDPC_N]` from caller; `.to_vec()` for info/codeword only fires on CRC pass.
2. **Scratch vec → fixed array** in `osd_npre1_pass` + `osd_npre2_pass` (#87 medium) — `ce_iflag`/`e2sub`/`e2`/`ce_pair` + `ce_misub`/`e2sub`/`ce_test`. `LDPC_N`/`LDPC_K` are const → stack.
3. **`OsdNpre2Table::insert` head-insert O(1)** (#87 medium) — previous tail-insert was O(L) chain traversal. Build loop reversed (forward outer/inner) so `iter_pairs` still yields WSJT-X sequence.
4. **`build_npre2_table` row_keys pre-compute** (#87 medium) — hoists per-row `ntau`-bit pack outside the C(K, 2) pairing loop. O(K² · ntau) → O(K · ntau + K²). Uses `[u16; LDPC_K]` stack scratch.
5. **`codeword: osd.codeword` reuse** (#86 medium) — at `osd_strategy.rs` + `process_candidates.rs`. `OsdResult` already carries the decoded codeword; previous `vec![0; N]` was wasteful AND dropped the real bits on the floor.

### Verified

- `cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings -D clippy::perf`: clean.
- Recall sweep (vs current main):
  - `ft8_decode_block_real_qso`: **15 passed** (unchanged)
  - `ft8_qso3_apoff_recall`: **16 passed** (unchanged)
  - `ft8_qso3_apon_recall`: **17 passed** (unchanged)
  - `ft8_qso3_jtdx_recall`: **16 passed** (incl. JTDX floor, unchanged)

### Pre-PR self-review (二段構え 第1層)

Per the `feedback_pre_pr_self_review` checklist:
- ✓ No `vec!` / `Vec::new` / `Vec::with_capacity` left in hot paths (only in comment strings)
- ✓ No struct construction re-allocating a field the source struct already provides
- ✓ `clippy::perf` gate clean
- N/A: defensive-code patterns (no error rollback / retry paths in this diff)

## Test plan

- [ ] CI green (lint job runs `-D clippy::perf`; ft8 recall + characterization sweep both run since src/ft8 + src/fec changed)
- [ ] Recall floors preserved post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)