### PR TITLE
fix(s3-app/uac): close two disconnect-cleanup race windows from #102

### DIFF
--- a/embedded-poc/m5stack-s3-app/src/uac.rs
+++ b/embedded-poc/m5stack-s3-app/src/uac.rs
@@ -189,15 +189,17 @@ impl Drop for ReaderActiveGuard {
 /// `DRIVER_EVENT_DISCONNECTED` (USB cable unplug, IC-705 power off,
 /// VBUS sag). The reader thread polls this at the top of every loop
 /// iteration and exits cleanly — disconnect latency = at most one
-/// `READER_READ_TIMEOUT_MS` (100 ms) instead of waiting for the next
+/// `READER_READ_TIMEOUT_MS` instead of waiting for the next
 /// `device_read` to fail. Also lets the reader's cleanup path skip
 /// `device_stop` / `device_close` (the IDF driver already
 /// invalidated the handle when DISCONNECTED fired) so the post-
 /// disconnect cleanup doesn't log spurious `INVALID_ARG` errors.
 ///
-/// Reset by [`handle_rx_connected`] at the start of a new session so
+/// Reset by [`handle_rx_connected`] at the start of a new session,
+/// before `uac_host_device_open` registers the device callback, so
 /// a stale `true` from a previous attach can't kill the freshly-
-/// spawned reader on its first iteration.
+/// spawned reader on its first iteration and a fresh DISCONNECT
+/// firing during open isn't silently dropped by the reset.
 static READER_STOP_REQUESTED: std::sync::atomic::AtomicBool =
     std::sync::atomic::AtomicBool::new(false);
 
@@ -329,6 +331,14 @@ fn usb_events_task() {
 /// will need a way to signal it on disconnect).
 fn handle_rx_connected(addr: u8, iface_num: u8) -> Result<()> {
     log::info!("uac: opening device addr={addr} iface={iface_num}");
+    // Clear any stale stop-request BEFORE `uac_host_device_open` —
+    // that call registers `device_event_cb` for the new handle, after
+    // which a fast DISCONNECT (e.g. cable yanked mid-bringup) would
+    // race against the reset and have its `true` silently dropped.
+    // Resetting now is safe: the previous session's callback was
+    // unregistered at its `device_close`, so it cannot fire across
+    // the boundary.
+    READER_STOP_REQUESTED.store(false, Ordering::Release);
     let dev_config = sys::uac::uac_host_device_config_t {
         addr,
         iface_num,
@@ -384,12 +394,6 @@ fn handle_rx_connected(addr: u8, iface_num: u8) -> Result<()> {
     RX_BYTES.store(0, Ordering::Relaxed);
     RX_PACKETS.store(0, Ordering::Relaxed);
     RX_ERRORS.store(0, Ordering::Relaxed);
-
-    // Clear any stale stop-request from a previous attach (#35).
-    // The previous session's `device_event_cb` may have set this if
-    // the device was unplugged before the reader noticed; we don't
-    // want it tripping the fresh reader on its first iteration.
-    READER_STOP_REQUESTED.store(false, Ordering::Release);
 
     let handle_wrapped = DeviceHandle(handle);
     if let Err(e) = std::thread::Builder::new()
@@ -453,8 +457,8 @@ fn reader_thread(handle: DeviceHandle) {
     loop {
         // Top-of-loop disconnect check (#35). `device_event_cb` sets
         // the flag immediately on DISCONNECTED; we exit on the next
-        // iteration (≤ READER_READ_TIMEOUT_MS = 100 ms latency)
-        // rather than waiting for the failing read to surface.
+        // iteration (≤ `READER_READ_TIMEOUT_MS` latency) rather than
+        // waiting for the failing read to surface.
         if READER_STOP_REQUESTED.load(Ordering::Acquire) {
             log::info!("uac: reader exiting — DISCONNECTED signaled by device_event_cb");
             disconnect_triggered = true;
@@ -592,8 +596,16 @@ fn reader_thread(handle: DeviceHandle) {
     //   the handle is still nominally valid; explicit stop + close
     //   releases the IDF state so a re-enumeration takes a clean path.
     //
+    // Re-consult the atomic at cleanup time so a DISCONNECT that
+    // fired between the top-of-loop check and a later break (read
+    // error, chunk-push failure, slot-push failure) still routes
+    // to the skip path. Without this, DISCONNECT racing a chunk
+    // push would still emit the spurious INVALID_ARG logs.
+    //
     // Either way `_gate: ReaderActiveGuard` drops below to release
     // `READER_ACTIVE` so the next RxConnected can re-take it.
+    let disconnect_triggered =
+        disconnect_triggered || READER_STOP_REQUESTED.load(Ordering::Acquire);
     if disconnect_triggered {
         log::info!(
             "uac: reader_thread cleanup (disconnect path — skipping device_stop/close, IDF already invalidated handle)"

--- a/embedded-poc/m5stack-s3-app/src/uac.rs
+++ b/embedded-poc/m5stack-s3-app/src/uac.rs
@@ -335,9 +335,15 @@ fn handle_rx_connected(addr: u8, iface_num: u8) -> Result<()> {
     // that call registers `device_event_cb` for the new handle, after
     // which a fast DISCONNECT (e.g. cable yanked mid-bringup) would
     // race against the reset and have its `true` silently dropped.
-    // Resetting now is safe: the previous session's callback was
-    // unregistered at its `device_close`, so it cannot fire across
-    // the boundary.
+    // Resetting now is safe because (1) `app_task` processes
+    // `DriverEvent`s sequentially on the mpsc channel, so the previous
+    // session's DISCONNECTED callback finished firing before this
+    // RxConnected was dispatched, and (2) the `READER_ACTIVE` gate
+    // guarantees the previous `reader_thread` has fully exited before
+    // we re-enter `handle_rx_connected` (Gemini PR #107 review —
+    // the older "callback unregistered at device_close" rationale was
+    // incorrect since the disconnect cleanup path explicitly skips
+    // `device_close`).
     READER_STOP_REQUESTED.store(false, Ordering::Release);
     let dev_config = sys::uac::uac_host_device_config_t {
         addr,


### PR DESCRIPTION
## Summary

Follow-up to #102. The original PR's disconnect-driven reader cleanup was Gemini-quota-skipped at review time; a post-merge independent review surfaced two real race windows. This PR closes them.

- **MED-1** — Stale-flag-reset race: `READER_STOP_REQUESTED` was reset to \`false\` **after** \`uac_host_device_open\` already registered the per-handle \`device_event_cb\`. A fast DISCONNECT firing in the open→reset gap was silently dropped, causing the reader to take the wrong cleanup path and re-introduce the spurious \`INVALID_ARG\` log #102 was meant to suppress. Fix: move the reset to before \`device_open\`.
- **MED-2** — Cleanup branch only consulted the local \`disconnect_triggered\` var. \`reader_thread\` has multiple break paths beyond the top-of-loop flag check (read-error, chunk-push, slot-push); a DISCONNECT racing one of those broke out via the non-disconnect path and again logged \`INVALID_ARG\`. Fix: re-consult \`READER_STOP_REQUESTED\` at cleanup time as a safety net.
- **STYLE** — Docstring + loop-top comment hard-coded the timeout as \"100 ms\"; swap to \`READER_READ_TIMEOUT_MS\` references so a later perf sweep doesn't silently break the documentation.

Full review with reasoning lives in [the #102 post-merge comment](https://github.com/jl1nie/mfsk-core/pull/102#issuecomment-4472732804).

Doc-only diff stats: 1 file, +23 / −11. No behaviour change on the happy path — only the two race windows behave correctly now.

## Test plan

- [x] \`cargo check --release\` on \`xtensa-esp32s3-espidf\` clean.
- [ ] Fetch + triage Gemini Code Assist review on this PR.
- [ ] Flash to M5StickS3 in UAC mode, plug + unplug IC-705 USB repeatedly — check serial log for absence of \`INVALID_ARG\` lines on disconnect (the bug this fix is targeting), and confirm reader respawns cleanly on each fresh attach.
- [ ] Bonus: yank cable during \`uac: opening device addr=...\` log window (the MED-1 race) — same expectation.

The LOW finding from the #102 review (cleanup-skip relies on undocumented IDF semantics; consider always calling stop/close and demoting log severity instead) is intentionally deferred — MED-1 + MED-2 close the surfaced bugs and the LOW is a defensiveness preference, not a fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)