### PR TITLE
fix(qso): slot-parity-aware TX gating to prevent peer collision on decode spill

### DIFF
--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -161,7 +161,15 @@ pub fn run() -> ! {
                         r.freq_hz, calibrated_snr, r.snr_db, text
                     );
                     qso.set_rx_snr(snr_i8);
-                    if qso.process_message(&text).is_some() {
+                    // See `m5stack-s3-app/src/decode_pipeline.rs` for
+                    // the rx_slot / parity_lock_ok rationale (issue #110).
+                    // Core2's wav_sim path uses the same wav_idx counter,
+                    // so the gate is identical.
+                    let parity_lock_ok = framing_settled_for_parity_lock();
+                    if qso
+                        .process_message(&text, wav_idx as u32, parity_lock_ok)
+                        .is_some()
+                    {
                         had_response_this_slot = true;
                     }
                 }
@@ -177,6 +185,19 @@ pub fn run() -> ! {
         let intent = qso.next_tx();
         push_tx_line(&qso, intent.as_ref());
     }
+}
+
+/// Same as the s3-app helper — see issue #110.
+fn framing_settled_for_parity_lock() -> bool {
+    use mfsk_app_shared::parity::{FRAMING_MIN_SLOTS_OBSERVED, SAFE_DT_THRESHOLD_SEC};
+    use mfsk_app_shared::time_sync;
+
+    if time_sync::slots_observed() < FRAMING_MIN_SLOTS_OBSERVED {
+        return false;
+    }
+    time_sync::slot_dt_offset()
+        .map(|dt| dt.abs() < SAFE_DT_THRESHOLD_SEC)
+        .unwrap_or(false)
 }
 
 fn push_tx_line(qso: &QsoManager, intent: Option<&qso::TxIntent>) {

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -165,7 +165,8 @@ pub fn run() -> ! {
                     // the rx_slot / parity_lock_ok rationale (issue #110).
                     // Core2's wav_sim path uses the same wav_idx counter,
                     // so the gate is identical.
-                    let parity_lock_ok = framing_settled_for_parity_lock();
+                    let parity_lock_ok =
+                        mfsk_app_shared::parity::framing_settled_for_parity_lock();
                     if qso
                         .process_message(&text, wav_idx as u32, parity_lock_ok)
                         .is_some()
@@ -185,19 +186,6 @@ pub fn run() -> ! {
         let intent = qso.next_tx();
         push_tx_line(&qso, intent.as_ref());
     }
-}
-
-/// Same as the s3-app helper — see issue #110.
-fn framing_settled_for_parity_lock() -> bool {
-    use mfsk_app_shared::parity::{FRAMING_MIN_SLOTS_OBSERVED, SAFE_DT_THRESHOLD_SEC};
-    use mfsk_app_shared::time_sync;
-
-    if time_sync::slots_observed() < FRAMING_MIN_SLOTS_OBSERVED {
-        return false;
-    }
-    time_sync::slot_dt_offset()
-        .map(|dt| dt.abs() < SAFE_DT_THRESHOLD_SEC)
-        .unwrap_or(false)
 }
 
 fn push_tx_line(qso: &QsoManager, intent: Option<&qso::TxIntent>) {

--- a/embedded-poc/m5stack-s3-app/src/audio.rs
+++ b/embedded-poc/m5stack-s3-app/src/audio.rs
@@ -803,13 +803,7 @@ pub fn capture_tx_thread(
             None
         };
         if let Some((intent, tx_slot)) = intent_opt {
-            do_tx_cycle(&mut i2s, &qso, &intent, &mut tx_out[..]);
-            // Issue #110: lock self_tx_parity to the slot we just
-            // transmitted in. First call sets it; subsequent calls in
-            // the same QSO are no-ops (sticky).
-            if let Ok(mut q) = qso.lock() {
-                q.record_self_tx(tx_slot);
-            }
+            do_tx_cycle(&mut i2s, &qso, &intent, tx_slot, &mut tx_out[..]);
             // Reset capture state — the gap in RX during ~12.6 s TX
             // makes any in-flight resample / slot accumulator stale.
             // Drop partial chunk; next slot will start fresh, self-sync
@@ -915,54 +909,39 @@ pub fn capture_tx_thread(
     }
 }
 
-/// Issue #110: must finish PTT + synth + I2S write inside the slot.
-/// Budget: 15 s slot − ~12.6 s frame − 100 ms PTT settle − 1 s safety
-/// margin ≈ 1.3 s window from slot start.
-const TX_LAUNCH_DEADLINE_US: i64 = 1_300_000;
-
 /// Pull the next TX intent if one is pending AND the current capture
 /// slot's parity matches our preferred TX parity AND we're still
-/// early enough in the slot to fit a full FT8 frame. Mirrors the same
-/// logic as `tx_scheduler::scheduler_thread` so the auto-CQ behaviour
-/// is identical between BootMode::TxTest (RX-less scheduler) and
-/// BootMode::Qso (combined thread).
+/// early enough in the slot to fit a full FT8 frame. Thin wrapper
+/// around `QsoManager::pick_tx_intent` that adds the audio-side
+/// slot bookkeeping (atomic `(slot, time_into_slot)` read +
+/// `TX_LAUNCH_DEADLINE_US` gate). Mirrors `tx_scheduler::scheduler_thread`
+/// so the auto-CQ behaviour is identical between BootMode::TxTest
+/// (RX-less scheduler) and BootMode::Qso (combined thread).
 ///
-/// Returns `(intent, slot_idx)` so the caller can record_self_tx with
-/// the correct slot after the TX completes.
+/// Returns `(intent, slot_idx)` so the caller can pair `record_self_tx`
+/// with the correct slot after the TX completes.
 fn tx_scheduler_pick_intent(
     qso: &std::sync::Arc<std::sync::Mutex<mfsk_app_shared::qso::QsoManager>>,
 ) -> Option<(mfsk_app_shared::qso::TxIntent, u32)> {
-    use mfsk_app_shared::parity::Parity;
+    use mfsk_app_shared::parity::{Parity, TX_LAUNCH_DEADLINE_US};
     use mfsk_app_shared::time_sync;
 
-    // Parity / launch-window gate. Skip silently before the audio
-    // source has published any capture slot (cold boot first slot).
-    let cur_slot = time_sync::current_capture_wav_idx()?;
+    // Atomic (slot, time_into_slot) read — `current_capture_info`
+    // takes the mutex once so the two values can't straddle a
+    // boundary (gemini PR #112 MEDIUM). Skip silently before the
+    // audio source has published any capture slot (cold boot first
+    // slot).
     let now_us = unsafe { sys::esp_timer_get_time() };
-    let into_us = time_sync::time_into_capture_slot_us(now_us)?;
+    let (cur_slot, into_us) = time_sync::current_capture_info(now_us)?;
     if into_us > TX_LAUNCH_DEADLINE_US {
         return None;
     }
     let cur_par = Parity::from_slot_index(cur_slot);
 
-    let mut q = qso.lock().ok()?;
-    let auto_cq = q.auto_cq_enabled;
-    let intent = q.next_tx();
-    let intent = if intent.is_some() {
-        intent
-    } else if auto_cq && q.state == mfsk_app_shared::qso::QsoState::Idle {
-        Some(q.call_cq(None))
-    } else {
-        None
-    }?;
-
-    // Parity check. `None` from preferred_tx_parity means fresh cold-
-    // boot CQ — accept any slot; that slot becomes self_tx_parity via
-    // record_self_tx after the TX completes.
-    let our_par = q.preferred_tx_parity().unwrap_or(cur_par);
-    if cur_par != our_par {
-        return None;
-    }
+    // Parity check + auto-CQ orchestration happen inside the FSM lock
+    // (`QsoManager::pick_tx_intent`) so `preferred_tx_parity()` sees
+    // any freshly transitioned state from the auto-CQ branch.
+    let intent = qso.lock().ok()?.pick_tx_intent(cur_par)?;
     Some((intent, cur_slot))
 }
 
@@ -973,6 +952,7 @@ fn do_tx_cycle(
     i2s: &mut I2sDriver<'static, I2sBiDir>,
     qso: &std::sync::Arc<std::sync::Mutex<mfsk_app_shared::qso::QsoManager>>,
     intent: &mfsk_app_shared::qso::TxIntent,
+    tx_slot: u32,
     tx_out: &mut [u8],
 ) {
     use esp_idf_svc::hal::delay::FreeRtos;
@@ -1046,8 +1026,11 @@ fn do_tx_cycle(
     crate::civ::set_ptt(false);
     AUDIO_GATE.store(true, Ordering::Release);
 
-    // Advance FSM (retry counter / Idle reset).
+    // Single qso-lock acquisition for both post-TX hooks (gemini PR
+    // #112 MEDIUM): lock self_tx_parity to the slot we just
+    // transmitted in (sticky for the rest of this QSO, issue #110)
+    // AND advance the FSM (retry counter / Idle reset).
     if let Ok(mut q) = qso.lock() {
-        let _ = q.on_period_end();
+        q.finish_self_tx(tx_slot);
     }
 }

--- a/embedded-poc/m5stack-s3-app/src/audio.rs
+++ b/embedded-poc/m5stack-s3-app/src/audio.rs
@@ -630,6 +630,17 @@ pub fn capture_thread(mut i2s: I2sDriver<'static, I2sRx>) -> ! {
                         slot_end_target = next_target;
                         wav_idx = wav_idx.wrapping_add(1);
                         slot_samples = 0;
+                        // Issue #110: publish the new capture-slot
+                        // boundary so the TX scheduler can parity-gate
+                        // and time-into-slot-gate against it. `wav_idx`
+                        // here is the index of the slot we're about to
+                        // start filling (= the slot id that will end up
+                        // in the NEXT SlotEnd message).
+                        let now_us = unsafe { sys::esp_timer_get_time() };
+                        mfsk_app_shared::time_sync::publish_capture_slot(
+                            wav_idx as u32,
+                            now_us,
+                        );
                     }
                 }
             }
@@ -791,8 +802,14 @@ pub fn capture_tx_thread(
         } else {
             None
         };
-        if let Some(intent) = intent_opt {
+        if let Some((intent, tx_slot)) = intent_opt {
             do_tx_cycle(&mut i2s, &qso, &intent, &mut tx_out[..]);
+            // Issue #110: lock self_tx_parity to the slot we just
+            // transmitted in. First call sets it; subsequent calls in
+            // the same QSO are no-ops (sticky).
+            if let Ok(mut q) = qso.lock() {
+                q.record_self_tx(tx_slot);
+            }
             // Reset capture state — the gap in RX during ~12.6 s TX
             // makes any in-flight resample / slot accumulator stale.
             // Drop partial chunk; next slot will start fresh, self-sync
@@ -872,6 +889,12 @@ pub fn capture_tx_thread(
                         slot_end_target = next_target;
                         wav_idx = wav_idx.wrapping_add(1);
                         slot_samples = 0;
+                        // Issue #110 — see capture_thread for rationale.
+                        let now_us = unsafe { sys::esp_timer_get_time() };
+                        mfsk_app_shared::time_sync::publish_capture_slot(
+                            wav_idx as u32,
+                            now_us,
+                        );
                     }
                 }
             }
@@ -892,25 +915,55 @@ pub fn capture_tx_thread(
     }
 }
 
-/// Pull the next TX intent if one is pending. Mirrors the same logic
-/// as `tx_scheduler::scheduler_thread` so the auto-CQ behaviour is
-/// identical between BootMode::TxTest (RX-less scheduler) and
+/// Issue #110: must finish PTT + synth + I2S write inside the slot.
+/// Budget: 15 s slot − ~12.6 s frame − 100 ms PTT settle − 1 s safety
+/// margin ≈ 1.3 s window from slot start.
+const TX_LAUNCH_DEADLINE_US: i64 = 1_300_000;
+
+/// Pull the next TX intent if one is pending AND the current capture
+/// slot's parity matches our preferred TX parity AND we're still
+/// early enough in the slot to fit a full FT8 frame. Mirrors the same
+/// logic as `tx_scheduler::scheduler_thread` so the auto-CQ behaviour
+/// is identical between BootMode::TxTest (RX-less scheduler) and
 /// BootMode::Qso (combined thread).
+///
+/// Returns `(intent, slot_idx)` so the caller can record_self_tx with
+/// the correct slot after the TX completes.
 fn tx_scheduler_pick_intent(
     qso: &std::sync::Arc<std::sync::Mutex<mfsk_app_shared::qso::QsoManager>>,
-) -> Option<mfsk_app_shared::qso::TxIntent> {
-    let q = qso.lock().ok()?;
+) -> Option<(mfsk_app_shared::qso::TxIntent, u32)> {
+    use mfsk_app_shared::parity::Parity;
+    use mfsk_app_shared::time_sync;
+
+    // Parity / launch-window gate. Skip silently before the audio
+    // source has published any capture slot (cold boot first slot).
+    let cur_slot = time_sync::current_capture_wav_idx()?;
+    let now_us = unsafe { sys::esp_timer_get_time() };
+    let into_us = time_sync::time_into_capture_slot_us(now_us)?;
+    if into_us > TX_LAUNCH_DEADLINE_US {
+        return None;
+    }
+    let cur_par = Parity::from_slot_index(cur_slot);
+
+    let mut q = qso.lock().ok()?;
     let auto_cq = q.auto_cq_enabled;
     let intent = q.next_tx();
-    if intent.is_some() {
-        return intent;
+    let intent = if intent.is_some() {
+        intent
+    } else if auto_cq && q.state == mfsk_app_shared::qso::QsoState::Idle {
+        Some(q.call_cq(None))
+    } else {
+        None
+    }?;
+
+    // Parity check. `None` from preferred_tx_parity means fresh cold-
+    // boot CQ — accept any slot; that slot becomes self_tx_parity via
+    // record_self_tx after the TX completes.
+    let our_par = q.preferred_tx_parity().unwrap_or(cur_par);
+    if cur_par != our_par {
+        return None;
     }
-    if auto_cq && q.state == mfsk_app_shared::qso::QsoState::Idle {
-        drop(q);
-        let mut q = qso.lock().ok()?;
-        return Some(q.call_cq(None));
-    }
-    None
+    Some((intent, cur_slot))
 }
 
 /// One full TX cycle: PTT bracket + synth + write to the bidir I2S TX

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -472,9 +472,24 @@ where
                     // Feed the FSM. SNR set first so an in-band reply
                     // ("JL1NIE W1AW FN31") gets reported with the
                     // correct rx_snr → tx_report.
+                    //
+                    // `rx_slot = wav_idx` decouples peer-parity locking
+                    // from "current slot when decode finished" — even
+                    // if BP spilled into the next slot, the FSM still
+                    // attributes the message to the slot whose audio
+                    // it came from (issue #110).
+                    //
+                    // `parity_lock_ok` gates the lock on bootstrap
+                    // convergence: when DT is still wandering, our
+                    // wav_idx parity may not match the band yet, and
+                    // locking would freeze us to the wrong parity for
+                    // the whole QSO.
+                    let parity_lock_ok = framing_settled_for_parity_lock();
                     if let Ok(mut q) = qso.lock() {
                         q.set_rx_snr(snr_i8);
-                        if q.process_message(&text).is_some() {
+                        if q.process_message(&text, wav_idx as u32, parity_lock_ok)
+                            .is_some()
+                        {
                             had_response_this_slot = true;
                         }
                     }
@@ -509,6 +524,23 @@ where
 
 /// Format the FSM's current intent and push it to the UI thread. Also
 /// echoed to the log so headless captures still record QSO state.
+/// Issue #110 gate: only let the QSO FSM lock `peer_parity` once
+/// bootstrap_slot_shift has converged enough that our `wav_idx`
+/// parity is trustworthy. Returns `false` during the first ~2 slots
+/// after boot / BtnA re-sync, AND on any slot whose median DT is
+/// outside the safe window.
+fn framing_settled_for_parity_lock() -> bool {
+    use mfsk_app_shared::parity::{FRAMING_MIN_SLOTS_OBSERVED, SAFE_DT_THRESHOLD_SEC};
+    use mfsk_app_shared::time_sync;
+
+    if time_sync::slots_observed() < FRAMING_MIN_SLOTS_OBSERVED {
+        return false;
+    }
+    time_sync::slot_dt_offset()
+        .map(|dt| dt.abs() < SAFE_DT_THRESHOLD_SEC)
+        .unwrap_or(false)
+}
+
 fn push_tx_line(qso: &QsoManager, intent: Option<&qso::TxIntent>) {
     let line = qso::format_tx_line(qso, intent);
     log::info!("[QSO] {}", line.as_str());

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -484,7 +484,8 @@ where
                     // wav_idx parity may not match the band yet, and
                     // locking would freeze us to the wrong parity for
                     // the whole QSO.
-                    let parity_lock_ok = framing_settled_for_parity_lock();
+                    let parity_lock_ok =
+                        mfsk_app_shared::parity::framing_settled_for_parity_lock();
                     if let Ok(mut q) = qso.lock() {
                         q.set_rx_snr(snr_i8);
                         if q.process_message(&text, wav_idx as u32, parity_lock_ok)
@@ -520,25 +521,6 @@ where
             push_tx_line(&q, intent.as_ref());
         }
     }
-}
-
-/// Format the FSM's current intent and push it to the UI thread. Also
-/// echoed to the log so headless captures still record QSO state.
-/// Issue #110 gate: only let the QSO FSM lock `peer_parity` once
-/// bootstrap_slot_shift has converged enough that our `wav_idx`
-/// parity is trustworthy. Returns `false` during the first ~2 slots
-/// after boot / BtnA re-sync, AND on any slot whose median DT is
-/// outside the safe window.
-fn framing_settled_for_parity_lock() -> bool {
-    use mfsk_app_shared::parity::{FRAMING_MIN_SLOTS_OBSERVED, SAFE_DT_THRESHOLD_SEC};
-    use mfsk_app_shared::time_sync;
-
-    if time_sync::slots_observed() < FRAMING_MIN_SLOTS_OBSERVED {
-        return false;
-    }
-    time_sync::slot_dt_offset()
-        .map(|dt| dt.abs() < SAFE_DT_THRESHOLD_SEC)
-        .unwrap_or(false)
 }
 
 fn push_tx_line(qso: &QsoManager, intent: Option<&qso::TxIntent>) {

--- a/embedded-poc/m5stack-s3-app/src/tx_scheduler.rs
+++ b/embedded-poc/m5stack-s3-app/src/tx_scheduler.rs
@@ -51,7 +51,17 @@ pub fn spawn(i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManager>>) -> Res
     Ok(())
 }
 
+/// Issue #110: matches `audio::TX_LAUNCH_DEADLINE_US`.
+const TX_LAUNCH_DEADLINE_US: i64 = 1_300_000;
+/// FT8 slot length in μs. Used by the TxTest path to drive synthetic
+/// capture-slot publications without a real audio source.
+const SLOT_LEN_US: i64 = 15_000_000;
+
 fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManager>>) {
+    use esp_idf_svc::sys::esp_timer_get_time;
+    use mfsk_app_shared::parity::Parity;
+    use mfsk_app_shared::time_sync;
+
     // Prio above stage1_inc/dual_core so the I2S DMA refill doesn't
     // starve during BP — same rationale as audio_thread (Phase 1.5
     // capture_thread used prio 8 for the same reason).
@@ -66,13 +76,46 @@ fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManage
     // BLE pair grace — same 10 s window the Phase 1.6 test loop used.
     FreeRtos::delay_ms(10_000);
 
+    // TxTest mode has no RX-side audio thread to publish capture-slot
+    // boundaries, so we synthesise them here from the monotonic clock.
+    // Picking wav_idx 0 at the moment auto-CQ goes live is fine —
+    // there's no peer to phase against in TxTest, and once a real
+    // QSO scenario runs (Qso/Acoustic mode) the audio thread is the
+    // authoritative publisher.
+    let mut synth_wav_idx: u32 = 0;
+    let mut synth_slot_start_us: i64 = unsafe { esp_timer_get_time() };
+    time_sync::publish_capture_slot(synth_wav_idx, synth_slot_start_us);
+
     loop {
+        // ── Synthetic slot tick ───────────────────────────────────
+        let now_us = unsafe { esp_timer_get_time() };
+        if now_us - synth_slot_start_us >= SLOT_LEN_US {
+            synth_wav_idx = synth_wav_idx.wrapping_add(1);
+            synth_slot_start_us += SLOT_LEN_US;
+            time_sync::publish_capture_slot(synth_wav_idx, synth_slot_start_us);
+        }
         // Poll cadence: 100 ms is fast enough to catch any slot-boundary
         // TX trigger within one FT8 symbol period. Not aligned to slot
         // start yet — `time_sync::bootstrap_slot_shift` would let us
         // schedule precisely against the band's slot cadence; for now
         // we rely on the FSM's per-slot state and the fact that auto-CQ
         // fires immediately when next_tx() exposes an intent.
+        // ── Parity + launch-window gate (issue #110) ──────────────
+        // Computed BEFORE we acquire the QSO lock so we don't hold
+        // the FSM mutex while doing the cheap parity arithmetic.
+        let Some(cur_slot) = time_sync::current_capture_wav_idx() else {
+            FreeRtos::delay_ms(100);
+            continue;
+        };
+        match time_sync::time_into_capture_slot_us(now_us) {
+            Some(i) if i <= TX_LAUNCH_DEADLINE_US => {}
+            _ => {
+                FreeRtos::delay_ms(100);
+                continue;
+            }
+        }
+        let cur_par = Parity::from_slot_index(cur_slot);
+
         let maybe_intent = {
             // Mutable lock — the auto-CQ branch may call `call_cq()`
             // (Gemini PR #103 MEDIUM: reuse the lock instead of
@@ -91,7 +134,10 @@ fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManage
             // the next_tx() intent — auto_cq only gates the cold-start
             // Idle → Calling auto-transition.
             let intent = q.next_tx();
-            if intent.is_none() && auto_cq && q.state == mfsk_app_shared::qso::QsoState::Idle {
+            let intent = if intent.is_none()
+                && auto_cq
+                && q.state == mfsk_app_shared::qso::QsoState::Idle
+            {
                 // Synthesise a fresh CQ by transitioning Idle → Calling.
                 // Reuse the existing MutexGuard rather than dropping and
                 // re-acquiring — `q` already has mutable access and the
@@ -101,7 +147,13 @@ fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManage
                 Some(q.call_cq(None))
             } else {
                 intent
-            }
+            };
+            // Parity check INSIDE the lock so preferred_tx_parity sees
+            // the freshly set Calling state.
+            intent.and_then(|i| {
+                let our_par = q.preferred_tx_parity().unwrap_or(cur_par);
+                if cur_par == our_par { Some(i) } else { None }
+            })
         };
 
         let Some(intent) = maybe_intent else {
@@ -181,8 +233,11 @@ fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManage
 
         // Advance the FSM — if the peer didn't reply during our TX
         // slot, `on_period_end` increments the retry counter (or
-        // resets to Idle when budget is exhausted).
+        // resets to Idle when budget is exhausted). Also lock
+        // self_tx_parity to the slot we just transmitted in
+        // (issue #110) — sticky for the rest of this QSO.
         if let Ok(mut q) = qso.lock() {
+            q.record_self_tx(cur_slot);
             let _ = q.on_period_end();
         }
 

--- a/embedded-poc/m5stack-s3-app/src/tx_scheduler.rs
+++ b/embedded-poc/m5stack-s3-app/src/tx_scheduler.rs
@@ -51,15 +51,13 @@ pub fn spawn(i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManager>>) -> Res
     Ok(())
 }
 
-/// Issue #110: matches `audio::TX_LAUNCH_DEADLINE_US`.
-const TX_LAUNCH_DEADLINE_US: i64 = 1_300_000;
 /// FT8 slot length in μs. Used by the TxTest path to drive synthetic
 /// capture-slot publications without a real audio source.
 const SLOT_LEN_US: i64 = 15_000_000;
 
 fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManager>>) {
     use esp_idf_svc::sys::esp_timer_get_time;
-    use mfsk_app_shared::parity::Parity;
+    use mfsk_app_shared::parity::{Parity, TX_LAUNCH_DEADLINE_US};
     use mfsk_app_shared::time_sync;
 
     // Prio above stage1_inc/dual_core so the I2S DMA refill doesn't
@@ -101,61 +99,31 @@ fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManage
         // we rely on the FSM's per-slot state and the fact that auto-CQ
         // fires immediately when next_tx() exposes an intent.
         // ── Parity + launch-window gate (issue #110) ──────────────
-        // Computed BEFORE we acquire the QSO lock so we don't hold
-        // the FSM mutex while doing the cheap parity arithmetic.
-        let Some(cur_slot) = time_sync::current_capture_wav_idx() else {
+        // Atomic (slot, time_into_slot) read so the two values can't
+        // straddle a boundary (gemini PR #112 MEDIUM —
+        // `current_capture_info` takes the time_sync mutex once).
+        let Some((cur_slot, into_us)) = time_sync::current_capture_info(now_us) else {
             FreeRtos::delay_ms(100);
             continue;
         };
-        match time_sync::time_into_capture_slot_us(now_us) {
-            Some(i) if i <= TX_LAUNCH_DEADLINE_US => {}
-            _ => {
-                FreeRtos::delay_ms(100);
-                continue;
-            }
+        if into_us > TX_LAUNCH_DEADLINE_US {
+            FreeRtos::delay_ms(100);
+            continue;
         }
         let cur_par = Parity::from_slot_index(cur_slot);
 
-        let maybe_intent = {
-            // Mutable lock — the auto-CQ branch may call `call_cq()`
-            // (Gemini PR #103 MEDIUM: reuse the lock instead of
-            // drop+reacquire to avoid the Idle race).
-            let mut q = match qso.lock() {
-                Ok(g) => g,
-                Err(e) => {
-                    log::error!("tx_scheduler: qso lock poisoned: {e}");
-                    FreeRtos::delay_ms(1000);
-                    continue;
-                }
-            };
-            let auto_cq = q.auto_cq_enabled;
-            // For Idle state, only fire CQ when auto_cq is enabled.
-            // For mid-QSO states (Calling/Report/Final), always honour
-            // the next_tx() intent — auto_cq only gates the cold-start
-            // Idle → Calling auto-transition.
-            let intent = q.next_tx();
-            let intent = if intent.is_none()
-                && auto_cq
-                && q.state == mfsk_app_shared::qso::QsoState::Idle
-            {
-                // Synthesise a fresh CQ by transitioning Idle → Calling.
-                // Reuse the existing MutexGuard rather than dropping and
-                // re-acquiring — `q` already has mutable access and the
-                // drop/reacquire opens a tiny window where another task
-                // can see Idle and start its own transition.
-                // Gemini PR #103 MEDIUM.
-                Some(q.call_cq(None))
-            } else {
-                intent
-            };
-            // Parity check INSIDE the lock so preferred_tx_parity sees
-            // the freshly set Calling state.
-            intent.and_then(|i| {
-                let our_par = q.preferred_tx_parity().unwrap_or(cur_par);
-                if cur_par == our_par { Some(i) } else { None }
-            })
+        // Auto-CQ + parity check inside `QsoManager::pick_tx_intent`
+        // — single FSM lock, no Idle race, no duplicated orchestration
+        // with `audio::tx_scheduler_pick_intent` (gemini PR #112
+        // MEDIUM, building on gemini PR #103 MEDIUM).
+        let maybe_intent = match qso.lock() {
+            Ok(mut q) => q.pick_tx_intent(cur_par),
+            Err(e) => {
+                log::error!("tx_scheduler: qso lock poisoned: {e}");
+                FreeRtos::delay_ms(1000);
+                continue;
+            }
         };
-
         let Some(intent) = maybe_intent else {
             FreeRtos::delay_ms(100);
             continue;
@@ -231,14 +199,12 @@ fn scheduler_thread(mut i2s: I2sDriver<'static, I2sTx>, qso: Arc<Mutex<QsoManage
         crate::civ::set_ptt(false);
         crate::audio::AUDIO_GATE.store(true, std::sync::atomic::Ordering::Release);
 
-        // Advance the FSM — if the peer didn't reply during our TX
-        // slot, `on_period_end` increments the retry counter (or
-        // resets to Idle when budget is exhausted). Also lock
-        // self_tx_parity to the slot we just transmitted in
-        // (issue #110) — sticky for the rest of this QSO.
+        // Single qso-lock acquisition for both post-TX hooks: lock
+        // self_tx_parity to the slot we just transmitted in (sticky
+        // for the rest of this QSO, issue #110) AND advance the FSM
+        // (retry counter / Idle reset when budget exhausted).
         if let Ok(mut q) = qso.lock() {
-            q.record_self_tx(cur_slot);
-            let _ = q.on_period_end();
+            q.finish_self_tx(cur_slot);
         }
 
         // Small slot gap so we don't immediately retransmit if FSM

--- a/embedded-poc/m5stack-s3-app/src/uac.rs
+++ b/embedded-poc/m5stack-s3-app/src/uac.rs
@@ -559,6 +559,17 @@ fn reader_thread(handle: DeviceHandle) {
                         );
                         wav_idx = wav_idx.wrapping_add(1);
                         slot_samples = 0;
+                        // Issue #110: publish capture-slot boundary for
+                        // any TX scheduler running in this BootMode.
+                        // BootMode::Uac is currently RX-only on the
+                        // S3 board, but published unconditionally to
+                        // keep the slot index live in case downstream
+                        // logging / TX wiring is added.
+                        let now_us = unsafe { sys::esp_timer_get_time() };
+                        mfsk_app_shared::time_sync::publish_capture_slot(
+                            wav_idx as u32,
+                            now_us,
+                        );
                     }
                 }
             }

--- a/embedded-poc/mfsk-app-shared/src/lib.rs
+++ b/embedded-poc/mfsk-app-shared/src/lib.rs
@@ -10,6 +10,7 @@ pub mod adif;
 pub mod boot_mode;
 pub mod flash_log;
 pub mod log_sink;
+pub mod parity;
 pub mod qso;
 pub mod snr_norm;
 pub mod time_sync;

--- a/embedded-poc/mfsk-app-shared/src/parity.rs
+++ b/embedded-poc/mfsk-app-shared/src/parity.rs
@@ -49,3 +49,33 @@ pub const FRAMING_MIN_SLOTS_OBSERVED: u32 = 2;
 /// TxTest schedulers both gate `time_into_capture_slot_us` ≤ this
 /// before firing TX.
 pub const TX_LAUNCH_DEADLINE_US: i64 = 1_300_000;
+
+/// Issue #110 gate: is the framing-self-sync settled enough to trust
+/// `wav_idx` parity for `QsoManager::process_message`'s
+/// `parity_lock_ok` argument? Two conditions, both required:
+///
+/// 1. `time_sync::slots_observed() >= FRAMING_MIN_SLOTS_OBSERVED` —
+///    the bootstrap_slot_shift estimator has had ≥2 passes to
+///    converge.
+/// 2. `time_sync::slot_dt_offset()` is finite and below
+///    `SAFE_DT_THRESHOLD_SEC` — the slot we measured DT for is
+///    aligned closely enough that a decode landing inside it can be
+///    unambiguously attributed to its parity (not the adjacent
+///    slot).
+///
+/// Returns `false` during the first ~2 slots after boot / BtnA
+/// re-sync AND on any slot whose median DT is outside the safe
+/// window. Board-agnostic — depends only on `time_sync` global
+/// state, so both `m5stack-s3-app` and `m5stack-core2-app` (and any
+/// future board crate) consume the same function instead of
+/// duplicating it in each `decode_pipeline.rs`.
+pub fn framing_settled_for_parity_lock() -> bool {
+    use crate::time_sync;
+
+    if time_sync::slots_observed() < FRAMING_MIN_SLOTS_OBSERVED {
+        return false;
+    }
+    time_sync::slot_dt_offset()
+        .map(|dt| dt.abs() < SAFE_DT_THRESHOLD_SEC)
+        .unwrap_or(false)
+}

--- a/embedded-poc/mfsk-app-shared/src/parity.rs
+++ b/embedded-poc/mfsk-app-shared/src/parity.rs
@@ -1,0 +1,44 @@
+//! Slot parity primitives shared by the QSO FSM, TX scheduler, and
+//! TX picker.
+//!
+//! FT8 alternates TX between even and odd 15 s slots. This module
+//! owns the canonical `Parity` enum plus the framing-settled
+//! threshold the FSM uses to gate peer-parity locking against the
+//! bootstrap_slot_shift convergence window. See issue #110 for the
+//! UTC-arbitrary / self-sync rationale.
+
+/// One bit of slot identity. `Even` = slot index bit 0 == 0.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Parity {
+    Even,
+    Odd,
+}
+
+impl Parity {
+    pub fn from_slot_index(slot: u32) -> Self {
+        if slot & 1 == 0 {
+            Parity::Even
+        } else {
+            Parity::Odd
+        }
+    }
+
+    pub fn opposite(self) -> Self {
+        match self {
+            Parity::Even => Parity::Odd,
+            Parity::Odd => Parity::Even,
+        }
+    }
+}
+
+/// `|median(DT)|` below which we trust our slot framing enough to
+/// lock `peer_parity` from a decoded message. Picked at 1.5 s — well
+/// inside the FT8 ±2.5 s coarse-sync window so a clean decode at this
+/// threshold is unambiguously inside OUR captured slot, not the
+/// previous one.
+pub const SAFE_DT_THRESHOLD_SEC: f32 = 1.5;
+
+/// `slots_observed` minimum before peer_parity locking is allowed.
+/// One bootstrap pass is normally enough to align (within ±50 ms);
+/// two gives us a re-check sample.
+pub const FRAMING_MIN_SLOTS_OBSERVED: u32 = 2;

--- a/embedded-poc/mfsk-app-shared/src/parity.rs
+++ b/embedded-poc/mfsk-app-shared/src/parity.rs
@@ -42,3 +42,10 @@ pub const SAFE_DT_THRESHOLD_SEC: f32 = 1.5;
 /// One bootstrap pass is normally enough to align (within ±50 ms);
 /// two gives us a re-check sample.
 pub const FRAMING_MIN_SLOTS_OBSERVED: u32 = 2;
+
+/// Issue #110: must finish PTT + synth + I2S write inside the slot.
+/// Budget: 15 s slot − ~12.6 s frame − 100 ms PTT settle − 1 s
+/// safety margin ≈ 1.3 s window from capture-slot start. Audio +
+/// TxTest schedulers both gate `time_into_capture_slot_us` ≤ this
+/// before firing TX.
+pub const TX_LAUNCH_DEADLINE_US: i64 = 1_300_000;

--- a/embedded-poc/mfsk-app-shared/src/qso.rs
+++ b/embedded-poc/mfsk-app-shared/src/qso.rs
@@ -15,6 +15,8 @@
 use core::fmt::Write as _;
 use heapless::String;
 
+use crate::parity::Parity;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum QsoState {
     Idle,
@@ -69,6 +71,17 @@ pub struct QsoManager {
     /// — only the Idle → Calling auto-transition is gated.
     /// Toggled from the menu UI; persisted in NVS as `"auto_cq"`.
     pub auto_cq_enabled: bool,
+    /// Confirmed peer TX-slot parity. Locked on the first
+    /// state-advancing decode for which the caller passes
+    /// `parity_lock_ok = true` (= bootstrap_slot_shift has converged
+    /// — see issue #110). Cleared by `reset()`; preserved across
+    /// retries within the same QSO.
+    pub peer_parity: Option<Parity>,
+    /// Self TX parity. Locked on the first own TX completion
+    /// (`record_self_tx`). Used as a fallback when `peer_parity` is
+    /// still unknown so that successive own-CQ retries don't drift
+    /// between even/odd slots.
+    pub self_tx_parity: Option<Parity>,
 }
 
 impl QsoManager {
@@ -89,6 +102,8 @@ impl QsoManager {
             retry_count: 0,
             cq_suffix: String::new(),
             auto_cq_enabled: false,
+            peer_parity: None,
+            self_tx_parity: None,
         }
     }
 
@@ -109,6 +124,38 @@ impl QsoManager {
         self.tx_report.clear();
         self.rx_report.clear();
         self.retry_count = 0;
+        // Parity locks are per-QSO; the next QSO may be with a peer
+        // on the opposite slot.
+        self.peer_parity = None;
+        self.self_tx_parity = None;
+    }
+
+    /// Preferred TX slot parity for the next own transmission.
+    ///
+    /// Precedence:
+    ///   1. `opposite(peer_parity)` — primary case, set as soon as
+    ///      we've cleanly decoded a peer message addressed to us.
+    ///   2. `self_tx_parity` — same-QSO continuation when peer_parity
+    ///      is still unlocked (e.g. peer transmitted but framing was
+    ///      not yet settled when we processed the decode).
+    ///   3. `None` — fresh cold-boot CQ. Caller may fire on any slot;
+    ///      that slot's parity then becomes `self_tx_parity` via
+    ///      `record_self_tx`.
+    pub fn preferred_tx_parity(&self) -> Option<Parity> {
+        if let Some(p) = self.peer_parity {
+            return Some(p.opposite());
+        }
+        self.self_tx_parity
+    }
+
+    /// Audio-side callback after a TX cycle completes. Locks
+    /// `self_tx_parity` if not already set, so that subsequent
+    /// retransmissions in this QSO stick to the same slot parity even
+    /// while peer_parity remains unknown.
+    pub fn record_self_tx(&mut self, tx_slot: u32) {
+        if self.self_tx_parity.is_none() {
+            self.self_tx_parity = Some(Parity::from_slot_index(tx_slot));
+        }
     }
 
     /// Begin calling CQ. Returns the TxIntent for the upcoming slot.
@@ -136,7 +183,21 @@ impl QsoManager {
 
     /// Process a decoded message. Returns Some(TxIntent) if the FSM
     /// wants to transmit in response.
-    pub fn process_message(&mut self, text: &str) -> Option<TxIntent> {
+    ///
+    /// `rx_slot` is the `wav_idx` of the audio slot the message was
+    /// captured from (= `SpecBundle.wav_idx`). When the message drives
+    /// a state transition AND `parity_lock_ok` is `true`, `peer_parity`
+    /// is locked to `rx_slot & 1`. `parity_lock_ok` should be `false`
+    /// during the bootstrap_slot_shift convergence window (see
+    /// `parity::SAFE_DT_THRESHOLD_SEC`) — state transitions and retry
+    /// counters still advance normally, but parity stays unlocked
+    /// until a later clean decode.
+    pub fn process_message(
+        &mut self,
+        text: &str,
+        rx_slot: u32,
+        parity_lock_ok: bool,
+    ) -> Option<TxIntent> {
         if self.my_call.is_empty() {
             return None;
         }
@@ -149,12 +210,24 @@ impl QsoManager {
         if words.len() < 2 {
             return None;
         }
-        match self.state {
+        let result = match self.state {
             QsoState::Idle => self.on_idle(&words),
             QsoState::Calling => self.on_calling(&words),
             QsoState::Report => self.on_report(&words),
             QsoState::Final => self.on_final(&words),
+        };
+        // Lock peer_parity only when (a) the decode actually drove a
+        // state transition (= `result.is_some()` OR we landed in Idle
+        // via Final's 73 handler) AND (b) the caller signalled that
+        // slot framing is settled enough to trust `rx_slot`.
+        // We use `result.is_some()` as the "addressed to us" proxy
+        // for non-Final transitions; for Final → Idle (73 received),
+        // the FSM has just completed and parity will be cleared on
+        // next reset anyway, so no lock needed.
+        if parity_lock_ok && self.peer_parity.is_none() && result.is_some() {
+            self.peer_parity = Some(Parity::from_slot_index(rx_slot));
         }
+        result
     }
 
     /// Slot end with no relevant response. Returns retry intent or None
@@ -436,12 +509,19 @@ mod tests {
         assert_eq!(m.state, QsoState::Calling);
     }
 
+    /// Helper: process_message with parity-lock disabled. Most legacy
+    /// tests don't care about parity; they exercise the protocol state
+    /// machine in isolation.
+    fn pm(m: &mut QsoManager, text: &str) -> Option<TxIntent> {
+        m.process_message(text, 0, false)
+    }
+
     #[test]
     fn responder_grid_triggers_report() {
         let mut m = mgr();
         m.call_cq(None);
         m.set_rx_snr(-7);
-        let tx = m.process_message("JL1NIE W1AW FN31").unwrap();
+        let tx = pm(&mut m, "JL1NIE W1AW FN31").unwrap();
         assert_eq!(m.state, QsoState::Report);
         assert_eq!(tx.formatted().as_str(), "W1AW JL1NIE -07");
     }
@@ -450,9 +530,9 @@ mod tests {
     fn report_to_rr73() {
         let mut m = mgr();
         m.call_cq(None);
-        m.process_message("JL1NIE W1AW FN31");
+        pm(&mut m, "JL1NIE W1AW FN31");
         // They send R-12 confirming our report
-        let tx = m.process_message("JL1NIE W1AW R-12").unwrap();
+        let tx = pm(&mut m, "JL1NIE W1AW R-12").unwrap();
         assert_eq!(m.state, QsoState::Final);
         assert_eq!(tx.formatted().as_str(), "W1AW JL1NIE RR73");
     }
@@ -461,9 +541,9 @@ mod tests {
     fn final_to_idle_on_73() {
         let mut m = mgr();
         m.call_cq(None);
-        m.process_message("JL1NIE W1AW FN31");
-        m.process_message("JL1NIE W1AW R-12");
-        let tx = m.process_message("JL1NIE W1AW 73");
+        pm(&mut m, "JL1NIE W1AW FN31");
+        pm(&mut m, "JL1NIE W1AW R-12");
+        let tx = pm(&mut m, "JL1NIE W1AW 73");
         assert!(tx.is_none());
         assert_eq!(m.state, QsoState::Idle);
     }
@@ -473,7 +553,7 @@ mod tests {
         let mut m = mgr();
         m.call_cq(None);
         // Two random stations QSOing — must not affect us
-        assert!(m.process_message("AA1AA BB2BB FN42").is_none());
+        assert!(pm(&mut m, "AA1AA BB2BB FN42").is_none());
         assert_eq!(m.state, QsoState::Calling);
     }
 
@@ -495,7 +575,7 @@ mod tests {
     fn report_directly_skips_grid() {
         let mut m = mgr();
         m.call_cq(None);
-        let tx = m.process_message("JL1NIE W1AW -15").unwrap();
+        let tx = pm(&mut m, "JL1NIE W1AW -15").unwrap();
         assert_eq!(m.state, QsoState::Report);
         assert_eq!(tx.formatted().as_str(), "W1AW JL1NIE R-15");
     }
@@ -505,7 +585,7 @@ mod tests {
         let mut m = mgr();
         // Someone calls us while we're idle (e.g., we just booted)
         m.set_rx_snr(3);
-        let tx = m.process_message("JL1NIE W1AW FN31").unwrap();
+        let tx = pm(&mut m, "JL1NIE W1AW FN31").unwrap();
         assert_eq!(m.state, QsoState::Report);
         assert_eq!(tx.formatted().as_str(), "W1AW JL1NIE +03");
     }
@@ -518,5 +598,117 @@ mod tests {
         let intent = m.next_tx();
         let line = format_tx_line(&m, intent.as_ref());
         assert_eq!(line.as_str(), "CALL: CQ JL1NIE PM95 [1/5]");
+    }
+
+    // ── Slot-parity tests (issue #110) ────────────────────────────
+
+    #[test]
+    fn parity_unlocked_at_boot() {
+        let m = mgr();
+        assert!(m.peer_parity.is_none());
+        assert!(m.self_tx_parity.is_none());
+        assert!(m.preferred_tx_parity().is_none());
+    }
+
+    #[test]
+    fn peer_parity_locks_on_clean_decode_in_calling() {
+        let mut m = mgr();
+        m.call_cq(None);
+        // Peer answers from an ODD slot (rx_slot = 7), framing settled.
+        let tx = m
+            .process_message("JL1NIE W1AW FN31", 7, true)
+            .expect("state advances");
+        assert_eq!(m.state, QsoState::Report);
+        assert_eq!(m.peer_parity, Some(Parity::Odd));
+        // Our TX should now be gated to EVEN.
+        assert_eq!(m.preferred_tx_parity(), Some(Parity::Even));
+        let _ = tx;
+    }
+
+    #[test]
+    fn peer_parity_locks_on_unsolicited_call_in_idle() {
+        let mut m = mgr();
+        m.set_rx_snr(3);
+        m.process_message("JL1NIE W1AW FN31", 4, true)
+            .expect("idle accepts unsolicited call");
+        assert_eq!(m.peer_parity, Some(Parity::Even));
+        assert_eq!(m.preferred_tx_parity(), Some(Parity::Odd));
+    }
+
+    #[test]
+    fn peer_parity_stays_locked_to_rx_slot_when_decode_spills() {
+        // Issue #110's core invariant: even if `process_message` is
+        // called LATE (during the slot after the one the audio came
+        // from), `peer_parity` reflects the audio's slot, not "now".
+        let mut m = mgr();
+        m.call_cq(None);
+        // Peer transmitted in slot 5 (ODD). Decode finished in slot 6
+        // — but we pass rx_slot = 5 (the SpecBundle.wav_idx).
+        m.process_message("JL1NIE W1AW FN31", 5, true)
+            .expect("state advances");
+        assert_eq!(m.peer_parity, Some(Parity::Odd));
+        assert_eq!(m.preferred_tx_parity(), Some(Parity::Even));
+    }
+
+    #[test]
+    fn peer_parity_does_not_lock_when_framing_unsettled() {
+        let mut m = mgr();
+        m.call_cq(None);
+        // parity_lock_ok = false (bootstrap_slot_shift not yet converged).
+        m.process_message("JL1NIE W1AW FN31", 5, false)
+            .expect("state still advances");
+        assert_eq!(m.state, QsoState::Report);
+        assert!(m.peer_parity.is_none(), "must NOT lock during bootstrap");
+        // Next clean decode (e.g. R-12 confirming our report) locks it.
+        m.process_message("JL1NIE W1AW R-12", 7, true)
+            .expect("report → final");
+        assert_eq!(m.peer_parity, Some(Parity::Odd));
+        // Our final 73 should go to Even.
+        assert_eq!(m.preferred_tx_parity(), Some(Parity::Even));
+    }
+
+    #[test]
+    fn peer_parity_does_not_lock_on_unrelated_decode() {
+        let mut m = mgr();
+        m.call_cq(None);
+        // Random QSO between two other stations — must not lock parity.
+        assert!(m.process_message("AA1AA BB2BB FN42", 3, true).is_none());
+        assert!(m.peer_parity.is_none());
+    }
+
+    #[test]
+    fn record_self_tx_locks_only_first_call() {
+        let mut m = mgr();
+        m.call_cq(None);
+        m.record_self_tx(4);
+        assert_eq!(m.self_tx_parity, Some(Parity::Even));
+        // Second call must NOT flip parity — sticky for the QSO.
+        m.record_self_tx(7);
+        assert_eq!(m.self_tx_parity, Some(Parity::Even));
+    }
+
+    #[test]
+    fn preferred_tx_parity_precedence() {
+        let mut m = mgr();
+        // No peer, no self → None (fresh cold CQ may use any slot).
+        assert!(m.preferred_tx_parity().is_none());
+        // Self TX locked first → that parity wins.
+        m.record_self_tx(3);
+        assert_eq!(m.preferred_tx_parity(), Some(Parity::Odd));
+        // Once peer_parity lands, it OVERRIDES self_tx_parity — we
+        // adapt to the peer's actual slot rather than perpetuating an
+        // arbitrary cold-boot choice.
+        m.peer_parity = Some(Parity::Odd);
+        assert_eq!(m.preferred_tx_parity(), Some(Parity::Even));
+    }
+
+    #[test]
+    fn reset_clears_both_parities() {
+        let mut m = mgr();
+        m.peer_parity = Some(Parity::Even);
+        m.self_tx_parity = Some(Parity::Odd);
+        m.reset();
+        assert!(m.peer_parity.is_none());
+        assert!(m.self_tx_parity.is_none());
     }
 }

--- a/embedded-poc/mfsk-app-shared/src/qso.rs
+++ b/embedded-poc/mfsk-app-shared/src/qso.rs
@@ -158,6 +158,55 @@ impl QsoManager {
         }
     }
 
+    /// Atomic next-TX pick, parity- and auto-CQ-aware. Returns the
+    /// `TxIntent` to fire iff one is pending (or `auto_cq_enabled` and
+    /// we're Idle) AND the supplied `cur_par` matches our preferred TX
+    /// parity. Returns `None` otherwise.
+    ///
+    /// Doing the parity check inside this method (rather than at each
+    /// caller after `next_tx()`) lets the FSM evaluate
+    /// `preferred_tx_parity()` against the **freshly transitioned**
+    /// state if the auto-CQ branch fires — important because the
+    /// `Idle → Calling` transition itself might affect
+    /// `self_tx_parity` later. It also removes the duplicate
+    /// orchestration block that was sitting in both
+    /// `audio::tx_scheduler_pick_intent` and `tx_scheduler::scheduler_thread`.
+    ///
+    /// `cur_par` is the parity of the slot the caller intends to TX in;
+    /// the caller is responsible for both bracketing this with the
+    /// launch-deadline check (`parity::TX_LAUNCH_DEADLINE_US`) and
+    /// pairing it with the matching `wav_idx` for later
+    /// `record_self_tx`. `current_capture_info` is the right source
+    /// for that pair.
+    pub fn pick_tx_intent(&mut self, cur_par: Parity) -> Option<TxIntent> {
+        let intent = self.next_tx().or_else(|| {
+            if self.auto_cq_enabled && self.state == QsoState::Idle {
+                Some(self.call_cq(None))
+            } else {
+                None
+            }
+        })?;
+        // `None` from preferred_tx_parity = fresh cold-boot CQ — fire
+        // in any slot; that slot becomes self_tx_parity via the
+        // caller's subsequent `record_self_tx`.
+        let our_par = self.preferred_tx_parity().unwrap_or(cur_par);
+        if cur_par == our_par {
+            Some(intent)
+        } else {
+            None
+        }
+    }
+
+    /// Combined post-TX hook: lock `self_tx_parity` to the slot we
+    /// just transmitted in (sticky for the rest of this QSO) AND
+    /// advance the per-period FSM (retry counter / Idle reset).
+    /// Single lock acquisition for callers that hold a
+    /// `Mutex<QsoManager>`.
+    pub fn finish_self_tx(&mut self, tx_slot: u32) {
+        self.record_self_tx(tx_slot);
+        let _ = self.on_period_end();
+    }
+
     /// Begin calling CQ. Returns the TxIntent for the upcoming slot.
     pub fn call_cq(&mut self, suffix: Option<&str>) -> TxIntent {
         self.cq_suffix.clear();
@@ -710,5 +759,58 @@ mod tests {
         m.reset();
         assert!(m.peer_parity.is_none());
         assert!(m.self_tx_parity.is_none());
+    }
+
+    // ── pick_tx_intent coverage (gemini PR #112 MEDIUM consolidation) ──
+
+    #[test]
+    fn pick_tx_intent_auto_cq_idle_fires_on_any_parity_when_unlocked() {
+        let mut m = mgr();
+        m.auto_cq_enabled = true;
+        // No peer_parity, no self_tx_parity → preferred = None →
+        // accept whichever slot we're polled in.
+        let i = m.pick_tx_intent(Parity::Even);
+        assert!(i.is_some());
+        assert_eq!(m.state, QsoState::Calling);
+    }
+
+    #[test]
+    fn pick_tx_intent_no_auto_cq_idle_returns_none() {
+        let mut m = mgr();
+        m.auto_cq_enabled = false;
+        // No next_tx pending AND auto_cq disabled AND state == Idle.
+        assert!(m.pick_tx_intent(Parity::Even).is_none());
+        assert_eq!(m.state, QsoState::Idle);
+    }
+
+    #[test]
+    fn pick_tx_intent_parity_mismatch_skips() {
+        let mut m = mgr();
+        m.auto_cq_enabled = true;
+        m.peer_parity = Some(Parity::Even); // → prefer Odd
+        // Polled on Even → parity mismatch, expect None and state
+        // unchanged (auto-CQ does fire `call_cq()` which transitions
+        // Idle → Calling regardless; the gate is on the parity match
+        // for the *returned* intent only).
+        assert!(m.pick_tx_intent(Parity::Even).is_none());
+    }
+
+    #[test]
+    fn pick_tx_intent_parity_match_returns_intent() {
+        let mut m = mgr();
+        m.auto_cq_enabled = true;
+        m.peer_parity = Some(Parity::Even); // → prefer Odd
+        let i = m.pick_tx_intent(Parity::Odd);
+        assert!(i.is_some());
+    }
+
+    #[test]
+    fn finish_self_tx_records_parity_and_advances_period() {
+        let mut m = mgr();
+        m.call_cq(None); // Calling, retry_count = 0
+        m.finish_self_tx(3); // Odd slot
+        assert_eq!(m.self_tx_parity, Some(Parity::Odd));
+        // on_period_end should have advanced retry counter.
+        assert_eq!(m.retry_count, 1);
     }
 }

--- a/embedded-poc/mfsk-app-shared/src/time_sync.rs
+++ b/embedded-poc/mfsk-app-shared/src/time_sync.rs
@@ -223,6 +223,21 @@ pub fn time_into_capture_slot_us(now_mono_us: i64) -> Option<i64> {
         .and_then(|g| g.map(|(_, start)| (now_mono_us - start).max(0)))
 }
 
+/// Atomic combined read of `(wav_idx, time_into_slot_us)`. Callers
+/// that need *both* values to refer to the same slot (e.g. the TX
+/// scheduler's parity + launch-deadline check) must use this instead
+/// of pairing `current_capture_wav_idx()` with
+/// `time_into_capture_slot_us()` — the two-call form holds the
+/// mutex twice and races with `publish_capture_slot()` if a slot
+/// boundary crosses between them, yielding `(slot N, time_into_N+1)`.
+/// `None` before the audio source has published any boundary.
+pub fn current_capture_info(now_mono_us: i64) -> Option<(u32, i64)> {
+    CAPTURE_SLOT
+        .lock()
+        .ok()
+        .and_then(|g| g.map(|(w, start)| (w, (now_mono_us - start).max(0))))
+}
+
 /// Test-only reset. The statics persist for the whole process so
 /// each test case starts uninitialised.
 #[cfg(test)]

--- a/embedded-poc/mfsk-app-shared/src/time_sync.rs
+++ b/embedded-poc/mfsk-app-shared/src/time_sync.rs
@@ -22,6 +22,8 @@
 use core::sync::atomic::{AtomicI32, Ordering};
 use std::sync::Mutex;
 
+use crate::parity::Parity;
+
 /// Maximum decodes-per-slot we'll keep for the median computation.
 /// qso3_busy peaks at ~7 on M5StickS3 / ship config, so 50 leaves
 /// >7× headroom for a more aggressive build.
@@ -161,4 +163,71 @@ pub fn slots_observed() -> u32 {
 /// and clears it atomically. Call at SlotEnd time.
 pub fn take_bootstrap_slot_shift_12k() -> i32 {
     BOOTSTRAP_SLOT_SHIFT_12K.swap(0, Ordering::AcqRel)
+}
+
+// ────────────────────────────────────────────────────────────────
+// Capture-slot index + parity (issue #110).
+//
+// Published by the audio source (capture_thread / wav_sim driver /
+// TxTest 15 s timer) at each slot boundary. Read by the TX scheduler
+// to decide whether to fire in this slot (parity match) and how much
+// time is left in the slot (TX must complete within 15 s).
+//
+// `wav_idx` is the audio-source canonical slot counter — same value
+// that ends up in `embedded_shared::pipeline::SpecBundle.wav_idx`
+// and `Slot.wav_idx`. Using one counter for both audio framing and
+// FSM gating guarantees the FSM's notion of "peer's slot" matches
+// the audio that actually fed the decode.
+//
+// Stored together behind a `Mutex` because Xtensa LX6 / LX7 don't
+// expose lock-free 64-bit atomics — and we need the (wav_idx,
+// start_us) pair to be torn-read-free anyway. Contention is trivial:
+// producer writes once per 15 s slot boundary, consumer reads once
+// per 100 ms scheduler poll.
+//
+// `None` = not yet published (cold boot). Readers return `None` so
+// the TX scheduler skips this iteration rather than firing on parity
+// bit 0 of an undefined counter.
+
+static CAPTURE_SLOT: Mutex<Option<(u32, i64)>> = Mutex::new(None);
+
+/// Audio source side. Call once per slot boundary, AT slot START
+/// (i.e. when capture of the new slot's audio begins). `wav_idx` is
+/// the slot identifier that will travel with this slot's audio
+/// through stage1_inc → SpecBundle/Slot → decode. `now_mono_us` is
+/// `esp_timer_get_time()` (or equivalent monotonic μs).
+pub fn publish_capture_slot(wav_idx: u32, now_mono_us: i64) {
+    if let Ok(mut g) = CAPTURE_SLOT.lock() {
+        *g = Some((wav_idx, now_mono_us));
+    }
+}
+
+/// Current capture slot's `wav_idx`, or `None` before the audio
+/// source has published any boundary.
+pub fn current_capture_wav_idx() -> Option<u32> {
+    CAPTURE_SLOT.lock().ok().and_then(|g| g.map(|(w, _)| w))
+}
+
+/// Parity of the current capture slot. `None` before first publish.
+pub fn current_capture_parity() -> Option<Parity> {
+    current_capture_wav_idx().map(Parity::from_slot_index)
+}
+
+/// Microseconds elapsed since the current capture slot started.
+/// Clamped to `>= 0` in case the monotonic clock somehow regresses
+/// (it doesn't on esp-idf, but defensive). `None` before first publish.
+pub fn time_into_capture_slot_us(now_mono_us: i64) -> Option<i64> {
+    CAPTURE_SLOT
+        .lock()
+        .ok()
+        .and_then(|g| g.map(|(_, start)| (now_mono_us - start).max(0)))
+}
+
+/// Test-only reset. The statics persist for the whole process so
+/// each test case starts uninitialised.
+#[cfg(test)]
+pub fn reset_capture_slot_for_test() {
+    if let Ok(mut g) = CAPTURE_SLOT.lock() {
+        *g = None;
+    }
 }

--- a/embedded-poc/mfsk-app-shared/src/tx_picker.rs
+++ b/embedded-poc/mfsk-app-shared/src/tx_picker.rs
@@ -22,21 +22,7 @@ pub const BIN_BASE_HZ: u16 = 200;
 pub const GUARD_HZ: u16 = 50;
 pub const HISTORY_SLOTS: usize = 10;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Parity {
-    Even,
-    Odd,
-}
-
-impl Parity {
-    pub fn from_slot_index(slot: u32) -> Self {
-        if slot % 2 == 0 {
-            Parity::Even
-        } else {
-            Parity::Odd
-        }
-    }
-}
+pub use crate::parity::Parity;
 
 #[derive(Debug, Clone)]
 pub struct TxCandidate {


### PR DESCRIPTION
## Summary

Closes #110.

The embedded QSO FSM had no concept of even/odd slot parity — TX fired on the next 100 ms scheduler poll after the FSM exposed an intent, with no slot-edge alignment. When the decoder of slot N completed during slot N+1 (the spill case the embedded decoder is explicitly built to handle), our reply was transmitted *in the peer's TX slot*, jamming them.

- New `mfsk_app_shared::parity` module owns `Parity {Even, Odd}` + the framing-settled thresholds (1.5 s DT, 2 bootstrap slots) that gate peer-parity locking against the self-sync convergence window for off-grid (no-UTC) operation.
- `time_sync` publishes capture-slot boundaries via `publish_capture_slot(wav_idx, now_mono_us)` + readers `current_capture_wav_idx` / `current_capture_parity` / `time_into_capture_slot_us`, stored behind `Mutex<Option<...>>` (Xtensa lacks lock-free 64-bit atomics; contention is trivial — writer once per 15 s, reader once per 100 ms).
- `QsoManager` gains `peer_parity` and `self_tx_parity: Option<Parity>`. `process_message(text, rx_slot, parity_lock_ok)` decouples parity attribution from "current slot when decode finished" — `rx_slot` comes from `SpecBundle.wav_idx`, so a spilled decode still records `peer_parity = (audio slot) & 1`. `parity_lock_ok = false` while bootstrap shift is still converging.
- `preferred_tx_parity()` precedence: opposite(peer_parity) → self_tx_parity → None (fresh cold-boot CQ accepts any slot).
- `record_self_tx(tx_slot)` locks `self_tx_parity` sticky for the QSO. `reset()` clears both.

Wiring: s3-app capture threads (Acoustic, Qso) + `tx_scheduler` (TxTest 15 s tick) + `uac` reader all publish capture-slot boundaries. `tx_scheduler_pick_intent` + tx_scheduler's loop gate on parity match AND `time_into_slot <= 1.3 s` (15 s − 12.6 s frame − 100 ms PTT settle − 1 s safety). Out-of-parity / late slots are silently skipped; `on_period_end` is NOT called, so retry budget is preserved. s3-app + core2-app decode pipelines pass `wav_idx` as `rx_slot` and gate parity-lock on `slots_observed >= 2 && |slot_dt_offset| < 1.5 s`.

## Test plan

- [x] 8 new unit tests in `qso.rs`: spill (rx_slot lag from "current"), `parity_lock_ok = false` during bootstrap, precedence ordering, sticky `self_tx_parity`, `reset` clears both. Legacy tests updated to pass dummy slot / lock_ok via a `pm()` helper.
- [ ] CI sweep (fmt + clippy + rustdoc + test matrix).
- [ ] Real-radio bench: confirm spilled-decode reply lands in our parity slot, not peer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)