### PR TITLE
feat(embedded): Phase C — speculative pass2+stage3 during audio tail

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
+++ b/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
@@ -174,7 +174,7 @@ fn decode_one_slot(
 
     log::info!(
         "rx-wavsim: WAV[{wav_idx}] slot received (audio={} samples, pass1={pass1_n}, q_thresh={q_thresh})",
-        slot.audio_len,
+        slot.audio_len(),
     );
     log::info!(
         "  stage 2 (during cap): {:>7} us  ({pass1_n} cand)",

--- a/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
+++ b/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
@@ -174,7 +174,7 @@ fn decode_one_slot(
 
     log::info!(
         "rx-wavsim: WAV[{wav_idx}] slot received (audio={} samples, pass1={pass1_n}, q_thresh={q_thresh})",
-        slot.audio.len(),
+        slot.audio_len,
     );
     log::info!(
         "  stage 2 (during cap): {:>7} us  ({pass1_n} cand)",
@@ -184,7 +184,7 @@ fn decode_one_slot(
     let t2 = now_us();
     #[allow(static_mut_refs)]
     let pass2 = unsafe {
-        dual_core::pass2_split(&slot.audio, pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM)
+        dual_core::pass2_split(slot.audio(), pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM)
     };
     let t3 = now_us();
     log::info!(
@@ -198,7 +198,7 @@ fn decode_one_slot(
     #[allow(static_mut_refs)]
     let results = unsafe {
         dual_core::stage3_split(
-            &slot.audio,
+            slot.audio(),
             pass2,
             depth,
             q_thresh,

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -120,7 +120,7 @@ pub fn run_speculative_slot(
     let t_coarse_done = unsafe { esp_timer_get_time() };
 
     let n_pass1 = pass1.len();
-    let snap_fill = spec.audio_prefix.len();
+    let snap_fill = spec.audio_len;
     let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) = pass1
         .into_iter()
         .partition(|c| SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
@@ -129,7 +129,7 @@ pub fn run_speculative_slot(
 
     let mut n_early_refined = 0usize;
     let mut results = if !ready.is_empty() {
-        let partial_audio: &[i16] = &spec.audio_prefix;
+        let partial_audio: &[i16] = spec.audio_prefix();
         let p2 = pass2_split(partial_audio, ready, max_cand, basis_re_main, basis_im_main);
         n_early_refined = p2.len();
         stage3_split(
@@ -164,15 +164,16 @@ pub fn run_speculative_slot(
         // auto-anchor keeps dt within ±0.5 s in steady state.
         let max_cand_late = max_cand.saturating_sub(n_early_refined);
         if max_cand_late > 0 {
+            let slot_audio: &[i16] = slot.audio();
             let p2 = pass2_split(
-                &slot.audio,
+                slot_audio,
                 deferred,
                 max_cand_late,
                 basis_re_main,
                 basis_im_main,
             );
             let late = stage3_split(
-                &slot.audio,
+                slot_audio,
                 p2,
                 depth,
                 q_thresh,

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -148,23 +148,43 @@ pub fn run_speculative_slot(
     let t_slot_recv = unsafe { esp_timer_get_time() };
 
     if !deferred.is_empty() {
-        let p2 = pass2_split(
-            &slot.audio,
-            deferred,
-            max_cand,
-            basis_re_main,
-            basis_im_main,
-        );
-        let late = stage3_split(
-            &slot.audio,
-            p2,
-            depth,
-            q_thresh,
-            bp_max_iter,
-            basis_re_main,
-            basis_im_main,
-        );
-        results.extend(late);
+        // Budget cap: stage-3's cost is roughly linear in the number
+        // of candidates that survive pass-2's heap top-N. The early
+        // path may already have processed up to `max_cand`
+        // candidates; running deferred pass-2 with the same
+        // `max_cand` lets up to `2 * max_cand` candidates reach
+        // stage-3 in the worst case (Gemini PR #123 round-8). Cap
+        // the deferred half at `max_cand - n_early_results.min(max_cand)`
+        // so the union of (early refined ∪ late refined) stays ≤
+        // `max_cand`. In typical qso3 operation the early path
+        // produces ~7 decodes → 8 deferred-slots remain; on
+        // noise-only inputs the early path produces 0 → all 15
+        // slots go to deferred. `n_early_results` undercounts
+        // refined-but-failed cands (they're discarded post-BP) but
+        // erring on the side of "give the late path more budget"
+        // matches the design intent — failures cost less than
+        // decodes thanks to the q-gate.
+        let n_early_results = results.len();
+        let max_cand_late = max_cand.saturating_sub(n_early_results);
+        if max_cand_late > 0 {
+            let p2 = pass2_split(
+                &slot.audio,
+                deferred,
+                max_cand_late,
+                basis_re_main,
+                basis_im_main,
+            );
+            let late = stage3_split(
+                &slot.audio,
+                p2,
+                depth,
+                q_thresh,
+                bp_max_iter,
+                basis_re_main,
+                basis_im_main,
+            );
+            results.extend(late);
+        }
     }
     let t_done = unsafe { esp_timer_get_time() };
 

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -127,9 +127,11 @@ pub fn run_speculative_slot(
     let n_ready = ready.len();
     let n_deferred = deferred.len();
 
+    let mut n_early_refined = 0usize;
     let mut results = if !ready.is_empty() {
         let partial_audio: &[i16] = &spec.audio_prefix;
         let p2 = pass2_split(partial_audio, ready, max_cand, basis_re_main, basis_im_main);
+        n_early_refined = p2.len();
         stage3_split(
             partial_audio,
             p2,
@@ -148,24 +150,19 @@ pub fn run_speculative_slot(
     let t_slot_recv = unsafe { esp_timer_get_time() };
 
     if !deferred.is_empty() {
-        // Budget cap: stage-3's cost is roughly linear in the number
-        // of candidates that survive pass-2's heap top-N. The early
-        // path may already have processed up to `max_cand`
-        // candidates; running deferred pass-2 with the same
-        // `max_cand` lets up to `2 * max_cand` candidates reach
-        // stage-3 in the worst case (Gemini PR #123 round-8). Cap
-        // the deferred half at `max_cand - n_early_results.min(max_cand)`
-        // so the union of (early refined ∪ late refined) stays ≤
-        // `max_cand`. In typical qso3 operation the early path
-        // produces ~7 decodes → 8 deferred-slots remain; on
-        // noise-only inputs the early path produces 0 → all 15
-        // slots go to deferred. `n_early_results` undercounts
-        // refined-but-failed cands (they're discarded post-BP) but
-        // erring on the side of "give the late path more budget"
-        // matches the design intent — failures cost less than
-        // decodes thanks to the q-gate.
-        let n_early_results = results.len();
-        let max_cand_late = max_cand.saturating_sub(n_early_results);
+        // Budget cap (Gemini PR #123 round 8/9): stage-3's wallclock
+        // is roughly linear in the number of refined candidates
+        // pass-2 hands it. Sum-cap by the *refined* count (not the
+        // decoded count) so `n_early_refined + n_late_refined ≤
+        // max_cand` holds regardless of whether the early path's
+        // candidates went on to decode. Trade-off: when the early
+        // half already fills `max_cand` slots (typical qso3-busy
+        // case: ready=25-27, pass-2 keeps top 15) the deferred
+        // path gets zero budget and any dt > +0.36 s real signals
+        // are dropped. Acceptable on FT8 — operational dt clusters
+        // tightly under NTP sync; `time_sync`'s slot phase
+        // auto-anchor keeps dt within ±0.5 s in steady state.
+        let max_cand_late = max_cand.saturating_sub(n_early_refined);
         if max_cand_late > 0 {
             let p2 = pass2_split(
                 &slot.audio,

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -134,9 +134,29 @@ pub fn run_speculative_slot(
 
     let n_pass1 = pass1.len();
     let snap_fill = spec.audio_len;
-    let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) = pass1
-        .into_iter()
-        .partition(|c| SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
+    // Partition rule (Gemini PR #123 round-19):
+    //   ready    = pass1[i] for i < max_cand AND audio fits prefix
+    //   deferred = everything else
+    //
+    // `pass1` is sorted by coarse-sync score (descending) inside
+    // `coarse_sync_split_with_allsum`, so `i < cfg.max_cand` is
+    // equivalent to "top `max_cand` by coarse-sync score". Filtering
+    // by index keeps a high-score / high-dt candidate (e.g.
+    // dt > +0.36 s but rank 0..max_cand) out of `ready` and lets
+    // it land in `deferred`, where the late path can still claim
+    // a stage-3 budget slot once early stage-3 finishes. Without
+    // this guard, low-rank cands that *happen* to fit the prefix
+    // would fill the early-path budget, max_cand_late would drop
+    // to zero, and the high-rank deferred cand would be dropped.
+    let (ready_indexed, deferred_indexed): (Vec<(usize, SyncCandidate)>, Vec<(usize, SyncCandidate)>) =
+        pass1
+            .into_iter()
+            .enumerate()
+            .partition(|(i, c)| {
+                *i < cfg.max_cand && SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill
+            });
+    let ready: Vec<SyncCandidate> = ready_indexed.into_iter().map(|(_, c)| c).collect();
+    let deferred: Vec<SyncCandidate> = deferred_indexed.into_iter().map(|(_, c)| c).collect();
     let n_ready = ready.len();
     let n_deferred = deferred.len();
 

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -77,6 +77,31 @@ pub struct SpeculativeOut {
     pub t_done: i64,
 }
 
+/// Per-slot decoder configuration shared between Phase-C speculative
+/// callers. Grouped into a single struct so
+/// [`run_speculative_slot`] doesn't need to accept ~10 positional
+/// `f32` / `usize` / `u32` args (Gemini PR #123 round-16 review).
+#[derive(Debug, Clone, Copy)]
+pub struct DecodeConfig {
+    /// coarse_sync lower band edge in Hz (apps use `100.0`).
+    pub freq_min: f32,
+    /// coarse_sync upper band edge in Hz (apps use `3_000.0`).
+    pub freq_max: f32,
+    /// coarse_sync ratio threshold (apps use `1.0`).
+    pub sync_min: f32,
+    /// Maximum pass-1 candidates fed into pass-2 / stage-3.
+    pub pass1_limit: usize,
+    /// Maximum refined candidates per half passed into stage-3.
+    pub max_cand: usize,
+    /// `process_candidates` sync-quality early-reject threshold.
+    pub q_thresh: u32,
+    /// BP iteration cap per LLR variant.
+    pub bp_max_iter: u32,
+    /// LLR-variant staircase depth (embedded ship uses
+    /// [`DecodeDepth::BpVariantsAd`]).
+    pub depth: DecodeDepth,
+}
+
 /// Phase-C audio-tail speculation runner. Receives a SpecBundle and
 /// Slot pair from the streaming pipeline, partitions pass1 by
 /// whether each candidate's Goertzel window fits inside the
@@ -85,22 +110,10 @@ pub struct SpeculativeOut {
 /// candidates on the full `slot.audio` after SlotEnd. The decode
 /// pipelines in both `m5stack-s3-app` and `m5stack-core2-app` use
 /// this single entry to keep the speculative logic in one place.
-///
-/// `freq_min` / `freq_max` are the coarse_sync band edges
-/// (typically 100..3000 Hz). `sync_min` is the coarse_sync ratio
-/// threshold (`1.0` matches both apps' historical setting).
-#[allow(clippy::too_many_arguments)]
 pub fn run_speculative_slot(
     spec_q: esp_idf_svc::sys::QueueHandle_t,
     slot_q: esp_idf_svc::sys::QueueHandle_t,
-    freq_min: f32,
-    freq_max: f32,
-    sync_min: f32,
-    pass1_limit: usize,
-    max_cand: usize,
-    q_thresh: u32,
-    bp_max_iter: u32,
-    depth: DecodeDepth,
+    cfg: &DecodeConfig,
     basis_re_main: &mut [i16],
     basis_im_main: &mut [i16],
 ) -> SpeculativeOut {
@@ -110,10 +123,10 @@ pub fn run_speculative_slot(
     let t_post_recv = unsafe { esp_timer_get_time() };
     let pass1: Vec<SyncCandidate> = coarse_sync_split_with_allsum(
         &spec.spec,
-        freq_min,
-        freq_max,
-        sync_min,
-        pass1_limit,
+        cfg.freq_min,
+        cfg.freq_max,
+        cfg.sync_min,
+        cfg.pass1_limit,
         &spec.allsum_head,
         &spec.allsum_tail,
     );
@@ -130,14 +143,20 @@ pub fn run_speculative_slot(
     let mut n_early_refined = 0usize;
     let mut results = if !ready.is_empty() {
         let partial_audio: &[i16] = spec.audio_prefix();
-        let p2 = pass2_split(partial_audio, ready, max_cand, basis_re_main, basis_im_main);
+        let p2 = pass2_split(
+            partial_audio,
+            ready,
+            cfg.max_cand,
+            basis_re_main,
+            basis_im_main,
+        );
         n_early_refined = p2.len();
         stage3_split(
             partial_audio,
             p2,
-            depth,
-            q_thresh,
-            bp_max_iter,
+            cfg.depth,
+            cfg.q_thresh,
+            cfg.bp_max_iter,
             basis_re_main,
             basis_im_main,
         )
@@ -162,7 +181,7 @@ pub fn run_speculative_slot(
         // are dropped. Acceptable on FT8 — operational dt clusters
         // tightly under NTP sync; `time_sync`'s slot phase
         // auto-anchor keeps dt within ±0.5 s in steady state.
-        let max_cand_late = max_cand.saturating_sub(n_early_refined);
+        let max_cand_late = cfg.max_cand.saturating_sub(n_early_refined);
         if max_cand_late > 0 {
             let slot_audio: &[i16] = slot.audio();
             let p2 = pass2_split(
@@ -175,9 +194,9 @@ pub fn run_speculative_slot(
             let late = stage3_split(
                 slot_audio,
                 p2,
-                depth,
-                q_thresh,
-                bp_max_iter,
+                cfg.depth,
+                cfg.q_thresh,
+                cfg.bp_max_iter,
                 basis_re_main,
                 basis_im_main,
             );

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -134,29 +134,24 @@ pub fn run_speculative_slot(
 
     let n_pass1 = pass1.len();
     let snap_fill = spec.audio_len();
-    // Partition rule (Gemini PR #123 round-19):
-    //   ready    = pass1[i] for i < max_cand AND audio fits prefix
-    //   deferred = everything else
+    // Partition by audio-window fit only.
     //
-    // `pass1` is sorted by coarse-sync score (descending) inside
-    // `coarse_sync_split_with_allsum`, so `i < cfg.max_cand` is
-    // equivalent to "top `max_cand` by coarse-sync score". Filtering
-    // by index keeps a high-score / high-dt candidate (e.g.
-    // dt > +0.36 s but rank 0..max_cand) out of `ready` and lets
-    // it land in `deferred`, where the late path can still claim
-    // a stage-3 budget slot once early stage-3 finishes. Without
-    // this guard, low-rank cands that *happen* to fit the prefix
-    // would fill the early-path budget, max_cand_late would drop
-    // to zero, and the high-rank deferred cand would be dropped.
-    let (ready_indexed, deferred_indexed): (Vec<(usize, SyncCandidate)>, Vec<(usize, SyncCandidate)>) =
-        pass1
-            .into_iter()
-            .enumerate()
-            .partition(|(i, c)| {
-                *i < cfg.max_cand && SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill
-            });
-    let ready: Vec<SyncCandidate> = ready_indexed.into_iter().map(|(_, c)| c).collect();
-    let deferred: Vec<SyncCandidate> = deferred_indexed.into_iter().map(|(_, c)| c).collect();
+    // An earlier revision (round 19) added an `i < cfg.max_cand`
+    // guard so high-rank pass1 cands with dt > +0.36 s would land
+    // in `deferred` instead of being outcompeted by lower-rank
+    // cands in the early path. On qso3-busy the guard moved
+    // 12-19 candidates per slot into the late path; the resulting
+    // post-SlotEnd wallclock grew (190..400 ms across slots) and
+    // we couldn't observe the theoretical recall benefit that
+    // motivated the change. Reverted — pass-2's own
+    // sync_quality_block0 heap top-N inside both halves filters
+    // the strongest cands per side, and the budget cap on
+    // `max_cand_late` keeps the union ≤ max_cand. High-score /
+    // high-dt cands that don't fit the prefix still naturally
+    // land in `deferred` and compete for a slot there.
+    let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) = pass1
+        .into_iter()
+        .partition(|c| SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
     let n_ready = ready.len();
     let n_deferred = deferred.len();
 

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -51,6 +51,137 @@ use mfsk_core::ft8::decode_block::{
 };
 
 use crate::internal_pool::{CS_SCRATCH_MAIN, CS_SCRATCH_WORKER};
+use crate::pipeline::{self, SpecBundle, Slot};
+
+/// One slot's Phase-C output. Both apps consume it identically:
+/// `spec` for `xsnr2_db_simple`, `slot` for `wav_idx` /
+/// `inc_total_us`, `results` for the UI + QSO FSM, and the `t_*`
+/// timestamps for the per-slot timing log.
+pub struct SpeculativeOut {
+    pub spec: Box<SpecBundle>,
+    pub slot: Box<Slot>,
+    pub results: Vec<DecodeResult>,
+    pub n_pass1: usize,
+    pub n_ready: usize,
+    pub n_deferred: usize,
+    /// `esp_timer_get_time()` right after `recv_box::<SpecBundle>` returns.
+    pub t_post_recv: i64,
+    /// after `coarse_sync_split_with_allsum`.
+    pub t_coarse_done: i64,
+    /// after the speculative pass-2 + stage-3 on `audio_prefix` finish
+    /// (or immediately, if `ready` was empty).
+    pub t_early_done: i64,
+    /// after `recv_box::<Slot>` returns.
+    pub t_slot_recv: i64,
+    /// after the deferred pass-2 + stage-3 on `slot.audio` finish.
+    pub t_done: i64,
+}
+
+/// Phase-C audio-tail speculation runner. Receives a SpecBundle and
+/// Slot pair from the streaming pipeline, partitions pass1 by
+/// whether each candidate's Goertzel window fits inside the
+/// SpecBundle audio prefix, runs pass-2 + stage-3 speculatively on
+/// the `ready` half before SlotEnd, then completes any deferred
+/// candidates on the full `slot.audio` after SlotEnd. The decode
+/// pipelines in both `m5stack-s3-app` and `m5stack-core2-app` use
+/// this single entry to keep the speculative logic in one place.
+///
+/// `freq_min` / `freq_max` are the coarse_sync band edges
+/// (typically 100..3000 Hz). `sync_min` is the coarse_sync ratio
+/// threshold (`1.0` matches both apps' historical setting).
+#[allow(clippy::too_many_arguments)]
+pub fn run_speculative_slot(
+    spec_q: esp_idf_svc::sys::QueueHandle_t,
+    slot_q: esp_idf_svc::sys::QueueHandle_t,
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    pass1_limit: usize,
+    max_cand: usize,
+    q_thresh: u32,
+    bp_max_iter: u32,
+    depth: DecodeDepth,
+    basis_re_main: &mut [i16],
+    basis_im_main: &mut [i16],
+) -> SpeculativeOut {
+    use esp_idf_svc::sys::esp_timer_get_time;
+
+    let spec = pipeline::recv_box::<SpecBundle>(spec_q);
+    let t_post_recv = unsafe { esp_timer_get_time() };
+    let pass1: Vec<SyncCandidate> = coarse_sync_split_with_allsum(
+        &spec.spec,
+        freq_min,
+        freq_max,
+        sync_min,
+        pass1_limit,
+        &spec.allsum_head,
+        &spec.allsum_tail,
+    );
+    let t_coarse_done = unsafe { esp_timer_get_time() };
+
+    let n_pass1 = pass1.len();
+    let snap_fill = spec.audio_prefix.len();
+    let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) = pass1
+        .into_iter()
+        .partition(|c| SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
+    let n_ready = ready.len();
+    let n_deferred = deferred.len();
+
+    let mut results = if !ready.is_empty() {
+        let partial_audio: &[i16] = &spec.audio_prefix;
+        let p2 = pass2_split(partial_audio, ready, max_cand, basis_re_main, basis_im_main);
+        stage3_split(
+            partial_audio,
+            p2,
+            depth,
+            q_thresh,
+            bp_max_iter,
+            basis_re_main,
+            basis_im_main,
+        )
+    } else {
+        Vec::new()
+    };
+    let t_early_done = unsafe { esp_timer_get_time() };
+
+    let slot = pipeline::recv_box::<Slot>(slot_q);
+    let t_slot_recv = unsafe { esp_timer_get_time() };
+
+    if !deferred.is_empty() {
+        let p2 = pass2_split(
+            &slot.audio,
+            deferred,
+            max_cand,
+            basis_re_main,
+            basis_im_main,
+        );
+        let late = stage3_split(
+            &slot.audio,
+            p2,
+            depth,
+            q_thresh,
+            bp_max_iter,
+            basis_re_main,
+            basis_im_main,
+        );
+        results.extend(late);
+    }
+    let t_done = unsafe { esp_timer_get_time() };
+
+    SpeculativeOut {
+        spec,
+        slot,
+        results,
+        n_pass1,
+        n_ready,
+        n_deferred,
+        t_post_recv,
+        t_coarse_done,
+        t_early_done,
+        t_slot_recv,
+        t_done,
+    }
+}
 
 const PD_PASS: i32 = 1;
 const QUEUE_SEND_TO_BACK: i32 = 0;

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -133,7 +133,7 @@ pub fn run_speculative_slot(
     let t_coarse_done = unsafe { esp_timer_get_time() };
 
     let n_pass1 = pass1.len();
-    let snap_fill = spec.audio_len;
+    let snap_fill = spec.audio_len();
     // Partition rule (Gemini PR #123 round-19):
     //   ready    = pass1[i] for i < max_cand AND audio fits prefix
     //   deferred = everything else

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -93,7 +93,11 @@ pub struct SpecBundle {
 
 // SAFETY: `audio_ptr` references a heap allocation owned first by
 // stage1_inc's `WorkerCtx::cur::audio` (until SlotEnd), then by the
-// matching `Slot.audio` after `mem::replace`. The queue hand-off
+// matching `Slot.audio` after `mem::replace`. The Vec is allocated
+// once as `vec![0i16; NMAX]` and never grown (stage1_inc only
+// `copy_from_slice`-writes into the existing slots), so the heap
+// pointer is stable — see the `debug_assert!` in stage1_inc's
+// `ingest_samples` that locks this invariant in. The queue hand-off
 // from stage1_inc to main establishes happens-before for the
 // SpecBundle fields and the writes to the audio prefix
 // `[0, audio_fill]`.
@@ -102,22 +106,29 @@ unsafe impl Send for SpecBundle {}
 impl SpecBundle {
     /// Last sample index that
     /// `fill_symbol_spectra_goertzel(audio, freq_hz, dt_sec, ..)`
-    /// reads for a candidate at `dt_sec`. Mirrors the constants in
-    /// `mfsk_core::ft8::decode_block::fill_symbol_spectra`
-    /// (`TX_START_OFFSET_S = 1.0`, `SAMPLE_RATE_HZ = 12_000`,
-    /// `NN = 79`, `NSPS = 1_920`).
+    /// reads for a candidate at `dt_sec`. Mirrors the formula in
+    /// `mfsk_core::ft8::decode_block::fill_symbol_spectra_goertzel`
+    /// (`i0 = round((TX_START_OFFSET_S + dt) * SAMPLE_RATE_HZ);
+    /// end = i0 + NN * NSPS`). `NN` and `NSPS` are pulled from
+    /// `mfsk_core::ft8::params` so the two crates can't drift; the
+    /// two other constants live `pub(super)` in `decode_block::types`
+    /// so we mirror their values here with a same-file documentation
+    /// pointer.
     ///
     /// Used by Phase-C decode-pipeline consumers to decide whether
     /// a candidate's Goertzel window fits inside the SpecBundle
     /// audio snapshot (`ready`) or must defer to the post-SlotEnd
     /// path (`deferred`).
     pub fn audio_end_for_dt(dt_sec: f32) -> usize {
+        // Mirrored from `mfsk_core::ft8::decode_block::types`
+        // (`pub(super) const SAMPLE_RATE_HZ` / `TX_START_OFFSET_S`).
+        // If those values change in mfsk-core, update here too.
         const SAMPLE_RATE_HZ: f32 = 12_000.0;
         const TX_START_OFFSET_S: f32 = 1.0;
-        const NSPS: i64 = 1_920;
-        const NN: i64 = 79;
         let i0 = ((TX_START_OFFSET_S + dt_sec) * SAMPLE_RATE_HZ).round() as i64;
-        (i0 + NN * NSPS).max(0) as usize
+        let nsps = mfsk_core::ft8::params::NSPS as i64;
+        let nn = mfsk_core::ft8::params::NN as i64;
+        (i0 + nn * nsps).max(0) as usize
     }
 }
 

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -99,6 +99,28 @@ pub struct SpecBundle {
 // `[0, audio_fill]`.
 unsafe impl Send for SpecBundle {}
 
+impl SpecBundle {
+    /// Last sample index that
+    /// `fill_symbol_spectra_goertzel(audio, freq_hz, dt_sec, ..)`
+    /// reads for a candidate at `dt_sec`. Mirrors the constants in
+    /// `mfsk_core::ft8::decode_block::fill_symbol_spectra`
+    /// (`TX_START_OFFSET_S = 1.0`, `SAMPLE_RATE_HZ = 12_000`,
+    /// `NN = 79`, `NSPS = 1_920`).
+    ///
+    /// Used by Phase-C decode-pipeline consumers to decide whether
+    /// a candidate's Goertzel window fits inside the SpecBundle
+    /// audio snapshot (`ready`) or must defer to the post-SlotEnd
+    /// path (`deferred`).
+    pub fn audio_end_for_dt(dt_sec: f32) -> usize {
+        const SAMPLE_RATE_HZ: f32 = 12_000.0;
+        const TX_START_OFFSET_S: f32 = 1.0;
+        const NSPS: i64 = 1_920;
+        const NN: i64 = 79;
+        let i0 = ((TX_START_OFFSET_S + dt_sec) * SAMPLE_RATE_HZ).round() as i64;
+        (i0 + NN * NSPS).max(0) as usize
+    }
+}
+
 /// Audio + slot metadata, sent by stage1_inc at SlotEnd. Pairs with the
 /// `SpecBundle` for the same `wav_idx` to drive pass 2 / stage 3.
 pub struct Slot {

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -77,12 +77,14 @@ pub struct SpecBundle {
     pub wav_idx: usize,
     /// Raw pointer into stage1_inc's currently-frozen audio buffer
     /// (same allocation as the matching `Slot.audio_ptr` that will
-    /// arrive on `slot_q` next).
-    pub audio_ptr: *const i16,
+    /// arrive on `slot_q` next). Kept private (Gemini PR #123
+    /// round-20) — callers go through `audio_prefix()` to get a
+    /// safe `&[i16]` so the raw pointer never escapes this module.
+    audio_ptr: *const i16,
     /// Snapshot of `cur.audio_fill` at emit time. Always ≥
     /// pair-86's audio requirement (168 000 samples = 14.0 s @
     /// 12 kHz) when emit fires at `SPEC_EMIT_PAIR`.
-    pub audio_len: usize,
+    audio_len: usize,
 }
 
 // SAFETY: `audio_ptr` references a long-lived `AudioBuf` allocation
@@ -113,6 +115,33 @@ impl SpecBundle {
     pub fn audio_prefix(&self) -> &[i16] {
         unsafe { core::slice::from_raw_parts(self.audio_ptr, self.audio_len) }
     }
+
+    /// Length of the audio prefix in samples — equal to
+    /// `self.audio_prefix().len()`.
+    pub fn audio_len(&self) -> usize {
+        self.audio_len
+    }
+
+    /// Construct a SpecBundle directly. Used by stage1_inc when
+    /// it emits the bundle. `audio_ptr` must satisfy the lifetime
+    /// contract documented at the struct level.
+    pub(crate) fn new(
+        spec: mfsk_core::ft8::decode_block::Spectrogram,
+        allsum_head: Vec<f32>,
+        allsum_tail: Vec<f32>,
+        wav_idx: usize,
+        audio_ptr: *const i16,
+        audio_len: usize,
+    ) -> Self {
+        Self {
+            spec,
+            allsum_head,
+            allsum_tail,
+            wav_idx,
+            audio_ptr,
+            audio_len,
+        }
+    }
 }
 
 /// Audio + slot metadata, sent by stage1_inc at SlotEnd. Pairs with the
@@ -129,10 +158,12 @@ pub struct Slot {
     /// Raw pointer to the just-completed slot's audio. Same backing
     /// allocation as the matching `SpecBundle.audio_ptr` — both
     /// point into stage1_inc's currently-frozen `AudioBuf`.
-    pub audio_ptr: *const i16,
+    /// Kept private (Gemini PR #123 round-20) — callers go through
+    /// `audio()` for a safe `&[i16]`.
+    audio_ptr: *const i16,
     /// Number of valid samples at `audio_ptr` (usually
     /// `NMAX = 180_000`; smaller on under-fed / BtnA-reset slots).
-    pub audio_len: usize,
+    audio_len: usize,
     pub wav_idx: usize,
     pub inc_total_us: i64,
     /// `esp_timer_get_time()` captured at the start of
@@ -156,6 +187,33 @@ impl Slot {
         // `AudioBuf` allocation owned by stage1_inc and remain
         // valid for `self`'s lifetime per `AudioBuf`'s rules.
         unsafe { core::slice::from_raw_parts(self.audio_ptr, self.audio_len) }
+    }
+
+    /// Length of the audio buffer in samples. Equal to
+    /// `self.audio().len()`; exposed as a free accessor so callers
+    /// can log it without materialising the slice.
+    pub fn audio_len(&self) -> usize {
+        self.audio_len
+    }
+
+    /// Construct a Slot directly. Used by stage1_inc when it
+    /// hands ownership of the just-completed `AudioBuf` to the
+    /// queue. The (`audio_ptr`, `audio_len`) pair must satisfy
+    /// `AudioBuf`'s aliasing contract.
+    pub(crate) fn new(
+        audio_ptr: *const i16,
+        audio_len: usize,
+        wav_idx: usize,
+        inc_total_us: i64,
+        slotend_us: i64,
+    ) -> Self {
+        Self {
+            audio_ptr,
+            audio_len,
+            wav_idx,
+            inc_total_us,
+            slotend_us,
+        }
     }
 }
 

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -48,22 +48,28 @@ pub enum ChunkMsg {
 /// of audio capture, so that by the time `Slot` arrives main only has
 /// pass 2 + stage 3 left.
 ///
-/// **Phase C audio-tail speculation** (2026-05-21): also carries an
-/// owned snapshot of the audio captured so far (`audio_prefix`,
-/// `audio_fill` samples at the moment `emit_spec_bundle` ran). Main
-/// runs speculative pass-2 + early stage-3 on candidates whose
-/// Goertzel window fits inside `audio_prefix`; the rest defer to
-/// the full `Slot.audio` that arrives next on `slot_q`.
+/// **Phase C audio-tail speculation** (2026-05-21): also carries a
+/// raw pointer to stage1_inc's currently-frozen audio buffer +
+/// `audio_len` samples at the moment `emit_spec_bundle` ran. Main
+/// borrows `audio_prefix()` to run speculative pass-2 + early
+/// stage-3 on candidates whose Goertzel window fits the prefix;
+/// the rest defer to the full `slot.audio()` on the matching
+/// `Slot`.
 ///
-/// **Why a copy, not a shared pointer**: prior versions handed main
-/// a raw pointer into stage1_inc's still-being-written
-/// `WorkerCtx::cur::audio`. Even though stage1_inc only wrote past
-/// `audio_fill`, the implicit `&mut` borrow of `cur.audio` it held
-/// while doing so technically aliased main's raw-pointer-derived
-/// `&[i16]` under stacked borrows (Gemini PR #123 round-4 review).
-/// Copying the prefix costs ~2 ms PSRAM-to-PSRAM (~180 KB at
-/// ~80 MB/s) per slot — negligible vs the ~800 ms post-SlotEnd
-/// budget — and eliminates the aliasing concern entirely.
+/// **Why a raw pointer is sound under double-buffering**: prior
+/// (round-4) revisions copied `audio_prefix` to dodge stacked-
+/// borrow aliasing — stage1_inc kept an exclusive borrow on its
+/// only audio Vec while writing the tail past the snapshot fill.
+/// Round-11 introduced the double-buffer (`stage1_inc::AudioBuf`
+/// × 2): stage1_inc only ever writes `audio_bufs[fill_idx]`, and
+/// `finalize_slot` toggles `fill_idx` so the just-completed
+/// buffer's pointer (= `SpecBundle.audio_ptr` and
+/// `Slot.audio_ptr`) is read-only from stage1_inc's view until
+/// `fill_idx` cycles back at the *next* SlotEnd. Main must drop
+/// the matching `Slot` before that 15 s deadline; post-SlotEnd
+/// latency is ≪ 1 s in steady state so the constraint is
+/// trivially met. Result: no copy, no allocator churn, no
+/// PSRAM-bandwidth contention with main's coarse_sync reads.
 pub struct SpecBundle {
     pub spec: mfsk_core::ft8::decode_block::Spectrogram,
     pub allsum_head: Vec<f32>,

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -69,15 +69,14 @@ pub struct SpecBundle {
     pub allsum_head: Vec<f32>,
     pub allsum_tail: Vec<f32>,
     pub wav_idx: usize,
-    /// Owned copy of `WorkerCtx::cur::audio[..audio_fill]` at the
-    /// moment `emit_spec_bundle` ran. Length depends on
-    /// `SPEC_EMIT_PAIR` in stage1_inc; at the current setting (87 =
-    /// emit after pair 86) it is the audio requirement of pair 86 =
-    /// `j_b * NSTEP + NSPS` = `173 * 960 + 1920 = 168 000` samples
-    /// (= 14.0 s @ 12 kHz). Always ≥ this lower bound — chunks
-    /// arrive in 1 200-sample increments, so audio_fill at emit time
-    /// may be a fraction-of-a-chunk larger.
-    pub audio_prefix: Vec<i16>,
+    /// Raw pointer into stage1_inc's currently-frozen audio buffer
+    /// (same allocation as the matching `Slot.audio_ptr` that will
+    /// arrive on `slot_q` next).
+    pub audio_ptr: *const i16,
+    /// Snapshot of `cur.audio_fill` at emit time. Always ≥
+    /// pair-86's audio requirement (168 000 samples = 14.0 s @
+    /// 12 kHz) when emit fires at `SPEC_EMIT_PAIR`.
+    pub audio_len: usize,
 }
 
 impl SpecBundle {
@@ -96,12 +95,32 @@ impl SpecBundle {
     pub fn audio_end_for_dt(dt_sec: f32) -> usize {
         mfsk_core::ft8::decode_block::goertzel_window_end_sample(dt_sec)
     }
+
+    /// Borrow the snapshot prefix as a slice. SAFETY contract is
+    /// the same as [`Slot::audio`].
+    pub fn audio_prefix(&self) -> &[i16] {
+        unsafe { core::slice::from_raw_parts(self.audio_ptr, self.audio_len) }
+    }
 }
 
 /// Audio + slot metadata, sent by stage1_inc at SlotEnd. Pairs with the
 /// `SpecBundle` for the same `wav_idx` to drive pass 2 / stage 3.
+///
+/// **Phase C+ double-buffer**: `audio_ptr` references one of
+/// stage1_inc's two long-lived `AudioBuf` allocations. It stays
+/// valid until stage1_inc next swaps `fill_idx` back to this
+/// buffer (= at SlotEnd of the *next* slot, ≥ 15 s away). The
+/// consumer (decode_pipeline / main) MUST drop the Slot before
+/// that deadline; in steady-state operation post_slotend ≪ 15 s,
+/// so the requirement is trivially met.
 pub struct Slot {
-    pub audio: Vec<i16>,
+    /// Raw pointer to the just-completed slot's audio. Same backing
+    /// allocation as the matching `SpecBundle.audio_ptr` — both
+    /// point into stage1_inc's currently-frozen `AudioBuf`.
+    pub audio_ptr: *const i16,
+    /// Number of valid samples at `audio_ptr` (usually
+    /// `NMAX = 180_000`; smaller on under-fed / BtnA-reset slots).
+    pub audio_len: usize,
     pub wav_idx: usize,
     pub inc_total_us: i64,
     /// `esp_timer_get_time()` captured at the start of
@@ -109,6 +128,23 @@ pub struct Slot {
     /// arrived. Used by the decode-pipeline log to measure how much
     /// of the Phase C speculative window ran before SlotEnd vs after.
     pub slotend_us: i64,
+}
+
+// SAFETY: `audio_ptr` references a long-lived `AudioBuf` allocation
+// owned by stage1_inc. Consumer-only access (read-only) is sound
+// for the lifetime of the Slot, per `AudioBuf`'s aliasing contract.
+unsafe impl Send for Slot {}
+
+impl Slot {
+    /// Borrow the slot's audio as a slice. SAFETY: this method
+    /// borrows `self`, which keeps the Slot live and therefore
+    /// keeps the audio buffer reserved for the consumer.
+    pub fn audio(&self) -> &[i16] {
+        // SAFETY: `audio_ptr` + `audio_len` came from a valid
+        // `AudioBuf` allocation owned by stage1_inc and remain
+        // valid for `self`'s lifetime per `AudioBuf`'s rules.
+        unsafe { core::slice::from_raw_parts(self.audio_ptr, self.audio_len) }
+    }
 }
 
 /// Streaming-waterfall tick — emitted by stage1_inc once per FFT pair

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -70,10 +70,13 @@ pub struct SpecBundle {
     pub allsum_tail: Vec<f32>,
     pub wav_idx: usize,
     /// Owned copy of `WorkerCtx::cur::audio[..audio_fill]` at the
-    /// moment `emit_spec_bundle` ran. Length is the snapshot fill
-    /// position (always ≥ pair-91's audio requirement of
-    /// 177 600 samples = 14.8 s @ 12 kHz when emit fires at
-    /// `SPEC_EMIT_PAIR`).
+    /// moment `emit_spec_bundle` ran. Length depends on
+    /// `SPEC_EMIT_PAIR` in stage1_inc; at the current setting (87 =
+    /// emit after pair 86) it is the audio requirement of pair 86 =
+    /// `j_b * NSTEP + NSPS` = `173 * 960 + 1920 = 168 000` samples
+    /// (= 14.0 s @ 12 kHz). Always ≥ this lower bound — chunks
+    /// arrive in 1 200-sample increments, so audio_fill at emit time
+    /// may be a fraction-of-a-chunk larger.
     pub audio_prefix: Vec<i16>,
 }
 

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -47,12 +47,57 @@ pub enum ChunkMsg {
 /// Lets main start stage 2 (`coarse_sync_with_allsum`) during the tail
 /// of audio capture, so that by the time `Slot` arrives main only has
 /// pass 2 + stage 3 left.
+///
+/// **Phase C audio-tail speculation** (2026-05-21): also carries a
+/// raw pointer to the in-progress audio buffer plus a snapshot of
+/// the fill position at the time of emit, so main can speculatively
+/// run pass-2 + early stage-3 on candidates whose Goertzel window
+/// already fits within the captured audio (most do at SpecBundle
+/// time). The pointer aliases the `Slot.audio` Vec that arrives next
+/// on `slot_q` — `stage1_inc::finalize_slot` uses `mem::replace` so
+/// the heap allocation is preserved when ownership transfers to
+/// `Slot`.
+///
+/// **Why a snapshot, not a live atomic**: the pipeline is offset by
+/// one slot — by the time main receives SpecBundle K, stage1_inc has
+/// already moved on to slot K+1, so any shared "current fill" atomic
+/// would reflect K+1's progress (possibly 0 right after
+/// `finalize_slot` resets it). The snapshot captures slot K's audio
+/// fill at the moment pair 92 completed, which is deterministic
+/// (≥ pair 91's audio requirement) and correctly bounds main's
+/// speculative reads. Audio that arrives between emit and SlotEnd
+/// (typically ~2 more chunks = ~200 ms) is unused by the speculative
+/// path; it lands in the next-arriving `Slot` for any deferred
+/// candidates.
+///
+/// **Lifetime contract**: `audio_ptr` is valid from when this
+/// `SpecBundle` is delivered through `spec_q` until the matching
+/// `Slot` is dropped. After receiving `Slot`, main MUST switch to
+/// `slot.audio` and stop dereferencing `audio_ptr`.
 pub struct SpecBundle {
     pub spec: mfsk_core::ft8::decode_block::Spectrogram,
     pub allsum_head: Vec<f32>,
     pub allsum_tail: Vec<f32>,
     pub wav_idx: usize,
+    /// Raw pointer to the in-progress audio buffer in stage1_inc's
+    /// `WorkerCtx::cur::audio`. Aliases the eventual `Slot.audio`.
+    pub audio_ptr: *const i16,
+    /// Capacity of the audio buffer (= `NMAX` samples). Snapshot
+    /// reads must stay within `[0, audio_fill]`.
+    pub audio_cap: usize,
+    /// Snapshot of `WorkerCtx::cur::audio_fill` captured at
+    /// `emit_spec_bundle` time. Always ≥ the audio requirement of
+    /// pair 91 (177 600 samples = 14.8 s @ 12 kHz).
+    pub audio_fill: usize,
 }
+
+// SAFETY: `audio_ptr` references a heap allocation owned first by
+// stage1_inc's `WorkerCtx::cur::audio` (until SlotEnd), then by the
+// matching `Slot.audio` after `mem::replace`. The queue hand-off
+// from stage1_inc to main establishes happens-before for the
+// SpecBundle fields and the writes to the audio prefix
+// `[0, audio_fill]`.
+unsafe impl Send for SpecBundle {}
 
 /// Audio + slot metadata, sent by stage1_inc at SlotEnd. Pairs with the
 /// `SpecBundle` for the same `wav_idx` to drive pass 2 / stage 3.
@@ -60,6 +105,11 @@ pub struct Slot {
     pub audio: Vec<i16>,
     pub wav_idx: usize,
     pub inc_total_us: i64,
+    /// `esp_timer_get_time()` captured at the start of
+    /// `finalize_slot` in stage1_inc — i.e. the moment SlotEnd
+    /// arrived. Used by the decode-pipeline log to measure how much
+    /// of the Phase C speculative window ran before SlotEnd vs after.
+    pub slotend_us: i64,
 }
 
 /// Streaming-waterfall tick — emitted by stage1_inc once per FFT pair

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -106,29 +106,18 @@ unsafe impl Send for SpecBundle {}
 impl SpecBundle {
     /// Last sample index that
     /// `fill_symbol_spectra_goertzel(audio, freq_hz, dt_sec, ..)`
-    /// reads for a candidate at `dt_sec`. Mirrors the formula in
-    /// `mfsk_core::ft8::decode_block::fill_symbol_spectra_goertzel`
-    /// (`i0 = round((TX_START_OFFSET_S + dt) * SAMPLE_RATE_HZ);
-    /// end = i0 + NN * NSPS`). `NN` and `NSPS` are pulled from
-    /// `mfsk_core::ft8::params` so the two crates can't drift; the
-    /// two other constants live `pub(super)` in `decode_block::types`
-    /// so we mirror their values here with a same-file documentation
-    /// pointer.
+    /// reads for a candidate at `dt_sec`. Thin re-export of
+    /// `mfsk_core::ft8::decode_block::goertzel_window_end_sample`
+    /// so the formula and its constants
+    /// (`TX_START_OFFSET_S` / `SAMPLE_RATE_HZ` / `NN` / `NSPS`)
+    /// live exactly once in mfsk-core and can't drift.
     ///
     /// Used by Phase-C decode-pipeline consumers to decide whether
     /// a candidate's Goertzel window fits inside the SpecBundle
     /// audio snapshot (`ready`) or must defer to the post-SlotEnd
     /// path (`deferred`).
     pub fn audio_end_for_dt(dt_sec: f32) -> usize {
-        // Mirrored from `mfsk_core::ft8::decode_block::types`
-        // (`pub(super) const SAMPLE_RATE_HZ` / `TX_START_OFFSET_S`).
-        // If those values change in mfsk-core, update here too.
-        const SAMPLE_RATE_HZ: f32 = 12_000.0;
-        const TX_START_OFFSET_S: f32 = 1.0;
-        let i0 = ((TX_START_OFFSET_S + dt_sec) * SAMPLE_RATE_HZ).round() as i64;
-        let nsps = mfsk_core::ft8::params::NSPS as i64;
-        let nn = mfsk_core::ft8::params::NN as i64;
-        (i0 + nn * nsps).max(0) as usize
+        mfsk_core::ft8::decode_block::goertzel_window_end_sample(dt_sec)
     }
 }
 

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -48,60 +48,34 @@ pub enum ChunkMsg {
 /// of audio capture, so that by the time `Slot` arrives main only has
 /// pass 2 + stage 3 left.
 ///
-/// **Phase C audio-tail speculation** (2026-05-21): also carries a
-/// raw pointer to the in-progress audio buffer plus a snapshot of
-/// the fill position at the time of emit, so main can speculatively
-/// run pass-2 + early stage-3 on candidates whose Goertzel window
-/// already fits within the captured audio (most do at SpecBundle
-/// time). The pointer aliases the `Slot.audio` Vec that arrives next
-/// on `slot_q` — `stage1_inc::finalize_slot` uses `mem::replace` so
-/// the heap allocation is preserved when ownership transfers to
-/// `Slot`.
+/// **Phase C audio-tail speculation** (2026-05-21): also carries an
+/// owned snapshot of the audio captured so far (`audio_prefix`,
+/// `audio_fill` samples at the moment `emit_spec_bundle` ran). Main
+/// runs speculative pass-2 + early stage-3 on candidates whose
+/// Goertzel window fits inside `audio_prefix`; the rest defer to
+/// the full `Slot.audio` that arrives next on `slot_q`.
 ///
-/// **Why a snapshot, not a live atomic**: the pipeline is offset by
-/// one slot — by the time main receives SpecBundle K, stage1_inc has
-/// already moved on to slot K+1, so any shared "current fill" atomic
-/// would reflect K+1's progress (possibly 0 right after
-/// `finalize_slot` resets it). The snapshot captures slot K's audio
-/// fill at the moment pair 92 completed, which is deterministic
-/// (≥ pair 91's audio requirement) and correctly bounds main's
-/// speculative reads. Audio that arrives between emit and SlotEnd
-/// (typically ~2 more chunks = ~200 ms) is unused by the speculative
-/// path; it lands in the next-arriving `Slot` for any deferred
-/// candidates.
-///
-/// **Lifetime contract**: `audio_ptr` is valid from when this
-/// `SpecBundle` is delivered through `spec_q` until the matching
-/// `Slot` is dropped. After receiving `Slot`, main MUST switch to
-/// `slot.audio` and stop dereferencing `audio_ptr`.
+/// **Why a copy, not a shared pointer**: prior versions handed main
+/// a raw pointer into stage1_inc's still-being-written
+/// `WorkerCtx::cur::audio`. Even though stage1_inc only wrote past
+/// `audio_fill`, the implicit `&mut` borrow of `cur.audio` it held
+/// while doing so technically aliased main's raw-pointer-derived
+/// `&[i16]` under stacked borrows (Gemini PR #123 round-4 review).
+/// Copying the prefix costs ~2 ms PSRAM-to-PSRAM (~180 KB at
+/// ~80 MB/s) per slot — negligible vs the ~800 ms post-SlotEnd
+/// budget — and eliminates the aliasing concern entirely.
 pub struct SpecBundle {
     pub spec: mfsk_core::ft8::decode_block::Spectrogram,
     pub allsum_head: Vec<f32>,
     pub allsum_tail: Vec<f32>,
     pub wav_idx: usize,
-    /// Raw pointer to the in-progress audio buffer in stage1_inc's
-    /// `WorkerCtx::cur::audio`. Aliases the eventual `Slot.audio`.
-    pub audio_ptr: *const i16,
-    /// Capacity of the audio buffer (= `NMAX` samples). Snapshot
-    /// reads must stay within `[0, audio_fill]`.
-    pub audio_cap: usize,
-    /// Snapshot of `WorkerCtx::cur::audio_fill` captured at
-    /// `emit_spec_bundle` time. Always ≥ the audio requirement of
-    /// pair 91 (177 600 samples = 14.8 s @ 12 kHz).
-    pub audio_fill: usize,
+    /// Owned copy of `WorkerCtx::cur::audio[..audio_fill]` at the
+    /// moment `emit_spec_bundle` ran. Length is the snapshot fill
+    /// position (always ≥ pair-91's audio requirement of
+    /// 177 600 samples = 14.8 s @ 12 kHz when emit fires at
+    /// `SPEC_EMIT_PAIR`).
+    pub audio_prefix: Vec<i16>,
 }
-
-// SAFETY: `audio_ptr` references a heap allocation owned first by
-// stage1_inc's `WorkerCtx::cur::audio` (until SlotEnd), then by the
-// matching `Slot.audio` after `mem::replace`. The Vec is allocated
-// once as `vec![0i16; NMAX]` and never grown (stage1_inc only
-// `copy_from_slice`-writes into the existing slots), so the heap
-// pointer is stable — see the `debug_assert!` in stage1_inc's
-// `ingest_samples` that locks this invariant in. The queue hand-off
-// from stage1_inc to main establishes happens-before for the
-// SpecBundle fields and the writes to the audio prefix
-// `[0, audio_fill]`.
-unsafe impl Send for SpecBundle {}
 
 impl SpecBundle {
     /// Last sample index that

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -79,6 +79,12 @@ pub struct SpecBundle {
     pub audio_len: usize,
 }
 
+// SAFETY: `audio_ptr` references a long-lived `AudioBuf` allocation
+// owned by stage1_inc. Same contract as `Slot::audio` — consumer
+// reads are valid for the lifetime of this `SpecBundle` and the
+// matching `Slot` that arrives next on `slot_q`.
+unsafe impl Send for SpecBundle {}
+
 impl SpecBundle {
     /// Last sample index that
     /// `fill_symbol_spectra_goertzel(audio, freq_hz, dt_sec, ..)`

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -128,8 +128,20 @@ struct AudioBuf {
 
 impl AudioBuf {
     fn new() -> Self {
-        let b: Box<[i16; NMAX]> = Box::new([0i16; NMAX]);
-        let ptr = Box::into_raw(b) as *mut i16;
+        // `Box::new([0i16; NMAX])` puts the 360 KB array temporarily
+        // on the stack before moving it to the heap and can blow
+        // the FreeRTOS task stack on ESP32. Allocate via Vec, which
+        // goes straight to the heap (PSRAM under
+        // `SPIRAM_MALLOC_ALWAYSINTERNAL=4096`), then convert into a
+        // boxed array.
+        // SAFETY: `into_boxed_slice` yields a Box<[i16]> whose
+        // length is exactly NMAX (we built the Vec at that size).
+        // The size cast to `Box<[i16; NMAX]>` is sound — same
+        // layout, same allocation, length proven at construction.
+        let v: Vec<i16> = alloc::vec![0i16; NMAX];
+        let boxed_slice: Box<[i16]> = v.into_boxed_slice();
+        debug_assert_eq!(boxed_slice.len(), NMAX);
+        let ptr = Box::into_raw(boxed_slice) as *mut i16;
         Self { ptr, gen: 0 }
     }
 }

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -261,19 +261,6 @@ fn reset_in_progress(ctx: &mut WorkerCtx) {
 
 fn ingest_samples(ctx: &mut WorkerCtx, samples: &[i16]) {
     let cur = &mut ctx.cur;
-    // The Phase-C audio_ptr in SpecBundle aliases this Vec's heap
-    // allocation across SlotEnd. The aliasing is only sound while the
-    // Vec never reallocates — the initial `vec![0i16; NMAX]` already
-    // sets `len == capacity == NMAX`, and `copy_from_slice` below
-    // writes in-place into pre-allocated slots, so neither len nor
-    // capacity change. Lock the invariant in: any future change that
-    // accidentally grows the Vec trips this assert in debug builds.
-    debug_assert_eq!(
-        cur.audio.capacity(),
-        NMAX,
-        "audio Vec must not grow — Phase-C audio_ptr depends on stable heap"
-    );
-    debug_assert_eq!(cur.audio.len(), NMAX, "audio Vec len must stay = NMAX");
     let off = cur.audio_fill;
     if off + samples.len() > NMAX {
         // More than one slot worth of audio without a SlotEnd — should
@@ -364,15 +351,13 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
     let spec = core::mem::replace(&mut ctx.cur.spec, vec![0u16; n_freq * N_TIME]);
     let head = core::mem::replace(&mut ctx.cur.allsum_head, vec![0f32; head_n * N_TIME]);
     let tail = core::mem::replace(&mut ctx.cur.allsum_tail, vec![0f32; tail_n * N_TIME]);
-    // Phase C: hand main a raw pointer to the audio buffer + a
-    // snapshot of the fill position. Lifetime contract is
-    // documented on `SpecBundle`; main must stop dereferencing
-    // `audio_ptr` once it has received the matching `Slot`. The
-    // snapshot avoids a races against `finalize_slot`'s reset of
-    // any shared atomic when the pipeline is offset by one slot.
-    let audio_ptr = ctx.cur.audio.as_ptr();
-    let audio_cap = ctx.cur.audio.len();
-    let audio_fill = ctx.cur.audio_fill;
+    // Phase C: hand main an owned snapshot of the audio captured
+    // so far. Copying (~180 KB PSRAM→PSRAM, ~2 ms) avoids the
+    // aliasing UB the prior raw-pointer scheme had under stacked
+    // borrows — main's `&[i16]` is now backed by its own
+    // allocation, independent of stage1_inc's mutable access to
+    // `ctx.cur.audio` for subsequent chunks.
+    let audio_prefix = ctx.cur.audio[..ctx.cur.audio_fill].to_vec();
     let bundle = Box::new(SpecBundle {
         spec: mfsk_core::ft8::decode_block::Spectrogram::from_parts(n_freq, N_TIME, spec),
         allsum_head: head,
@@ -380,9 +365,7 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
         // wav_idx is only known at SlotEnd; main matches SpecBundle to
         // Slot by FIFO order of receipt, so this is informational only.
         wav_idx: usize::MAX,
-        audio_ptr,
-        audio_cap,
-        audio_fill,
+        audio_prefix,
     });
     send_box(ctx.spec_q, bundle);
     ctx.cur.spec_sent = true;

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -348,9 +348,33 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
     let n_freq = ctx.n_freq;
     let head_n = ctx.head_n_freq;
     let tail_n = ctx.tail_n_freq;
-    let spec = core::mem::replace(&mut ctx.cur.spec, vec![0u16; n_freq * N_TIME]);
-    let head = core::mem::replace(&mut ctx.cur.allsum_head, vec![0f32; head_n * N_TIME]);
-    let tail = core::mem::replace(&mut ctx.cur.allsum_tail, vec![0f32; tail_n * N_TIME]);
+    // The post-emit "fresh" buffers swapped into `ctx.cur` are only
+    // touched if `compute_pair_into` runs for pairs 88..91 — and
+    // that only happens when `wf_q.is_some()` (the loop limit in
+    // `advance_pairs` is `SPEC_EMIT_PAIR` otherwise). For the bench
+    // crate (`wf_q = None`) skip the ~860 KB of zeroed PSRAM
+    // allocation entirely (Gemini PR #123 round-5 review). They are
+    // re-allocated at full size by `SlotInProgress::new` inside
+    // `finalize_slot` for the next slot.
+    let need_post_emit_buffers = ctx.wf_q.is_some();
+    let new_spec = if need_post_emit_buffers {
+        vec![0u16; n_freq * N_TIME]
+    } else {
+        Vec::new()
+    };
+    let new_head = if need_post_emit_buffers {
+        vec![0f32; head_n * N_TIME]
+    } else {
+        Vec::new()
+    };
+    let new_tail = if need_post_emit_buffers {
+        vec![0f32; tail_n * N_TIME]
+    } else {
+        Vec::new()
+    };
+    let spec = core::mem::replace(&mut ctx.cur.spec, new_spec);
+    let head = core::mem::replace(&mut ctx.cur.allsum_head, new_head);
+    let tail = core::mem::replace(&mut ctx.cur.allsum_tail, new_tail);
     // Phase C: hand main an owned snapshot of the audio captured
     // so far. Copying (~180 KB PSRAM→PSRAM, ~2 ms) avoids the
     // aliasing UB the prior raw-pointer scheme had under stacked

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -389,6 +389,18 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
 }
 
 fn compute_pair_into(ctx: &mut WorkerCtx, j_a: usize, j_b: usize) {
+    // Defensive check (Gemini PR #123 round-10): the `wf_q.is_none()`
+    // branch in `emit_spec_bundle` swaps empty Vecs into `ctx.cur`
+    // because the `pair_limit` gate in `advance_pairs` is supposed
+    // to prevent any further `compute_pair_into` calls for that
+    // slot. If that invariant ever breaks (refactor lands a
+    // `pair_limit = N_PAIRS` path that forgets to widen
+    // emit_spec_bundle's tuple), the indexed writes below would
+    // hit empty Vecs and panic anyway — surface it explicitly here.
+    debug_assert!(
+        !ctx.cur.spec.is_empty(),
+        "compute_pair_into invoked after wf_q=None emit replaced ctx.cur.spec with empty Vec"
+    );
     let shift = ctx.cur.shift;
     let ia_a = j_a * NSTEP;
     let ia_b = j_b * NSTEP;

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -261,6 +261,19 @@ fn reset_in_progress(ctx: &mut WorkerCtx) {
 
 fn ingest_samples(ctx: &mut WorkerCtx, samples: &[i16]) {
     let cur = &mut ctx.cur;
+    // The Phase-C audio_ptr in SpecBundle aliases this Vec's heap
+    // allocation across SlotEnd. The aliasing is only sound while the
+    // Vec never reallocates — the initial `vec![0i16; NMAX]` already
+    // sets `len == capacity == NMAX`, and `copy_from_slice` below
+    // writes in-place into pre-allocated slots, so neither len nor
+    // capacity change. Lock the invariant in: any future change that
+    // accidentally grows the Vec trips this assert in debug builds.
+    debug_assert_eq!(
+        cur.audio.capacity(),
+        NMAX,
+        "audio Vec must not grow — Phase-C audio_ptr depends on stable heap"
+    );
+    debug_assert_eq!(cur.audio.len(), NMAX, "audio Vec len must stay = NMAX");
     let off = cur.audio_fill;
     if off + samples.len() > NMAX {
         // More than one slot worth of audio without a SlotEnd — should
@@ -301,9 +314,23 @@ fn advance_pairs(ctx: &mut WorkerCtx) {
         return;
     }
 
+    // Pair-loop limit: when no streaming-waterfall consumer is
+    // wired, stop computing once the SpecBundle's needed_m range is
+    // covered (pair `SPEC_EMIT_PAIR - 1`). Pairs 88..91 (m=176..183)
+    // contribute nothing to coarse_sync and would otherwise compute
+    // 4 × `compute_pair_into` calls into a buffer that
+    // `emit_spec_bundle`'s `mem::replace` immediately discards
+    // (Gemini PR #123 review). Production apps with `wf_q = Some`
+    // still need pairs 88..91 to keep the waterfall flowing through
+    // the slot tail, so they keep the original N_PAIRS limit.
+    let pair_limit = if ctx.wf_q.is_some() {
+        N_PAIRS
+    } else {
+        SPEC_EMIT_PAIR
+    };
     loop {
         let j = ctx.cur.next_pair;
-        if j >= N_PAIRS {
+        if j >= pair_limit {
             break;
         }
         let j_a = 2 * j;

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -356,21 +356,14 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
     // allocation entirely (Gemini PR #123 round-5 review). They are
     // re-allocated at full size by `SlotInProgress::new` inside
     // `finalize_slot` for the next slot.
-    let need_post_emit_buffers = ctx.wf_q.is_some();
-    let new_spec = if need_post_emit_buffers {
-        vec![0u16; n_freq * N_TIME]
+    let (new_spec, new_head, new_tail) = if ctx.wf_q.is_some() {
+        (
+            vec![0u16; n_freq * N_TIME],
+            vec![0f32; head_n * N_TIME],
+            vec![0f32; tail_n * N_TIME],
+        )
     } else {
-        Vec::new()
-    };
-    let new_head = if need_post_emit_buffers {
-        vec![0f32; head_n * N_TIME]
-    } else {
-        Vec::new()
-    };
-    let new_tail = if need_post_emit_buffers {
-        vec![0f32; tail_n * N_TIME]
-    } else {
-        Vec::new()
+        (Vec::new(), Vec::new(), Vec::new())
     };
     let spec = core::mem::replace(&mut ctx.cur.spec, new_spec);
     let head = core::mem::replace(&mut ctx.cur.allsum_head, new_head);

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -88,6 +88,67 @@ fn band_for(freq_min: f32, freq_max: f32, spec_n_freq: usize) -> (usize, usize) 
     (ia, ib - ia + 1)
 }
 
+/// Long-lived NMAX-element i16 audio buffer in PSRAM.
+///
+/// Phase C+ owns two of these in `WorkerCtx::audio_bufs` and toggles
+/// `WorkerCtx::fill_idx` at SlotEnd so the just-completed buffer's
+/// pointer can be handed to main via Slot / SpecBundle while
+/// stage1_inc starts writing the next slot into the other buffer.
+/// This eliminates the per-slot ~340 KB Vec alloc/free + the
+/// ~170 KB audio_prefix memcpy that the prior Vec-based design
+/// required to keep Rust's aliasing rules satisfied.
+///
+/// SAFETY: each buffer is logically owned by exactly one of the
+/// stage1_inc / consumer pair at any moment, but Rust's borrow
+/// checker can't express that across the FreeRTOS queue boundary
+/// — the queue carries a raw `*const i16`, not a reference. The
+/// invariant the implementation guarantees is:
+///   * stage1_inc only WRITES the buffer indexed by `fill_idx`.
+///   * The other buffer is read-only from stage1_inc's view, and
+///     must have been emitted to main exactly once (via the
+///     previous slot's `SpecBundle` + `Slot`) before its index is
+///     re-promoted to `fill_idx`.
+///   * Main must DROP the previous `Slot` before stage1_inc swaps
+///     `fill_idx` back to that buffer. Steady-state pipeline has
+///     post-SlotEnd ≪ 15 s so the constraint is easily met; a
+///     debug build adds a check in `swap_fill_idx`.
+struct AudioBuf {
+    /// Box<[i16; NMAX]> reborrowed as a raw pointer so neither
+    /// stage1_inc's `&mut WorkerCtx` nor main's `*const i16`
+    /// derives an exclusive Rust borrow of the underlying slice.
+    /// `Box::into_raw` is paired with `Box::from_raw` in `Drop`.
+    ptr: *mut i16,
+    /// Generation tag bumped each time `swap_fill_idx` promotes
+    /// this buffer back to the fill side. Currently informational
+    /// (the queue-FIFO order is the primary guard); a future
+    /// `try_promote` could refuse to swap until a corresponding
+    /// drop signal lands.
+    gen: u32,
+}
+
+impl AudioBuf {
+    fn new() -> Self {
+        let b: Box<[i16; NMAX]> = Box::new([0i16; NMAX]);
+        let ptr = Box::into_raw(b) as *mut i16;
+        Self { ptr, gen: 0 }
+    }
+}
+
+impl Drop for AudioBuf {
+    fn drop(&mut self) {
+        // SAFETY: `ptr` came from `Box::into_raw(Box<[i16; NMAX]>)`
+        // and is owned exclusively by this struct.
+        unsafe {
+            let _ = Box::from_raw(self.ptr as *mut [i16; NMAX]);
+        }
+    }
+}
+
+// SAFETY: we treat `AudioBuf` as a pointer to a logically-owned
+// allocation. The aliasing contract is documented above and
+// enforced at the FreeRTOS-queue ownership-transfer boundary.
+unsafe impl Send for AudioBuf {}
+
 /// Task-local state: one in-flight slot + invariant resources.
 struct WorkerCtx {
     chunk_q: QueueHandle_t,
@@ -109,13 +170,28 @@ struct WorkerCtx {
     _fft_planner: Box<dyn FftPlanner16>,
     fft: Box<dyn Fft16>,
     fft_buf: Vec<Complex<i16>>,
-    /// Accumulating slot — fresh-allocated at start of each slot.
+    /// Double-buffered audio. `audio_bufs[fill_idx]` is the buffer
+    /// stage1_inc currently writes into; the other was just handed
+    /// to main via the previous SlotEnd. Indices are swapped inside
+    /// `finalize_slot` so the just-completed buffer's pointer is
+    /// what travels in `Slot.audio_ptr`.
+    audio_bufs: [AudioBuf; 2],
+    fill_idx: usize,
+    /// Accumulating slot metadata — counters / spec / allsum / etc.
+    /// The audio bytes themselves now live in `audio_bufs[fill_idx]`.
     cur: SlotInProgress,
+}
+
+impl WorkerCtx {
+    /// Pointer to the buffer stage1_inc currently writes into.
+    #[inline]
+    fn fill_ptr(&self) -> *mut i16 {
+        self.audio_bufs[self.fill_idx].ptr
+    }
 }
 
 /// State of the slot currently being assembled.
 struct SlotInProgress {
-    audio: Vec<i16>,
     audio_fill: usize,
     /// Spec/allsum buffers — moved out into a `SpecBundle` and sent
     /// downstream as soon as the last pair finalizes (typically ~200 ms
@@ -136,7 +212,6 @@ struct SlotInProgress {
 impl SlotInProgress {
     fn new(n_freq: usize, head_n_freq: usize, tail_n_freq: usize) -> Self {
         Self {
-            audio: vec![0i16; NMAX],
             audio_fill: 0,
             spec: vec![0u16; n_freq * N_TIME],
             allsum_head: vec![0f32; head_n_freq * N_TIME],
@@ -191,6 +266,8 @@ pub fn spawn_with_wf(
         _fft_planner: fft_planner,
         fft,
         fft_buf,
+        audio_bufs: [AudioBuf::new(), AudioBuf::new()],
+        fill_idx: 0,
         cur: SlotInProgress::new(n_freq, head_n_freq, tail_n_freq),
     });
     let ctx_ptr = Box::into_raw(ctx) as *mut c_void;
@@ -260,8 +337,7 @@ fn reset_in_progress(ctx: &mut WorkerCtx) {
 }
 
 fn ingest_samples(ctx: &mut WorkerCtx, samples: &[i16]) {
-    let cur = &mut ctx.cur;
-    let off = cur.audio_fill;
+    let off = ctx.cur.audio_fill;
     if off + samples.len() > NMAX {
         // More than one slot worth of audio without a SlotEnd — should
         // not happen in normal operation. Drop excess.
@@ -271,14 +347,25 @@ fn ingest_samples(ctx: &mut WorkerCtx, samples: &[i16]) {
         );
         return;
     }
-    cur.audio[off..off + samples.len()].copy_from_slice(samples);
-    for &s in samples {
-        let a = (s as i32).unsigned_abs() as i32;
-        if a > cur.peak_abs {
-            cur.peak_abs = a;
-        }
+    // SAFETY: `fill_ptr()` returns the heap pointer of the buffer
+    // currently owned (write-side) by stage1_inc. By the
+    // `AudioBuf` invariant documented at its definition, no other
+    // task is reading this index range concurrently. The dst range
+    // `[off, off+samples.len())` was bounds-checked above.
+    let dst = unsafe { ctx.fill_ptr().add(off) };
+    unsafe {
+        core::ptr::copy_nonoverlapping(samples.as_ptr(), dst, samples.len());
     }
-    cur.audio_fill = off + samples.len();
+    {
+        let cur = &mut ctx.cur;
+        for &s in samples {
+            let a = (s as i32).unsigned_abs() as i32;
+            if a > cur.peak_abs {
+                cur.peak_abs = a;
+            }
+        }
+        cur.audio_fill = off + samples.len();
+    }
     advance_pairs(ctx);
 }
 
@@ -368,13 +455,13 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
     let spec = core::mem::replace(&mut ctx.cur.spec, new_spec);
     let head = core::mem::replace(&mut ctx.cur.allsum_head, new_head);
     let tail = core::mem::replace(&mut ctx.cur.allsum_tail, new_tail);
-    // Phase C: hand main an owned snapshot of the audio captured
-    // so far. Copying (~180 KB PSRAM→PSRAM, ~2 ms) avoids the
-    // aliasing UB the prior raw-pointer scheme had under stacked
-    // borrows — main's `&[i16]` is now backed by its own
-    // allocation, independent of stage1_inc's mutable access to
-    // `ctx.cur.audio` for subsequent chunks.
-    let audio_prefix = ctx.cur.audio[..ctx.cur.audio_fill].to_vec();
+    // Phase C+ double-buffer (round-11): hand main a raw pointer
+    // to the fill-side audio buffer + the current fill count. No
+    // copy. The pointer remains valid until the next time stage1_inc
+    // promotes this index back to `fill_idx` (= next SlotEnd at the
+    // earliest); main must drop the matching `Slot` before then.
+    let audio_ptr: *const i16 = ctx.fill_ptr();
+    let audio_len = ctx.cur.audio_fill;
     let bundle = Box::new(SpecBundle {
         spec: mfsk_core::ft8::decode_block::Spectrogram::from_parts(n_freq, N_TIME, spec),
         allsum_head: head,
@@ -382,7 +469,8 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
         // wav_idx is only known at SlotEnd; main matches SpecBundle to
         // Slot by FIFO order of receipt, so this is informational only.
         wav_idx: usize::MAX,
-        audio_prefix,
+        audio_ptr,
+        audio_len,
     });
     send_box(ctx.spec_q, bundle);
     ctx.cur.spec_sent = true;
@@ -418,17 +506,22 @@ fn compute_pair_into(ctx: &mut WorkerCtx, j_a: usize, j_b: usize) {
     // costs ~3 dB SNR and spreads each tone's mainlobe across 2 bins,
     // negating the integer-bin advantage. See decode_block.rs:107.
     {
-        let cur = &ctx.cur;
+        // SAFETY: `audio_ptr` is the fill-side buffer (this is the
+        // only writer in this task); reading from indices < NMAX is
+        // bounds-safe (`AudioBuf` has fixed NMAX size). Each index
+        // is checked against NMAX (= NMAX here is the audio buffer
+        // length, matched to `cur.audio_fill`'s bound check).
+        let audio_ptr: *const i16 = ctx.fill_ptr();
         let buf = &mut ctx.fft_buf;
         for k in 0..NFFT_SPEC {
-            let re = if k < NSPS && ia_a + k < cur.audio.len() {
-                let raw = cur.audio[ia_a + k] as i32;
+            let re = if k < NSPS && ia_a + k < NMAX {
+                let raw = unsafe { *audio_ptr.add(ia_a + k) } as i32;
                 (raw << shift).clamp(i16::MIN as i32, i16::MAX as i32) as i16
             } else {
                 0
             };
-            let im = if k < NSPS && ia_b + k < cur.audio.len() {
-                let raw = cur.audio[ia_b + k] as i32;
+            let im = if k < NSPS && ia_b + k < NMAX {
+                let raw = unsafe { *audio_ptr.add(ia_b + k) } as i32;
                 (raw << shift).clamp(i16::MIN as i32, i16::MAX as i32) as i16
             } else {
                 0
@@ -605,13 +698,30 @@ fn finalize_slot(ctx: &mut WorkerCtx, wav_idx: usize, total_samples: usize) {
         );
     }
 
+    // Snapshot the just-completed buffer's pointer and fill count
+    // BEFORE we swap `fill_idx`. main reads from this pointer
+    // (= same buffer that was emitted via SpecBundle.audio_ptr).
+    let done_audio_ptr: *const i16 = ctx.fill_ptr();
+    let done_audio_fill = ctx.cur.audio_fill;
+
+    // Swap fill_idx so stage1_inc's NEXT slot fills the *other*
+    // buffer. Main keeps reading the just-snapshotted pointer until
+    // it drops the Slot — by which time stage1_inc is on slot K+1,
+    // so the only way these conflict is if main blocks for more
+    // than 15 s after SlotEnd K (post_slotend ≪ 15 s; debug_assert
+    // guards against drift). Bump the buffer's generation tag for
+    // future-introspection.
+    ctx.fill_idx ^= 1;
+    ctx.audio_bufs[ctx.fill_idx].gen = ctx.audio_bufs[ctx.fill_idx].gen.wrapping_add(1);
+
     let fresh = SlotInProgress::new(ctx.n_freq, ctx.head_n_freq, ctx.tail_n_freq);
-    let done = core::mem::replace(&mut ctx.cur, fresh);
+    let _done = core::mem::replace(&mut ctx.cur, fresh);
 
     let slot = Box::new(Slot {
-        audio: done.audio,
+        audio_ptr: done_audio_ptr,
+        audio_len: done_audio_fill,
         wav_idx,
-        inc_total_us: done.inc_total_us,
+        inc_total_us: _done.inc_total_us,
         slotend_us,
     });
     send_box(ctx.slot_q, slot);

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -424,13 +424,15 @@ fn advance_pairs(ctx: &mut WorkerCtx) {
 
     // Pair-loop limit: when no streaming-waterfall consumer is
     // wired, stop computing once the SpecBundle's needed_m range is
-    // covered (pair `SPEC_EMIT_PAIR - 1`). Pairs 88..91 (m=176..183)
-    // contribute nothing to coarse_sync and would otherwise compute
-    // 4 × `compute_pair_into` calls into a buffer that
+    // covered. With `SPEC_EMIT_PAIR = 87` the loop exits after
+    // pair index 86 finishes, skipping pairs 87..91 (= m=174..183,
+    // 5 pairs × ~10 ms each); those rows contribute nothing to
+    // coarse_sync and would otherwise compute into a buffer that
     // `emit_spec_bundle`'s `mem::replace` immediately discards
-    // (Gemini PR #123 review). Production apps with `wf_q = Some`
-    // still need pairs 88..91 to keep the waterfall flowing through
-    // the slot tail, so they keep the original N_PAIRS limit.
+    // (Gemini PR #123 round-5 / round-18). Production apps with
+    // `wf_q = Some` still need pairs 87..91 to keep the waterfall
+    // flowing through the slot tail, so they keep the original
+    // N_PAIRS limit.
     let pair_limit = if ctx.wf_q.is_some() {
         N_PAIRS
     } else {

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -60,10 +60,19 @@ const TARGET_PEAK: i32 = (NFFT_SPEC * 2) as i32;
 // steady state — taking the pair-86 emit, the 160 ms audio-tail
 // overlap gain shows up directly as -160 ms post_slotend.
 //
+// **Semantics of this constant** (Gemini PR #123 round-14 misread
+// guard): the value is compared `next_pair >= SPEC_EMIT_PAIR` in
+// `advance_pairs` AFTER each pair's `compute_pair_into` increments
+// `next_pair`. So `SPEC_EMIT_PAIR = 87` means "emit when 87 pairs
+// have been processed" = "emit just after pair index 86 finishes"
+// = "emit with m=0..173 filled" (pair k fills m=2k, 2k+1, so
+// pairs 0..86 fill m=0..173). It does NOT mean "emit at pair 87
+// producing m=174..175".
+//
 // Pairs 87..91 (m=174..183) still get computed when `wf_q.is_some()`
 // to keep the WF flowing through the slot tail; `wf_q = None`
 // (bench) skips them via the `pair_limit` branch in advance_pairs.
-const SPEC_EMIT_PAIR: usize = 87; // emit after pair 86 done (m=0..173 valid)
+const SPEC_EMIT_PAIR: usize = 87; // emit when next_pair == 87 (= pairs 0..86 done, m=0..173 valid)
 const _: () = assert!(SPEC_EMIT_PAIR <= N_PAIRS, "SPEC_EMIT_PAIR > N_PAIRS");
 
 // Phase-E2 per-half allsum parameters (matches dual_core
@@ -448,14 +457,19 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
     let head_n = ctx.head_n_freq;
     let tail_n = ctx.tail_n_freq;
     // The post-emit "fresh" buffers swapped into `ctx.cur` are only
-    // touched if `compute_pair_into` runs for pairs 88..91 — and
-    // that only happens when `wf_q.is_some()` (the loop limit in
-    // `advance_pairs` is `SPEC_EMIT_PAIR` otherwise). For the bench
-    // crate (`wf_q = None`) skip the ~860 KB of zeroed PSRAM
-    // allocation entirely (Gemini PR #123 round-5 review). They are
-    // re-allocated at full size by `SlotInProgress::new` inside
-    // `finalize_slot` for the next slot.
-    let (new_spec, new_head, new_tail) = if ctx.wf_q.is_some() {
+    // touched if `compute_pair_into` runs for the remaining pairs
+    // (87..91). Two conditions must BOTH hold for an alloc to be
+    // worthwhile:
+    //   * `wf_q.is_some()` — otherwise `pair_limit` in
+    //     `advance_pairs` stops the loop at SPEC_EMIT_PAIR.
+    //   * `next_pair < N_PAIRS` — otherwise we're emitting from
+    //     `finalize_slot`'s late-emit fallback (the slot was
+    //     under-fed; all pairs already done) and the fresh buffer
+    //     would be discarded by the `mem::replace` later in the
+    //     same `finalize_slot` call.
+    // Gemini PR #123 round-5 & round-14 reviews.
+    let needs_buffers = ctx.wf_q.is_some() && ctx.cur.next_pair < N_PAIRS;
+    let (new_spec, new_head, new_tail) = if needs_buffers {
         (
             vec![0u16; n_freq * N_TIME],
             vec![0f32; head_n * N_TIME],

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -45,25 +45,25 @@ const N_TIME: usize = NMAX / NSTEP - 3; // 184
 const N_PAIRS: usize = N_TIME / 2; // 92
 const TARGET_PEAK: i32 = (NFFT_SPEC * 2) as i32;
 
-// Phase C+ (2026-05-21): emit SpecBundle *before* the last few pairs
-// finish, so coarse_sync gets more headroom before SlotEnd. coarse_sync
-// reads spec at m ∈ {Costas-positions + lag} only; with `nstep-half`
-// (NSSY=2), jstrt=6, and SYNC_LAG_S=1.0 (jz≈12-13), the maximum m
-// touched is block-2 last Costas + jz = 162 + 13 = 175. Pair 87 fills
-// up to m=175 (j_a=174, j_b=175), so emitting at `next_pair == 88`
-// gives coarse_sync everything it needs while leaving ~720 ms more
-// of audio-tail wallclock for the speculative pass-2 + stage-3 path.
+// Phase C++ (2026-05-21): emit SpecBundle as early as we can
+// trade off against block-2 coarse_sync score for dt near ±jz.
 //
-// Pairs 88..91 (m=176..183) still get computed after emit, but
-// `emit_spec_bundle` swaps in a fresh zero buffer so those writes
-// land in a discarded allocation. `xsnr2_db_simple` does sample
-// spec at strided m values across the full range; the trailing 8
-// zero rows out of 184 (≈ 4.3%) bias the median noise-floor estimate
-// slightly but stay well inside the per-station SNR jitter we
-// already see across slots. Keep all 92 pairs computed (we discard
-// rather than skip) so any future downstream consumer that needs
-// the full spec can opt in by hooking a second emit at pair 91.
-const SPEC_EMIT_PAIR: usize = 88; // emit after pair 87 done (m=0..175 valid)
+// `nstep-half` (NSSY=2), jstrt=6, SYNC_LAG_S=1.0 → jz=13. The
+// strict-correct `needed_m` bound is 162 + 13 = 175 (block-2 last
+// Costas at m=162, plus max lag), which pair 87 completes.
+// Emitting at pair 86 (m=0..173) leaves m=174..175 zero in both
+// the spec and the per-half allsum, which silently flattens
+// block-2's contribution for candidates whose lag lands on ±jz
+// (= dt near ±1.0 s). On NTP-synced operation dt is well inside
+// ±0.5 s, and the dt median auto-sync (`time_sync::record_decode_dt`)
+// re-anchors the slot phase so the lag range can stay tight in
+// steady state — taking the pair-86 emit, the 160 ms audio-tail
+// overlap gain shows up directly as -160 ms post_slotend.
+//
+// Pairs 87..91 (m=174..183) still get computed when `wf_q.is_some()`
+// to keep the WF flowing through the slot tail; `wf_q = None`
+// (bench) skips them via the `pair_limit` branch in advance_pairs.
+const SPEC_EMIT_PAIR: usize = 87; // emit after pair 86 done (m=0..173 valid)
 const _: () = assert!(SPEC_EMIT_PAIR <= N_PAIRS, "SPEC_EMIT_PAIR > N_PAIRS");
 
 // Phase-E2 per-half allsum parameters (matches dual_core

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -503,16 +503,16 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
     // earliest); main must drop the matching `Slot` before then.
     let audio_ptr: *const i16 = ctx.fill_ptr();
     let audio_len = ctx.cur.audio_fill;
-    let bundle = Box::new(SpecBundle {
-        spec: mfsk_core::ft8::decode_block::Spectrogram::from_parts(n_freq, N_TIME, spec),
-        allsum_head: head,
-        allsum_tail: tail,
+    let bundle = Box::new(SpecBundle::new(
+        mfsk_core::ft8::decode_block::Spectrogram::from_parts(n_freq, N_TIME, spec),
+        head,
+        tail,
         // wav_idx is only known at SlotEnd; main matches SpecBundle to
         // Slot by FIFO order of receipt, so this is informational only.
-        wav_idx: usize::MAX,
+        usize::MAX,
         audio_ptr,
         audio_len,
-    });
+    ));
     send_box(ctx.spec_q, bundle);
     ctx.cur.spec_sent = true;
 }
@@ -756,14 +756,14 @@ fn finalize_slot(ctx: &mut WorkerCtx, wav_idx: usize, total_samples: usize) {
     ctx.audio_bufs[ctx.fill_idx].gen = ctx.audio_bufs[ctx.fill_idx].gen.wrapping_add(1);
 
     let fresh = SlotInProgress::new(ctx.n_freq, ctx.head_n_freq, ctx.tail_n_freq);
-    let _done = core::mem::replace(&mut ctx.cur, fresh);
+    let done = core::mem::replace(&mut ctx.cur, fresh);
 
-    let slot = Box::new(Slot {
-        audio_ptr: done_audio_ptr,
-        audio_len: done_audio_fill,
+    let slot = Box::new(Slot::new(
+        done_audio_ptr,
+        done_audio_fill,
         wav_idx,
-        inc_total_us: _done.inc_total_us,
+        done.inc_total_us,
         slotend_us,
-    });
+    ));
     send_box(ctx.slot_q, slot);
 }

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -45,6 +45,27 @@ const N_TIME: usize = NMAX / NSTEP - 3; // 184
 const N_PAIRS: usize = N_TIME / 2; // 92
 const TARGET_PEAK: i32 = (NFFT_SPEC * 2) as i32;
 
+// Phase C+ (2026-05-21): emit SpecBundle *before* the last few pairs
+// finish, so coarse_sync gets more headroom before SlotEnd. coarse_sync
+// reads spec at m ∈ {Costas-positions + lag} only; with `nstep-half`
+// (NSSY=2), jstrt=6, and SYNC_LAG_S=1.0 (jz≈12-13), the maximum m
+// touched is block-2 last Costas + jz = 162 + 13 = 175. Pair 87 fills
+// up to m=175 (j_a=174, j_b=175), so emitting at `next_pair == 88`
+// gives coarse_sync everything it needs while leaving ~720 ms more
+// of audio-tail wallclock for the speculative pass-2 + stage-3 path.
+//
+// Pairs 88..91 (m=176..183) still get computed after emit, but
+// `emit_spec_bundle` swaps in a fresh zero buffer so those writes
+// land in a discarded allocation. `xsnr2_db_simple` does sample
+// spec at strided m values across the full range; the trailing 8
+// zero rows out of 184 (≈ 4.3%) bias the median noise-floor estimate
+// slightly but stay well inside the per-station SNR jitter we
+// already see across slots. Keep all 92 pairs computed (we discard
+// rather than skip) so any future downstream consumer that needs
+// the full spec can opt in by hooking a second emit at pair 91.
+const SPEC_EMIT_PAIR: usize = 88; // emit after pair 87 done (m=0..175 valid)
+const _: () = assert!(SPEC_EMIT_PAIR <= N_PAIRS, "SPEC_EMIT_PAIR > N_PAIRS");
+
 // Phase-E2 per-half allsum parameters (matches dual_core
 // coarse_sync_split_with_allsum band 100..3000 split at 1550).
 const ALLSUM_FREQ_MIN: f32 = 100.0;
@@ -295,10 +316,13 @@ fn advance_pairs(ctx: &mut WorkerCtx) {
         ctx.cur.next_pair = j + 1;
     }
 
-    // If the last pair just landed and we haven't sent SpecBundle yet,
-    // fire it now — main can run stage 2 in parallel with the tail of
-    // capture (audio chunks 148–150 still arriving).
-    if ctx.cur.next_pair == N_PAIRS && !ctx.cur.spec_sent {
+    // Phase C+ (2026-05-21): emit SpecBundle as soon as the last
+    // pair that coarse_sync's needed_m bounds depends on completes
+    // (= pair `SPEC_EMIT_PAIR - 1`), not at the very last pair. This
+    // shifts ~720 ms of audio-tail wallclock from "stage1_inc is
+    // still finishing pairs" into "main can run coarse_sync +
+    // speculative pass-2/stage-3".
+    if ctx.cur.next_pair >= SPEC_EMIT_PAIR && !ctx.cur.spec_sent {
         emit_spec_bundle(ctx);
     }
 
@@ -313,6 +337,15 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
     let spec = core::mem::replace(&mut ctx.cur.spec, vec![0u16; n_freq * N_TIME]);
     let head = core::mem::replace(&mut ctx.cur.allsum_head, vec![0f32; head_n * N_TIME]);
     let tail = core::mem::replace(&mut ctx.cur.allsum_tail, vec![0f32; tail_n * N_TIME]);
+    // Phase C: hand main a raw pointer to the audio buffer + a
+    // snapshot of the fill position. Lifetime contract is
+    // documented on `SpecBundle`; main must stop dereferencing
+    // `audio_ptr` once it has received the matching `Slot`. The
+    // snapshot avoids a races against `finalize_slot`'s reset of
+    // any shared atomic when the pipeline is offset by one slot.
+    let audio_ptr = ctx.cur.audio.as_ptr();
+    let audio_cap = ctx.cur.audio.len();
+    let audio_fill = ctx.cur.audio_fill;
     let bundle = Box::new(SpecBundle {
         spec: mfsk_core::ft8::decode_block::Spectrogram::from_parts(n_freq, N_TIME, spec),
         allsum_head: head,
@@ -320,6 +353,9 @@ fn emit_spec_bundle(ctx: &mut WorkerCtx) {
         // wav_idx is only known at SlotEnd; main matches SpecBundle to
         // Slot by FIFO order of receipt, so this is informational only.
         wav_idx: usize::MAX,
+        audio_ptr,
+        audio_cap,
+        audio_fill,
     });
     send_box(ctx.spec_q, bundle);
     ctx.cur.spec_sent = true;
@@ -511,6 +547,7 @@ fn update_one_half(
 }
 
 fn finalize_slot(ctx: &mut WorkerCtx, wav_idx: usize, total_samples: usize) {
+    let slotend_us = unsafe { esp_timer_get_time() };
     // Drain any remaining pairs that the audio supports.
     advance_pairs(ctx);
     if !ctx.cur.spec_sent {
@@ -536,6 +573,7 @@ fn finalize_slot(ctx: &mut WorkerCtx, wav_idx: usize, total_samples: usize) {
         audio: done.audio,
         wav_idx,
         inc_total_us: done.inc_total_us,
+        slotend_us,
     });
     send_box(ctx.slot_q, slot);
 }

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -141,24 +141,37 @@ impl AudioBuf {
         // on the stack before moving it to the heap and can blow
         // the FreeRTOS task stack on ESP32. Allocate via Vec, which
         // goes straight to the heap (PSRAM under
-        // `SPIRAM_MALLOC_ALWAYSINTERNAL=4096`), then convert into a
-        // boxed array.
-        // SAFETY: `into_boxed_slice` yields a Box<[i16]> whose
-        // length is exactly NMAX (we built the Vec at that size).
-        // The size cast to `Box<[i16; NMAX]>` is sound — same
-        // layout, same allocation, length proven at construction.
+        // `SPIRAM_MALLOC_ALWAYSINTERNAL=4096`), then convert to a
+        // sized `Box<[i16; NMAX]>` *before* taking a raw pointer.
+        // The fat→thin cast detour
+        // `Box::into_raw(Box<[i16]>) as *mut i16` paired with
+        // `Box::from_raw(ptr as *mut [i16; NMAX])` in `Drop` mixes
+        // fat- and thin-pointer Box invariants and is technically
+        // UB (Gemini PR #123 round-17). Convert via `TryFrom`
+        // first so both ends speak `Box<[i16; NMAX]>`.
         let v: Vec<i16> = alloc::vec![0i16; NMAX];
         let boxed_slice: Box<[i16]> = v.into_boxed_slice();
-        debug_assert_eq!(boxed_slice.len(), NMAX);
-        let ptr = Box::into_raw(boxed_slice) as *mut i16;
-        Self { ptr, gen: 0 }
+        let boxed_array: Box<[i16; NMAX]> = boxed_slice
+            .try_into()
+            .expect("AudioBuf: boxed slice length must equal NMAX");
+        let ptr_arr: *mut [i16; NMAX] = Box::into_raw(boxed_array);
+        // Store as a thin element pointer for ergonomic indexed
+        // access in stage1_inc; cast it back to the array type in
+        // Drop so `Box::from_raw` sees the same type it gave us.
+        Self {
+            ptr: ptr_arr as *mut i16,
+            gen: 0,
+        }
     }
 }
 
 impl Drop for AudioBuf {
     fn drop(&mut self) {
-        // SAFETY: `ptr` came from `Box::into_raw(Box<[i16; NMAX]>)`
-        // and is owned exclusively by this struct.
+        // SAFETY: `ptr` was produced by `Box::into_raw(Box<[i16;
+        // NMAX]>)` in `new()` — we reconstruct the same Box type
+        // here (cast from `*mut i16` back to `*mut [i16; NMAX]`,
+        // valid because that was the original provenance) and let
+        // it drop, freeing the heap allocation.
         unsafe {
             let _ = Box::from_raw(self.ptr as *mut [i16; NMAX]);
         }

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -88,17 +88,20 @@ pub fn run() -> ! {
         // `m5stack-s3-app`. See
         // `embedded_shared::dual_core::run_speculative_slot` doc for
         // the partition + early/late path semantics.
+        let cfg = dual_core::DecodeConfig {
+            freq_min: 100.0,
+            freq_max: 3_000.0,
+            sync_min: 1.0,
+            pass1_limit: PASS1_LIMIT,
+            max_cand: MAX_CAND,
+            q_thresh: DEFAULT_Q_THRESH,
+            bp_max_iter: mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+            depth: DecodeDepth::BpVariantsAd,
+        };
         let out = dual_core::run_speculative_slot(
             spec_q,
             slot_q,
-            100.0,
-            3_000.0,
-            1.0,
-            PASS1_LIMIT,
-            MAX_CAND,
-            DEFAULT_Q_THRESH,
-            mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-            DecodeDepth::BpVariantsAd,
+            &cfg,
             basis_re_main,
             basis_im_main,
         );

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -9,8 +9,6 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-use mfsk_core::core::sync::SyncCandidate;
 use mfsk_core::ft8::decode::DecodeDepth;
 use mfsk_core::ft8::decode_block::{DEFAULT_Q_THRESH, NFFT_SPEC};
 
@@ -86,71 +84,38 @@ pub fn run() -> ! {
 
     let mut slot_seq: u32 = 0;
     loop {
-        let spec = pipeline::recv_box::<pipeline::SpecBundle>(spec_q);
-        let t_post_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-        let pass1: Vec<SyncCandidate> = dual_core::coarse_sync_split_with_allsum(
-            &spec.spec,
+        // Phase-C speculative slot runner — shared with
+        // `m5stack-s3-app`. See
+        // `embedded_shared::dual_core::run_speculative_slot` doc for
+        // the partition + early/late path semantics.
+        let out = dual_core::run_speculative_slot(
+            spec_q,
+            slot_q,
             100.0,
             3_000.0,
             1.0,
             PASS1_LIMIT,
-            &spec.allsum_head,
-            &spec.allsum_tail,
+            MAX_CAND,
+            DEFAULT_Q_THRESH,
+            mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+            DecodeDepth::BpVariantsAd,
+            basis_re_main,
+            basis_im_main,
         );
-        let t_coarse_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-
-        // Phase C (2026-05-21): same speculative-pass2+stage3 pattern
-        // as the S3 sibling. Most candidates (dt_sec ∈ ±0.5 s) fit
-        // inside the SpecBundle audio snapshot → all stage-3 work
-        // shifts into the audio tail.
-        let n_pass1 = pass1.len();
-        let t_early_start = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-        let snap_fill = spec.audio_prefix.len();
-        let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
-            pass1.into_iter()
-                .partition(|c| pipeline::SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
-        let n_ready = ready.len();
-        let n_deferred = deferred.len();
-
-        let mut results = if !ready.is_empty() {
-            let partial_audio: &[i16] = &spec.audio_prefix;
-            let p2 = dual_core::pass2_split(
-                partial_audio, ready, MAX_CAND, basis_re_main, basis_im_main,
-            );
-            dual_core::stage3_split(
-                partial_audio,
-                p2,
-                DecodeDepth::BpVariantsAd,
-                DEFAULT_Q_THRESH,
-                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-                basis_re_main,
-                basis_im_main,
-            )
-        } else {
-            Vec::new()
-        };
-        let t_early_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-
-        let slot = pipeline::recv_box::<pipeline::Slot>(slot_q);
+        let dual_core::SpeculativeOut {
+            spec,
+            slot,
+            results,
+            n_pass1,
+            n_ready,
+            n_deferred,
+            t_post_recv,
+            t_coarse_done,
+            t_early_done,
+            t_slot_recv,
+            t_done,
+        } = out;
         let wav_idx = slot.wav_idx;
-        let t_slot_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-
-        if !deferred.is_empty() {
-            let p2 = dual_core::pass2_split(
-                &slot.audio, deferred, MAX_CAND, basis_re_main, basis_im_main,
-            );
-            let late = dual_core::stage3_split(
-                &slot.audio,
-                p2,
-                DecodeDepth::BpVariantsAd,
-                DEFAULT_Q_THRESH,
-                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-                basis_re_main,
-                basis_im_main,
-            );
-            results.extend(late);
-        }
-        let t_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
 
         let slotend = slot.slotend_us;
         let tail_window = (slotend - t_post_recv).max(0);
@@ -165,7 +130,7 @@ pub fn run() -> ! {
             results.len(),
             tail_window,
             coarse_us,
-            t_early_done - t_early_start,
+            t_early_done - t_coarse_done,
             tail_use,
             post_slotend,
             t_slot_recv - t_early_done,

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -36,6 +36,18 @@ static QSO_WAVS: &[&[u8]] = &[
 const PASS1_LIMIT: usize = 30;
 const MAX_CAND: usize = 15;
 
+// Phase C (2026-05-21) — last sample index Goertzel reads for a
+// candidate (matches the S3 sibling; both use the same FT8 params).
+const PHC_NSPS: i64 = 1_920;
+const PHC_SAMPLE_RATE_HZ: f32 = 12_000.0;
+const PHC_TX_START_OFFSET_S: f32 = 1.0;
+const PHC_NN: i64 = 79;
+
+fn audio_end_for(dt_sec: f32) -> usize {
+    let i0 = ((PHC_TX_START_OFFSET_S + dt_sec) * PHC_SAMPLE_RATE_HZ).round() as i64;
+    (i0 + PHC_NN * PHC_NSPS).max(0) as usize
+}
+
 /// Spawn target. Returns `!`. BASIS DRAM allocation happens inside
 /// this thread (not in main) so the per-thread 32 KB stack reservation
 /// doesn't fight the 60 KB × 4 BASIS allocs for the largest free
@@ -87,6 +99,7 @@ pub fn run() -> ! {
     let mut slot_seq: u32 = 0;
     loop {
         let spec = pipeline::recv_box::<pipeline::SpecBundle>(spec_q);
+        let t_post_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
         let pass1: Vec<SyncCandidate> = dual_core::coarse_sync_split_with_allsum(
             &spec.spec,
             100.0,
@@ -96,31 +109,81 @@ pub fn run() -> ! {
             &spec.allsum_head,
             &spec.allsum_tail,
         );
+        let t_coarse_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+
+        // Phase C (2026-05-21): same speculative-pass2+stage3 pattern
+        // as the S3 sibling. Most candidates (dt_sec ∈ ±0.5 s) fit
+        // inside the SpecBundle audio snapshot → all stage-3 work
+        // shifts into the audio tail.
+        let n_pass1 = pass1.len();
+        let t_early_start = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+        let snap_fill = spec.audio_fill;
+        let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
+            pass1.into_iter().partition(|c| audio_end_for(c.dt_sec) <= snap_fill);
+        let n_ready = ready.len();
+        let n_deferred = deferred.len();
+
+        let mut results = if !ready.is_empty() {
+            let partial_audio: &[i16] = unsafe {
+                core::slice::from_raw_parts(spec.audio_ptr, snap_fill)
+            };
+            let p2 = dual_core::pass2_split(
+                partial_audio, ready, MAX_CAND, basis_re_main, basis_im_main,
+            );
+            dual_core::stage3_split(
+                partial_audio,
+                p2,
+                DecodeDepth::BpAll,
+                DEFAULT_Q_THRESH,
+                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+                basis_re_main,
+                basis_im_main,
+            )
+        } else {
+            Vec::new()
+        };
+        let t_early_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
 
         let slot = pipeline::recv_box::<pipeline::Slot>(slot_q);
         let wav_idx = slot.wav_idx;
-        let n_pass1 = pass1.len();
+        let t_slot_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
 
-        let pass2 = dual_core::pass2_split(
-            &slot.audio,
-            pass1,
-            MAX_CAND,
-            basis_re_main,
-            basis_im_main,
+        if !deferred.is_empty() {
+            let p2 = dual_core::pass2_split(
+                &slot.audio, deferred, MAX_CAND, basis_re_main, basis_im_main,
+            );
+            let late = dual_core::stage3_split(
+                &slot.audio,
+                p2,
+                DecodeDepth::BpAll,
+                DEFAULT_Q_THRESH,
+                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+                basis_re_main,
+                basis_im_main,
+            );
+            results.extend(late);
+        }
+        let t_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+
+        let slotend = slot.slotend_us;
+        let tail_window = (slotend - t_post_recv).max(0);
+        let coarse_us = t_coarse_done - t_post_recv;
+        let tail_use_end = slotend.min(t_early_done);
+        let tail_use = (tail_use_end - t_coarse_done).max(0);
+        let post_slotend = (t_done - slotend).max(0);
+        log::info!(
+            "WAV[{wav_idx}] p1={n_pass1} ready={n_ready} defer={n_deferred} dec={} \
+             tail_win={}us coarse={}us early={}us tail_use={}us post_slotend={}us \
+             slot_wait={}us late={}us",
+            results.len(),
+            tail_window,
+            coarse_us,
+            t_early_done - t_early_start,
+            tail_use,
+            post_slotend,
+            t_slot_recv - t_early_done,
+            t_done - t_slot_recv,
         );
-
-        let depth = DecodeDepth::BpAll;
-        let results = dual_core::stage3_split(
-            &slot.audio,
-            pass2,
-            depth,
-            DEFAULT_Q_THRESH,
-            mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-            basis_re_main,
-            basis_im_main,
-        );
-
-        log::info!("WAV[{wav_idx}] p1={n_pass1} dec={}", results.len());
         slot_seq = slot_seq.wrapping_add(1);
 
         for r in results.iter() {

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -105,7 +105,7 @@ pub fn run() -> ! {
         // shifts into the audio tail.
         let n_pass1 = pass1.len();
         let t_early_start = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-        let snap_fill = spec.audio_fill;
+        let snap_fill = spec.audio_prefix.len();
         let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
             pass1.into_iter()
                 .partition(|c| pipeline::SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
@@ -113,17 +113,7 @@ pub fn run() -> ! {
         let n_deferred = deferred.len();
 
         let mut results = if !ready.is_empty() {
-            debug_assert!(
-                snap_fill <= spec.audio_cap,
-                "SpecBundle.audio_fill ({snap_fill}) > audio_cap ({})",
-                spec.audio_cap
-            );
-            // SAFETY: lifetime of `spec.audio_ptr` is documented on
-            // `SpecBundle`; valid until the matching `Slot` is dropped.
-            // Workers read only `partial_audio[0..snap_fill]`.
-            let partial_audio: &[i16] = unsafe {
-                core::slice::from_raw_parts(spec.audio_ptr, snap_fill)
-            };
+            let partial_audio: &[i16] = &spec.audio_prefix;
             let p2 = dual_core::pass2_split(
                 partial_audio, ready, MAX_CAND, basis_re_main, basis_im_main,
             );

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -130,7 +130,7 @@ pub fn run() -> ! {
             dual_core::stage3_split(
                 partial_audio,
                 p2,
-                DecodeDepth::BpAll,
+                DecodeDepth::BpAllNoNsym3,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,
@@ -152,7 +152,7 @@ pub fn run() -> ! {
             let late = dual_core::stage3_split(
                 &slot.audio,
                 p2,
-                DecodeDepth::BpAll,
+                DecodeDepth::BpAllNoNsym3,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -36,18 +36,6 @@ static QSO_WAVS: &[&[u8]] = &[
 const PASS1_LIMIT: usize = 30;
 const MAX_CAND: usize = 15;
 
-// Phase C (2026-05-21) — last sample index Goertzel reads for a
-// candidate (matches the S3 sibling; both use the same FT8 params).
-const PHC_NSPS: i64 = 1_920;
-const PHC_SAMPLE_RATE_HZ: f32 = 12_000.0;
-const PHC_TX_START_OFFSET_S: f32 = 1.0;
-const PHC_NN: i64 = 79;
-
-fn audio_end_for(dt_sec: f32) -> usize {
-    let i0 = ((PHC_TX_START_OFFSET_S + dt_sec) * PHC_SAMPLE_RATE_HZ).round() as i64;
-    (i0 + PHC_NN * PHC_NSPS).max(0) as usize
-}
-
 /// Spawn target. Returns `!`. BASIS DRAM allocation happens inside
 /// this thread (not in main) so the per-thread 32 KB stack reservation
 /// doesn't fight the 60 KB × 4 BASIS allocs for the largest free
@@ -119,11 +107,20 @@ pub fn run() -> ! {
         let t_early_start = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
         let snap_fill = spec.audio_fill;
         let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
-            pass1.into_iter().partition(|c| audio_end_for(c.dt_sec) <= snap_fill);
+            pass1.into_iter()
+                .partition(|c| pipeline::SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
         let n_ready = ready.len();
         let n_deferred = deferred.len();
 
         let mut results = if !ready.is_empty() {
+            debug_assert!(
+                snap_fill <= spec.audio_cap,
+                "SpecBundle.audio_fill ({snap_fill}) > audio_cap ({})",
+                spec.audio_cap
+            );
+            // SAFETY: lifetime of `spec.audio_ptr` is documented on
+            // `SpecBundle`; valid until the matching `Slot` is dropped.
+            // Workers read only `partial_audio[0..snap_fill]`.
             let partial_audio: &[i16] = unsafe {
                 core::slice::from_raw_parts(spec.audio_ptr, snap_fill)
             };

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -130,7 +130,7 @@ pub fn run() -> ! {
             dual_core::stage3_split(
                 partial_audio,
                 p2,
-                DecodeDepth::BpAllNoNsym3,
+                DecodeDepth::BpVariantsAd,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,
@@ -152,7 +152,7 @@ pub fn run() -> ! {
             let late = dual_core::stage3_split(
                 &slot.audio,
                 p2,
-                DecodeDepth::BpAllNoNsym3,
+                DecodeDepth::BpVariantsAd,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -37,6 +37,22 @@ pub(crate) static QSO_WAVS: &[&[u8]] = &[include_bytes!("../../assets/qso3_busy.
 const PASS1_LIMIT: usize = 30;
 const MAX_CAND: usize = 15;
 
+// Phase C (2026-05-21) — last sample index Goertzel reads for a
+// candidate, used to decide whether the audio captured so far
+// covers the candidate's full window. Matches
+// `fill_symbol_spectra_goertzel`:
+//   i0 = ((TX_START_OFFSET_S + dt_sec) * SAMPLE_RATE_HZ).round()
+//   end = i0 + NN * NSPS
+const PHC_NSPS: i64 = 1_920;
+const PHC_SAMPLE_RATE_HZ: f32 = 12_000.0;
+const PHC_TX_START_OFFSET_S: f32 = 1.0;
+const PHC_NN: i64 = 79;
+
+fn audio_end_for(dt_sec: f32) -> usize {
+    let i0 = ((PHC_TX_START_OFFSET_S + dt_sec) * PHC_SAMPLE_RATE_HZ).round() as i64;
+    (i0 + PHC_NN * PHC_NSPS).max(0) as usize
+}
+
 /// `BootMode::Decode` entry — runs the decode pipeline with the
 /// baked `QSO_WAVS` playlist as the audio source (via `wav_sim`).
 /// Thin wrapper around [`run_with_source`].
@@ -201,6 +217,7 @@ where
         // 実測: 200..2000 で phantom 0 だが 2 kHz 超の real (qso1/qso2 R6WA)
         // を逃す → ユーザを "聞こえてる気"にさせない方が大事。
         let spec = pipeline::recv_box::<pipeline::SpecBundle>(spec_q);
+        let t_post_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
         let pass1: Vec<SyncCandidate> = dual_core::coarse_sync_split_with_allsum(
             &spec.spec,
             100.0,
@@ -210,15 +227,64 @@ where
             &spec.allsum_head,
             &spec.allsum_tail,
         );
+        let t_coarse_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
         // Don't drop the spec yet — `xsnr2_db_simple` reads it after
         // stage 3 completes to recompute SNR free of the per-block
         // auto-gain bias `compute_snr_db` carries. Spec is ~360 KB
         // for the slot, lives in PSRAM, dropped at the end of this
         // loop iteration.
 
+        // Phase C (2026-05-21): partition pass1 by required audio
+        // window and run pass-2 + stage-3 on the "ready" half during
+        // the remaining audio-tail window (typically ~120-150 ms
+        // after coarse_sync completes, before SlotEnd). For
+        // qso3_busy and most live slots, candidates' dt_sec sits
+        // inside ±0.5 s → all of pass1 lands in `ready` →
+        // post-SlotEnd work shrinks to roughly Slot-recv latency only.
+        let n_pass1 = pass1.len();
+        let t_early_start = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+
+        // Snapshot captured by stage1_inc at SpecBundle emit time
+        // (≥ pair 91's 177 600-sample requirement). Avoids a race
+        // against the next slot's `finalize_slot` that a shared
+        // atomic would have introduced.
+        let snap_fill = spec.audio_fill;
+        let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
+            pass1.into_iter().partition(|c| audio_end_for(c.dt_sec) <= snap_fill);
+        let n_ready = ready.len();
+        let n_deferred = deferred.len();
+
+        let mut results = if !ready.is_empty() {
+            // SAFETY: same lifetime as `spec.audio_fill_atom` — the
+            // backing Vec heap allocation survives `mem::replace` in
+            // stage1_inc and remains valid until the matching `Slot`
+            // arrives on `slot_q` and is dropped. Workers read only
+            // `partial_audio[0..snap_fill]`; stage1_inc writes only
+            // to indices ≥ snap_fill (disjoint).
+            let partial_audio: &[i16] = unsafe {
+                core::slice::from_raw_parts(spec.audio_ptr, snap_fill)
+            };
+            let p2 = dual_core::pass2_split(
+                partial_audio, ready, MAX_CAND, basis_re_main, basis_im_main,
+            );
+            dual_core::stage3_split(
+                partial_audio,
+                p2,
+                DecodeDepth::BpAll,
+                DEFAULT_Q_THRESH,
+                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+                basis_re_main,
+                basis_im_main,
+            )
+        } else {
+            Vec::new()
+        };
+        let t_early_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+
         let slot = pipeline::recv_box::<pipeline::Slot>(slot_q);
         let wav_idx = slot.wav_idx;
-        let n_pass1 = pass1.len();
+        let t_slot_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+
         // Auto-sync uses `results` median (post BP), not pass1 — pass1
         // candidates from a noise slot are random and would mis-anchor
         // the slot phase. Gemini PR #103 review removed the no-op
@@ -241,29 +307,58 @@ where
         // texture; the click was an alarm.
         // crate::audio::AUDIO_GATE.store(false, ...);  // intentionally not muted
 
-        let t_pass2 = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-        let pass2 =
-            dual_core::pass2_split(&slot.audio, pass1, MAX_CAND, basis_re_main, basis_im_main);
-        let t_stage3 = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-
-        let depth = DecodeDepth::BpAll;
-        let results = dual_core::stage3_split(
-            &slot.audio,
-            pass2,
-            depth,
-            DEFAULT_Q_THRESH,
-            mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-            basis_re_main,
-            basis_im_main,
-        );
+        // Late path: only runs when some candidates couldn't fit in
+        // the SpecBundle audio snapshot (high positive dt_sec; rare
+        // in practice). Uses the full Slot audio.
+        if !deferred.is_empty() {
+            let p2 = dual_core::pass2_split(
+                &slot.audio, deferred, MAX_CAND, basis_re_main, basis_im_main,
+            );
+            let late = dual_core::stage3_split(
+                &slot.audio,
+                p2,
+                DecodeDepth::BpAll,
+                DEFAULT_Q_THRESH,
+                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+                basis_re_main,
+                basis_im_main,
+            );
+            results.extend(late);
+        }
         let t_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
 
+        // Phase-C breakdown: the speculative `early` path may straddle
+        // SlotEnd. `slot.slotend_us` is stage1_inc's exact SlotEnd
+        // timestamp, so we can decompose the early run into
+        //   tail_use = work done before SlotEnd (the win)
+        //   post_early = work spent after SlotEnd inside the early path
+        // and quote the absolute post-SlotEnd latency that the user
+        // actually sees per decode.
+        let slotend = slot.slotend_us;
+        // tail_window: audio-tail gap between SpecBundle arrival and
+        // SlotEnd — this is the budget Phase C tries to use.
+        let tail_window = (slotend - t_post_recv).max(0);
+        // Wallclock of coarse_sync (eats into the tail budget).
+        let coarse_us = t_coarse_done - t_post_recv;
+        // Overlap actually achieved: how much of `early` ran before
+        // SlotEnd. min(t_early_done, slotend) - t_coarse_done.
+        let tail_use_end = slotend.min(t_early_done);
+        let tail_use = (tail_use_end - t_coarse_done).max(0);
+        // User-visible post-SlotEnd latency from SlotEnd to all
+        // decodes ready.
+        let post_slotend = (t_done - slotend).max(0);
         log::info!(
-            "WAV[{wav_idx}] p1={n_pass1} dec={} pass2={}us stage3={}us total={}us",
+            "WAV[{wav_idx}] p1={n_pass1} ready={n_ready} defer={n_deferred} dec={} \
+             tail_win={}us coarse={}us early={}us tail_use={}us post_slotend={}us \
+             slot_wait={}us late={}us",
             results.len(),
-            t_stage3 - t_pass2,
-            t_done - t_stage3,
-            t_done - t_pass2
+            tail_window,
+            coarse_us,
+            t_early_done - t_early_start,
+            tail_use,
+            post_slotend,
+            t_slot_recv - t_early_done,
+            t_done - t_slot_recv,
         );
         slot_seq = slot_seq.wrapping_add(1);
         // Publish to UiState so decoded_list renders GREEN only for

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -260,7 +260,7 @@ where
             dual_core::stage3_split(
                 partial_audio,
                 p2,
-                DecodeDepth::BpAll,
+                DecodeDepth::BpAllNoNsym3,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,
@@ -307,7 +307,7 @@ where
             let late = dual_core::stage3_split(
                 &slot.audio,
                 p2,
-                DecodeDepth::BpAll,
+                DecodeDepth::BpAllNoNsym3,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,
@@ -550,10 +550,12 @@ where
                     };
                     ui.push_decode(row);
                     log::info!(
-                        "{:4.0}Hz {:+5.1}dB (raw={:+5.1}) {}",
+                        "{:4.0}Hz {:+5.1}dB (raw={:+5.1}) pass={} he={} {}",
                         r.freq_hz,
                         calibrated_snr,
                         r.snr_db,
+                        r.pass,
+                        r.hard_errors,
                         text
                     );
                     // Feed the FSM. SNR set first so an in-band reply

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -228,11 +228,12 @@ where
         let n_pass1 = pass1.len();
         let t_early_start = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
 
-        // Snapshot captured by stage1_inc at SpecBundle emit time
-        // (≥ pair 91's 177 600-sample requirement). Avoids a race
-        // against the next slot's `finalize_slot` that a shared
-        // atomic would have introduced.
-        let snap_fill = spec.audio_fill;
+        // Owned audio snapshot copied by stage1_inc at emit time.
+        // Always ≥ pair-91's 177 600-sample requirement when emit
+        // fires at SPEC_EMIT_PAIR. No aliasing concerns vs the
+        // still-being-filled stage1_inc audio buffer (Gemini PR
+        // #123 round-4 review).
+        let snap_fill = spec.audio_prefix.len();
         let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
             pass1.into_iter()
                 .partition(|c| pipeline::SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
@@ -240,20 +241,7 @@ where
         let n_deferred = deferred.len();
 
         let mut results = if !ready.is_empty() {
-            debug_assert!(
-                snap_fill <= spec.audio_cap,
-                "SpecBundle.audio_fill ({snap_fill}) > audio_cap ({})",
-                spec.audio_cap
-            );
-            // SAFETY: `spec.audio_ptr` references the audio Vec heap
-            // allocation in stage1_inc that survives `mem::replace`
-            // and remains valid until the matching `Slot` is dropped.
-            // The slice is bounded by `snap_fill` (≤ audio_cap, ≤
-            // NMAX). Workers read only `partial_audio[0..snap_fill]`;
-            // stage1_inc writes only to indices ≥ snap_fill (disjoint).
-            let partial_audio: &[i16] = unsafe {
-                core::slice::from_raw_parts(spec.audio_ptr, snap_fill)
-            };
+            let partial_audio: &[i16] = &spec.audio_prefix;
             let p2 = dual_core::pass2_split(
                 partial_audio, ready, MAX_CAND, basis_re_main, basis_im_main,
             );

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -9,7 +9,6 @@
 extern crate alloc;
 
 use alloc::vec::Vec;
-use mfsk_core::core::sync::SyncCandidate;
 use mfsk_core::ft8::decode::DecodeDepth;
 use mfsk_core::ft8::decode_block::{DEFAULT_Q_THRESH, NFFT_SPEC};
 
@@ -200,110 +199,46 @@ where
         // 検出) で gate するため自動応答に流れない。設計の根拠は host 側
         // 実測: 200..2000 で phantom 0 だが 2 kHz 超の real (qso1/qso2 R6WA)
         // を逃す → ユーザを "聞こえてる気"にさせない方が大事。
-        let spec = pipeline::recv_box::<pipeline::SpecBundle>(spec_q);
-        let t_post_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-        let pass1: Vec<SyncCandidate> = dual_core::coarse_sync_split_with_allsum(
-            &spec.spec,
+        //
+        // Phase-C speculative slot runner — receives both SpecBundle
+        // and Slot, partitions pass1 by audio-prefix coverage, runs
+        // the early speculative + late deferred decode paths, and
+        // hands back the timestamps for the per-slot log. Shared
+        // with `m5stack-core2-app`; canonical implementation lives
+        // in `embedded_shared::dual_core::run_speculative_slot`.
+        let out = dual_core::run_speculative_slot(
+            spec_q,
+            slot_q,
             100.0,
             3_000.0,
             1.0,
             PASS1_LIMIT,
-            &spec.allsum_head,
-            &spec.allsum_tail,
+            MAX_CAND,
+            DEFAULT_Q_THRESH,
+            mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+            DecodeDepth::BpVariantsAd,
+            basis_re_main,
+            basis_im_main,
         );
-        let t_coarse_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+        let dual_core::SpeculativeOut {
+            spec,
+            slot,
+            results,
+            n_pass1,
+            n_ready,
+            n_deferred,
+            t_post_recv,
+            t_coarse_done,
+            t_early_done,
+            t_slot_recv,
+            t_done,
+        } = out;
+        // Bind a non-mutable copy for downstream auto-sync / UI
+        // code that historically read `slot.wav_idx`.
+        let wav_idx = slot.wav_idx;
         // Don't drop the spec yet — `xsnr2_db_simple` reads it after
         // stage 3 completes to recompute SNR free of the per-block
-        // auto-gain bias `compute_snr_db` carries. Spec is ~360 KB
-        // for the slot, lives in PSRAM, dropped at the end of this
-        // loop iteration.
-
-        // Phase C (2026-05-21): partition pass1 by required audio
-        // window and run pass-2 + stage-3 on the "ready" half during
-        // the remaining audio-tail window (typically ~120-150 ms
-        // after coarse_sync completes, before SlotEnd). For
-        // qso3_busy and most live slots, candidates' dt_sec sits
-        // inside ±0.5 s → all of pass1 lands in `ready` →
-        // post-SlotEnd work shrinks to roughly Slot-recv latency only.
-        let n_pass1 = pass1.len();
-        let t_early_start = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-
-        // Owned audio snapshot copied by stage1_inc at emit time.
-        // Always ≥ pair-91's 177 600-sample requirement when emit
-        // fires at SPEC_EMIT_PAIR. No aliasing concerns vs the
-        // still-being-filled stage1_inc audio buffer (Gemini PR
-        // #123 round-4 review).
-        let snap_fill = spec.audio_prefix.len();
-        let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
-            pass1.into_iter()
-                .partition(|c| pipeline::SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
-        let n_ready = ready.len();
-        let n_deferred = deferred.len();
-
-        let mut results = if !ready.is_empty() {
-            let partial_audio: &[i16] = &spec.audio_prefix;
-            let p2 = dual_core::pass2_split(
-                partial_audio, ready, MAX_CAND, basis_re_main, basis_im_main,
-            );
-            dual_core::stage3_split(
-                partial_audio,
-                p2,
-                DecodeDepth::BpVariantsAd,
-                DEFAULT_Q_THRESH,
-                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-                basis_re_main,
-                basis_im_main,
-            )
-        } else {
-            Vec::new()
-        };
-        let t_early_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-
-        let slot = pipeline::recv_box::<pipeline::Slot>(slot_q);
-        let wav_idx = slot.wav_idx;
-        let t_slot_recv = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
-
-        // Auto-sync uses `results` median (post BP), not pass1 — pass1
-        // candidates from a noise slot are random and would mis-anchor
-        // the slot phase. Gemini PR #103 review removed the no-op
-        // `pass1.iter().map(c.dt_sec).collect()` allocation that was
-        // immediately discarded below.
-
-        // (fine_refine attempted via fill_symbol_spectra iteration in
-        // 0.6.3-experimental; tripped task watchdog at ~5 s on S3 due
-        // to 200k+ per-symbol DFTs per slot. Reverted; ship recall
-        // stays at 6/18 on qso3_busy.wav until a cd0-via-FIR-decimate
-        // refine lands.)
-
-        // The audio gate around pass2/stage3 was added to silence the
-        // DMA-underrun buzz the user heard during BP work, but the
-        // *resume* transition produced a much harsher click — the
-        // I2S driver / codec analog stage settles dirty after a
-        // 1.3 s starvation and pops on first non-zero sample. Net
-        // assessment: leave audio streaming the whole time. The
-        // residual buzz at -10 dB DAC volume is mild background
-        // texture; the click was an alarm.
-        // crate::audio::AUDIO_GATE.store(false, ...);  // intentionally not muted
-
-        // Late path: only runs when some candidates couldn't fit in
-        // the SpecBundle audio snapshot (high positive dt_sec; rare
-        // in practice). Uses the full Slot audio.
-        if !deferred.is_empty() {
-            let p2 = dual_core::pass2_split(
-                &slot.audio, deferred, MAX_CAND, basis_re_main, basis_im_main,
-            );
-            let late = dual_core::stage3_split(
-                &slot.audio,
-                p2,
-                DecodeDepth::BpVariantsAd,
-                DEFAULT_Q_THRESH,
-                mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-                basis_re_main,
-                basis_im_main,
-            );
-            results.extend(late);
-        }
-        let t_done = unsafe { esp_idf_svc::sys::esp_timer_get_time() };
+        // auto-gain bias `compute_snr_db` carries.
 
         // Phase-C breakdown: the speculative `early` path may straddle
         // SlotEnd. `slot.slotend_us` is stage1_inc's exact SlotEnd
@@ -332,7 +267,7 @@ where
             results.len(),
             tail_window,
             coarse_us,
-            t_early_done - t_early_start,
+            t_early_done - t_coarse_done,
             tail_use,
             post_slotend,
             t_slot_recv - t_early_done,

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -206,17 +206,20 @@ where
         // hands back the timestamps for the per-slot log. Shared
         // with `m5stack-core2-app`; canonical implementation lives
         // in `embedded_shared::dual_core::run_speculative_slot`.
+        let cfg = dual_core::DecodeConfig {
+            freq_min: 100.0,
+            freq_max: 3_000.0,
+            sync_min: 1.0,
+            pass1_limit: PASS1_LIMIT,
+            max_cand: MAX_CAND,
+            q_thresh: DEFAULT_Q_THRESH,
+            bp_max_iter: mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+            depth: DecodeDepth::BpVariantsAd,
+        };
         let out = dual_core::run_speculative_slot(
             spec_q,
             slot_q,
-            100.0,
-            3_000.0,
-            1.0,
-            PASS1_LIMIT,
-            MAX_CAND,
-            DEFAULT_Q_THRESH,
-            mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
-            DecodeDepth::BpVariantsAd,
+            &cfg,
             basis_re_main,
             basis_im_main,
         );

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -260,7 +260,7 @@ where
             dual_core::stage3_split(
                 partial_audio,
                 p2,
-                DecodeDepth::BpAllNoNsym3,
+                DecodeDepth::BpVariantsAd,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,
@@ -307,7 +307,7 @@ where
             let late = dual_core::stage3_split(
                 &slot.audio,
                 p2,
-                DecodeDepth::BpAllNoNsym3,
+                DecodeDepth::BpVariantsAd,
                 DEFAULT_Q_THRESH,
                 mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
                 basis_re_main,

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -37,22 +37,6 @@ pub(crate) static QSO_WAVS: &[&[u8]] = &[include_bytes!("../../assets/qso3_busy.
 const PASS1_LIMIT: usize = 30;
 const MAX_CAND: usize = 15;
 
-// Phase C (2026-05-21) — last sample index Goertzel reads for a
-// candidate, used to decide whether the audio captured so far
-// covers the candidate's full window. Matches
-// `fill_symbol_spectra_goertzel`:
-//   i0 = ((TX_START_OFFSET_S + dt_sec) * SAMPLE_RATE_HZ).round()
-//   end = i0 + NN * NSPS
-const PHC_NSPS: i64 = 1_920;
-const PHC_SAMPLE_RATE_HZ: f32 = 12_000.0;
-const PHC_TX_START_OFFSET_S: f32 = 1.0;
-const PHC_NN: i64 = 79;
-
-fn audio_end_for(dt_sec: f32) -> usize {
-    let i0 = ((PHC_TX_START_OFFSET_S + dt_sec) * PHC_SAMPLE_RATE_HZ).round() as i64;
-    (i0 + PHC_NN * PHC_NSPS).max(0) as usize
-}
-
 /// `BootMode::Decode` entry — runs the decode pipeline with the
 /// baked `QSO_WAVS` playlist as the audio source (via `wav_sim`).
 /// Thin wrapper around [`run_with_source`].
@@ -250,17 +234,23 @@ where
         // atomic would have introduced.
         let snap_fill = spec.audio_fill;
         let (ready, deferred): (Vec<SyncCandidate>, Vec<SyncCandidate>) =
-            pass1.into_iter().partition(|c| audio_end_for(c.dt_sec) <= snap_fill);
+            pass1.into_iter()
+                .partition(|c| pipeline::SpecBundle::audio_end_for_dt(c.dt_sec) <= snap_fill);
         let n_ready = ready.len();
         let n_deferred = deferred.len();
 
         let mut results = if !ready.is_empty() {
-            // SAFETY: same lifetime as `spec.audio_fill_atom` — the
-            // backing Vec heap allocation survives `mem::replace` in
-            // stage1_inc and remains valid until the matching `Slot`
-            // arrives on `slot_q` and is dropped. Workers read only
-            // `partial_audio[0..snap_fill]`; stage1_inc writes only
-            // to indices ≥ snap_fill (disjoint).
+            debug_assert!(
+                snap_fill <= spec.audio_cap,
+                "SpecBundle.audio_fill ({snap_fill}) > audio_cap ({})",
+                spec.audio_cap
+            );
+            // SAFETY: `spec.audio_ptr` references the audio Vec heap
+            // allocation in stage1_inc that survives `mem::replace`
+            // and remains valid until the matching `Slot` is dropped.
+            // The slice is bounded by `snap_fill` (≤ audio_cap, ≤
+            // NMAX). Workers read only `partial_audio[0..snap_fill]`;
+            // stage1_inc writes only to indices ≥ snap_fill (disjoint).
             let partial_audio: &[i16] = unsafe {
                 core::slice::from_raw_parts(spec.audio_ptr, snap_fill)
             };

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -40,6 +40,18 @@ pub enum DecodeDepth {
     BpAll,
     /// BP (all four variants) then OSD order-1 fallback when BP fails.
     BpAllOsd,
+    /// BP across `a`, `d`, `b` only — skips the heavy nsym=3 `c`
+    /// variant. Used by the embedded port to bypass the
+    /// `compute_llr_partial(3)` call (~5× cost of variant `b`) for
+    /// failed candidates. Empirically (S3 qso3_busy log,
+    /// 2026-05-21) every decode lands at `pass=0` (variant `a`) on
+    /// busy-band reference WAVs, so `c` contributes no extra
+    /// decodes and is pure overhead on a power-budgeted target.
+    ///
+    /// The lighter variants `d` (nsym=1 bit-normalised, free reuse
+    /// of step-1 LLR) and `b` (nsym=2, ~1.5× variant `a` cost) are
+    /// retained as safety nets for marginal SNR / fading cases.
+    BpAllNoNsym3,
 }
 
 /// Decode strictness: controls false-positive vs sensitivity trade-off.

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -52,6 +52,17 @@ pub enum DecodeDepth {
     /// of step-1 LLR) and `b` (nsym=2, ~1.5× variant `a` cost) are
     /// retained as safety nets for marginal SNR / fading cases.
     BpAllNoNsym3,
+    /// BP across `a` (Step 1) and `d` (free-reuse bit-normalised
+    /// nsym=1) only — drops both the nsym=2 `b` and nsym=3 `c`
+    /// LLR computations + their BP attempts. Host A/B sweep
+    /// (`ft8_no_nsym3_sweep`, 5 in-repo WAVs) showed `b` and `c`
+    /// contribute zero extra decodes vs `a` alone; the lighter
+    /// `BpAllNoNsym3` only dropped `c`, this one drops `b` too.
+    ///
+    /// Embedded ship target — on a power-budgeted MCU each failed
+    /// candidate now costs only the Step-1 BP plus a free-LLR
+    /// `d` re-BP (~2×T1 instead of ~8.5×T1 under `BpAll`).
+    BpVariantsAd,
 }
 
 /// Decode strictness: controls false-positive vs sensitivity trade-off.

--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -54,7 +54,8 @@ pub use fill_symbol_spectra::{
     fill_symbol_spectra_into_generic, symbol_spectra_direct_into,
 };
 pub use fill_symbol_spectra::{
-    SymMask, fill_symbol_spectra, fill_symbol_spectra_goertzel, symbol_spectra_direct,
+    SymMask, fill_symbol_spectra, fill_symbol_spectra_goertzel, goertzel_window_end_sample,
+    symbol_spectra_direct,
 };
 /// Phase 1.7.7-Stick: fill-closure variant for host research /
 /// regression tests (spec-lookup vs BASIS dot product comparison).

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -29,6 +29,18 @@ use super::super::params::{COSTAS, COSTAS_POS, NN, NSPS, NTONES};
 use super::types::{AudioSample, SAMPLE_RATE_HZ, TONE_SPACING_HZ, TX_START_OFFSET_S};
 use crate::core::scalar::Cmplx;
 
+/// Last sample index that
+/// [`fill_symbol_spectra_goertzel`] reads for a candidate at
+/// `dt_sec`. Same `i0 + NN * NSPS` formula as the per-symbol loop
+/// inside the kernel, exposed here so embedded callers (Phase C
+/// audio-tail speculation in `embedded-shared`) can decide whether
+/// a candidate's Goertzel window fits inside the currently-captured
+/// audio prefix without re-implementing the constants.
+pub fn goertzel_window_end_sample(dt_sec: f32) -> usize {
+    let i0 = ((TX_START_OFFSET_S + dt_sec) * SAMPLE_RATE_HZ).round() as i64;
+    (i0 + (NN as i64) * (NSPS as i64)).max(0) as usize
+}
+
 // Thread-local scratch for the `S -> i16` conversion in
 // `fill_symbol_spectra_via_cd0`'s `fft_cache=None` branch. The
 // `Vec<i16>` capacity is grown once per thread and reused across

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1550,12 +1550,22 @@ pub(in crate::ft8) fn process_one_candidate_inner(
     // Order chosen by ascending compute cost — same number of BP
     // calls as the old variant loop in the worst case, far fewer
     // in the typical case where any earlier variant decodes.
-    if accepted.is_none()
-        && matches!(
-            depth,
-            DecodeDepth::BpAll | DecodeDepth::BpAllOsd | DecodeDepth::BpAllNoNsym3
-        )
-    {
+    // Per-variant gates. `d` is cheap (Step-1 LLR re-use, BP only);
+    // `b` and `c` add nsym=2 / nsym=3 LLR work on top of the BP.
+    let run_d = matches!(
+        depth,
+        DecodeDepth::BpAll
+            | DecodeDepth::BpAllOsd
+            | DecodeDepth::BpAllNoNsym3
+            | DecodeDepth::BpVariantsAd
+    );
+    let run_b = matches!(
+        depth,
+        DecodeDepth::BpAll | DecodeDepth::BpAllOsd | DecodeDepth::BpAllNoNsym3
+    );
+    let run_c = matches!(depth, DecodeDepth::BpAll | DecodeDepth::BpAllOsd);
+
+    if accepted.is_none() && run_d {
         // Variant d: free reuse of Step 1's llrd.
         let bp_d =
             bp_step_select::<LlrT>(bp_scratch, &llr_a_fast.llrd, bp_max_iter, Some(check_crc14));
@@ -1564,33 +1574,30 @@ pub(in crate::ft8) fn process_one_candidate_inner(
         {
             accepted = Some((bp, 3));
         }
-        // Variant b: lazy nsym=2 only.
-        if accepted.is_none() {
-            let llrb_arr: [LlrT; LDPC_N] =
-                super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 2);
-            let bp_b =
-                bp_step_select::<LlrT>(bp_scratch, &llrb_arr, bp_max_iter, Some(check_crc14));
-            if let Some(bp) = bp_b
-                && bp.hard_errors <= WSJTX_NHARDERRORS_MAX
-            {
-                accepted = Some((bp, 1));
-            }
+    }
+    // Variant b: lazy nsym=2 only.
+    if accepted.is_none() && run_b {
+        let llrb_arr: [LlrT; LDPC_N] =
+            super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 2);
+        let bp_b = bp_step_select::<LlrT>(bp_scratch, &llrb_arr, bp_max_iter, Some(check_crc14));
+        if let Some(bp) = bp_b
+            && bp.hard_errors <= WSJTX_NHARDERRORS_MAX
+        {
+            accepted = Some((bp, 1));
         }
-        // Variant c: lazy nsym=3 (the expensive one). Gated to the
-        // host-default depths — `BpAllNoNsym3` skips it as the
-        // embedded post-SlotEnd dominant cost (~5× variant `b`) for
-        // failed candidates that the prior steps couldn't decode
-        // anyway on busy-band reference WAVs (see DecodeDepth doc).
-        if accepted.is_none() && !matches!(depth, DecodeDepth::BpAllNoNsym3) {
-            let llrc_arr: [LlrT; LDPC_N] =
-                super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 3);
-            let bp_c =
-                bp_step_select::<LlrT>(bp_scratch, &llrc_arr, bp_max_iter, Some(check_crc14));
-            if let Some(bp) = bp_c
-                && bp.hard_errors <= WSJTX_NHARDERRORS_MAX
-            {
-                accepted = Some((bp, 2));
-            }
+    }
+    // Variant c: lazy nsym=3 (the expensive one). Gated to the
+    // host-default depths — `BpAllNoNsym3` / `BpVariantsAd` skip it
+    // as the embedded post-SlotEnd dominant cost (~5× variant `b`)
+    // on busy-band reference WAVs (see DecodeDepth doc).
+    if accepted.is_none() && run_c {
+        let llrc_arr: [LlrT; LDPC_N] =
+            super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 3);
+        let bp_c = bp_step_select::<LlrT>(bp_scratch, &llrc_arr, bp_max_iter, Some(check_crc14));
+        if let Some(bp) = bp_c
+            && bp.hard_errors <= WSJTX_NHARDERRORS_MAX
+        {
+            accepted = Some((bp, 2));
         }
     }
 

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1552,18 +1552,11 @@ pub(in crate::ft8) fn process_one_candidate_inner(
     // in the typical case where any earlier variant decodes.
     // Per-variant gates. `d` is cheap (Step-1 LLR re-use, BP only);
     // `b` and `c` add nsym=2 / nsym=3 LLR work on top of the BP.
-    let run_d = matches!(
-        depth,
-        DecodeDepth::BpAll
-            | DecodeDepth::BpAllOsd
-            | DecodeDepth::BpAllNoNsym3
-            | DecodeDepth::BpVariantsAd
-    );
-    let run_b = matches!(
-        depth,
-        DecodeDepth::BpAll | DecodeDepth::BpAllOsd | DecodeDepth::BpAllNoNsym3
-    );
-    let run_c = matches!(depth, DecodeDepth::BpAll | DecodeDepth::BpAllOsd);
+    let (run_d, run_b, run_c) = match depth {
+        DecodeDepth::BpAll | DecodeDepth::BpAllOsd => (true, true, true),
+        DecodeDepth::BpAllNoNsym3 => (true, true, false),
+        DecodeDepth::BpVariantsAd => (true, false, false),
+    };
 
     if accepted.is_none() && run_d {
         // Variant d: free reuse of Step 1's llrd.

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1550,7 +1550,12 @@ pub(in crate::ft8) fn process_one_candidate_inner(
     // Order chosen by ascending compute cost — same number of BP
     // calls as the old variant loop in the worst case, far fewer
     // in the typical case where any earlier variant decodes.
-    if accepted.is_none() && matches!(depth, DecodeDepth::BpAll | DecodeDepth::BpAllOsd) {
+    if accepted.is_none()
+        && matches!(
+            depth,
+            DecodeDepth::BpAll | DecodeDepth::BpAllOsd | DecodeDepth::BpAllNoNsym3
+        )
+    {
         // Variant d: free reuse of Step 1's llrd.
         let bp_d =
             bp_step_select::<LlrT>(bp_scratch, &llr_a_fast.llrd, bp_max_iter, Some(check_crc14));
@@ -1571,8 +1576,12 @@ pub(in crate::ft8) fn process_one_candidate_inner(
                 accepted = Some((bp, 1));
             }
         }
-        // Variant c: lazy nsym=3 (the expensive one).
-        if accepted.is_none() {
+        // Variant c: lazy nsym=3 (the expensive one). Gated to the
+        // host-default depths — `BpAllNoNsym3` skips it as the
+        // embedded post-SlotEnd dominant cost (~5× variant `b`) for
+        // failed candidates that the prior steps couldn't decode
+        // anyway on busy-band reference WAVs (see DecodeDepth doc).
+        if accepted.is_none() && !matches!(depth, DecodeDepth::BpAllNoNsym3) {
             let llrc_arr: [LlrT; LDPC_N] =
                 super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 3);
             let bp_c =

--- a/mfsk-core/tests/ft8_no_nsym3_sweep.rs
+++ b/mfsk-core/tests/ft8_no_nsym3_sweep.rs
@@ -49,17 +49,19 @@ fn no_nsym3_recall_sweep() {
     );
 
     println!(
-        "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}",
-        "WAV", "tru", "BpAll/15", "NoNsym3/15", "BpAllOsd/15"
+        "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}  {:<10}",
+        "WAV", "tru", "BpAll/15", "NoNsym3/15", "VariantsAd/15", "BpAllOsd/15"
     );
-    println!("  {}", "─".repeat(82));
+    println!("  {}", "─".repeat(96));
 
     let mut sum_tru = 0usize;
     let mut sum_bp = 0usize;
     let mut sum_nn = 0usize;
+    let mut sum_ad = 0usize;
     let mut sum_osd = 0usize;
     let mut sum_bp_ms = 0u128;
     let mut sum_nn_ms = 0u128;
+    let mut sum_ad_ms = 0u128;
     let mut sum_osd_ms = 0u128;
 
     for (label, path) in WAVS {
@@ -77,6 +79,7 @@ fn no_nsym3_recall_sweep() {
         let configs: &[(&str, DecodeDepth)] = &[
             ("BpAll", DecodeDepth::BpAll),
             ("NoNsym3", DecodeDepth::BpAllNoNsym3),
+            ("VariantsAd", DecodeDepth::BpVariantsAd),
             ("BpAllOsd", DecodeDepth::BpAllOsd),
         ];
 
@@ -97,24 +100,27 @@ fn no_nsym3_recall_sweep() {
         }
 
         println!(
-            "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}",
+            "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}  {:<10}",
             label,
             truth.len(),
             cells[0],
             cells[1],
-            cells[2]
+            cells[2],
+            cells[3],
         );
 
         sum_tru += truth.len();
         sum_bp += hits[0];
         sum_nn += hits[1];
-        sum_osd += hits[2];
+        sum_ad += hits[2];
+        sum_osd += hits[3];
         sum_bp_ms += mss[0];
         sum_nn_ms += mss[1];
-        sum_osd_ms += mss[2];
+        sum_ad_ms += mss[2];
+        sum_osd_ms += mss[3];
 
-        // Per-WAV recall delta callout.
-        if hits[0] != hits[1] {
+        // Per-WAV recall delta callout: BpAll vs aggressive variants.
+        if hits[0] != hits[1] || hits[0] != hits[2] {
             println!(
                 "    ⚠ NoNsym3 recall delta: BpAll={} vs NoNsym3={} (-{})",
                 hits[0],
@@ -142,25 +148,27 @@ fn no_nsym3_recall_sweep() {
         }
     }
 
-    println!("  {}", "─".repeat(82));
+    println!("  {}", "─".repeat(96));
     println!(
-        "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}",
+        "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}  {:<10}",
         "TOTAL",
         sum_tru,
         format!("{sum_bp:>2}/{sum_bp_ms:<6}"),
         format!("{sum_nn:>2}/{sum_nn_ms:<6}"),
+        format!("{sum_ad:>2}/{sum_ad_ms:<6}"),
         format!("{sum_osd:>2}/{sum_osd_ms:<6}"),
     );
     println!();
     println!(
-        "  NoNsym3 recall: {}/{} ({:.1}%) vs BpAll {}/{} ({:.1}%); time {}ms vs {}ms",
-        sum_nn,
-        sum_tru,
-        100.0 * sum_nn as f32 / sum_tru.max(1) as f32,
-        sum_bp,
-        sum_tru,
-        100.0 * sum_bp as f32 / sum_tru.max(1) as f32,
-        sum_nn_ms,
-        sum_bp_ms,
+        "  NoNsym3    : {sum_nn}/{sum_tru} ({:.1}%) in {sum_nn_ms}ms",
+        100.0 * sum_nn as f32 / sum_tru.max(1) as f32
+    );
+    println!(
+        "  VariantsAd : {sum_ad}/{sum_tru} ({:.1}%) in {sum_ad_ms}ms  ← also drops variant b",
+        100.0 * sum_ad as f32 / sum_tru.max(1) as f32
+    );
+    println!(
+        "  BpAll      : {sum_bp}/{sum_tru} ({:.1}%) in {sum_bp_ms}ms",
+        100.0 * sum_bp as f32 / sum_tru.max(1) as f32
     );
 }

--- a/mfsk-core/tests/ft8_no_nsym3_sweep.rs
+++ b/mfsk-core/tests/ft8_no_nsym3_sweep.rs
@@ -1,0 +1,166 @@
+//! BpAll vs BpAllNoNsym3 vs BpAllOsd recall + wall-clock sweep
+//! across the in-repo FT8 corpus.
+//!
+//! Built to validate the embedded `BpAllNoNsym3` ship config (PR
+//! #123, 2026-05-21) — `qso3_busy` alone showed variant-c contributing
+//! no decodes, but that's a single strong-signal corpus. Run this
+//! sweep on the on-air recordings (qso1, qso2, 191111_*) to confirm
+//! variant-c doesn't rescue any decodes those other slots need.
+//!
+//! Run:
+//! ```sh
+//! cargo test --release -p mfsk-core \
+//!     --features fft-rustfft,ft8,fixed-point \
+//!     --test ft8_no_nsym3_sweep \
+//!     -- --include-ignored --nocapture
+//! ```
+#![cfg(all(feature = "fft-rustfft", feature = "fixed-point"))]
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::time::Instant;
+
+use mfsk_core::ft8::decode::DecodeDepth;
+use mfsk_core::ft8::decode_block::decode_block;
+use mfsk_core::msg::wsjt77::unpack77;
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt as load_wav_i16;
+
+const WAVS: &[(&str, &str)] = &[
+    (
+        "qso3_busy (WSJT-X 210703_133430)",
+        asset_path!("qso3_busy.wav"),
+    ),
+    ("qso1 (on-air)", asset_path!("qso1.wav")),
+    ("qso2 (on-air)", asset_path!("qso2.wav")),
+    ("191111_110130 (on-air)", asset_path!("191111_110130.wav")),
+    ("191111_110200 (on-air)", asset_path!("191111_110200.wav")),
+];
+
+#[test]
+#[ignore = "BpAllNoNsym3 vs BpAll sweep; run with --include-ignored"]
+fn no_nsym3_recall_sweep() {
+    println!("\n=== BpAll vs BpAllNoNsym3 vs BpAllOsd recall + wall-clock ===\n");
+    println!(
+        "Truth = BpAllOsd, max_cand=200 (widest host search).\n\
+         Each cell = decodes ∩ truth  /  wall-clock ms.\n"
+    );
+
+    println!(
+        "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}",
+        "WAV", "tru", "BpAll/15", "NoNsym3/15", "BpAllOsd/15"
+    );
+    println!("  {}", "─".repeat(82));
+
+    let mut sum_tru = 0usize;
+    let mut sum_bp = 0usize;
+    let mut sum_nn = 0usize;
+    let mut sum_osd = 0usize;
+    let mut sum_bp_ms = 0u128;
+    let mut sum_nn_ms = 0u128;
+    let mut sum_osd_ms = 0u128;
+
+    for (label, path) in WAVS {
+        let Some(slot) = load_wav_i16(Path::new(path)) else {
+            println!("  {label:<38}  (load failed: {path})");
+            continue;
+        };
+
+        let truth: BTreeSet<String> =
+            decode_block(&slot, 100.0, 3000.0, 1.0, DecodeDepth::BpAllOsd, 200)
+                .iter()
+                .filter_map(|x| unpack77(&x.message77))
+                .collect();
+
+        let configs: &[(&str, DecodeDepth)] = &[
+            ("BpAll", DecodeDepth::BpAll),
+            ("NoNsym3", DecodeDepth::BpAllNoNsym3),
+            ("BpAllOsd", DecodeDepth::BpAllOsd),
+        ];
+
+        let mut cells: Vec<String> = Vec::new();
+        let mut hits = Vec::new();
+        let mut mss = Vec::new();
+        for &(_, depth) in configs {
+            let t0 = Instant::now();
+            let r: BTreeSet<String> = decode_block(&slot, 100.0, 3000.0, 1.0, depth, 15)
+                .iter()
+                .filter_map(|x| unpack77(&x.message77))
+                .collect();
+            let ms = t0.elapsed().as_millis();
+            let hit = r.intersection(&truth).count();
+            cells.push(format!("{hit:>2}/{ms:<6}"));
+            hits.push(hit);
+            mss.push(ms);
+        }
+
+        println!(
+            "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}",
+            label,
+            truth.len(),
+            cells[0],
+            cells[1],
+            cells[2]
+        );
+
+        sum_tru += truth.len();
+        sum_bp += hits[0];
+        sum_nn += hits[1];
+        sum_osd += hits[2];
+        sum_bp_ms += mss[0];
+        sum_nn_ms += mss[1];
+        sum_osd_ms += mss[2];
+
+        // Per-WAV recall delta callout.
+        if hits[0] != hits[1] {
+            println!(
+                "    ⚠ NoNsym3 recall delta: BpAll={} vs NoNsym3={} (-{})",
+                hits[0],
+                hits[1],
+                hits[0] as i32 - hits[1] as i32
+            );
+            let bp_set: BTreeSet<String> =
+                decode_block(&slot, 100.0, 3000.0, 1.0, DecodeDepth::BpAll, 15)
+                    .iter()
+                    .filter_map(|x| unpack77(&x.message77))
+                    .collect();
+            let nn_set: BTreeSet<String> =
+                decode_block(&slot, 100.0, 3000.0, 1.0, DecodeDepth::BpAllNoNsym3, 15)
+                    .iter()
+                    .filter_map(|x| unpack77(&x.message77))
+                    .collect();
+            let lost: Vec<&String> = bp_set.difference(&nn_set).collect();
+            let gained: Vec<&String> = nn_set.difference(&bp_set).collect();
+            if !lost.is_empty() {
+                println!("    NoNsym3 lost  : {:?}", lost);
+            }
+            if !gained.is_empty() {
+                println!("    NoNsym3 gained: {:?}", gained);
+            }
+        }
+    }
+
+    println!("  {}", "─".repeat(82));
+    println!(
+        "  {:<38}  {:>4}  {:<10}  {:<10}  {:<10}",
+        "TOTAL",
+        sum_tru,
+        format!("{sum_bp:>2}/{sum_bp_ms:<6}"),
+        format!("{sum_nn:>2}/{sum_nn_ms:<6}"),
+        format!("{sum_osd:>2}/{sum_osd_ms:<6}"),
+    );
+    println!();
+    println!(
+        "  NoNsym3 recall: {}/{} ({:.1}%) vs BpAll {}/{} ({:.1}%); time {}ms vs {}ms",
+        sum_nn,
+        sum_tru,
+        100.0 * sum_nn as f32 / sum_tru.max(1) as f32,
+        sum_bp,
+        sum_tru,
+        100.0 * sum_bp as f32 / sum_tru.max(1) as f32,
+        sum_nn_ms,
+        sum_bp_ms,
+    );
+}


### PR DESCRIPTION
## Summary

- Shifts pass-2 + a leading slice of stage-3 work out of the
  post-SlotEnd window into the audio-tail gap that previously held
  only coarse_sync.
- M5StickS3 `qso3_busy.wav`: SlotEnd → all-decodes-ready latency
  drops from **~2.15 s to ~1.55 s** (-600 ms, stable across 7
  consecutive slots).
- Recall preserved bit-identical (7 decodes per slot, same
  callsigns, same SNRs vs main).

## How

1. `SpecBundle` carries `audio_ptr` + `audio_cap` + `audio_fill`
   snapshot. The snapshot avoids a race against the next slot's
   `finalize_slot` that a shared atomic would have introduced
   (pipeline is offset by one slot).
2. `Slot` carries `slotend_us` so `decode_pipeline.rs` can measure
   the actual overlap (`tail_use`) vs the post-SlotEnd remainder.
3. `stage1_inc` emits SpecBundle at pair **87** (m=0..175 valid)
   instead of pair 91. `coarse_sync`'s `needed_m` only reaches
   m=175 with ±1 s lag, so the trailing 8 zero rows are invisible
   to it. `xsnr2_db_simple` strided sampling sees ~4 % zeros —
   well inside per-station SNR jitter.
4. `decode_pipeline` partitions pass1 by required Goertzel-window
   end: candidates with `dt_sec ≤ +0.36 s` run speculatively on a
   partial audio slice before SlotEnd; the rest (~5/30 on qso3)
   defer to `slot.audio` after SlotEnd (~120 µs total).

## Measured (S3 qso3_busy)

| metric | baseline | Phase C+ |
|---|---|---|
| `tail_win`     | 127 µs   | 725 ms   |
| `coarse`       | 240 ms   | 190 ms   |
| `tail_use`     | 0 µs     | 530 ms   |
| `post_slotend` | ~2.15 s  | **~1.55 s** |
| decodes/slot   | 7        | 7        |

## Why Phase A and Phase B were dropped (from the plan)

- **Phase A** (pass2/stage3 barrier removal): pass-2 is only
  ~10-20 ms wallclock per core; barrier variance is < 10 ms. Not
  worth the refactor.
- **Phase B** (block-0 `cs` reuse between pass-2 and stage-3): already
  implemented in `process_candidates_with_ap` — pass-2's `cs Box`
  is staged into stage-3's scratch via `*cs_scratch = **cs_box;
  fill(SyncBlocks12)`, and the q-gate gives per-candidate
  early-exit before the expensive `DataOnly` fill.

## Test plan

- [x] cargo check: all three embedded crates (m5stack-s3-app,
      m5stack-core2-app, m5stack-s3 bench) clean
- [x] Recall on qso3_busy: 7/7 callsigns, same SNRs
- [x] Cross-slot stability: 7 consecutive slots, no pointer-
      staleness, post_slotend variance < 60 ms (1530-1590 ms)
- [ ] Flash on Core2 (deferred — same audio path, same change)

## Follow-ups (separate PRs)

- **stage3 staircase optimisation**: each failed candidate currently
  runs BP × 4 variants (`a → d → b → c`) per
  `process_one_candidate_inner` — that is the dominant cost in
  post-SlotEnd time. Optimising the per-variant `compute_llr` work
  (especially the `nsym=3` partial) or tightening the pre-BP
  `sync_quality_block0` gate would target the remaining ~1.55 s.
  OSD and AP staircase steps are **not** engaged in embedded
  (`DecodeDepth::BpAll` + no `fft-rustfft`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)