### PR TITLE
fix: 9 historical Gemini MEDIUM findings (1 bp_scratch hoist deferred)

### DIFF
--- a/embedded-poc/m5stack-core2-app/src/display.rs
+++ b/embedded-poc/m5stack-core2-app/src/display.rs
@@ -208,7 +208,16 @@ pub fn run_log_panel(
         let tx_seq;
         let tx_line_snapshot: heapless::String<48>;
         {
-            let mut ui = UI.lock().expect("UI mutex poisoned");
+            // Skip this render iteration if the UI mutex is poisoned
+            // (i.e. another thread panicked while holding it). Matches
+            // the non-panicking `if let Ok(mut ui) = ...` pattern used
+            // in `decode_pipeline.rs` — keeps the render loop alive
+            // through transient cross-thread panics instead of taking
+            // the main task down with it. Gemini PR #76 review.
+            let Ok(mut ui) = UI.lock() else {
+                log::warn!("UI mutex poisoned — skipping render frame");
+                continue;
+            };
             ui.status.free_heap_kb = (heap / 1024) as u32;
             status_snapshot = ui.status.clone();
             decoded_snapshot = ui

--- a/embedded-poc/m5stack-core2-app/src/main.rs
+++ b/embedded-poc/m5stack-core2-app/src/main.rs
@@ -87,7 +87,15 @@ fn main() -> ! {
     log::info!("boot_mode: {} (NVS-only on Core2)", mode.label());
 
     // ── WiFi STA + UDP log sink — same path as the s3-app sibling. ──
-    static mut WIFI_SLOT: Option<wifi::WifiHandle> = None;
+    // `_wifi_slot` is a local `mut Option<WifiHandle>` (not `static
+    // mut`) because `main` never returns: the eventual
+    // `display::run_log_panel` call below is `-> !`, so the local
+    // outlives every consumer of the WiFi handle. Avoids the
+    // `unsafe { static mut ... }` block + `allow(static_mut_refs)`
+    // that the s3-app sibling needs (s3 cycles modes via reboot, but
+    // Core2 stays in one mode for the life of the binary). Gemini PR
+    // #76 review.
+    let mut _wifi_slot: Option<wifi::WifiHandle> = None;
     let wifi_should_start = mode == boot_mode::BootMode::Wifi && !WIFI_SSID.is_empty();
     if mode == boot_mode::BootMode::Wifi && WIFI_SSID.is_empty() {
         log::warn!(
@@ -125,10 +133,7 @@ fn main() -> ! {
                     }
                     Err(e) => log::warn!("UDP socket bind failed: {e}"),
                 }
-                #[allow(static_mut_refs)]
-                unsafe {
-                    WIFI_SLOT = Some(handle);
-                }
+                _wifi_slot = Some(handle);
             }
             Err(e) => log::warn!("WiFi STA failed: {e:#} — UDP log disabled"),
         }

--- a/embedded-poc/m5stack-core2-app/src/pmic.rs
+++ b/embedded-poc/m5stack-core2-app/src/pmic.rs
@@ -98,9 +98,12 @@ pub fn init_lcd_power<'d>(
 
     // ── Enable all power outputs (M5Unified Core2 default) ───────────
     //   bit0 DCDC1 / bit1 DCDC3 / bit2 LDO2 / bit3 LDO3 / bit4 DCDC2 /
-    //   bit6 EXTEN. 0xFF == every rail on except the reserved bit5.
-    write_reg(&mut i2c, REG_POWER_OUT_CTL, 0xFF)?;
-    log::info!("AXP192 power outputs enabled (reg 0x12=0xFF)");
+    //   bit6 EXTEN. bit5 + bit7 reserved per AXP192 datasheet; the
+    //   previous 0xFF wrote `1` into both reserved bits. Switch to the
+    //   intended bit mask 0x5F (bits 0,1,2,3,4,6) so the reserved
+    //   bits stay 0. Gemini PR #76 review.
+    write_reg(&mut i2c, REG_POWER_OUT_CTL, 0x5F)?;
+    log::info!("AXP192 power outputs enabled (reg 0x12=0x5F)");
 
     // Settle the rails before driving the LCD reset.
     FreeRtos::delay_ms(20);

--- a/embedded-poc/mfsk-app-shared/src/boot_mode.rs
+++ b/embedded-poc/mfsk-app-shared/src/boot_mode.rs
@@ -104,10 +104,27 @@ pub fn write(nvs: &EspNvs<NvsDefault>, mode: BootMode) -> Result<(), esp_idf_svc
 /// `gpio_pin` is the board's KEY1/BtnA pin (the board crate passes
 /// `board::BTN_A_PIN`; on Core2 this will be a different GPIO).
 pub fn override_held_at_boot(gpio_pin: i32) -> bool {
-    use esp_idf_svc::sys::{gpio_get_level, gpio_pullup_en, gpio_set_direction, GPIO_MODE_DEF_INPUT};
-    unsafe {
-        gpio_set_direction(gpio_pin, GPIO_MODE_DEF_INPUT);
-        gpio_pullup_en(gpio_pin);
+    use esp_idf_svc::sys::{
+        ESP_OK, GPIO_MODE_DEF_INPUT, gpio_get_level, gpio_pullup_en, gpio_set_direction,
+    };
+    // Check both gpio_set_direction + gpio_pullup_en return codes —
+    // silent failure would mean a floating input + a default-mode
+    // boot regardless of what the user pressed. Log + fall through
+    // returning `false` so the stored mode wins; better than
+    // pretending the button worked. Gemini PR #76 review.
+    let dir_err = unsafe { gpio_set_direction(gpio_pin, GPIO_MODE_DEF_INPUT) };
+    if dir_err != ESP_OK {
+        log::warn!(
+            "KEY1 gpio_set_direction(pin={gpio_pin}) failed err={dir_err:#x} — override disabled"
+        );
+        return false;
+    }
+    let pull_err = unsafe { gpio_pullup_en(gpio_pin) };
+    if pull_err != ESP_OK {
+        log::warn!(
+            "KEY1 gpio_pullup_en(pin={gpio_pin}) failed err={pull_err:#x} — override disabled"
+        );
+        return false;
     }
     // Settle pull-up. KEY1 is active-low; level 0 = pressed.
     esp_idf_svc::hal::delay::FreeRtos::delay_ms(20);

--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -426,10 +426,15 @@ fn coarse_sync_inner(
             .fold(0.0f32, f32::max);
     }
     let base = {
+        // 40th-percentile noise floor: `select_nth_unstable_by` is O(N)
+        // average vs the previous full-sort's O(N log N). Pivot
+        // ordering inside the percentile isn't load-bearing
+        // (downstream only uses `red[pct_idx]` as a normaliser), so
+        // unstable selection is fine. Gemini PR #79 review.
         let mut sorted = red.clone();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
-        let pct_idx = (0.40 * n_freq as f32) as usize;
-        sorted[pct_idx.min(n_freq - 1)].max(f32::EPSILON)
+        let pct_idx = ((0.40 * n_freq as f32) as usize).min(n_freq - 1);
+        sorted.select_nth_unstable_by(pct_idx, |a, b| a.partial_cmp(b).unwrap());
+        sorted[pct_idx].max(f32::EPSILON)
     };
 
     let mut cands: Vec<SyncCandidate> = Vec::new();

--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -430,10 +430,15 @@ fn coarse_sync_inner(
         // average vs the previous full-sort's O(N log N). Pivot
         // ordering inside the percentile isn't load-bearing
         // (downstream only uses `red[pct_idx]` as a normaliser), so
-        // unstable selection is fine. Gemini PR #79 review.
+        // unstable selection is fine. `unwrap_or(Ordering::Equal)`
+        // for NaN safety — matches the same pattern at
+        // `process_candidates.rs` xsnr2_db_simple median.
+        // Gemini PR #79 + #101 review.
         let mut sorted = red.clone();
         let pct_idx = ((0.40 * n_freq as f32) as usize).min(n_freq - 1);
-        sorted.select_nth_unstable_by(pct_idx, |a, b| a.partial_cmp(b).unwrap());
+        sorted.select_nth_unstable_by(pct_idx, |a, b| {
+            a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal)
+        });
         sorted[pct_idx].max(f32::EPSILON)
     };
 

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -34,22 +34,28 @@ use crate::core::scalar::Cmplx;
 // `Vec<i16>` capacity is grown once per thread and reused across
 // every per-candidate call — replaces the previous per-call
 // `collect::<Vec<i16>>()` that allocated ~360 KB × 30 cand × 3 pass
-// = ~32 MB of allocator traffic per slot (Gemini PR #80 review).
-//
-// Gated on `fft-rustfft` only — matching the usage site's gate in
-// `fill_symbol_spectra_via_cd0`. `fft-rustfft` implies `std` per the
-// Cargo.toml feature closure (`fft-rustfft = ["std", "dep:rustfft"]`)
-// so `std::thread_local!` always resolves on this path. An earlier
-// amend tried to add an explicit `feature = "std"` part for
-// documentation, but Gemini PR #100 r3 pointed out that asymmetry
-// (definition `all(fft-rustfft, std)`, usage `fft-rustfft` only)
-// would break compilation if fft-rustfft were ever enabled without
-// std. Keep the gates symmetric.
+// = ~32 MB of allocator traffic per slot (Gemini PR #80 / #100
+// review). Gated on `fft-rustfft` only — matches the usage site's
+// gate; `fft-rustfft` implies `std` via the Cargo.toml feature
+// closure (`fft-rustfft = ["std", "dep:rustfft"]`).
 #[cfg(feature = "fft-rustfft")]
 std::thread_local! {
     static AUDIO_I16_SCRATCH: core::cell::RefCell<alloc::vec::Vec<i16>> =
         const { core::cell::RefCell::new(alloc::vec::Vec::new()) };
 }
+
+// 32-pt rustfft plan cached at first use. The size is constant
+// (per-symbol DFT in `fill_symbol_spectra_via_cd0`), so building a
+// fresh `FftPlanner` + `plan_fft_forward(32)` per candidate just
+// re-allocates the same twiddle tables (~30 cand × 3 pass = 90 plans
+// per slot). Gemini PR #80 review. `OnceLock` is `Sync` so the same
+// `Arc<dyn Fft>` is shared across all decoder threads; rustfft
+// `Fft::process` is thread-safe (no internal mutable state — it
+// works on the caller's scratch buffer).
+#[cfg(feature = "fft-rustfft")]
+use std::sync::OnceLock;
+#[cfg(feature = "fft-rustfft")]
+static SYMBOL_FFT_32: OnceLock<alloc::sync::Arc<dyn rustfft::Fft<f32>>> = OnceLock::new();
 
 // ── Per-symbol direct DFT (no FFT cache) ────────────────────────────────────
 
@@ -234,8 +240,17 @@ fn fill_symbol_spectra_via_cd0<S: AudioSample>(
     // so the first symbol starts at sample (0.5 + dt) × 200.
     let ibest = ((TX_START_OFFSET_S + dt_sec) * 200.0).round() as i32;
 
-    let mut planner = FftPlanner::<f32>::new();
-    let fft = planner.plan_fft_forward(32);
+    // FFT planner + 32-pt plan are constant (size never changes
+    // here); building them inside the candidate loop allocates fresh
+    // twiddle tables per call. Cache once at first use — Gemini PR
+    // #80 review. `Arc<dyn Fft>` is what `plan_fft_forward` returns;
+    // each call here just clones the Arc (~10 ns refcount bump).
+    let fft = SYMBOL_FFT_32
+        .get_or_init(|| {
+            let mut planner = FftPlanner::<f32>::new();
+            planner.plan_fft_forward(32)
+        })
+        .clone();
     let mut buf = [Complex::new(0.0_f32, 0.0); 32];
 
     // WSJT-X scales `cs = csymb / 1e3` (ft8b.f90:159). The /1e3 is

--- a/mfsk-core/src/ft8/decode_block/osd_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/osd_strategy.rs
@@ -75,6 +75,7 @@ pub(super) const PASS_ID_OSD_A: u8 = 14;
 /// .or_else(|| osd_strategy::try_fallback(...))`).
 pub(super) fn try_fallback(
     cs_scratch: &[[Cmplx<f32>; 8]; 79],
+    precomputed_llr: Option<&super::super::llr::LlrSet<f32>>,
     depth: DecodeDepth,
     q: u32,
 ) -> Option<(BpResult, u8)> {
@@ -83,10 +84,22 @@ pub(super) fn try_fallback(
     }
 
     // OSD operates on `&[f32]` directly — independent of the embedded
-    // `LlrT` choice — so we compute a fresh f32 LLR bundle here. Only
-    // fires when Steps 1+2 BP failed and `q >= 12`, so the extra
-    // compute_llr is cheap relative to the OSD work itself.
-    let llr_full_f32: super::super::llr::LlrSet<f32> = super::super::llr::compute_llr(cs_scratch);
+    // `LlrT` choice. The caller (`process_one_candidate_inner`)
+    // may pass a pre-computed LLR via `precomputed_llr` so the same
+    // bundle gets reused for both OSD here and the AP loop after —
+    // saves one full `compute_llr` (the nsym=3 LLR is the expensive
+    // one) when both paths fire on the same candidate (Gemini PR #81
+    // review). If `precomputed_llr` is `None` we compute locally
+    // (embedded path with no AP, or callers that haven't been
+    // updated).
+    let owned_llr_storage;
+    let llr_full_f32: &super::super::llr::LlrSet<f32> = match precomputed_llr {
+        Some(llr) => llr,
+        None => {
+            owned_llr_storage = super::super::llr::compute_llr(cs_scratch);
+            &owned_llr_storage
+        }
+    };
 
     // Pass-ID space (post-0.6.1): BP variants 0..3, AP iaptypes
     // 5..12 (mirroring WSJT-X ipass 5..12), host OSD-Deep 13,

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -467,11 +467,18 @@ pub fn xsnr2_db_simple(spec: &Spectrogram, result: &DecodeResult, cell_scale: f3
             t += t_stride;
         }
     }
-    samples.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+    // Median via O(N) `select_nth_unstable_by` instead of a full
+    // O(N log N) sort — only the middle element matters here, the
+    // pivot ordering inside the partition is irrelevant. Gemini PR
+    // #81 review.
     let median = if samples.is_empty() {
         0.0
     } else {
-        samples[samples.len() / 2]
+        let mid = samples.len() / 2;
+        samples.select_nth_unstable_by(mid, |a, b| {
+            a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal)
+        });
+        samples[mid]
     };
     let xbase = median * cell_scale;
     if xbase <= 0.0 || !xbase.is_finite() {
@@ -1251,11 +1258,26 @@ where
     // dt is already parabolically refined by coarse_sync; no grid here.
 
     let mut results: Vec<DecodeResult> = Vec::new();
-    // BP scratch pool — instantiated once and reused across all
-    // candidates × all 5 BP calls per candidate. Eliminates the
-    // ~12 KB-per-call `tlsf_malloc` traffic that dominated stage-3
-    // non-DFT cost on Core2 (~50–100 ms / qso). See
-    // `mfsk_core::fec::ldpc::bp::BpScratch`.
+    // BP scratch pool — instantiated once per call to this function
+    // and reused across this call's `cands` × all 5 BP calls per
+    // candidate. Eliminates the ~12 KB-per-BP-call `tlsf_malloc`
+    // traffic that dominated stage-3 non-DFT cost on Core2
+    // (~50–100 ms / qso). See `mfsk_core::fec::ldpc::bp::BpScratch`.
+    //
+    // **Caveat (Gemini PR #81 review, deferred follow-up):** the
+    // host multipass driver in `decode_block_multipass` (line ~250)
+    // calls `process_candidates_tuned_with_ap` ONCE PER CANDIDATE
+    // with a 1-element `vec![cand]` per call, so this scratch is
+    // actually re-allocated on every outer-loop iteration. Lifting
+    // it up to the `decode_block_multipass` loop scope is the right
+    // fix but needs propagating the `LlrT` generic + `&mut
+    // BpScratch` through two wrapping layers
+    // (`process_candidates_tuned_with_ap` → `process_candidates_with_ap`);
+    // tracked as a separate refactor. The non-multipass callers
+    // (`process_candidates_tuned` etc., line 1031) pass multi-cand
+    // vecs so they ALREADY get the documented reuse benefit; the
+    // comment as written was misleading only for the multipass
+    // entry, not for the function itself.
     let mut bp_scratch =
         crate::fec::ldpc::bp::BpScratch::<crate::fec::ldpc::params::Ldpc174_91Params, LlrT>::new();
     for (cand, cs_box, _q_block0) in cands {
@@ -1421,12 +1443,34 @@ pub(in crate::ft8) fn process_one_candidate_inner(
         }
     }
 
+    // Pre-compute the nsym=3 LLR once if BOTH the OSD fallback AND
+    // the AP loop will run on this candidate — both stages use the
+    // same `compute_llr(cs_scratch)` output and recomputing it twice
+    // is the dominant per-candidate cost when OSD fails into AP
+    // (Gemini PR #81 review). Gate: `accepted.is_none()` (Steps 1-2
+    // failed), `depth = BpAllOsd`, `q >= 12` (OSD will fire), and
+    // `ap_hint.is_some()` (AP will follow on OSD failure). On the
+    // embedded path `ap_hint` is always `None`, so this entire
+    // pre-compute is constant-folded away.
+    #[cfg(feature = "fft-rustfft")]
+    let prefetched_llr: Option<super::super::llr::LlrSet<f32>> = if accepted.is_none()
+        && matches!(depth, DecodeDepth::BpAllOsd)
+        && q >= 12
+        && ap_hint.is_some()
+    {
+        Some(super::super::llr::compute_llr(cs_scratch))
+    } else {
+        None
+    };
+    #[cfg(not(feature = "fft-rustfft"))]
+    let prefetched_llr: Option<super::super::llr::LlrSet<f32>> = None;
+
     // Step 3: OSD fallback (sync_quality gated; only for BpAllOsd).
     // The actual dispatch — including the WSJT-X-faithfulness
     // deviation #63 tracks restoring — lives in `super::osd_strategy`
     // so #63 can patch it without touching the rest of this function.
     if accepted.is_none() {
-        accepted = super::osd_strategy::try_fallback(cs_scratch, depth, q);
+        accepted = super::osd_strategy::try_fallback(cs_scratch, prefetched_llr.as_ref(), depth, q);
     }
 
     // Step 4: AP iaptype loop (host f32 only; gated on fft-rustfft).
@@ -1446,8 +1490,12 @@ pub(in crate::ft8) fn process_one_candidate_inner(
     if accepted.is_none()
         && let Some(ap) = ap_hint
     {
+        // Reuse the pre-computed LLR from above if it ran; otherwise
+        // compute fresh. The unwrap_or_else only fires when the
+        // pre-compute gate was `false` (BpAll with no OSD) but AP
+        // still ran somehow — defensive, but not the dominant path.
         let llr_full_f32: super::super::llr::LlrSet<f32> =
-            super::super::llr::compute_llr(cs_scratch);
+            prefetched_llr.unwrap_or_else(|| super::super::llr::compute_llr(cs_scratch));
         let apmag = llr_full_f32
             .llra
             .iter()

--- a/mfsk-core/src/ft8/decode_block/spectrogram.rs
+++ b/mfsk-core/src/ft8/decode_block/spectrogram.rs
@@ -25,6 +25,18 @@ use super::types::{AudioSample, NFFT_SPEC, NSTEP, SAMPLE_RATE_HZ, TONE_SPACING_H
 #[cfg(not(feature = "fixed-point"))]
 use crate::core::fft::default_planner;
 
+// Hann window table for the fixed-point `compute_spectrogram`.
+// Cached at first use — the table is constant in shape and length
+// (NSPS = 1920), so recomputing 1920 `cos()` per call (= per
+// multipass pass) was wasted work on every decode. Gemini PR #83
+// review. `OnceLock` requires `std`; `fixed-point` builds also
+// enable `std` (the embedded path uses `stage1_inc` which has its
+// own cached table), so this is safe.
+#[cfg(all(feature = "fixed-point", feature = "std"))]
+use std::sync::OnceLock;
+#[cfg(all(feature = "fixed-point", feature = "std"))]
+static HANN_NSPS: OnceLock<[i16; NSPS]> = OnceLock::new();
+
 /// Spectrogram cell type. f32 (4 bytes) by default; u16 (2 bytes)
 /// under `fixed-point` — magnitude squared right-shifted by
 /// `FP_SPEC_SHIFT` to fit u16. `Spectrogram::power` returns f32 in
@@ -277,12 +289,21 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
     // signals, not just the cross-tone neighbours we predicted, and
     // the auto-gain shift on i16 amplifies that leakage. Keep Hann
     // here (it's also what stage1_inc already does on embedded).
-    let mut hann = [0i16; NSPS];
-    for n in 0..NSPS {
-        let phase = 2.0 * core::f32::consts::PI * (n as f32) / (NSPS as f32);
-        let w = 0.5 - 0.5 * phase.cos();
-        hann[n] = (w * 32767.0) as i16;
-    }
+    //
+    // Cached in `HANN_NSPS`: the window is constant in shape and
+    // length (NSPS = 1920), so recomputing the 1920 `cos()` calls
+    // per `compute_spectrogram` (= per multipass pass) burned cycles
+    // on every decode. Initialised once at first use. Gemini PR #83
+    // review.
+    let hann = HANN_NSPS.get_or_init(|| {
+        let mut table = [0i16; NSPS];
+        for n in 0..NSPS {
+            let phase = 2.0 * core::f32::consts::PI * (n as f32) / (NSPS as f32);
+            let w = 0.5 - 0.5 * phase.cos();
+            table[n] = (w * 32767.0) as i16;
+        }
+        table
+    });
     let pack = |buf: &mut [Complex<i16>], ia_a: usize, ia_b: Option<usize>| {
         for (k, c) in buf.iter_mut().enumerate() {
             let re = if k < NSPS && ia_a + k < audio.len() {

--- a/mfsk-core/src/ft8/decode_block/spectrogram.rs
+++ b/mfsk-core/src/ft8/decode_block/spectrogram.rs
@@ -290,12 +290,17 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
     // the auto-gain shift on i16 amplifies that leakage. Keep Hann
     // here (it's also what stage1_inc already does on embedded).
     //
-    // Cached in `HANN_NSPS`: the window is constant in shape and
-    // length (NSPS = 1920), so recomputing the 1920 `cos()` calls
-    // per `compute_spectrogram` (= per multipass pass) burned cycles
-    // on every decode. Initialised once at first use. Gemini PR #83
+    // Cached in `HANN_NSPS` on `std` builds: the window is constant
+    // in shape + length (NSPS = 1920), so recomputing the 1920
+    // `cos()` calls per `compute_spectrogram` (= per multipass pass)
+    // burned cycles on every decode. `OnceLock` is std-only so the
+    // no_std fixed-point path keeps the per-call recompute — that
+    // path runs on Xtensa anyway, and the embedded production
+    // pipeline routes via `stage1_inc` which has its own cached
+    // Hann (per the comment immediately above). Gemini PR #83 + #101
     // review.
-    let hann = HANN_NSPS.get_or_init(|| {
+    #[cfg(feature = "std")]
+    let hann_cached = HANN_NSPS.get_or_init(|| {
         let mut table = [0i16; NSPS];
         for n in 0..NSPS {
             let phase = 2.0 * core::f32::consts::PI * (n as f32) / (NSPS as f32);
@@ -304,6 +309,20 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
         }
         table
     });
+    #[cfg(not(feature = "std"))]
+    let hann_local = {
+        let mut table = [0i16; NSPS];
+        for n in 0..NSPS {
+            let phase = 2.0 * core::f32::consts::PI * (n as f32) / (NSPS as f32);
+            let w = 0.5 - 0.5 * phase.cos();
+            table[n] = (w * 32767.0) as i16;
+        }
+        table
+    };
+    #[cfg(feature = "std")]
+    let hann: &[i16; NSPS] = hann_cached;
+    #[cfg(not(feature = "std"))]
+    let hann: &[i16; NSPS] = &hann_local;
     let pack = |buf: &mut [Complex<i16>], ia_a: usize, ia_b: Option<usize>| {
         for (k, c) in buf.iter_mut().enumerate() {
             let re = if k < NSPS && ia_a + k < audio.len() {


### PR DESCRIPTION
## Summary

Batch addresses MEDIUM-severity Gemini items left unaddressed on older merged PRs (#76, #79, #80, #81, #83). 9 of 10 fixed; the remaining `bp_scratch` hoist (#81 line ~1235) is deferred with a clarifying comment + tracked as task #46.

Discovered during the 2026-05-17 session-start audit prompted by the user noticing the unaddressed-Gemini gap. Combined with PR #100 (HIGH fixes) this closes the historical backlog.

## mfsk-core (host decode path)

- **#79 coarse_sync.rs:432** — 40th-percentile noise floor: full sort → `select_nth_unstable_by`.
- **#80 fill_symbol_spectra.rs:213** — cache the 32-pt FFT plan in a `static OnceLock<Arc<dyn Fft>>` instead of building a fresh `FftPlanner` per candidate.
- **#81 process_candidates.rs:438** — median sort → select_nth in `xsnr2_db_simple`.
- **#81 process_candidates.rs:1235** — clarify the misleading `bp_scratch` reuse comment + add deferred-refactor TODO (task #46).
- **#81 process_candidates.rs:1457** — eliminate redundant `compute_llr(cs_scratch)`. Pre-compute once when both OSD + AP will run, pass to `osd_strategy::try_fallback` (new `precomputed_llr: Option<&LlrSet<f32>>` arg) AND the AP block.
- **#83 spectrogram.rs:285** — cache the 1920-entry Q15 Hann window in a `static OnceLock<[i16; NSPS]>`.

## embedded-poc

- **#76 boot_mode.rs:93** — check `gpio_set_direction` + `gpio_pullup_en` return codes; disable override on failure.
- **#76 m5stack-core2-app/display.rs:211** — UI mutex `.expect()` → `let Ok(mut ui) = ... else { continue }`.
- **#76 m5stack-core2-app/main.rs:90+132** — `static mut WIFI_SLOT` → local `let mut _wifi_slot`. `main` is `!` on Core2 so a local lives long enough.
- **#76 m5stack-core2-app/pmic.rs:102** — AXP192 `REG_POWER_OUT_CTL` `0xFF` → `0x5F`. bit5 + bit7 are reserved per datasheet.

## Verified

`cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings -D clippy::perf`: clean.
`cargo check --release` on m5stack-core2-app embedded target: clean.

Recall sweep (vs current main):
- `ft8_decode_block_real_qso`: **15 passed** (unchanged)
- `ft8_qso3_apoff_recall`: **16 passed** (unchanged)
- `ft8_qso3_apon_recall`: **17 passed** (unchanged)
- `ft8_qso3_jtdx_recall`: **16 passed** (incl. JTDX floor, unchanged)

## Deferred

- `bp_scratch` hoist out of `process_candidates_with_ap` up to the `decode_block_multipass` loop scope (Gemini #81). Requires propagating `&mut BpScratch<.., LlrT>` through two wrapping layers (`process_candidates_tuned_with_ap` → `..._with_ap`); tracked as task #46.

## Test plan

- [ ] CI green (ft8 recall + characterization sweeps, embedded-poc paths-ignored)
- [ ] Recall floors preserved post-merge
- [ ] Core2 hardware: AXP192 0x5F write still brings all rails up (DCDC1/3, LDO2/3, DCDC2, EXTEN) — visually verifiable as "LCD lights up + audio amp clicks" on boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)