### PR TITLE
feat(s3-app): BtnA long-press demo mode in BootMode::Qso

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -293,14 +293,18 @@ in module doc-comments:
   canonical reference; lifted to `m5stack-cores3-app` in
   Phase 0-Core, then hoisted into `mfsk-app-shared` in
   Phase 1.5-Core after dual-board verification.
-- **Phase 1.5 (Acoustic capture)** — Pending. Internal MEMS mic via
-  ES8311 ADC mode → I2S RX → existing `LinearResamplerI16To12k` →
-  `decode_pipeline::run_with_source`. IC-705 SPEAKER OUT picked up
-  acoustically; no cable / dongle. Acceptable SNR penalty (~5-10 dB,
-  FT8 floor is -21 dB). Adds `BootMode::Acoustic` between `Wifi`
-  and `Uac` in the boot-mode cycle. Tracked as task #47.
+- **Phase 1.5 (Acoustic capture)** — ✅ Done (Phase 1.7.1-Stick).
+  ES8311 ADC mic-mode → I2S RX → `LinearResamplerI16To12k` →
+  `decode_pipeline::run_with_source`. `BootMode::Acoustic` added to
+  the NVS cycle; live on `main`.
+- **Phase 1.7 (QSO mode bidir I2S + demo toggle)** — ✅ Done. PR
+  #121 adds a BtnA-long-press demo mode inside `BootMode::Qso`:
+  audio source switches from mic to baked-in `qso3_busy.wav`,
+  speaker plays back the WAV, TX scheduler is suppressed, LCD shows
+  `DEMO MODE — TX OFF`. Deterministic demo safety net when ambient
+  acoustic conditions kill the live WebFT8-to-mic path.
 - **Phases 2 / 5 / 6 / TX keying** — Rolled forward to Phase B-Core.
-  Stick stays frozen at Phase 1.5 once that lands.
+  Stick frozen after Phase 1.7 demo toggle.
 
 ### Phase B-Core — m5stack-cores3-app (MAIN TARGET, NEW)
 

--- a/embedded-poc/m5stack-s3-app/CLAUDE.md
+++ b/embedded-poc/m5stack-s3-app/CLAUDE.md
@@ -43,7 +43,7 @@ entry) update that file, not this one.
   `New-NetFirewallHyperVRule` invocation is captured in the
   Phase 0.6 commit log (search `git log --grep "Phase 0.6"`).
 
-## Status (2026-05-17 pivot — demo / acoustic-fallback role)
+## Status (2026-05-21 — demo / acoustic-fallback, frozen after Phase 1.7)
 
 Phase 0 / 0.5 / 3 / 4 / 0.6 / 0.7 shipped on `main`. Phase 1 UAC
 hardware verification confirmed **M5StickS3 cannot do USB host**
@@ -51,13 +51,19 @@ hardware verification confirmed **M5StickS3 cannot do USB host**
 IC; see memory `project_m5stick_s3_no_usb_host`). This crate is
 repositioned as the **demo / acoustic-fallback** path:
 
-- **Phase 1.5 (next, task #47)**: internal MEMS mic via ES8311 ADC
-  mode → I2S RX → `decode_pipeline::run_with_source`. Picks up
-  IC-705 SPEAKER OUT acoustically; no cable / dongle required. Adds
-  `BootMode::Acoustic` between `Wifi` and `Uac` in the boot cycle.
+- **Phase 1.5 (Acoustic) — ✅ done**: ES8311 ADC mic-mode → I2S RX →
+  `LinearResamplerI16To12k` → `decode_pipeline::run_with_source`.
+  `BootMode::Acoustic` added to the NVS cycle. Live on `main`.
+- **Phase 1.7 (QSO bidir I2S + demo toggle) — ✅ done**: BtnA
+  long-press in `BootMode::Qso` toggles `demo_mode_enabled`; the
+  audio thread substitutes `qso3_busy.wav` for both the decoder's
+  chunk feed and the speaker output. On `feat/demo-mode-qso`, PR #121.
+- **Phase 1.7.8 (NextMode menu item) — ✅ done**: 4th menu item
+  lets the user switch boot mode from within the menu overlay (no
+  3-reboot KEY dance). On `feat/demo-mode-qso` (same PR #121 branch).
 - **Phase 1 (UAC), Phase 2 (BLE CI-V), Phase 5 (ADIF), Phase 6
   (buttons), TX keying**: rolled forward to `m5stack-cores3-app`
-  (Phase B-Core in `docs/ROADMAP.md`).
+  (Phase B-Core in `docs/ROADMAP.md`). **Stick frozen after 1.7.8.**
 
 The `uac.rs` module (~445 lines) stays in-tree as canonical
 reference; it's cloned verbatim into `m5stack-cores3-app` in Phase

--- a/embedded-poc/m5stack-s3-app/src/audio.rs
+++ b/embedded-poc/m5stack-s3-app/src/audio.rs
@@ -785,8 +785,9 @@ pub fn capture_tx_thread(
     // identical to `audio_thread` (Decode-mode WAV playback). The
     // -18 dBFS digital attenuation (`s >> 3`) likewise matches.
     let demo_pcm: &'static [u8] = {
+        const WAV_HEADER_SIZE: usize = 44;
         let wav = crate::decode_pipeline::QSO_WAVS[0];
-        if wav.len() > 44 { &wav[44..] } else { wav }
+        if wav.len() > WAV_HEADER_SIZE { &wav[WAV_HEADER_SIZE..] } else { &[] }
     };
     let mut demo_cursor_bytes: usize = 0;
 
@@ -888,8 +889,8 @@ pub fn capture_tx_thread(
         //     -18 dBFS attenuation (`s >> 3`) — same as `audio_thread`
         //     (Decode mode). TODO: extract shared helper once the
         //     gate-envelope / loop-fade features land in this path.
+        let stereo_samples = bytes_read / 4;
         if demo_on {
-            let stereo_samples = bytes_read / 4;
             // 48 k → 12 k decimation factor = 4, so the equivalent
             // 12 k mono count is stereo_samples / 4.
             let mut demo_samples_remaining = stereo_samples / 4;
@@ -969,7 +970,6 @@ pub fn capture_tx_thread(
             continue;
         }
 
-        let stereo_samples = bytes_read / 4;
         debug_assert!(stereo_samples <= left_scratch.len());
         for i in 0..stereo_samples {
             let off = i * 4;

--- a/embedded-poc/m5stack-s3-app/src/audio.rs
+++ b/embedded-poc/m5stack-s3-app/src/audio.rs
@@ -770,6 +770,26 @@ pub fn capture_tx_thread(
             .try_into()
             .expect("TX_IN_CHUNK sizes match");
 
+    // Demo-mode state (Phase 1.7.8-Stick). When `UiState::demo_mode_enabled`
+    // is true the loop ignores mic samples and reads the baked qso3 WAV
+    // instead, simultaneously streaming the same WAV out the speaker so
+    // the operator gets a deterministic decode demo when ambient
+    // conditions kill the live WebFT8→mic path. TX intent is skipped
+    // (no PTT key) — see plan `generic-yawning-honey.md` §5 for the
+    // audio-layer-override rationale.
+    //
+    // The 44-byte slice skips qso3_busy.wav's RIFF/fmt/data header
+    // (the file is canonical 12 kHz mono i16 LE — same format the
+    // chunk_q expects, so no resample needed for the decoder feed).
+    // For TX we still do 4× zero-order-hold upsample to 48 kHz stereo,
+    // identical to `audio_thread` (Decode-mode WAV playback). The
+    // -18 dBFS digital attenuation (`s >> 3`) likewise matches.
+    let demo_pcm: &'static [u8] = {
+        let wav = crate::decode_pipeline::QSO_WAVS[0];
+        if wav.len() > 44 { &wav[44..] } else { wav }
+    };
+    let mut demo_cursor_bytes: usize = 0;
+
     loop {
         // Phase 1.7.4-Stick coordinated reset (mirrors capture_thread).
         // Drain pre-BtnA chunks + clear stale shift + signal stage1_inc
@@ -796,8 +816,20 @@ pub fn capture_tx_thread(
             resampler = LinearResamplerI16To12k::new(48_000);
         }
 
+        // ── Snapshot demo flag once per iteration ─────────────────
+        // Two reads of this flag would race against a mid-iteration
+        // toggle (benign — user can't toggle within ~21 ms — but
+        // single-read is cleaner).
+        let demo_on = mfsk_app_shared::ui::state::UI
+            .lock()
+            .ok()
+            .map(|u| u.demo_mode_enabled)
+            .unwrap_or(false);
+
         // ── TX priority check ─────────────────────────────────────
-        let intent_opt = if std::time::Instant::now() >= bring_up_grace {
+        // Demo mode: skip — audio layer overrides synth with WAV and
+        // PTT must not key (no actual TX during demo).
+        let intent_opt = if !demo_on && std::time::Instant::now() >= bring_up_grace {
             tx_scheduler_pick_intent(&qso)
         } else {
             None
@@ -832,12 +864,110 @@ pub fn capture_tx_thread(
             continue;
         }
         // AUDIO_GATE: when false (e.g. just before/during TX), drain
-        // the read but don't push to the decode pipeline.
-        if !AUDIO_GATE.load(Ordering::Acquire) {
+        // the read but don't push to the decode pipeline. Demo mode
+        // bypasses the gate — we own the TX path entirely.
+        if !demo_on && !AUDIO_GATE.load(Ordering::Acquire) {
             continue;
         }
         CAPTURE_BYTES.fetch_add(bytes_read as u32, Ordering::Relaxed);
         CAPTURE_PACKETS.fetch_add(1, Ordering::Relaxed);
+
+        let chunk_q_addr = CAPTURE_CHUNK_Q_ADDR.load(Ordering::Acquire);
+        if chunk_q_addr == 0 {
+            continue;
+        }
+        let chunk_q = chunk_q_addr as sys::QueueHandle_t;
+
+        // ── Demo-mode branch: WAV in / WAV out ────────────────────
+        // Use the I2S read's duration as pacing (already ~21 ms for
+        // a full ~4 KB stereo read), substitute WAV samples in both
+        // directions:
+        //   - chunk_q: push 12 kHz mono samples direct from WAV
+        //     (no resample — qso3_busy.wav is canonical 12 kHz mono)
+        //   - I2S TX: 4× zero-order hold upsample to 48 kHz stereo,
+        //     -18 dBFS attenuation (`s >> 3`) — same as `audio_thread`
+        //     (Decode mode). TODO: extract shared helper once the
+        //     gate-envelope / loop-fade features land in this path.
+        if demo_on {
+            let stereo_samples = bytes_read / 4;
+            // 48 k → 12 k decimation factor = 4, so the equivalent
+            // 12 k mono count is stereo_samples / 4.
+            let mut demo_samples_remaining = stereo_samples / 4;
+            while demo_samples_remaining > 0 {
+                let batch = demo_samples_remaining.min(TX_IN_CHUNK);
+                let mut tx_o = 0usize;
+                for _ in 0..batch {
+                    if demo_cursor_bytes + 2 > demo_pcm.len() {
+                        demo_cursor_bytes = 0;
+                    }
+                    let s = i16::from_le_bytes([
+                        demo_pcm[demo_cursor_bytes],
+                        demo_pcm[demo_cursor_bytes + 1],
+                    ]);
+                    demo_cursor_bytes += 2;
+
+                    // Decoder feed (raw 12 k mono).
+                    chunk.push(s);
+                    if chunk.len() >= CHUNK_LEN {
+                        let to_send =
+                            core::mem::replace(&mut chunk, Vec::with_capacity(CHUNK_LEN));
+                        send_box(chunk_q, Box::new(ChunkMsg::Samples(to_send)));
+                        slot_samples += CHUNK_LEN;
+                        if slot_samples >= slot_end_target {
+                            send_box(
+                                chunk_q,
+                                Box::new(ChunkMsg::SlotEnd {
+                                    wav_idx,
+                                    total_samples: slot_samples,
+                                }),
+                            );
+                            // Demo path doesn't drift (cursor wraps the
+                            // WAV cleanly), so always restore the
+                            // canonical slot length. Skip the shift
+                            // consumption that the mic path applies —
+                            // any pending shift was for the mic timing.
+                            slot_end_target = CAPTURE_SLOT_SAMPLES_12K;
+                            wav_idx = wav_idx.wrapping_add(1);
+                            slot_samples = 0;
+                            // Don't publish capture_slot in demo mode —
+                            // TX scheduler is gated above anyway, and
+                            // posting a slot here would compete with
+                            // the wall-clock real slot when demo flips
+                            // off.
+                        }
+                    }
+
+                    // TX side: 4× ZOH stereo i16 with -18 dBFS attn.
+                    let attn = (s >> 3).to_le_bytes();
+                    for _ in 0..4 {
+                        tx_out[tx_o] = attn[0];
+                        tx_out[tx_o + 1] = attn[1];
+                        tx_out[tx_o + 2] = attn[0];
+                        tx_out[tx_o + 3] = attn[1];
+                        tx_o += 4;
+                    }
+                }
+                if let Err(e) = i2s
+                    .write_all(&tx_out[..tx_o], TickType::new_millis(500).ticks())
+                {
+                    log::warn!("demo: i2s tx write err {e:?}");
+                }
+                demo_samples_remaining -= batch;
+            }
+
+            let now = std::time::Instant::now();
+            if now.duration_since(last_log).as_secs() >= 1 {
+                let bytes = CAPTURE_BYTES.load(Ordering::Relaxed);
+                let bps = bytes.wrapping_sub(last_bytes);
+                log::info!(
+                    "audio capture+tx (DEMO): {bps} B/s rx (slot={slot_samples}/12k, cursor={demo_cursor_bytes}/{})",
+                    demo_pcm.len()
+                );
+                last_log = now;
+                last_bytes = bytes;
+            }
+            continue;
+        }
 
         let stereo_samples = bytes_read / 4;
         debug_assert!(stereo_samples <= left_scratch.len());
@@ -845,12 +975,6 @@ pub fn capture_tx_thread(
             let off = i * 4;
             left_scratch[i] = i16::from_le_bytes([buf[off], buf[off + 1]]);
         }
-
-        let chunk_q_addr = CAPTURE_CHUNK_Q_ADDR.load(Ordering::Acquire);
-        if chunk_q_addr == 0 {
-            continue;
-        }
-        let chunk_q = chunk_q_addr as sys::QueueHandle_t;
 
         let mut src_offset = 0usize;
         while src_offset < stereo_samples {

--- a/embedded-poc/m5stack-s3-app/src/audio.rs
+++ b/embedded-poc/m5stack-s3-app/src/audio.rs
@@ -95,6 +95,59 @@ pub fn init_es8311(i2c: &mut I2cDriver) -> Result<()> {
     Ok(())
 }
 
+/// Combined ADC+DAC init for QSO bidir mode (mic capture + speaker output
+/// simultaneously). Uses reg 0x01=0xBF (= 0xB5 speaker | 0xBA mic) to
+/// engage both the DAC and ADC internal clock paths. A single reset +
+/// settle avoids the order-dependency of calling the two single-direction
+/// inits in sequence (each starts with a soft RESET that wipes the other's
+/// register writes).
+pub fn init_es8311_bidir(i2c: &mut I2cDriver) -> Result<()> {
+    use esp_idf_svc::hal::delay::FreeRtos;
+    // Configure PMIC GPIO3 as push-pull output (same sequence as
+    // init_es8311). init_es8311_capture skips this because Acoustic mode
+    // never enables PA; init_es8311_bidir needs it for demo + TX synth.
+    pmic_bit_off(i2c, 0x16, 1 << 3)?; // GPIO3 = GPIO function (not alt)
+    pmic_bit_on(i2c, 0x10, 1 << 3)?;  // GPIO3 = output direction
+    pmic_bit_off(i2c, 0x13, 1 << 3)?; // push-pull
+    pmic_bit_off(i2c, 0x11, 1 << 3)?; // output LOW (PA off until play)
+    // Disable → settle → enable (same rationale as init_es8311_capture).
+    let disable_seq: &[(u8, u8)] = &[
+        (0x0D, 0xFC),
+        (0x0E, 0x6A),
+        (0x00, 0x00),
+    ];
+    for &(reg, val) in disable_seq {
+        let _ = i2c.write(ES8311_ADDR, &[reg, val], I2C_TIMEOUT);
+    }
+    FreeRtos::delay_ms(20);
+    // Full bidir register set.
+    // 0x01=0xBF: OR of 0xB5 (DAC clock path) and 0xBA (ADC clock path)
+    // so both internal clock chains are active simultaneously.
+    let seq: &[(u8, u8)] = &[
+        (0x00, 0x80), // RESET + CSM power on
+        (0x01, 0xBF), // CLOCK_MANAGER: MCLK=BCLK, ADC+DAC clocks
+        (0x02, 0x18), // CLOCK_MANAGER: MULT_PRE=3
+        (0x0D, 0x01), // SYSTEM: power up analog
+        (0x0E, 0x02), // SYSTEM: enable PGA + ADC modulator
+        (0x12, 0x00), // SYSTEM: power up DAC
+        (0x13, 0x10), // SYSTEM: enable HP drive output
+        (0x14, 0x10), // ADC: Mic1 differential, PGA gain MIN
+        (0x17, 0xFF), // ADC volume: MAX
+        (0x1C, 0x6A), // ADC: EQ bypass + DC offset cancel
+        (0x32, 0xA9), // DAC volume: ~-22 dB
+        (0x37, 0x08), // DAC: bypass equalizer
+    ];
+    i2c.write(ES8311_ADDR, &[seq[0].0, seq[0].1], I2C_TIMEOUT)
+        .with_context(|| format!("ES8311 bidir reg 0x{:02X} write failed", seq[0].0))?;
+    FreeRtos::delay_ms(10); // wait for CSM after RESET
+    for &(reg, val) in &seq[1..] {
+        i2c.write(ES8311_ADDR, &[reg, val], I2C_TIMEOUT)
+            .with_context(|| format!("ES8311 bidir reg 0x{reg:02X} write failed"))?;
+    }
+    log::info!("ES8311 bidir init OK (0x01=0xBF, ADC+DAC clocks, mic+speaker)");
+    Ok(())
+}
+
 /// Drive the speaker amplifier's enable pin (PMIC GPIO3 high). Call
 /// this once just before starting playback; pair with [`pa_disable`]
 /// when the audio thread shuts down.
@@ -922,11 +975,11 @@ pub fn capture_tx_thread(
                                     total_samples: slot_samples,
                                 }),
                             );
-                            // Demo path doesn't drift (cursor wraps the
-                            // WAV cleanly), so always restore the
-                            // canonical slot length. Skip the shift
-                            // consumption that the mic path applies —
-                            // any pending shift was for the mic timing.
+                            // Reset cursor to WAV start on every slot
+                            // boundary so each 15-s slot decodes the
+                            // same audio (WAV is 180079 samples ≠ 180000
+                            // — without reset the slot/WAV grids drift).
+                            demo_cursor_bytes = 0;
                             slot_end_target = CAPTURE_SLOT_SAMPLES_12K;
                             wav_idx = wav_idx.wrapping_add(1);
                             slot_samples = 0;
@@ -1020,6 +1073,16 @@ pub fn capture_tx_thread(
                 break;
             }
             src_offset += consumed;
+        }
+
+        // Silence TX DMA so stale demo-mode audio doesn't loop after
+        // demo is toggled off. In normal mode the only TX output is the
+        // synth FT8 tone written by do_tx_cycle; between TX bursts the
+        // speaker must be silent.
+        let silence_len = (stereo_samples * 4).min(tx_out.len());
+        tx_out[..silence_len].fill(0);
+        if let Err(e) = i2s.write_all(&tx_out[..silence_len], TickType::new_millis(500).ticks()) {
+            log::warn!("audio capture+tx: i2s tx silence err {e:?}");
         }
 
         let now = std::time::Instant::now();

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -30,7 +30,9 @@ const MY_CALL: &str = env!("MY_CALL");
 const MY_GRID: &str = env!("MY_GRID");
 
 /// 開発用 WAV (qso3_busy のみ単独ループ — UI 構築用に最も多くのデコード結果を出す)。
-static QSO_WAVS: &[&[u8]] = &[include_bytes!("../../assets/qso3_busy.wav")];
+/// `pub(crate)` so the Qso-mode demo path in `display.rs::capture_tx_thread`
+/// can reference the same baked bytes without a second `include_bytes!`.
+pub(crate) static QSO_WAVS: &[&[u8]] = &[include_bytes!("../../assets/qso3_busy.wav")];
 
 const PASS1_LIMIT: usize = 30;
 const MAX_CAND: usize = 15;

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -688,6 +688,10 @@ pub fn run_log_panel(
                             }
                             log::info!("menu: auto_cq → {}", if on { "ON" } else { "OFF" });
                         },
+                        next_mode: &mut || {
+                            log::info!("menu: next_mode → {} (flip + restart)", mode.flipped().label());
+                            boot_mode::flip_and_restart(&nvs, mode);
+                        },
                     };
                     if let Ok(mut ui) = UI.lock() {
                         menu::activate(&mut ui, &mut actions);
@@ -818,6 +822,7 @@ pub fn run_log_panel(
                 menu_snapshot.2,
                 menu_snapshot.3,
                 menu_snapshot.4,
+                mode.flipped().label(),
             )
             .ok();
             // When menu closes, force a full re-render of WF + decoded

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -294,12 +294,12 @@ pub fn run_log_panel(
             // alternate RX read iterations and TX synth play — no need
             // for i2s1 or driver swap.
             if let Some(i2c_drv) = i2c.as_mut() {
-                if let Err(e) = crate::audio::init_es8311_capture(i2c_drv) {
-                    log::warn!("ES8311 mic-mode init failed (Qso disabled): {e:#}");
+                if let Err(e) = crate::audio::init_es8311_bidir(i2c_drv) {
+                    log::warn!("ES8311 bidir init failed (Qso disabled): {e:#}");
                 } else {
-                    // Speaker amp enable so the TX synth side actually
-                    // drives the audio out the speaker (mic input via
-                    // ADC stays unaffected).
+                    // PA on — init_es8311_bidir leaves PA off to avoid
+                    // power-up howl; enable here so demo + TX synth both
+                    // drive the speaker.
                     if let Err(e) = crate::audio::pa_enable(i2c_drv) {
                         log::warn!("PA enable failed: {e:#}");
                     }

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -497,7 +497,7 @@ pub fn run_log_panel(
     // tx strip fingerprint: (tx_seq, sync_state, sync_mark_pending).
     // Changes on QSO state update, sync established/lost, or BtnA
     // mark/clear.
-    let mut last_tx_fp: (u32, bool, bool) = (u32::MAX, false, false);
+    let mut last_tx_fp: (u32, bool, bool, bool) = (u32::MAX, false, false, false);
     let mut last_observed_at_mark: u32 = 0;
     let mut last_menu_seq: u32 = u32::MAX;
     // Phase 0.7c: poll KEY1/KEY2 here on the 100 ms cadence. Long-press
@@ -599,6 +599,22 @@ pub fn run_log_panel(
                         );
                         continue;
                     };
+                    // Demo-mode guard: TX is fully suppressed at the
+                    // audio layer (capture_tx_thread overrides synth
+                    // tones with WAV), so initiating a call has no
+                    // audible effect. Surface that explicitly to the
+                    // log instead of silently advancing the FSM.
+                    let demo_on = UI.lock().ok().map(|u| u.demo_mode_enabled).unwrap_or(false);
+                    if demo_on {
+                        log::info!(
+                            "BtnA: call_station('{}') skipped — TX disabled in demo mode",
+                            dx.as_str()
+                        );
+                        if let Ok(mut ui) = UI.lock() {
+                            ui.clear_decode_cursor();
+                        }
+                        continue;
+                    }
                     if let Ok(mut q) = qso.lock() {
                         let intent = q.call_station(dx.as_str());
                         log::info!(
@@ -677,8 +693,35 @@ pub fn run_log_panel(
                         menu::activate(&mut ui, &mut actions);
                     }
                 }
-                (ButtonEvent::LongPress(Key::Key1), _) => {
-                    log::info!("KEY1 long-press (no action wired yet)");
+                (ButtonEvent::LongPress(Key::Key1), menu_open) => {
+                    // Phase 1.7.8-Stick: BtnA long-press toggles a
+                    // Qso-mode-only "demo mode" that swaps mic / TX
+                    // for the baked qso3_busy.wav (deterministic decode
+                    // backup when ambient acoustic conditions kill the
+                    // live WebFT8→mic path). In other modes the stub
+                    // stays log-only.
+                    if menu_open {
+                        log::info!("KEY1 long-press ignored (menu open)");
+                    } else if mode == BootMode::Qso {
+                        let new_state = match UI.lock() {
+                            Ok(mut ui) => ui.toggle_demo_mode(),
+                            Err(_) => {
+                                log::warn!("KEY1 long-press: UI lock poisoned");
+                                continue;
+                            }
+                        };
+                        // Realign the decoder slot boundary to the WAV
+                        // grid (or back to real time on toggle-off).
+                        // Same debounce path the no-row-selected BtnA
+                        // short-press uses.
+                        let _ = crate::audio::reset_slot_boundary();
+                        log::info!(
+                            "KEY1 long-press → demo_mode {}",
+                            if new_state { "ON" } else { "OFF" }
+                        );
+                    } else {
+                        log::info!("KEY1 long-press (no action wired in this BootMode)");
+                    }
                 }
             }
         }
@@ -721,6 +764,7 @@ pub fn run_log_panel(
         let selected_decode_idx: Option<u8>;
         let sync_mark_pending_snapshot: bool;
         let latest_slot_seq_snapshot: u32;
+        let demo_mode_snapshot: bool;
         {
             let mut ui = UI.lock().expect("UI mutex poisoned");
             ui.status.free_heap_kb = (heap / 1024) as u32;
@@ -740,6 +784,7 @@ pub fn run_log_panel(
             selected_decode_idx = ui.selected_decode_idx;
             sync_mark_pending_snapshot = ui.sync_mark_pending;
             latest_slot_seq_snapshot = ui.latest_slot_seq;
+            demo_mode_snapshot = ui.demo_mode_enabled;
             let mut buf: heapless::String<48> = heapless::String::new();
             for ch in ui.tx_line().chars() {
                 if buf.push(ch).is_err() {
@@ -838,7 +883,12 @@ pub fn run_log_panel(
                 ui.bump_menu();
             }
         }
-        let tx_fp = (tx_seq, sync_state, sync_mark_pending_snapshot);
+        let tx_fp = (
+            tx_seq,
+            sync_state,
+            sync_mark_pending_snapshot,
+            demo_mode_snapshot,
+        );
         if tx_fp != last_tx_fp {
             Rectangle::new(
                 Point::new(0, TX_REGION_Y),
@@ -847,7 +897,14 @@ pub fn run_log_panel(
             .into_styled(PrimitiveStyle::with_fill(tx_bg))
             .draw(&mut display)
             .ok();
-            let text = if sync_mark_pending_snapshot {
+            // Demo mode overrides the FSM-driven TX strip entirely —
+            // TX is suppressed at the audio layer, so showing
+            // "IDLE / CALL / RPT" would be misleading. The "TX OFF"
+            // suffix spells out the consequence for the operator at
+            // a glance even when "DEMO" alone is ambiguous.
+            let text = if demo_mode_snapshot {
+                "DEMO MODE — TX OFF"
+            } else if sync_mark_pending_snapshot {
                 "SYNC SET — wait slot"
             } else if !sync_state {
                 "SYNC: A at slot start"

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -604,16 +604,15 @@ pub fn run_log_panel(
                     // tones with WAV), so initiating a call has no
                     // audible effect. Surface that explicitly to the
                     // log instead of silently advancing the FSM.
-                    let demo_on = UI.lock().ok().map(|u| u.demo_mode_enabled).unwrap_or(false);
-                    if demo_on {
-                        log::info!(
-                            "BtnA: call_station('{}') skipped — TX disabled in demo mode",
-                            dx.as_str()
-                        );
-                        if let Ok(mut ui) = UI.lock() {
+                    if let Ok(mut ui) = UI.lock() {
+                        if ui.demo_mode_enabled {
+                            log::info!(
+                                "BtnA: call_station('{}') skipped — TX disabled in demo mode",
+                                dx.as_str()
+                            );
                             ui.clear_decode_cursor();
+                            continue;
                         }
-                        continue;
                     }
                     if let Ok(mut q) = qso.lock() {
                         let intent = q.call_station(dx.as_str());

--- a/embedded-poc/mfsk-app-shared/src/ui/menu.rs
+++ b/embedded-poc/mfsk-app-shared/src/ui/menu.rs
@@ -61,10 +61,18 @@ pub enum MenuItem {
     FindDf,
     /// Toggle auto-CQ master gate on the QSO FSM.
     AutoCq,
+    /// Persist the next boot mode to NVS and restart. Lets the user
+    /// switch from Acoustic ↔ Qso ↔ … without the 3-reboot KEY dance.
+    NextMode,
 }
 
-pub const MENU_ITEMS: &[MenuItem] = &[MenuItem::Band, MenuItem::FindDf, MenuItem::AutoCq];
-pub const MENU_ITEM_COUNT: u8 = 3;
+pub const MENU_ITEMS: &[MenuItem] = &[
+    MenuItem::Band,
+    MenuItem::FindDf,
+    MenuItem::AutoCq,
+    MenuItem::NextMode,
+];
+pub const MENU_ITEM_COUNT: u8 = 4;
 
 /// Compact representation of a single menu entry's display row.
 fn item_label(item: MenuItem) -> &'static str {
@@ -72,6 +80,7 @@ fn item_label(item: MenuItem) -> &'static str {
         MenuItem::Band => "Band:",
         MenuItem::FindDf => "FindDF:",
         MenuItem::AutoCq => "AutoCQ:",
+        MenuItem::NextMode => "Mode→:",
     }
 }
 
@@ -90,6 +99,11 @@ pub struct MenuActions<'a> {
     /// (the menu already toggled `auto_cq_enabled` in UiState; this
     /// callback also propagates to the QSO FSM and NVS).
     pub set_auto_cq: &'a mut dyn FnMut(bool),
+    /// Called when the user activates NextMode. Implementation should
+    /// persist the next boot mode to NVS and restart (via
+    /// `boot_mode::flip_and_restart`). The callback returns `!` so
+    /// the device reboots before the menu can repaint.
+    pub next_mode: &'a mut dyn FnMut(),
 }
 
 /// Advance the highlighted item. Caller already holds the UI mutex.
@@ -123,6 +137,13 @@ pub fn activate(ui: &mut super::state::UiState, actions: &mut MenuActions<'_>) {
             ui.auto_cq_enabled = !ui.auto_cq_enabled;
             (actions.set_auto_cq)(ui.auto_cq_enabled);
         }
+        MenuItem::NextMode => {
+            // Persist next boot mode + restart. The callback never
+            // returns (`!`), so bump_menu below is unreachable — the
+            // device reboots before the menu repaints.
+            (actions.next_mode)();
+            // Fallback (unreachable in practice): just drop it.
+        }
     }
     ui.bump_menu();
 }
@@ -135,13 +156,13 @@ pub fn activate(ui: &mut super::state::UiState, actions: &mut MenuActions<'_>) {
 /// pipeline writes). No-op when `visible == false`.
 ///
 /// Layout (LCD 135×240, menu top-right of WF region):
-/// - origin (32, 16), size 100×54 px
+/// - origin (32, 16), size 100×68 px
 /// - background fill: dark blue (Rgb565::new(0,0,8))
 /// - border: white 1-px
-/// - 3 rows × 14-px tall, cursor `>` in column 0 of selected row
+/// - 4 rows × 14-px tall, cursor `>` in column 0 of selected row
 ///
-/// `M: Mutability` const param distinguishes peekable values stored
-/// in UiState (band, df, autocq) from item-specific dynamic strings.
+/// `next_mode_label` is the label of the boot mode the device would
+/// switch to if the NextMode item is activated (e.g. `"QSO"`).
 pub fn render<D, E>(
     display: &mut D,
     visible: bool,
@@ -149,6 +170,7 @@ pub fn render<D, E>(
     band_idx: u8,
     df_hz: u16,
     auto_cq: bool,
+    next_mode_label: &str,
 ) -> Result<(), E>
 where
     D: DrawTarget<Color = Rgb565, Error = E>,
@@ -157,7 +179,7 @@ where
         return Ok(());
     }
     const ORIGIN: Point = Point::new(32, 16);
-    const SIZE: Size = Size::new(100, 54);
+    const SIZE: Size = Size::new(100, 68);
     const ROW_H: i32 = 14;
 
     // Background + border.
@@ -194,8 +216,18 @@ where
         &mut autocq_line,
         format_args!(" AutoCQ: {}", if auto_cq { "ON" } else { "OFF" }),
     );
+    let mut mode_line: heapless::String<16> = heapless::String::new();
+    let _ = core::fmt::Write::write_fmt(
+        &mut mode_line,
+        format_args!(" Mode→:{next_mode_label}"),
+    );
 
-    let rows: [&str; 3] = [band_line.as_str(), df_line.as_str(), autocq_line.as_str()];
+    let rows: [&str; 4] = [
+        band_line.as_str(),
+        df_line.as_str(),
+        autocq_line.as_str(),
+        mode_line.as_str(),
+    ];
 
     for (i, text) in rows.iter().enumerate() {
         let y = ORIGIN.y + 2 + (i as i32) * ROW_H;

--- a/embedded-poc/mfsk-app-shared/src/ui/state.rs
+++ b/embedded-poc/mfsk-app-shared/src/ui/state.rs
@@ -98,6 +98,13 @@ pub struct UiState {
     /// menu render path can read without taking the QSO lock.
     /// Toggled together with the FSM field by the menu activate path.
     pub auto_cq_enabled: bool,
+    /// Qso-mode demo toggle (BtnA long-press). When true, the audio
+    /// layer swaps both decoder input and speaker output for the
+    /// baked-in `qso3_busy.wav` and TX is suppressed — gives a
+    /// deterministic decode demo when ambient acoustic conditions
+    /// kill the live WebFT8-to-mic path. Reset to false at boot;
+    /// not persisted to NVS.
+    pub demo_mode_enabled: bool,
     /// Cursor over the decoded-list (Phase 1.7.2). `None` = no
     /// selection (display loop won't draw a cursor); `Some(i)` =
     /// highlight row `i` (0 = newest visible, increases toward older).
@@ -146,6 +153,7 @@ impl UiState {
             current_band_idx: 4, // 20m default
             current_df_hz: 0,
             auto_cq_enabled: false,
+            demo_mode_enabled: false,
             selected_decode_idx: None,
             sync_mark_pending: false,
             latest_slot_seq: 0,
@@ -158,6 +166,16 @@ impl UiState {
     pub fn bump_menu(&self) {
         self.menu_seq.fetch_add(1, Ordering::AcqRel);
         self.bump();
+    }
+
+    /// Toggle the Qso-mode demo flag. Returns the new value so the
+    /// caller can log / branch on it without re-locking. Bumps the
+    /// menu watermark so the button-strip + title row repaint with
+    /// the DEMO indicator.
+    pub fn toggle_demo_mode(&mut self) -> bool {
+        self.demo_mode_enabled = !self.demo_mode_enabled;
+        self.bump_menu();
+        self.demo_mode_enabled
     }
 
     pub fn menu_seq(&self) -> u32 {


### PR DESCRIPTION
## Summary

- **Demo toggle**: BtnA ≥2 s in `BootMode::Qso` flips `demo_mode_enabled` in `UiState`. LCD TX strip immediately shows `DEMO MODE — TX OFF`.
- **Audio source switch**: `capture_tx_thread` reads `demo_mode_enabled` once per iteration; in demo mode it drains the baked-in `qso3_busy.wav` (12 kHz mono, 16-bit LE) into `chunk_q` instead of the live mic, and also plays the same WAV back on the speaker (4× ZOH upsample → I2S TX). Mic I2S DMA keeps running as the pacing signal; mic samples are discarded.
- **TX suppression**: `tx_scheduler_pick_intent` is not called while demo is active — no synth tones enqueue.
- **BtnA guard**: short-press → `call_station` skips and logs a warning when demo is on.
- **Other boot modes**: unaffected — BtnA long-press keeps the existing `"no action wired"` log stub.
- **`QSO_WAVS` visibility**: promoted from private to `pub(crate)` so `capture_tx_thread` can access the same static bytes without a second `include_bytes!`.

## Test plan

- [ ] `cargo check --release -p m5stack-s3-app` clean (verified locally, pre-commit hook passed)
- [ ] Flash to M5StickS3; boots clean in Acoustic mode (verified: no panic, ES8311 OK, LCD OK)
- [ ] Cycle to `BootMode::Qso` (KEY2 long-press), confirm normal mic decode works
- [ ] Long-press BtnA (≥2 s) → LCD shows `DEMO MODE — TX OFF`, speaker plays qso3 busy-band audio, decode rows populate (~7/slot from qso3_busy.wav)
- [ ] Select a decode row, short-press BtnA → warning logged, no TX, cursor cleared
- [ ] Long-press BtnA again → `DEMO MODE` clears, speaker silences, mic decode resumes
- [ ] Open menu (BtnB long-press), then BtnA long-press → demo does **not** toggle (menu guard active)
- [ ] Repeat toggle ≥5 cycles for lock / cursor stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)