### PR TITLE
ci: skip Build/Test/C++ matrix on docs-only PRs (#113)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
     name: path filter
     runs-on: ubuntu-latest
     outputs:
+      src: ${{ steps.filter.outputs.src }}
       ft8: ${{ steps.filter.outputs.ft8 }}
       q65: ${{ steps.filter.outputs.q65 }}
       uvpacket: ${{ steps.filter.outputs.uvpacket }}
@@ -70,6 +71,24 @@ jobs:
         uses: dorny/paths-filter@v3
         with:
           filters: |
+            # `src` is the docs-only escape hatch (issue #113). True when
+            # any compilation-relevant input changed. False on pure
+            # docs/CHANGELOG/README/rustdoc-only PRs, which lets the
+            # Build/Test/C++ matrix skip while rustfmt+clippy, rustdoc,
+            # and publish-dry-run still run as the doc-surface gate.
+            # `Cargo.lock` is in because `cargo update` legitimately
+            # changes what gets compiled.
+            src:
+              - '.github/workflows/**'
+              - 'Cargo.lock'
+              - 'mfsk-core/Cargo.toml'
+              - 'mfsk-core/build.rs'
+              - 'mfsk-core/src/**'
+              - 'mfsk-core/tests/**'
+              - 'mfsk-core/examples/**'
+              - 'mfsk-core/benches/**'
+              - 'mfsk-ffi/**'
+              - 'mfsk-ffi-ft8/**'
             ft8:
               - '.github/workflows/**'
               - 'mfsk-core/Cargo.toml'
@@ -214,9 +233,13 @@ jobs:
           # coverage). `push_only: true` skips on regular PRs and
           # only runs on push-to-main or when the PR carries the
           # `run-full-sweep` label.
+          # `src` gate (issue #113): default suite still covers every
+          # protocol's non-ignored tests, but is skipped entirely on
+          # docs-only PRs (README / CHANGELOG / docs/** / rustdoc) since
+          # the inputs to the compiler/test binaries did not move.
           - name: default
             kind: default
-            changes_key: always
+            changes_key: src
             push_only: false
           # FT8 recall protection (real-QSO regression + WSJT-X
           # reference WAV recall across all distributed samples).
@@ -275,6 +298,7 @@ jobs:
           CHANGES_KEY: ${{ matrix.suite.changes_key }}
           PUSH_ONLY: ${{ matrix.suite.push_only }}
           EVENT_NAME: ${{ github.event_name }}
+          SRC: ${{ needs.changes.outputs.src }}
           FT8: ${{ needs.changes.outputs.ft8 }}
           Q65: ${{ needs.changes.outputs.q65 }}
           UVPACKET: ${{ needs.changes.outputs.uvpacket }}
@@ -315,6 +339,7 @@ jobs:
               should_run=true
             else
               case "$CHANGES_KEY" in
+                src)      [ "$SRC" = "true" ]      && should_run=true ;;
                 ft8)      [ "$FT8" = "true" ]      && should_run=true ;;
                 q65)      [ "$Q65" = "true" ]      && should_run=true ;;
                 uvpacket) [ "$UVPACKET" = "true" ] && should_run=true ;;
@@ -391,6 +416,11 @@ jobs:
   # ───────────────────────────────────────────────────────────────
   feature-matrix:
     name: Build (${{ matrix.features }})
+    needs: changes
+    # Skip on docs-only PRs (issue #113). On push to main, always run
+    # as a post-merge safety net even if the merge commit only touched
+    # docs (defensive — a rebase could surface a regression).
+    if: github.event_name == 'push' || needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -434,6 +464,10 @@ jobs:
   # ───────────────────────────────────────────────────────────────
   ffi:
     name: mfsk-ffi + C++ driver
+    needs: changes
+    # Skip on docs-only PRs (issue #113); see feature-matrix for the
+    # push-to-main rationale.
+    if: github.event_name == 'push' || needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Add `src` output to the existing `dorny/paths-filter@v3` job, true when any compilation-relevant input changed (`mfsk-core/{src,tests,examples,benches,Cargo.toml,build.rs}`, `mfsk-ffi*/**`, `.github/workflows/**`, `Cargo.lock`).
- Gate three job clusters on it: `test` matrix `default` suite (was `always`), `feature-matrix` (14-entry Build matrix), and `ffi` (C++ driver). Push-to-main always runs them as a post-merge safety net.
- Keep `lint` (rustfmt+clippy), `rustdoc`, `publish-dry-run`, and the `changes` filter itself unconditional — these are cheap and can actually fail on doc-only inputs.

Closes #113.

## Effect
- Pure docs / CHANGELOG / README / `docs/**` PR: ~25 checks → ~4-5 (rustfmt+clippy, rustdoc, publish-dry-run, path-filter; sweep entries already gated under #85).
- Source-touching PR: identical behaviour to today.
- Push to main: always runs every job, regardless of the merge commit's diff (defensive against rebase-only surfaces).

## Out of scope (per the issue)
- `src/**/*.rs` doc-comment-only edits still run Build/Test (no diff-content inspection at the paths-filter level — `rustfmt`/`clippy`/`rustdoc` already cover them, and Build/Test on `src/` is not the wasteful case).
- `Release` workflow untouched (runs on tag push, no PR diff to filter on).

## Test plan
- [ ] CI on this PR itself: since this touches `.github/workflows/**`, the `src` filter resolves to **true** here — full matrix should run, which exercises the new gate's "true" branch end-to-end before merging.
- [ ] Follow-up: confirm next docs-only PR (touching only `*.md` / `docs/**`) skips Build/Test/C++ and only runs lint/rustdoc/publish-dry-run/path-filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)