### PR TITLE
perf(embedded): Phase D1 _aes3_ FFT + D2' Goertzel hot-path; fix menu overlay render order

### DIFF
--- a/embedded-poc/embedded-shared/Cargo.toml
+++ b/embedded-poc/embedded-shared/Cargo.toml
@@ -21,6 +21,12 @@ rust-version = "1.82"
 [lib]
 name = "embedded_shared"
 
+[features]
+# Enable LX7 PIE _aes3_ esp-dsp kernels (fc32 + sc16 radix-2 FFT).
+# Default-off so LX6 (Core2, xtensa-esp32-espidf) keeps the _ae32_ path.
+# Enabled by m5stack-s3 and m5stack-s3-app via features = ["aes3"].
+aes3 = []
+
 [dependencies]
 log = "0.4"
 esp-idf-svc = { version = "0.52.1", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -455,6 +455,9 @@ impl Fft16 for MixedRadix3840Sc16Fft {
         let mut rows_box: alloc::boxed::Box<AlignedRows> = unsafe {
             let layout = alloc::alloc::Layout::new::<AlignedRows>();
             let ptr = alloc::alloc::alloc_zeroed(layout) as *mut AlignedRows;
+            if ptr.is_null() {
+                alloc::alloc::handle_alloc_error(layout);
+            }
             alloc::boxed::Box::from_raw(ptr)
         };
         let rows: &mut [Complex<i16>] = &mut rows_box.0;

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -121,9 +121,9 @@ unsafe extern "C" {
 
     // ── i16 (sc16) variants ──────────────────────────────────
     fn dsps_fft2r_init_sc16(fft_table_buff: *mut i16, table_size: i32) -> i32;
-    #[cfg(not(feature = "aes3"))]
     fn dsps_fft2r_sc16_ae32_(data: *mut i16, N: i32, w: *const i16) -> i32;
-    /// LX7 PIE radix-2 sc16 FFT.
+    /// LX7 PIE sc16 FFT. Requires 16-byte aligned input — caller must use
+    /// an aligned buffer (see `Aligned16Rows` in `MixedRadix3840Sc16Fft`).
     #[cfg(feature = "aes3")]
     fn dsps_fft2r_sc16_aes3_(data: *mut i16, N: i32, w: *const i16) -> i32;
     fn dsps_bit_rev_sc16_ansi(data: *mut i16, N: i32) -> i32;
@@ -445,11 +445,19 @@ impl Fft16 for MixedRadix3840Sc16Fft {
 
         // ── Step 1+2: reshape to 15 rows × 256 cols (i16) and run a
         //              256-pt sc16 esp-dsp FFT on each row.
-        // We allocate the row buffer on the heap to avoid a 2 KB stack
-        // bump; this path runs once per 184-frame slot tail so the alloc
-        // cost is negligible.
-        let mut rows: alloc::vec::Vec<Complex<i16>> =
-            alloc::vec![Complex::new(0i16, 0i16); N];
+        //
+        // dsps_fft2r_sc16_aes3_ (PIE) requires 16-byte aligned input.
+        // alloc::vec! only guarantees align_of::<Complex<i16>>() = 2 bytes,
+        // so we use alloc_zeroed with a repr(align(16)) struct and
+        // Box::from_raw — Box drop then calls dealloc with the correct layout.
+        #[repr(C, align(16))]
+        struct AlignedRows([Complex<i16>; N]);
+        let mut rows_box: alloc::boxed::Box<AlignedRows> = unsafe {
+            let layout = alloc::alloc::Layout::new::<AlignedRows>();
+            let ptr = alloc::alloc::alloc_zeroed(layout) as *mut AlignedRows;
+            alloc::boxed::Box::from_raw(ptr)
+        };
+        let rows: &mut [Complex<i16>] = &mut rows_box.0;
         for n1 in 0..N1 {
             for n2 in 0..N2 {
                 rows[n2 * N1 + n1] = buf[15 * n1 + n2];
@@ -515,10 +523,7 @@ impl Fft16 for EspDspFft16 {
         }
         // SAFETY: 2*N contiguous i16; `dsps_fft_w_table_sc16` valid post-init.
         unsafe {
-            #[cfg(not(feature = "aes3"))]
             dsps_fft2r_sc16_ae32_(ptr, self.len as i32, dsps_fft_w_table_sc16);
-            #[cfg(feature = "aes3")]
-            dsps_fft2r_sc16_aes3_(ptr, self.len as i32, dsps_fft_w_table_sc16);
             dsps_bit_rev_sc16_ansi(ptr, self.len as i32);
         }
         if !self.forward {

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -103,10 +103,16 @@ unsafe extern "C" {
     /// register `a4` (the `w` pointer) uninitialised — the asm
     /// then reads from a garbage address inside the inner butterfly
     /// loop and crashes with `LoadProhibited` on real hardware.
+    /// LX6 baseline radix-2 fc32 FFT. Active when `aes3` feature is off.
+    #[cfg(not(feature = "aes3"))]
     fn dsps_fft2r_fc32_ae32_(data: *mut f32, N: i32, w: *const f32) -> i32;
 
+    /// LX7 PIE radix-2 fc32 FFT — ~2× throughput on ESP32-S3.
+    #[cfg(feature = "aes3")]
+    fn dsps_fft2r_fc32_aes3_(data: *mut f32, N: i32, w: *const f32) -> i32;
+
     /// Bit-reverse the radix-2 output into natural order. Call after
-    /// `dsps_fft2r_fc32_ae32_`.
+    /// `dsps_fft2r_fc32_ae32_` / `_aes3_`.
     fn dsps_bit_rev_fc32_ansi(data: *mut f32, N: i32) -> i32;
 
     /// Twiddle-factor table allocated and populated by
@@ -115,7 +121,11 @@ unsafe extern "C" {
 
     // ── i16 (sc16) variants ──────────────────────────────────
     fn dsps_fft2r_init_sc16(fft_table_buff: *mut i16, table_size: i32) -> i32;
+    #[cfg(not(feature = "aes3"))]
     fn dsps_fft2r_sc16_ae32_(data: *mut i16, N: i32, w: *const i16) -> i32;
+    /// LX7 PIE radix-2 sc16 FFT.
+    #[cfg(feature = "aes3")]
+    fn dsps_fft2r_sc16_aes3_(data: *mut i16, N: i32, w: *const i16) -> i32;
     fn dsps_bit_rev_sc16_ansi(data: *mut i16, N: i32) -> i32;
     static dsps_fft_w_table_sc16: *const i16;
 
@@ -281,7 +291,10 @@ impl Fft for MixedRadix3840Fft {
         let mut esp_dsp_256 = |row: &mut [Complex32; 256]| {
             let ptr = row.as_mut_ptr() as *mut f32;
             unsafe {
+                #[cfg(not(feature = "aes3"))]
                 dsps_fft2r_fc32_ae32_(ptr, 256, dsps_fft_w_table_fc32);
+                #[cfg(feature = "aes3")]
+                dsps_fft2r_fc32_aes3_(ptr, 256, dsps_fft_w_table_fc32);
                 dsps_bit_rev_fc32_ansi(ptr, 256);
             }
         };
@@ -321,7 +334,10 @@ impl Fft for EspDspFft {
         // `dsps_fft_w_table_fc32` is valid because `ensure_table` has
         // already called `dsps_fft2r_init_fc32` which populates it.
         unsafe {
+            #[cfg(not(feature = "aes3"))]
             dsps_fft2r_fc32_ae32_(ptr, self.len as i32, dsps_fft_w_table_fc32);
+            #[cfg(feature = "aes3")]
+            dsps_fft2r_fc32_aes3_(ptr, self.len as i32, dsps_fft_w_table_fc32);
             // Bit-reverse the in-place output to get natural order.
             dsps_bit_rev_fc32_ansi(ptr, self.len as i32);
         }
@@ -442,7 +458,10 @@ impl Fft16 for MixedRadix3840Sc16Fft {
         for n2 in 0..N2 {
             let row_ptr = rows[n2 * N1..(n2 + 1) * N1].as_mut_ptr() as *mut i16;
             unsafe {
+                #[cfg(not(feature = "aes3"))]
                 dsps_fft2r_sc16_ae32_(row_ptr, N1 as i32, dsps_fft_w_table_sc16);
+                #[cfg(feature = "aes3")]
+                dsps_fft2r_sc16_aes3_(row_ptr, N1 as i32, dsps_fft_w_table_sc16);
                 dsps_bit_rev_sc16_ansi(row_ptr, N1 as i32);
             }
         }
@@ -496,7 +515,10 @@ impl Fft16 for EspDspFft16 {
         }
         // SAFETY: 2*N contiguous i16; `dsps_fft_w_table_sc16` valid post-init.
         unsafe {
+            #[cfg(not(feature = "aes3"))]
             dsps_fft2r_sc16_ae32_(ptr, self.len as i32, dsps_fft_w_table_sc16);
+            #[cfg(feature = "aes3")]
+            dsps_fft2r_sc16_aes3_(ptr, self.len as i32, dsps_fft_w_table_sc16);
             dsps_bit_rev_sc16_ansi(ptr, self.len as i32);
         }
         if !self.forward {

--- a/embedded-poc/m5stack-s3-app/Cargo.toml
+++ b/embedded-poc/m5stack-s3-app/Cargo.toml
@@ -45,7 +45,7 @@ mfsk-core = { path = "../../mfsk-core", default-features = false, features = ["a
 mfsk-ffi-ft8 = { path = "../../mfsk-ffi-ft8", default-features = false, features = ["embedded-fixed-point"] }
 
 # 共有 embedded glue (streaming buffer / esp_dsp_fft / dual_core / Q3i8 LLR)
-embedded-shared = { path = "../embedded-shared" }
+embedded-shared = { path = "../embedded-shared", features = ["aes3"] }
 
 # Board-agnostic app logic (QSO FSM, time sync, TX picker, SNR norm,
 # NVS boot mode, log fanout, WiFi + UDP, UI data + draw routines).

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -834,7 +834,6 @@ pub fn run_log_panel(
             selected_decode_idx,
             latest_slot_seq_snapshot,
         );
-        let mut decoded_redrawn = false;
         if decoded_fp_with_cursor != last_decoded_fp_with_cursor {
             decoded_list::render_with_cursor(
                 &mut display,
@@ -844,21 +843,18 @@ pub fn run_log_panel(
             )
             .ok();
             last_decoded_fp_with_cursor = decoded_fp_with_cursor;
-            decoded_redrawn = true;
         }
 
-        // Menu overlay — render AFTER WF + decoded so the overlay
-        // paints on top of whatever they put down. The menu region
-        // (32, 16) … (132, 84) sits fully inside the WF region
-        // y ∈ [14, 114), so a WF repaint (~80 ms cadence per FFT
-        // pair) would otherwise erase the menu within one or two
-        // ticks. We track both the menu_seq watermark *and* the
-        // WF/decoded redraw flags so the menu re-paints whenever
-        // anything underneath it changed.
+        // Menu overlay — render AFTER WF so the overlay paints on
+        // top of any WF repaint. The menu region (32, 16) … (132,
+        // 84) sits fully inside the WF region y ∈ [14, 114), so a
+        // WF repaint (~80 ms cadence per FFT pair) would otherwise
+        // erase the menu within one or two ticks. The decoded
+        // list (y ∈ [114, …]) does NOT overlap the menu, so its
+        // redraws are irrelevant here (Gemini PR #124 review).
         let menu_seq = menu_snapshot.5;
         let menu_seq_changed = menu_seq != last_menu_seq;
-        let underlying_redrawn = wf_redrawn || decoded_redrawn;
-        if menu_seq_changed || (menu_snapshot.0 && underlying_redrawn) {
+        if menu_seq_changed || (menu_snapshot.0 && wf_redrawn) {
             menu::render(
                 &mut display,
                 menu_snapshot.0,
@@ -869,11 +865,12 @@ pub fn run_log_panel(
                 mode.flipped().label(),
             )
             .ok();
-            // When menu closes, force a full re-render of WF + decoded
-            // next iteration so the overlay's residual pixels go away.
+            // When menu closes, force a full WF re-render next
+            // iteration so the overlay's residual pixels get
+            // wiped. The decoded list doesn't share pixels with
+            // the menu so we don't touch its watermark.
             if menu_seq_changed && !menu_snapshot.0 {
                 last_wf_seq = u32::MAX;
-                last_decoded_fp_with_cursor = (usize::MAX, u32::MAX, None, u32::MAX);
             }
             last_menu_seq = menu_seq;
         }

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -810,6 +810,16 @@ pub fn run_log_panel(
         // wipe in the renderer so it doesn't flicker).
         status_bar::render(&mut display, &status_snapshot).ok();
 
+        // Pre-detect menu close (transition from visible → hidden)
+        // and force a WF repaint in this same iteration so the
+        // overlay's residual pixels get wiped without the 100 ms
+        // one-tick lag a post-WF check would have caused.
+        let menu_seq = menu_snapshot.5;
+        let menu_seq_changed = menu_seq != last_menu_seq;
+        if menu_seq_changed && !menu_snapshot.0 {
+            last_wf_seq = u32::MAX;
+        }
+
         // Waterfall: streams at per-pair cadence. Trigger on
         // `wf_push_seq` so the redraw still fires after the ring
         // saturates at WF_DEPTH (= ~8 s into runtime).
@@ -850,10 +860,7 @@ pub fn run_log_panel(
         // 84) sits fully inside the WF region y ∈ [14, 114), so a
         // WF repaint (~80 ms cadence per FFT pair) would otherwise
         // erase the menu within one or two ticks. The decoded
-        // list (y ∈ [114, …]) does NOT overlap the menu, so its
-        // redraws are irrelevant here (Gemini PR #124 review).
-        let menu_seq = menu_snapshot.5;
-        let menu_seq_changed = menu_seq != last_menu_seq;
+        // list (y ∈ [114, …]) does NOT overlap the menu.
         if menu_seq_changed || (menu_snapshot.0 && wf_redrawn) {
             menu::render(
                 &mut display,
@@ -865,13 +872,6 @@ pub fn run_log_panel(
                 mode.flipped().label(),
             )
             .ok();
-            // When menu closes, force a full WF re-render next
-            // iteration so the overlay's residual pixels get
-            // wiped. The decoded list doesn't share pixels with
-            // the menu so we don't touch its watermark.
-            if menu_seq_changed && !menu_snapshot.0 {
-                last_wf_seq = u32::MAX;
-            }
             last_menu_seq = menu_seq;
         }
 

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -810,32 +810,10 @@ pub fn run_log_panel(
         // wipe in the renderer so it doesn't flicker).
         status_bar::render(&mut display, &status_snapshot).ok();
 
-        // Menu overlay — render after WF/decoded so it paints on top.
-        // Tracking last menu_seq to avoid redraw when nothing changed.
-        let menu_seq = menu_snapshot.5;
-        if menu_seq != last_menu_seq {
-            menu::render(
-                &mut display,
-                menu_snapshot.0,
-                menu_snapshot.1,
-                menu_snapshot.2,
-                menu_snapshot.3,
-                menu_snapshot.4,
-                mode.flipped().label(),
-            )
-            .ok();
-            // When menu closes, force a full re-render of WF + decoded
-            // next iteration so the overlay's residual pixels go away.
-            if !menu_snapshot.0 {
-                last_wf_seq = u32::MAX;
-                last_decoded_fp_with_cursor = (usize::MAX, u32::MAX, None, u32::MAX);
-            }
-            last_menu_seq = menu_seq;
-        }
-
         // Waterfall: streams at per-pair cadence. Trigger on
         // `wf_push_seq` so the redraw still fires after the ring
         // saturates at WF_DEPTH (= ~8 s into runtime).
+        let mut wf_redrawn = false;
         if wf_seq != last_wf_seq {
             let wf_refs: heapless::Vec<
                 &mfsk_app_shared::ui::state::WfLine,
@@ -843,6 +821,7 @@ pub fn run_log_panel(
             > = wf_snapshot.iter().collect();
             waterfall::render(&mut display, &wf_refs).ok();
             last_wf_seq = wf_seq;
+            wf_redrawn = true;
         }
 
         // Decoded list: redraw when a new slot's results landed OR
@@ -855,6 +834,7 @@ pub fn run_log_panel(
             selected_decode_idx,
             latest_slot_seq_snapshot,
         );
+        let mut decoded_redrawn = false;
         if decoded_fp_with_cursor != last_decoded_fp_with_cursor {
             decoded_list::render_with_cursor(
                 &mut display,
@@ -864,6 +844,38 @@ pub fn run_log_panel(
             )
             .ok();
             last_decoded_fp_with_cursor = decoded_fp_with_cursor;
+            decoded_redrawn = true;
+        }
+
+        // Menu overlay — render AFTER WF + decoded so the overlay
+        // paints on top of whatever they put down. The menu region
+        // (32, 16) … (132, 84) sits fully inside the WF region
+        // y ∈ [14, 114), so a WF repaint (~80 ms cadence per FFT
+        // pair) would otherwise erase the menu within one or two
+        // ticks. We track both the menu_seq watermark *and* the
+        // WF/decoded redraw flags so the menu re-paints whenever
+        // anything underneath it changed.
+        let menu_seq = menu_snapshot.5;
+        let menu_seq_changed = menu_seq != last_menu_seq;
+        let underlying_redrawn = wf_redrawn || decoded_redrawn;
+        if menu_seq_changed || (menu_snapshot.0 && underlying_redrawn) {
+            menu::render(
+                &mut display,
+                menu_snapshot.0,
+                menu_snapshot.1,
+                menu_snapshot.2,
+                menu_snapshot.3,
+                menu_snapshot.4,
+                mode.flipped().label(),
+            )
+            .ok();
+            // When menu closes, force a full re-render of WF + decoded
+            // next iteration so the overlay's residual pixels go away.
+            if menu_seq_changed && !menu_snapshot.0 {
+                last_wf_seq = u32::MAX;
+                last_decoded_fp_with_cursor = (usize::MAX, u32::MAX, None, u32::MAX);
+            }
+            last_menu_seq = menu_seq;
         }
 
         // TX line: 3-way priority — sync prompt > sync-mark

--- a/embedded-poc/m5stack-s3-app/src/main.rs
+++ b/embedded-poc/m5stack-s3-app/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> ! {
 
     log::info!("=== mfsk-core-m5stack-s3-app boot ===");
     log::info!("phase 0.7c: runtime boot-mode (NVS + KEY1 override + KEY2 long-press)");
-    log::info!("build-stamp 2026-05-17-phase17-qso");
+    log::info!("build-stamp 2026-05-22-phaseD1-aes3-goertzel");
 
     // Global QSO FSM instance. Empty MY_CALL keeps the FSM Idle so
     // the TX scheduler / auto-CQ stays a no-op until cfg.toml provides

--- a/embedded-poc/m5stack-s3/Cargo.toml
+++ b/embedded-poc/m5stack-s3/Cargo.toml
@@ -63,7 +63,7 @@ num-complex = { version = "0.4", default-features = false }
 
 # Shared embedded glue (wav_sim / esp_dsp_fft / dual_core / stage1_inc /
 # internal_pool). Compiled per-target alongside this binary.
-embedded-shared = { path = "../embedded-shared" }
+embedded-shared = { path = "../embedded-shared", features = ["aes3"] }
 
 [build-dependencies]
 embuild = "0.33"

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -704,7 +704,7 @@ pub fn fill_symbol_spectra_goertzel<S: AudioSample>(
         // sequential load that LLVM's unroll + Xtensa FPU pipeline can
         // run at ~1 cycle/tone/sample. Cold path (first/last ~1 symbol
         // per candidate) keeps the original per-sample check.
-        if sym_start >= 0 && sym_start as usize + NSPS <= audio.len() {
+        if sym_start >= 0 && (sym_start as usize) <= audio.len().saturating_sub(NSPS) {
             let base = sym_start as usize;
             for n in 0..NSPS {
                 let sample = audio[base + n].to_i16() as f32;

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -698,21 +698,36 @@ pub fn fill_symbol_spectra_goertzel<S: AudioSample>(
         let mut s_prev = [0.0_f32; NTONES];
         let mut s_prev2 = [0.0_f32; NTONES];
 
-        for n in 0..NSPS {
-            let idx = sym_start + n as i64;
-            let sample = if idx >= 0 && (idx as usize) < audio.len() {
-                audio[idx as usize].to_i16() as f32
-            } else {
-                0.0
-            };
-            // NTONES=8 is `const`; LLVM unrolls this and the 8
-            // resulting fmul/fadd/fsub chains run independently — the
-            // Xtensa FPU's pipeline absorbs ~all of the per-chain
-            // latency in parallel.
-            for tone in 0..NTONES {
-                let s = sample + coeff[tone] * s_prev[tone] - s_prev2[tone];
-                s_prev2[tone] = s_prev[tone];
-                s_prev[tone] = s;
+        // Hot path: entire symbol window lies within audio bounds.
+        // The bounds check (idx >= 0 && idx < audio.len()) can then be
+        // hoisted out of the 1920-iteration inner loop, leaving a clean
+        // sequential load that LLVM's unroll + Xtensa FPU pipeline can
+        // run at ~1 cycle/tone/sample. Cold path (first/last ~1 symbol
+        // per candidate) keeps the original per-sample check.
+        if sym_start >= 0 && sym_start as usize + NSPS <= audio.len() {
+            let base = sym_start as usize;
+            for n in 0..NSPS {
+                let sample = audio[base + n].to_i16() as f32;
+                for tone in 0..NTONES {
+                    let s = sample + coeff[tone] * s_prev[tone] - s_prev2[tone];
+                    s_prev2[tone] = s_prev[tone];
+                    s_prev[tone] = s;
+                }
+            }
+        } else {
+            let audio_len = audio.len() as i64;
+            for n in 0..NSPS {
+                let idx = sym_start + n as i64;
+                let sample = if idx >= 0 && idx < audio_len {
+                    audio[idx as usize].to_i16() as f32
+                } else {
+                    0.0
+                };
+                for tone in 0..NTONES {
+                    let s = sample + coeff[tone] * s_prev[tone] - s_prev2[tone];
+                    s_prev2[tone] = s_prev[tone];
+                    s_prev[tone] = s;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary

- **fix(s3-app)**: Menu overlay render order — 3 commits fixing the WF-repaints-over-menu bug without the button GPIO swap in PR #124 (this is the overlay-only subset)
- **perf(embedded): Phase D1** — rebind `esp-dsp` FFI from `_ae32_` to `_aes3_` (LX7 PIE) for `dsps_fft2r_fc32_aes3_` + `dsps_fft2r_sc16_aes3_`. Gated by a new `aes3` feature in `embedded-shared`; enabled only in S3 crates (not LX6/Core2)
- **perf(embedded): Phase D2'** — hoist Goertzel bounds-check out of the per-sample inner loop (hot-path/cold-path split). Numerically identical; no measurable improvement (FPU-bound at 1.6 cy/tone/sample — see "D2 reconsidered" in PR #126)
- **fix(embedded): aligned sc16 buf for _aes3_ PIE** — `dsps_fft2r_sc16_aes3_` requires 16-byte aligned input. Changed `Vec<Complex<i16>>` (2-byte aligned) to `Box<AlignedRows>` via `alloc_zeroed` + `#[repr(C, align(16))]` newtype. Unaligned → TLSF double-free / `rst:0xc` crash loop on first flash.

## Hardware measurements (M5StickS3, S3 LX7 @ 240 MHz)

| Stage | Baseline (ae32) | D1+D2' (aes3) | Delta |
|---|---|---|---|
| stage 1 inc FFT × 184 | 1.980 s | **1.648 s** | **-16.7%** ✅ |
| stage 2 (sync) | ~370 ms | ~370 ms | — |
| pass 2 (Goertzel) | 180 ms | 181 ms | — (D2' no effect) |

`rx_wavsim` post-SlotEnd: 1.4–1.8 s (pass 2 181 ms + stage 3 1.2–1.6 s). The pre-Phase D baseline for pass 2 on rx_wavsim was also ~180 ms — the "122 ms" in the Phase D plan (PR #126) was from Phase C era with BASIS asm dotprod, which Phase 1.7.7 traded for 120 KB DRAM. D2' made no measurable impact; FPU throughput is the bottleneck.

## Test plan

- [x] Stage 1 regression: `cargo test -p mfsk-core` (host, qso3 recall unchanged)
- [x] S3 compute_bench: `s3_phaseD1_aes3_aligned_2026-05-22.log` — 120 s stable, no TLSF crashes, stage 1 1.65 s modal
- [x] S3 rx_wavsim (D2'.3): `s3_phaseD1D2_rxwavsim_2026-05-22.log` — 120 s stable, pass 2 181 ms, post-SlotEnd 1.4–1.8 s
- [ ] Gemini review (trigger below)

## Related

- Closes / supersedes menu-overlay part from PR #124 (button GPIO swap intentionally excluded)
- Phase D plan: PR #126
- Next: D3 (PIE coarse_sync allsum) per Phase D plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)