### PR TITLE
fix: 2 historical HIGH Gemini findings — i32 overflow + audio buffer churn

### DIFF
--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -36,9 +36,14 @@ use crate::core::scalar::Cmplx;
 // `collect::<Vec<i16>>()` that allocated ~360 KB × 30 cand × 3 pass
 // = ~32 MB of allocator traffic per slot (Gemini PR #80 review).
 // Only the `fft-rustfft` path uses this (embedded `fft-extern` path
-// doesn't build `fill_symbol_spectra_via_cd0` at all), so the
-// `thread_local!` requirement on `std` is satisfied.
-#[cfg(feature = "fft-rustfft")]
+// doesn't build `fill_symbol_spectra_via_cd0` at all). The
+// `feature = "std"` part of the cfg is **redundant in practice** —
+// `fft-rustfft` already implies `std` via the Cargo.toml feature
+// closure (`fft-rustfft = ["std", "dep:rustfft"]`) — but spelling
+// it out documents the runtime requirement at the use site and
+// hardens against a future feature-graph edit that loosens that
+// implication (Gemini PR #100 review).
+#[cfg(all(feature = "fft-rustfft", feature = "std"))]
 std::thread_local! {
     static AUDIO_I16_SCRATCH: core::cell::RefCell<alloc::vec::Vec<i16>> =
         const { core::cell::RefCell::new(alloc::vec::Vec::new()) };

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -35,15 +35,17 @@ use crate::core::scalar::Cmplx;
 // every per-candidate call — replaces the previous per-call
 // `collect::<Vec<i16>>()` that allocated ~360 KB × 30 cand × 3 pass
 // = ~32 MB of allocator traffic per slot (Gemini PR #80 review).
-// Only the `fft-rustfft` path uses this (embedded `fft-extern` path
-// doesn't build `fill_symbol_spectra_via_cd0` at all). The
-// `feature = "std"` part of the cfg is **redundant in practice** —
-// `fft-rustfft` already implies `std` via the Cargo.toml feature
-// closure (`fft-rustfft = ["std", "dep:rustfft"]`) — but spelling
-// it out documents the runtime requirement at the use site and
-// hardens against a future feature-graph edit that loosens that
-// implication (Gemini PR #100 review).
-#[cfg(all(feature = "fft-rustfft", feature = "std"))]
+//
+// Gated on `fft-rustfft` only — matching the usage site's gate in
+// `fill_symbol_spectra_via_cd0`. `fft-rustfft` implies `std` per the
+// Cargo.toml feature closure (`fft-rustfft = ["std", "dep:rustfft"]`)
+// so `std::thread_local!` always resolves on this path. An earlier
+// amend tried to add an explicit `feature = "std"` part for
+// documentation, but Gemini PR #100 r3 pointed out that asymmetry
+// (definition `all(fft-rustfft, std)`, usage `fft-rustfft` only)
+// would break compilation if fft-rustfft were ever enabled without
+// std. Keep the gates symmetric.
+#[cfg(feature = "fft-rustfft")]
 std::thread_local! {
     static AUDIO_I16_SCRATCH: core::cell::RefCell<alloc::vec::Vec<i16>> =
         const { core::cell::RefCell::new(alloc::vec::Vec::new()) };

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -29,6 +29,21 @@ use super::super::params::{COSTAS, COSTAS_POS, NN, NSPS, NTONES};
 use super::types::{AudioSample, SAMPLE_RATE_HZ, TONE_SPACING_HZ, TX_START_OFFSET_S};
 use crate::core::scalar::Cmplx;
 
+// Thread-local scratch for the `S -> i16` conversion in
+// `fill_symbol_spectra_via_cd0`'s `fft_cache=None` branch. The
+// `Vec<i16>` capacity is grown once per thread and reused across
+// every per-candidate call — replaces the previous per-call
+// `collect::<Vec<i16>>()` that allocated ~360 KB × 30 cand × 3 pass
+// = ~32 MB of allocator traffic per slot (Gemini PR #80 review).
+// Only the `fft-rustfft` path uses this (embedded `fft-extern` path
+// doesn't build `fill_symbol_spectra_via_cd0` at all), so the
+// `thread_local!` requirement on `std` is satisfied.
+#[cfg(feature = "fft-rustfft")]
+std::thread_local! {
+    static AUDIO_I16_SCRATCH: core::cell::RefCell<alloc::vec::Vec<i16>> =
+        const { core::cell::RefCell::new(alloc::vec::Vec::new()) };
+}
+
 // ── Per-symbol direct DFT (no FFT cache) ────────────────────────────────────
 
 /// Compute the 79 × 8 complex tone spectra for one candidate by
@@ -187,21 +202,24 @@ fn fill_symbol_spectra_via_cd0<S: AudioSample>(
     use rustfft::FftPlanner;
     extern crate alloc;
 
-    // S → i16 conversion (no-op when S=i16 already). Per-call alloc
-    // — still wasteful when cand-loop calls this 30+ times per slot.
-    // See #55 (perf-B) for the caller-buffer hoist. Skipped entirely
-    // when `fft_cache` is supplied (the slot-cache path doesn't need
-    // the audio bytes — only the precomputed forward FFT).
+    // S → i16 conversion (no-op when S=i16 already). Hoisted into a
+    // thread-local Vec so we don't re-allocate ~360 KB per candidate
+    // (the cand loop calls this ~30 cand × 3 pass = 90 times per slot
+    // in the multipass driver). Skipped entirely when `fft_cache` is
+    // supplied (the slot-cache path doesn't touch the audio bytes —
+    // only the precomputed forward FFT). Gemini PR #80 review.
     let cd0 = match fft_cache {
         Some(cache) => crate::core::dsp::downsample::downsample_cached(
             cache,
             freq_hz,
             &crate::ft8::downsample::FT8_CFG,
         ),
-        None => {
-            let audio_i16: alloc::vec::Vec<i16> = audio.iter().map(|s| s.to_i16()).collect();
-            crate::ft8::downsample::downsample(&audio_i16, freq_hz, None).0
-        }
+        None => AUDIO_I16_SCRATCH.with_borrow_mut(|buf| {
+            buf.clear();
+            buf.reserve(audio.len());
+            buf.extend(audio.iter().map(|s| s.to_i16()));
+            crate::ft8::downsample::downsample(buf.as_slice(), freq_hz, None).0
+        }),
     };
 
     // ibest in cd0 sample units (200 sps). dt_sec is offset from

--- a/mfsk-core/src/ft8/decode_block/spectrogram.rs
+++ b/mfsk-core/src/ft8/decode_block/spectrogram.rs
@@ -326,8 +326,22 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
             let a_im = (yk_im - yn_im) >> 1;
             let b_re = (yk_im + yn_im) >> 1;
             let b_im = (yn_re - yk_re) >> 1;
-            let mag2_a = ((a_re * a_re + a_im * a_im) as u32) >> FP_SPEC_SHIFT;
-            let mag2_b = ((b_re * b_re + b_im * b_im) as u32) >> FP_SPEC_SHIFT;
+            // Square via `unsigned_abs` to dodge the `i32` overflow at
+            // `(-32768)² + (-32768)² = 2^31`, which doesn't fit in i32
+            // (panic in debug, wrap to negative in release). Squaring as
+            // `u32` keeps the sum in 2^31 with one bit to spare —
+            // `>> FP_SPEC_SHIFT` (= 12) lands in u32.
+            // `.min(u16::MAX as u32)` then saturates the u16 cast so
+            // extremely-strong signals (two coincident tones at the
+            // same bin per the FP_SPEC_SHIFT comment) cap at u16::MAX
+            // instead of wrapping to a tiny value. Gemini PR #83 + #100
+            // review.
+            let mag2_a = ((a_re.unsigned_abs().pow(2) + a_im.unsigned_abs().pow(2))
+                >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32);
+            let mag2_b = ((b_re.unsigned_abs().pow(2) + b_im.unsigned_abs().pow(2))
+                >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32);
             data[row_a + k] = mag2_a as u16;
             data[row_b + k] = mag2_b as u16;
         }
@@ -344,7 +358,11 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
         for i in 0..n_freq {
             let re = buf[i].re as i32;
             let im = buf[i].im as i32;
-            let mag2 = ((re * re + im * im) as u32) >> FP_SPEC_SHIFT;
+            // Same `unsigned_abs` square + saturating `.min(u16::MAX
+            // as u32)` pattern as the demux loop above. Gemini PR #83
+            // + #100 review.
+            let mag2 = ((re.unsigned_abs().pow(2) + im.unsigned_abs().pow(2)) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32);
             data[row_base + i] = mag2 as u16;
         }
     }

--- a/mfsk-core/src/ft8/decode_block/spectrogram.rs
+++ b/mfsk-core/src/ft8/decode_block/spectrogram.rs
@@ -336,12 +336,12 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
             // same bin per the FP_SPEC_SHIFT comment) cap at u16::MAX
             // instead of wrapping to a tiny value. Gemini PR #83 + #100
             // review.
-            let mag2_a = ((a_re.unsigned_abs().pow(2) + a_im.unsigned_abs().pow(2))
-                >> FP_SPEC_SHIFT)
-                .min(u16::MAX as u32);
-            let mag2_b = ((b_re.unsigned_abs().pow(2) + b_im.unsigned_abs().pow(2))
-                >> FP_SPEC_SHIFT)
-                .min(u16::MAX as u32);
+            let aru = a_re.unsigned_abs();
+            let aiu = a_im.unsigned_abs();
+            let bru = b_re.unsigned_abs();
+            let biu = b_im.unsigned_abs();
+            let mag2_a = ((aru * aru + aiu * aiu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
+            let mag2_b = ((bru * bru + biu * biu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
             data[row_a + k] = mag2_a as u16;
             data[row_b + k] = mag2_b as u16;
         }
@@ -361,8 +361,9 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
             // Same `unsigned_abs` square + saturating `.min(u16::MAX
             // as u32)` pattern as the demux loop above. Gemini PR #83
             // + #100 review.
-            let mag2 = ((re.unsigned_abs().pow(2) + im.unsigned_abs().pow(2)) >> FP_SPEC_SHIFT)
-                .min(u16::MAX as u32);
+            let ru = re.unsigned_abs();
+            let iu = im.unsigned_abs();
+            let mag2 = ((ru * ru + iu * iu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
             data[row_base + i] = mag2 as u16;
         }
     }


### PR DESCRIPTION
## Summary

Two HIGH-severity Gemini findings sitting unaddressed on already-merged PRs (#80 + #83), discovered during a 2026-05-17 session-start audit. Memory `feedback-gemini-review-required` updated to require a session-start sweep of recently merged PRs going forward.

## Fixes

### #83 HIGH — `i32` overflow in `(a_re² + a_im²)` (×2 sites in spectrogram.rs)

Lines 330 + 347: squaring two `i32` values that originated from `i16` FFT outputs, then summing, can hit `(-32768)² + (-32768)² = 2^31` which doesn't fit `i32::MAX`. Debug = panic. Release = wraps to negative, then `as u32` reads as huge positive, `>> FP_SPEC_SHIFT` keeps it large, `as u16` truncates nonsense into the spectrogram cell.

Fix: `i32::unsigned_abs().pow(2)` so the product is `u32` (max `2^30`), sum stays in `u32` (max `2^31`, fits with one bit). Mathematically identical for non-extremes; non-panicking at the extreme.

### #80 HIGH — audio buffer full copy per candidate (fill_symbol_spectra.rs)

Line 202: `audio_i16: Vec<i16>` collect allocates ~360 KB per candidate when `fft_cache=None` (ALWAYS in current multipass driver — slot-cache wiring is #64). Multipass calls this ~30 cand × 3 pass = 90 times/slot → ~32 MB allocator traffic per slot.

Fix: hoist the `Vec<i16>` into a `thread_local!` scratch that's cleared + refilled per call but never freed. Replaces 90 allocs+frees per slot with a single steady-state Vec.

## Verified

`cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings -D clippy::perf`: clean.

Recall sweep (vs current main):
- `ft8_decode_block_real_qso`: **15 passed** (unchanged)
- `ft8_qso3_apoff_recall`: **16 passed** (unchanged)
- `ft8_qso3_apon_recall`: **17 passed** (unchanged)
- `ft8_qso3_jtdx_recall`: **16 passed** (incl. JTDX floor, unchanged)

## Pre-PR self-review (二段構え)

- ✓ No `vec!` / `Vec::new` added in hot paths (the hoist REMOVES a per-call `.collect::<Vec<_>>()`)
- ✓ No discarded struct fields
- ✓ Reference: spectrogram comment cites the `(-32768)² + (-32768)² = 2^31` overflow case; fill_symbol_spectra cites the 90 calls/slot multipass cadence
- ✓ `clippy::perf` gate clean

## Test plan

- [ ] CI green (ft8 recall + characterization both run since src/ft8 changed)
- [ ] Recall floors preserved post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)