### PR TITLE
ci(release): pass GITHUB_TOKEN to xtensa-toolchain action to dodge 403 race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,6 +161,18 @@ jobs:
           default: true
           buildtargets: esp32
           ldproxy: false
+        # The action wraps `espup install`, which queries
+        # api.github.com/repos/esp-rs/rust-build/releases/latest for
+        # the toolchain version. Without auth this hits the 60 req/h
+        # unauthenticated GitHub API limit shared across the runner's
+        # IP pool — easy to lose the race when the s3 sibling job
+        # consumed a slot a few seconds earlier (v0.6.5 release run
+        # 26005313390 hit this and the publish job got skipped until
+        # `gh run rerun --failed` re-ran the lost job in a fresh
+        # window). Passing the auto-injected workflow token bumps
+        # the limit to 5000 req/h, making the race deterministic.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - uses: Swatinem/rust-cache@v2
       - name: Build static lib for xtensa-esp32-espidf
         # The +esp toolchain ships rust-src but no precompiled core
@@ -202,6 +214,12 @@ jobs:
           default: true
           buildtargets: esp32s3
           ldproxy: false
+        # Same GitHub-API rate-limit story as the esp32 sibling job
+        # above — pass the workflow token to bump from 60 to 5000
+        # req/h. Without this the two jobs race for the same per-IP
+        # unauthenticated budget and one of them loses periodically.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - uses: Swatinem/rust-cache@v2
       - name: Build static lib for xtensa-esp32s3-espidf
         # See the esp32 job for why `-Z build-std=...` is needed.


### PR DESCRIPTION
## Summary

\`esp-rs/xtensa-toolchain@v1.5\` wraps \`espup install\`, which queries \`api.github.com/repos/esp-rs/rust-build/releases/latest\` for the toolchain version. Without auth this shares the 60 req/h unauthenticated GitHub API limit across the runner's IP pool — easy to lose the race when the sibling ESP32-S3 build consumed a slot a few seconds earlier.

**v0.6.5 release run [26005313390](https://github.com/jl1nie/mfsk-core/actions/runs/26005313390) hit this exact failure**: ESP32-S3 build won, ESP32 build got 403 immediately after, \`publish\` was \`needs:\`-skipped, and a \`gh run rerun --failed\` was needed to recover (manual intervention 30+ min after merge). Same flake is latent in every future release.

Fix: pass the auto-injected workflow token (\`${{ github.token }}\`) as \`GITHUB_TOKEN\` env to both Xtensa-toolchain install steps. Authenticated GitHub API limit is 5000 req/h instead of 60 → race becomes deterministic.

Workflow-only change. No source code touched. **Not a release PR** — can land independently of the version cycle.

## Test plan

- [ ] Fetch + triage Gemini Code Assist review.
- [ ] Trigger CI (PR build) — runs the workspace check, doesn't exercise the changed jobs (those only run on tag push). Pre-merge verification limited.
- [ ] Real verification will happen on the **next** \`vX.Y.Z\` tag push, when the LX6/LX7 builds run with the token-authenticated espup query. Look for the absence of \`Failed to get latest Xtensa Rust version: HTTP GET Error: ... 403\` in the build logs.
- [ ] Optional follow-up: pin \`version:\` on the action to a specific Xtensa Rust release if a deterministic toolchain across releases becomes desirable (skips the latest-query API call entirely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)