### PR TITLE
feat(s3-app/uac): disconnect-driven reader cleanup (#35)

### DIFF
--- a/embedded-poc/m5stack-s3-app/src/uac.rs
+++ b/embedded-poc/m5stack-s3-app/src/uac.rs
@@ -186,6 +186,22 @@ impl Drop for ReaderActiveGuard {
     }
 }
 
+/// Set by [`device_event_cb`] when the IDF driver fires
+/// `DRIVER_EVENT_DISCONNECTED` (USB cable unplug, IC-705 power off,
+/// VBUS sag). The reader thread polls this at the top of every loop
+/// iteration and exits cleanly — disconnect latency = at most one
+/// `READER_READ_TIMEOUT_MS` (100 ms) instead of waiting for the next
+/// `device_read` to fail. Also lets the reader's cleanup path skip
+/// `device_stop` / `device_close` (the IDF driver already
+/// invalidated the handle when DISCONNECTED fired) so the post-
+/// disconnect cleanup doesn't log spurious `INVALID_ARG` errors.
+///
+/// Reset by [`handle_rx_connected`] at the start of a new session so
+/// a stale `true` from a previous attach can't kill the freshly-
+/// spawned reader on its first iteration.
+static READER_STOP_REQUESTED: std::sync::atomic::AtomicBool =
+    std::sync::atomic::AtomicBool::new(false);
+
 /// Chunk queue handle the reader thread pushes decimated 12 kHz mono
 /// samples into. Set by [`set_chunk_q`] from the `decode_pipeline`'s
 /// source-spawn closure (`run_with_source(|q| uac::set_chunk_q(q))`).
@@ -275,6 +291,16 @@ extern "C" fn device_event_cb(
     if event != sys::uac::uac_host_device_event_t_UAC_HOST_DEVICE_EVENT_RX_DONE {
         log::info!("uac: device event {kind}");
     }
+    // Disconnect signal: the IDF driver invalidates the handle after
+    // this callback returns, so any pending `device_read` will fail.
+    // Setting the flag lets the reader thread exit on its next loop
+    // iteration (≤ 100 ms latency) instead of waiting for the failing
+    // read to surface — and lets the reader skip the
+    // `device_stop` / `device_close` cleanup since the IDF already
+    // released the underlying state (#35 disconnect polish).
+    if event == sys::uac::uac_host_device_event_t_UAC_HOST_DRIVER_EVENT_DISCONNECTED {
+        READER_STOP_REQUESTED.store(true, Ordering::Release);
+    }
 }
 
 /// USB host event-pump body. Blocks indefinitely on
@@ -359,6 +385,12 @@ fn handle_rx_connected(addr: u8, iface_num: u8) -> Result<()> {
     RX_PACKETS.store(0, Ordering::Relaxed);
     RX_ERRORS.store(0, Ordering::Relaxed);
 
+    // Clear any stale stop-request from a previous attach (#35).
+    // The previous session's `device_event_cb` may have set this if
+    // the device was unplugged before the reader noticed; we don't
+    // want it tripping the fresh reader on its first iteration.
+    READER_STOP_REQUESTED.store(false, Ordering::Release);
+
     let handle_wrapped = DeviceHandle(handle);
     if let Err(e) = std::thread::Builder::new()
         .stack_size(READER_TASK_STACK)
@@ -409,7 +441,21 @@ fn reader_thread(handle: DeviceHandle) {
     let mut wav_idx: usize = 0;
     let mut last_log = std::time::Instant::now();
     let mut last_bytes: u32 = 0;
+    // Track whether we exited via DISCONNECTED so the cleanup path
+    // can skip the redundant `device_stop` / `device_close` calls
+    // (#35) — the IDF driver already invalidated the handle at
+    // callback time, so calling them just logs spurious INVALID_ARG.
+    let mut disconnect_triggered = false;
     loop {
+        // Top-of-loop disconnect check (#35). `device_event_cb` sets
+        // the flag immediately on DISCONNECTED; we exit on the next
+        // iteration (≤ READER_READ_TIMEOUT_MS = 100 ms latency)
+        // rather than waiting for the failing read to surface.
+        if READER_STOP_REQUESTED.load(Ordering::Acquire) {
+            log::info!("uac: reader exiting — DISCONNECTED signaled by device_event_cb");
+            disconnect_triggered = true;
+            break;
+        }
         let mut bytes_read: u32 = 0;
         let err = unsafe {
             sys::uac::uac_host_device_read(
@@ -536,21 +582,34 @@ fn reader_thread(handle: DeviceHandle) {
             last_bytes = bytes;
         }
     }
-    // Cleanup before exit so the IDF driver state matches reality —
-    // without this a re-enumeration (next IC-705 plug) finds the
-    // device already "started" in the driver's bookkeeping and
-    // `device_start` returns INVALID_STATE on the second attempt
-    // (Gemini PR #98 review). Best-effort: if stop or close fails we
-    // can't do much beyond log.
-    let stop_err = unsafe { sys::uac::uac_host_device_stop(handle.0) };
-    if stop_err != sys::ESP_OK as sys::esp_err_t {
-        log::error!("uac: device_stop on reader exit failed err={stop_err:#x}");
-    }
-    let close_err = unsafe { sys::uac::uac_host_device_close(handle.0) };
-    if close_err != sys::ESP_OK as sys::esp_err_t {
-        log::error!("uac: device_close on reader exit failed err={close_err:#x}");
+    // Cleanup paths differ by exit reason (#35):
+    //
+    // - Disconnect-triggered exit: the IDF driver already invalidated
+    //   the handle when DISCONNECTED fired in `device_event_cb`.
+    //   Calling `device_stop` / `device_close` on the invalidated
+    //   handle returns INVALID_ARG/STATE — harmless but it would log
+    //   confusing errors. Skip.
+    // - Read-error exit (terminal non-TIMEOUT error from device_read):
+    //   the handle is still nominally valid; explicit stop + close
+    //   releases the IDF state so a re-enumeration takes a clean path.
+    //
+    // Either way `_gate: ReaderActiveGuard` drops below to release
+    // `READER_ACTIVE` so the next RxConnected can re-take it.
+    if disconnect_triggered {
+        log::info!(
+            "uac: reader_thread cleanup (disconnect path — skipping device_stop/close, IDF already invalidated handle)"
+        );
     } else {
-        log::info!("uac: reader_thread cleanup complete (device stopped + closed)");
+        let stop_err = unsafe { sys::uac::uac_host_device_stop(handle.0) };
+        if stop_err != sys::ESP_OK as sys::esp_err_t {
+            log::error!("uac: device_stop on reader exit failed err={stop_err:#x}");
+        }
+        let close_err = unsafe { sys::uac::uac_host_device_close(handle.0) };
+        if close_err != sys::ESP_OK as sys::esp_err_t {
+            log::error!("uac: device_close on reader exit failed err={close_err:#x}");
+        } else {
+            log::info!("uac: reader_thread cleanup complete (device stopped + closed)");
+        }
     }
     // `_gate: ReaderActiveGuard` is dropped here, clearing
     // READER_ACTIVE so the next RxConnected can re-take the gate


### PR DESCRIPTION
## Summary

Phase 1 UAC polish — final step (#35). The reader thread now exits on a dedicated DISCONNECT signal from the device callback instead of waiting for the next `device_read` to fail, and the post-loop cleanup branches on exit reason so post-disconnect cleanup doesn't log spurious INVALID_ARG errors.

## Implementation

- **`READER_STOP_REQUESTED: AtomicBool`** — set by `device_event_cb` when the IDF fires `UAC_HOST_DRIVER_EVENT_DISCONNECTED`. The reader polls it at the top of each loop iteration. Disconnect latency ≤ `READER_READ_TIMEOUT_MS` (100 ms) instead of waiting for the failing read.
- **`handle_rx_connected` clears the flag** at the start of each new session so a stale flag from a previous attach can't kill the freshly-spawned reader.
- **`reader_thread` cleanup branches on `disconnect_triggered: bool`:**
  - disconnect path → skip `device_stop` + `_close` (IDF already invalidated the handle), log a clear "disconnect path" line.
  - other-error path → call `device_stop` + `_close` as before, so a re-enumeration finds clean IDF state.
- **`ReaderActiveGuard` RAII (#98) unchanged** — still releases `READER_ACTIVE` on every exit path including panic, so re-plug after disconnect works without reboot.

## Verified

`source ~/export-esp.sh && cargo build --release` on `embedded-poc/m5stack-s3-app/`: clean link, **ELF = 3.16 MB** (+ ~280 B vs #32).

### Pre-PR self-review (二段構え)

- ✓ No `vec!` / `Vec::new` added (only an `AtomicBool` static + a `bool` local)
- ✓ No discarded struct fields
- ✓ Defensive cleanup: both exit paths handled, no resource leak on either
- ✓ Reference: `audio_player/main.c` upstream example uses the same DISCONNECTED-from-callback pattern

## Hardware verification path (#33-#34)

1. Boot in UAC mode, plug IC-705.
2. UDP log: `uac: reader thread spawned`.
3. **Unplug IC-705.** Within ~100 ms expect:
   - \`uac: device event DISCONNECTED\`
   - \`uac: reader exiting — DISCONNECTED signaled by device_event_cb\`
   - \`uac: reader_thread cleanup (disconnect path — skipping device_stop/close, IDF already invalidated handle)\`
4. **Replug.** Should re-enumerate cleanly without reboot:
   - \`uac: driver event RxConnected { addr: N, iface_num: M }\`
   - \`uac: device opened, starting stream 2ch / 16b / 48000Hz\`
   - \`uac: reader thread spawned\`

## Test plan

- [ ] CI (no checks — embedded-poc paths-ignored)
- [ ] User flashes + tests the unplug/replug cycle per the path above
- [ ] No regression on the wav_sim-style boot (BootMode::Decode unaffected)

## What this completes

With #35 merged, the Phase 1 UAC sequence is closed:
1. #29 component + bindings ✓
2. #30 host install + hot-plug callback ✓
3. #31 iso IN streaming + stats ✓
4. #32 resample + decode pipeline integration ✓
5. **#35 disconnect/reconnect polish ✓**

Remaining UAC tasks are hardware verification (#33, #34) and an unrelated follow-up (#42 esp_dsp_fft.rs migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)