### PR TITLE
perf(ft8): D4 demux-mag² DC-hoist + 4× unroll; migrate rx_wavsim to run_speculative_slot

### DIFF
--- a/embedded-poc/embedded-shared/Cargo.toml
+++ b/embedded-poc/embedded-shared/Cargo.toml
@@ -21,6 +21,12 @@ rust-version = "1.82"
 [lib]
 name = "embedded_shared"
 
+[features]
+# Enable LX7 PIE _aes3_ esp-dsp kernels (fc32 + sc16 radix-2 FFT).
+# Default-off so LX6 (Core2, xtensa-esp32-espidf) keeps the _ae32_ path.
+# Enabled by m5stack-s3 and m5stack-s3-app via features = ["aes3"].
+aes3 = []
+
 [dependencies]
 log = "0.4"
 esp-idf-svc = { version = "0.52.1", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }

--- a/embedded-poc/embedded-shared/src/apps/compute_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/compute_bench.rs
@@ -175,9 +175,8 @@ fn ffi_smoke_one(slot: &[i16]) {
     if !results.items.is_null() {
         let items = unsafe { core::slice::from_raw_parts(results.items, results.len) };
         for (i, r) in items.iter().enumerate() {
-            let bytes: &[u8] = unsafe {
-                core::slice::from_raw_parts(r.text.as_ptr() as *const u8, r.text.len())
-            };
+            let bytes: &[u8] =
+                unsafe { core::slice::from_raw_parts(r.text.as_ptr() as *const u8, r.text.len()) };
             let n = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
             let text = core::str::from_utf8(&bytes[..n]).unwrap_or("<bad utf8>");
             log::info!(
@@ -215,9 +214,8 @@ fn decode_one(slot: &[i16], max_cand: usize, _dt_grid: u8, _df_grid: u8, _q_thre
 
     let t_pass2 = now_us();
     #[allow(static_mut_refs)]
-    let pass2 = unsafe {
-        dual_core::pass2_split(slot, pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM)
-    };
+    let pass2 =
+        unsafe { dual_core::pass2_split(slot, pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM) };
     let t_pass2_end = now_us();
     log::info!(
         "  pass 2 (re-rank):     {:>8} us  → top {} by sync_quality_block0",

--- a/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
+++ b/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
@@ -5,9 +5,11 @@
 //! wav_sim → ChunkMsg → stage1_inc → SpecBundle/Slot → main → dual_core
 //! ```
 //!
-//! Stage 2 (`coarse_sync_split_with_allsum`) starts on `SpecBundle`
-//! arrival (≈ 200 ms before SlotEnd), so it overlaps the tail of audio
-//! capture. Post-SlotEnd decode = pass 2 + stage 3 only.
+//! Uses [`dual_core::run_speculative_slot`] — the same Phase-C
+//! speculative runner as `m5stack-s3-app` and `m5stack-core2-app`.
+//! Both the early (audio-tail overlap) and deferred (post-SlotEnd)
+//! decode paths run; the per-slot log shows the Phase-C breakdown so
+//! bench results are directly comparable to production timing.
 //!
 //! Per-target binaries (m5stack-core2 / m5stack-s3) just supply the
 //! WAV byte slices and call `run()`. No target-specific code lives
@@ -15,47 +17,11 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-
-use mfsk_ft8::mfsk_ft8_basis_scratch_len;
-
-use mfsk_core::core::sync::SyncCandidate;
 use mfsk_core::ft8::decode::DecodeDepth;
-use mfsk_core::ft8::decode_block::BASIS_SCRATCH_LEN;
 use mfsk_core::msg::wsjt77::unpack77;
 
 use crate::{dual_core, esp_dsp_fft, pipeline, stage1_inc, wav_sim};
 
-/// Per-core BASIS scratch. 60 KB × 4, internal DRAM `.bss`. Phase 0.7:
-/// both pairs live here so rx_wavsim keeps a single static allocation
-/// strategy; only the m5stack-s3-app runtime heap-allocates so it can
-/// skip the 120 KB worker pair in WiFi mode.
-static mut BASIS_RE: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-static mut BASIS_IM: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-static mut BASIS_RE_C1: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-static mut BASIS_IM_C1: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-
-fn now_us() -> i64 {
-    unsafe { esp_idf_svc::sys::esp_timer_get_time() }
-}
-
-/// Run the rx_wavsim bench.
-///
-/// * `wavs` — playlist (≥ 1 baked WAV; cycled indefinitely).
-/// * `pass1_limit` — coarse_sync candidate cap (typical 30 for ship
-///   recall floor; raise to 100 to recover one extra borderline weak
-///   signal at ~1.7× post-SlotEnd time on LX7).
-/// * `max_cand` — pass 2 / stage 3 candidate cap (typical 15; raise
-///   to 30 alongside `pass1_limit=100`).
-/// * `q_thresh` — stage-3 `sync_quality` early-reject threshold; pass
-///   [`mfsk_core::ft8::decode_block::DEFAULT_Q_THRESH`] (= 12) for
-///   full recall.
-/// * `bp_max_iter` — stage-3 BP iteration cap per LLR variant. Pass
-///   [`mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER`] (= 30, WSJT-X
-///   reference) for full recall; lower (e.g. 20 / 15) trades weak-
-///   signal recall for post-SlotEnd time. Stage 3 wall-clock scales
-///   roughly linearly with this on cands that exhaust all 4 LLR
-///   variants (≈ half of `max_cand` on busy bands).
 /// One sweep config — applied per-slot when `run_sweep` is used.
 #[derive(Clone, Copy, Debug)]
 pub struct RxSweepCfg {
@@ -95,8 +61,14 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
         mfsk_core::ft8::decode_block::NFFT_SPEC
     );
 
-    let need = mfsk_ft8_basis_scratch_len();
-    assert!(BASIS_SCRATCH_LEN >= need, "BASIS_SCRATCH_LEN too small");
+    // Phase 1.7.7: BASIS scratch retired — Goertzel needs no internal
+    // DRAM scratch. Pass null to dual_core::init; empty slices to
+    // run_speculative_slot. The 4 × 30 KB that used to live here as
+    // `static mut BASIS_*` arrays is now free DRAM.
+    let basis_re_main: &'static mut [i16] =
+        alloc::boxed::Box::leak(alloc::vec![].into_boxed_slice());
+    let basis_im_main: &'static mut [i16] =
+        alloc::boxed::Box::leak(alloc::vec![].into_boxed_slice());
 
     // Bump main task priority above wav_sim (4) and stage1_inc (3).
     unsafe {
@@ -104,11 +76,8 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
     }
 
     esp_dsp_fft::prewarm(mfsk_core::ft8::decode_block::NFFT_SPEC);
+    dual_core::init(core::ptr::null_mut(), core::ptr::null_mut());
 
-    #[allow(static_mut_refs)]
-    unsafe {
-        dual_core::init(BASIS_RE_C1.as_mut_ptr(), BASIS_IM_C1.as_mut_ptr());
-    }
     let chunk_q = pipeline::create_chunk_queue(4);
     let slot_q = pipeline::create_slot_queue(2);
     let spec_q = pipeline::create_spec_queue(2);
@@ -121,118 +90,83 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
     );
     let mut slot_i: usize = 0;
     loop {
-        let cfg = cfgs[slot_i % cfgs.len()];
+        let rx_cfg = cfgs[slot_i % cfgs.len()];
         slot_i = slot_i.wrapping_add(1);
-        // SpecBundle arrives ≈ 200 ms before SlotEnd, so stage 2 runs
-        // in parallel with the tail of capture.
-        let spec = pipeline::recv_box::<pipeline::SpecBundle>(spec_q);
+
         log::info!(
             "─── slot {} cfg pass1={} max_cand={} q={} BP={}",
             slot_i,
-            cfg.pass1_limit,
-            cfg.max_cand,
-            cfg.q_thresh,
-            cfg.bp_max_iter,
+            rx_cfg.pass1_limit,
+            rx_cfg.max_cand,
+            rx_cfg.q_thresh,
+            rx_cfg.bp_max_iter,
         );
-        let t_s2_start = now_us();
-        let pass1 = dual_core::coarse_sync_split_with_allsum(
-            &spec.spec,
-            100.0,
-            3_000.0,
-            1.0,
-            cfg.pass1_limit,
-            &spec.allsum_head,
-            &spec.allsum_tail,
+
+        let dc = dual_core::DecodeConfig {
+            freq_min: 100.0,
+            freq_max: 3_000.0,
+            sync_min: 1.0,
+            pass1_limit: rx_cfg.pass1_limit,
+            max_cand: rx_cfg.max_cand,
+            q_thresh: rx_cfg.q_thresh,
+            bp_max_iter: rx_cfg.bp_max_iter,
+            depth: DecodeDepth::BpVariantsAd,
+        };
+        let out =
+            dual_core::run_speculative_slot(spec_q, slot_q, &dc, basis_re_main, basis_im_main);
+        let dual_core::SpeculativeOut {
+            spec,
+            slot,
+            results,
+            n_pass1,
+            n_ready,
+            n_deferred,
+            t_post_recv,
+            t_coarse_done,
+            t_early_done,
+            t_slot_recv,
+            t_done,
+        } = out;
+
+        let slotend = slot.slotend_us;
+        let inc_us = slot.inc_total_us;
+        let wav_idx = slot.wav_idx;
+        let tail_window = (slotend - t_post_recv).max(0);
+        let coarse_us = t_coarse_done - t_post_recv;
+        let early_us = t_early_done - t_coarse_done;
+        let tail_use = (slotend.min(t_early_done) - t_coarse_done).max(0);
+        let post_slotend = (t_done - slotend).max(0);
+
+        log::info!(
+            "WAV[{wav_idx}] p1={n_pass1} ready={n_ready} defer={n_deferred} dec={} \
+             tail_win={}us coarse={}us early={}us tail_use={}us post_slotend={}us \
+             slot_wait={}us late={}us",
+            results.len(),
+            tail_window,
+            coarse_us,
+            early_us,
+            tail_use,
+            post_slotend,
+            t_slot_recv - t_early_done,
+            t_done - t_slot_recv,
         );
-        let t_s2_end = now_us();
-        drop(spec);
-
-        let slot = pipeline::recv_box::<pipeline::Slot>(slot_q);
-        decode_one_slot(
-            *slot,
-            pass1,
-            t_s2_end - t_s2_start,
-            cfg.max_cand,
-            cfg.q_thresh,
-            cfg.bp_max_iter,
+        log::info!(
+            "  Phase-E: stage1_inc {} us in advance ({}% of capture)",
+            inc_us,
+            (inc_us * 100) / 15_000_000
         );
-    }
-}
 
-fn decode_one_slot(
-    slot: pipeline::Slot,
-    pass1: Vec<SyncCandidate>,
-    stage2_us: i64,
-    max_cand: usize,
-    q_thresh: u32,
-    bp_max_iter: u32,
-) {
-    let wav_idx = slot.wav_idx;
-    let inc_us = slot.inc_total_us;
-    let pass1_n = pass1.len();
-    let post_slot_t0 = now_us();
-
-    log::info!(
-        "rx-wavsim: WAV[{wav_idx}] slot received (audio={} samples, pass1={pass1_n}, q_thresh={q_thresh})",
-        slot.audio_len(),
-    );
-    log::info!(
-        "  stage 2 (during cap): {:>7} us  ({pass1_n} cand)",
-        stage2_us
-    );
-
-    let t2 = now_us();
-    #[allow(static_mut_refs)]
-    let pass2 = unsafe {
-        dual_core::pass2_split(slot.audio(), pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM)
-    };
-    let t3 = now_us();
-    log::info!(
-        "  pass 2:               {:>7} us  → top {}",
-        t3 - t2,
-        pass2.len()
-    );
-
-    let depth = DecodeDepth::BpAll;
-    let t4 = now_us();
-    #[allow(static_mut_refs)]
-    let results = unsafe {
-        dual_core::stage3_split(
-            slot.audio(),
-            pass2,
-            depth,
-            q_thresh,
-            bp_max_iter,
-            &mut BASIS_RE,
-            &mut BASIS_IM,
-        )
-    };
-    let t5 = now_us();
-    log::info!(
-        "  stage 3:              {:>7} us  ({} result(s))",
-        t5 - t4,
-        results.len()
-    );
-    log::info!(
-        "  ─── post-SlotEnd:     {:>7} us = {:.3} s",
-        t5 - post_slot_t0,
-        (t5 - post_slot_t0) as f64 / 1e6
-    );
-    log::info!(
-        "  Phase-E: stage1_inc {} us in advance ({}% of capture)",
-        inc_us,
-        (inc_us * 100) / 15_000_000
-    );
-
-    for (i, r) in results.iter().enumerate() {
-        if let Some(text) = unpack77(&r.message77) {
-            log::info!(
-                "    [{i}]  {:>4.0} Hz  SNR={:>5.1} dB  e={}  '{}'",
-                r.freq_hz,
-                r.snr_db,
-                r.hard_errors,
-                text
-            );
+        for (i, r) in results.iter().enumerate() {
+            if let Some(text) = unpack77(&r.message77) {
+                log::info!(
+                    "    [{i}]  {:>4.0} Hz  SNR={:>5.1} dB  e={}  '{}'",
+                    r.freq_hz,
+                    r.snr_db,
+                    r.hard_errors,
+                    text
+                );
+            }
         }
+        drop(spec);
     }
 }

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -35,8 +35,8 @@ use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use esp_idf_svc::sys::{
-    xQueueGenericCreate, xQueueGenericSend, xQueueReceive, xTaskCreatePinnedToCore,
-    xTaskGetCoreID, QueueHandle_t,
+    xQueueGenericCreate, xQueueGenericSend, xQueueReceive, xTaskCreatePinnedToCore, xTaskGetCoreID,
+    QueueHandle_t,
 };
 
 use alloc::boxed::Box;
@@ -51,7 +51,7 @@ use mfsk_core::ft8::decode_block::{
 };
 
 use crate::internal_pool::{CS_SCRATCH_MAIN, CS_SCRATCH_WORKER};
-use crate::pipeline::{self, SpecBundle, Slot};
+use crate::pipeline::{self, Slot, SpecBundle};
 
 /// One slot's Phase-C output. Both apps consume it identically:
 /// `spec` for `xsnr2_db_simple`, `slot` for `wav_idx` /
@@ -384,13 +384,8 @@ extern "C" fn worker_main(_arg: *mut core::ffi::c_void) {
                 let basis_im = unsafe {
                     core::slice::from_raw_parts_mut(BASIS_IM_C1.get(), BASIS_SCRATCH_LEN)
                 };
-                let result = refine_candidates_into(
-                    audio_slice,
-                    cands,
-                    max_cand,
-                    basis_re,
-                    basis_im,
-                );
+                let result =
+                    refine_candidates_into(audio_slice, cands, max_cand, basis_re, basis_im);
                 let raw = Box::into_raw(Box::new(result));
                 unsafe { queue_send_ptr(PASS2_RESULT_Q.get(), raw) };
             }
@@ -470,7 +465,9 @@ pub fn init(re_c1: *mut i16, im_c1: *mut i16) {
         BASIS_RE_C1.set(re_c1);
         BASIS_IM_C1.set(im_c1);
         JOB_Q.set(queue_create(core::mem::size_of::<*mut Job>()));
-        PASS2_RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<RefinedCandidate>>()));
+        PASS2_RESULT_Q.set(queue_create(
+            core::mem::size_of::<*mut Vec<RefinedCandidate>>(),
+        ));
         STAGE3_RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<DecodeResult>>()));
         COARSE_RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<SyncCandidate>>()));
 
@@ -542,8 +539,7 @@ pub fn coarse_sync_split_with_allsum(
     });
     unsafe { queue_send_ptr(JOB_Q.get(), Box::into_raw(job)) };
 
-    let mut local =
-        coarse_sync_with_allsum(spec, freq_min, mid, sync_min, max_cand, allsum_head);
+    let mut local = coarse_sync_with_allsum(spec, freq_min, mid, sync_min, max_cand, allsum_head);
 
     let worker_ptr = unsafe { queue_recv_ptr::<Vec<SyncCandidate>>(COARSE_RESULT_Q.get()) };
     let worker = unsafe { *Box::from_raw(worker_ptr) };

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -455,6 +455,9 @@ impl Fft16 for MixedRadix3840Sc16Fft {
         let mut rows_box: alloc::boxed::Box<AlignedRows> = unsafe {
             let layout = alloc::alloc::Layout::new::<AlignedRows>();
             let ptr = alloc::alloc::alloc_zeroed(layout) as *mut AlignedRows;
+            if ptr.is_null() {
+                alloc::alloc::handle_alloc_error(layout);
+            }
             alloc::boxed::Box::from_raw(ptr)
         };
         let rows: &mut [Complex<i16>] = &mut rows_box.0;

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -282,9 +282,7 @@ impl Fft for MixedRadix3840Fft {
     fn process(&self, buf: &mut [Complex32]) {
         const N: usize = mfsk_core::core::dsp::fft_mixed_3840::N;
         assert_eq!(buf.len(), N, "3840 FFT input length mismatch");
-        let buf_arr: &mut [Complex32; N] = buf
-            .try_into()
-            .expect("buf.len() == N already asserted");
+        let buf_arr: &mut [Complex32; N] = buf.try_into().expect("buf.len() == N already asserted");
 
         // Inner 256-pt forward FFT via esp-dsp asm path. Mirrors
         // `EspDspFft::process` but specialised to len=256.
@@ -478,8 +476,7 @@ impl Fft16 for MixedRadix3840Sc16Fft {
         }
 
         // ── Step 3+4: convert to f32, twiddle, run 15-pt PFA per column.
-        let mut m: alloc::vec::Vec<Complex32> =
-            alloc::vec![Complex32::new(0.0, 0.0); N];
+        let mut m: alloc::vec::Vec<Complex32> = alloc::vec![Complex32::new(0.0, 0.0); N];
         for (i, c) in rows.iter().enumerate() {
             m[i] = Complex32::new(c.re as f32, c.im as f32) * self.twiddles[i];
         }

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -121,9 +121,9 @@ unsafe extern "C" {
 
     // ── i16 (sc16) variants ──────────────────────────────────
     fn dsps_fft2r_init_sc16(fft_table_buff: *mut i16, table_size: i32) -> i32;
-    #[cfg(not(feature = "aes3"))]
     fn dsps_fft2r_sc16_ae32_(data: *mut i16, N: i32, w: *const i16) -> i32;
-    /// LX7 PIE radix-2 sc16 FFT.
+    /// LX7 PIE sc16 FFT. Requires 16-byte aligned input — caller must use
+    /// an aligned buffer (see `Aligned16Rows` in `MixedRadix3840Sc16Fft`).
     #[cfg(feature = "aes3")]
     fn dsps_fft2r_sc16_aes3_(data: *mut i16, N: i32, w: *const i16) -> i32;
     fn dsps_bit_rev_sc16_ansi(data: *mut i16, N: i32) -> i32;
@@ -445,11 +445,19 @@ impl Fft16 for MixedRadix3840Sc16Fft {
 
         // ── Step 1+2: reshape to 15 rows × 256 cols (i16) and run a
         //              256-pt sc16 esp-dsp FFT on each row.
-        // We allocate the row buffer on the heap to avoid a 2 KB stack
-        // bump; this path runs once per 184-frame slot tail so the alloc
-        // cost is negligible.
-        let mut rows: alloc::vec::Vec<Complex<i16>> =
-            alloc::vec![Complex::new(0i16, 0i16); N];
+        //
+        // dsps_fft2r_sc16_aes3_ (PIE) requires 16-byte aligned input.
+        // alloc::vec! only guarantees align_of::<Complex<i16>>() = 2 bytes,
+        // so we use alloc_zeroed with a repr(align(16)) struct and
+        // Box::from_raw — Box drop then calls dealloc with the correct layout.
+        #[repr(C, align(16))]
+        struct AlignedRows([Complex<i16>; N]);
+        let mut rows_box: alloc::boxed::Box<AlignedRows> = unsafe {
+            let layout = alloc::alloc::Layout::new::<AlignedRows>();
+            let ptr = alloc::alloc::alloc_zeroed(layout) as *mut AlignedRows;
+            alloc::boxed::Box::from_raw(ptr)
+        };
+        let rows: &mut [Complex<i16>] = &mut rows_box.0;
         for n1 in 0..N1 {
             for n2 in 0..N2 {
                 rows[n2 * N1 + n1] = buf[15 * n1 + n2];
@@ -515,10 +523,7 @@ impl Fft16 for EspDspFft16 {
         }
         // SAFETY: 2*N contiguous i16; `dsps_fft_w_table_sc16` valid post-init.
         unsafe {
-            #[cfg(not(feature = "aes3"))]
             dsps_fft2r_sc16_ae32_(ptr, self.len as i32, dsps_fft_w_table_sc16);
-            #[cfg(feature = "aes3")]
-            dsps_fft2r_sc16_aes3_(ptr, self.len as i32, dsps_fft_w_table_sc16);
             dsps_bit_rev_sc16_ansi(ptr, self.len as i32);
         }
         if !self.forward {

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -103,10 +103,16 @@ unsafe extern "C" {
     /// register `a4` (the `w` pointer) uninitialised — the asm
     /// then reads from a garbage address inside the inner butterfly
     /// loop and crashes with `LoadProhibited` on real hardware.
+    /// LX6 baseline radix-2 fc32 FFT. Active when `aes3` feature is off.
+    #[cfg(not(feature = "aes3"))]
     fn dsps_fft2r_fc32_ae32_(data: *mut f32, N: i32, w: *const f32) -> i32;
 
+    /// LX7 PIE radix-2 fc32 FFT — ~2× throughput on ESP32-S3.
+    #[cfg(feature = "aes3")]
+    fn dsps_fft2r_fc32_aes3_(data: *mut f32, N: i32, w: *const f32) -> i32;
+
     /// Bit-reverse the radix-2 output into natural order. Call after
-    /// `dsps_fft2r_fc32_ae32_`.
+    /// `dsps_fft2r_fc32_ae32_` / `_aes3_`.
     fn dsps_bit_rev_fc32_ansi(data: *mut f32, N: i32) -> i32;
 
     /// Twiddle-factor table allocated and populated by
@@ -115,7 +121,11 @@ unsafe extern "C" {
 
     // ── i16 (sc16) variants ──────────────────────────────────
     fn dsps_fft2r_init_sc16(fft_table_buff: *mut i16, table_size: i32) -> i32;
+    #[cfg(not(feature = "aes3"))]
     fn dsps_fft2r_sc16_ae32_(data: *mut i16, N: i32, w: *const i16) -> i32;
+    /// LX7 PIE radix-2 sc16 FFT.
+    #[cfg(feature = "aes3")]
+    fn dsps_fft2r_sc16_aes3_(data: *mut i16, N: i32, w: *const i16) -> i32;
     fn dsps_bit_rev_sc16_ansi(data: *mut i16, N: i32) -> i32;
     static dsps_fft_w_table_sc16: *const i16;
 
@@ -281,7 +291,10 @@ impl Fft for MixedRadix3840Fft {
         let mut esp_dsp_256 = |row: &mut [Complex32; 256]| {
             let ptr = row.as_mut_ptr() as *mut f32;
             unsafe {
+                #[cfg(not(feature = "aes3"))]
                 dsps_fft2r_fc32_ae32_(ptr, 256, dsps_fft_w_table_fc32);
+                #[cfg(feature = "aes3")]
+                dsps_fft2r_fc32_aes3_(ptr, 256, dsps_fft_w_table_fc32);
                 dsps_bit_rev_fc32_ansi(ptr, 256);
             }
         };
@@ -321,7 +334,10 @@ impl Fft for EspDspFft {
         // `dsps_fft_w_table_fc32` is valid because `ensure_table` has
         // already called `dsps_fft2r_init_fc32` which populates it.
         unsafe {
+            #[cfg(not(feature = "aes3"))]
             dsps_fft2r_fc32_ae32_(ptr, self.len as i32, dsps_fft_w_table_fc32);
+            #[cfg(feature = "aes3")]
+            dsps_fft2r_fc32_aes3_(ptr, self.len as i32, dsps_fft_w_table_fc32);
             // Bit-reverse the in-place output to get natural order.
             dsps_bit_rev_fc32_ansi(ptr, self.len as i32);
         }
@@ -442,7 +458,10 @@ impl Fft16 for MixedRadix3840Sc16Fft {
         for n2 in 0..N2 {
             let row_ptr = rows[n2 * N1..(n2 + 1) * N1].as_mut_ptr() as *mut i16;
             unsafe {
+                #[cfg(not(feature = "aes3"))]
                 dsps_fft2r_sc16_ae32_(row_ptr, N1 as i32, dsps_fft_w_table_sc16);
+                #[cfg(feature = "aes3")]
+                dsps_fft2r_sc16_aes3_(row_ptr, N1 as i32, dsps_fft_w_table_sc16);
                 dsps_bit_rev_sc16_ansi(row_ptr, N1 as i32);
             }
         }
@@ -496,7 +515,10 @@ impl Fft16 for EspDspFft16 {
         }
         // SAFETY: 2*N contiguous i16; `dsps_fft_w_table_sc16` valid post-init.
         unsafe {
+            #[cfg(not(feature = "aes3"))]
             dsps_fft2r_sc16_ae32_(ptr, self.len as i32, dsps_fft_w_table_sc16);
+            #[cfg(feature = "aes3")]
+            dsps_fft2r_sc16_aes3_(ptr, self.len as i32, dsps_fft_w_table_sc16);
             dsps_bit_rev_sc16_ansi(ptr, self.len as i32);
         }
         if !self.forward {

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -9,9 +9,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::ptr;
 
-use esp_idf_svc::sys::{
-    xQueueGenericCreate, xQueueGenericSend, xQueueReceive, QueueHandle_t,
-};
+use esp_idf_svc::sys::{xQueueGenericCreate, xQueueGenericSend, xQueueReceive, QueueHandle_t};
 
 const PD_PASS: i32 = 1;
 const QUEUE_SEND_TO_BACK: i32 = 0;
@@ -310,13 +308,7 @@ pub fn try_send_box<T>(q: QueueHandle_t, boxed: Box<T>) -> Result<(), Box<T>> {
 /// stage1_inc to discard its in-progress spec.
 pub fn try_recv_box<T>(q: QueueHandle_t) -> Option<Box<T>> {
     let mut raw: *mut T = ptr::null_mut();
-    let r = unsafe {
-        xQueueReceive(
-            q,
-            (&mut raw as *mut *mut T) as *mut core::ffi::c_void,
-            0,
-        )
-    };
+    let r = unsafe { xQueueReceive(q, (&mut raw as *mut *mut T) as *mut core::ffi::c_void, 0) };
     if r == PD_PASS {
         debug_assert!(!raw.is_null());
         Some(unsafe { Box::from_raw(raw) })

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -580,36 +580,65 @@ fn compute_pair_into(ctx: &mut WorkerCtx, j_a: usize, j_b: usize) {
     ctx.fft.process(&mut ctx.fft_buf);
 
     // Demux pair → spec rows.
+    // D4: DC bin hoisted (kn=0 special case removed from inner loop);
+    // 4× unrolled main loop; per-square u32 cast avoids i32 addition
+    // overflow at ±32768 edges (each square ≤ 2^30, sum ≤ 2^31 < u32::MAX).
     let row_a = j_a * n_freq;
     let row_b = j_b * n_freq;
     {
         let buf = &ctx.fft_buf;
         let spec = &mut ctx.cur.spec;
-        for k in 0..n_freq {
-            let kn = if k == 0 { 0 } else { NFFT_SPEC - k };
-            let yk_re = buf[k].re as i32;
-            let yk_im = buf[k].im as i32;
-            let yn_re = buf[kn].re as i32;
-            let yn_im = buf[kn].im as i32;
-            let a_re = (yk_re + yn_re) >> 1;
-            let a_im = (yk_im - yn_im) >> 1;
-            let b_re = (yk_im + yn_im) >> 1;
-            let b_im = (yn_re - yk_re) >> 1;
-            // mag² saturate at u16::MAX. Wrapping `as u16` (the
-            // pre-Phase 1.7.7b behaviour) was a real bug: very strong
-            // co-channel bins overflowed u16 after `>> FP_SPEC_SHIFT`
-            // and aliased to a tiny residue, making strong stations
-            // *invisible* to `coarse_sync`. Caught while tracing the
-            // host vs embedded NSTEP divergence — the host fixed-point
-            // path already saturates (`spectrogram.rs::compute_spectrogram`
-            // mag2 sites). Matching it here keeps the two paths
-            // algorithmically identical.
-            let mag2_a =
-                (((a_re * a_re + a_im * a_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            let mag2_b =
-                (((b_re * b_re + b_im * b_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            spec[row_a + k] = mag2_a as u16;
-            spec[row_b + k] = mag2_b as u16;
+
+        // k=0: DC bin — kn=0 so yn=yk; b = imaginary half-band (zero-phase)
+        if n_freq > 0 {
+            let r0 = buf[0].re as i32;
+            let i0 = buf[0].im as i32;
+            spec[row_a] = ((r0 * r0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b] = ((i0 * i0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+        }
+
+        // k=1..n_freq: kn = NFFT_SPEC - k (no branch needed).
+        // 4× unrolled to expose independent multiply chains to the FPU
+        // pipeline (opt-level=1 does not auto-unroll on Xtensa LX7).
+        let mut k = 1usize;
+        while k + 4 <= n_freq {
+            let yk0 = buf[k];
+            let yk1 = buf[k + 1];
+            let yk2 = buf[k + 2];
+            let yk3 = buf[k + 3];
+            let yn0 = buf[NFFT_SPEC - k];
+            let yn1 = buf[NFFT_SPEC - k - 1];
+            let yn2 = buf[NFFT_SPEC - k - 2];
+            let yn3 = buf[NFFT_SPEC - k - 3];
+
+            let (a0r, a0i) = ((yk0.re as i32 + yn0.re as i32) >> 1, (yk0.im as i32 - yn0.im as i32) >> 1);
+            let (b0r, b0i) = ((yk0.im as i32 + yn0.im as i32) >> 1, (yn0.re as i32 - yk0.re as i32) >> 1);
+            let (a1r, a1i) = ((yk1.re as i32 + yn1.re as i32) >> 1, (yk1.im as i32 - yn1.im as i32) >> 1);
+            let (b1r, b1i) = ((yk1.im as i32 + yn1.im as i32) >> 1, (yn1.re as i32 - yk1.re as i32) >> 1);
+            let (a2r, a2i) = ((yk2.re as i32 + yn2.re as i32) >> 1, (yk2.im as i32 - yn2.im as i32) >> 1);
+            let (b2r, b2i) = ((yk2.im as i32 + yn2.im as i32) >> 1, (yn2.re as i32 - yk2.re as i32) >> 1);
+            let (a3r, a3i) = ((yk3.re as i32 + yn3.re as i32) >> 1, (yk3.im as i32 - yn3.im as i32) >> 1);
+            let (b3r, b3i) = ((yk3.im as i32 + yn3.im as i32) >> 1, (yn3.re as i32 - yk3.re as i32) >> 1);
+
+            spec[row_a + k]     = (((a0r*a0r) as u32 + (a0i*a0i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k]     = (((b0r*b0r) as u32 + (b0i*b0i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_a + k + 1] = (((a1r*a1r) as u32 + (a1i*a1i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k + 1] = (((b1r*b1r) as u32 + (b1i*b1i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_a + k + 2] = (((a2r*a2r) as u32 + (a2i*a2i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k + 2] = (((b2r*b2r) as u32 + (b2i*b2i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_a + k + 3] = (((a3r*a3r) as u32 + (a3i*a3i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k + 3] = (((b3r*b3r) as u32 + (b3i*b3i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+
+            k += 4;
+        }
+        while k < n_freq {
+            let yn = buf[NFFT_SPEC - k];
+            let yk = buf[k];
+            let (ar, ai) = ((yk.re as i32 + yn.re as i32) >> 1, (yk.im as i32 - yn.im as i32) >> 1);
+            let (br, bi) = ((yk.im as i32 + yn.im as i32) >> 1, (yn.re as i32 - yk.re as i32) >> 1);
+            spec[row_a + k] = (((ar*ar) as u32 + (ai*ai) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k] = (((br*br) as u32 + (bi*bi) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            k += 1;
         }
     }
 

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -16,9 +16,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use esp_idf_svc::sys::{
-    esp_timer_get_time, xTaskCreatePinnedToCore, QueueHandle_t,
-};
+use esp_idf_svc::sys::{esp_timer_get_time, xTaskCreatePinnedToCore, QueueHandle_t};
 
 use mfsk_core::core::fft::{Fft16, FftPlanner16};
 use num_complex::Complex;
@@ -37,7 +35,10 @@ const NTONES: usize = 8;
 // candidates land in the wrong frequency bins and the entire slot
 // silently produces zero results (recall=0). Keep `assert!` below.
 const NFFT_SPEC: usize = mfsk_core::ft8::decode_block::NFFT_SPEC;
-const _: () = assert!(NFFT_SPEC == 3_840, "stage1_inc NFFT_SPEC must match mfsk_core (3840)");
+const _: () = assert!(
+    NFFT_SPEC == 3_840,
+    "stage1_inc NFFT_SPEC must match mfsk_core (3840)"
+);
 const FP_SPEC_SHIFT: u32 = 12;
 const TONE_SPACING_HZ: f32 = 6.25;
 const SAMPLE_RATE_HZ: f32 = 12_000.0;
@@ -332,7 +333,10 @@ pub fn spawn_with_wf(
             1, // APP_CPU
         )
     };
-    assert_eq!(r, PD_PASS, "xTaskCreatePinnedToCore(stage1_inc) failed: {r}");
+    assert_eq!(
+        r, PD_PASS,
+        "xTaskCreatePinnedToCore(stage1_inc) failed: {r}"
+    );
     log::info!(
         "stage1_inc: spawned (APP_CPU prio 6 — preempts dsp_worker); n_time={} n_pairs={} n_freq={}",
         N_TIME,
@@ -351,7 +355,10 @@ extern "C" fn worker_main(arg: *mut c_void) {
             ChunkMsg::Samples(samples) => {
                 ingest_samples(ctx, &samples);
             }
-            ChunkMsg::SlotEnd { wav_idx, total_samples } => {
+            ChunkMsg::SlotEnd {
+                wav_idx,
+                total_samples,
+            } => {
                 finalize_slot(ctx, wav_idx, total_samples);
             }
             ChunkMsg::SlotResetMark => {
@@ -597,10 +604,10 @@ fn compute_pair_into(ctx: &mut WorkerCtx, j_a: usize, j_b: usize) {
             // path already saturates (`spectrogram.rs::compute_spectrogram`
             // mag2 sites). Matching it here keeps the two paths
             // algorithmically identical.
-            let mag2_a = (((a_re * a_re + a_im * a_im) as u32) >> FP_SPEC_SHIFT)
-                .min(u16::MAX as u32);
-            let mag2_b = (((b_re * b_re + b_im * b_im) as u32) >> FP_SPEC_SHIFT)
-                .min(u16::MAX as u32);
+            let mag2_a =
+                (((a_re * a_re + a_im * a_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
+            let mag2_b =
+                (((b_re * b_re + b_im * b_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
             spec[row_a + k] = mag2_a as u16;
             spec[row_b + k] = mag2_b as u16;
         }
@@ -642,10 +649,11 @@ fn decimate_pair_to_wf(
     let row_b = j_b * n_freq;
     let mut out = [0u8; crate::pipeline::WF_ROW_LEN];
     for col in 0..crate::pipeline::WF_ROW_LEN {
-        let f0 = WF_FREQ_LO_HZ + (col as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ)
-            / crate::pipeline::WF_ROW_LEN as f32;
-        let f1 = WF_FREQ_LO_HZ + ((col + 1) as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ)
-            / crate::pipeline::WF_ROW_LEN as f32;
+        let f0 = WF_FREQ_LO_HZ
+            + (col as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ) / crate::pipeline::WF_ROW_LEN as f32;
+        let f1 = WF_FREQ_LO_HZ
+            + ((col + 1) as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ)
+                / crate::pipeline::WF_ROW_LEN as f32;
         let bin_lo = (f0 / df).floor() as usize;
         let bin_hi = ((f1 / df).ceil() as usize).min(n_freq);
         if bin_hi <= bin_lo {
@@ -696,26 +704,42 @@ fn update_one_half(
     dst: &mut [f32],
 ) {
     // 7-tone gather at 2-bin step — matches WSJT-X `sync8.f90:66`
-    // (k=0..6; tone 7 is data-only, never a Costas position) and
-    // `coarse_sync_inner`'s score-formula divisor `(NTONES - 2) = 6`.
+    // (k=0..6; tone 7 is data-only, never a Costas position).
+    // NFFT=3840 → tone_step_bins=2.0 exactly → single-bin gather.
     //
-    // NFFT=3840 → tone_step_bins = 2.0 exactly. The earlier 16-bin
-    // contiguous sliding window matched the NFFT=4096 era when
-    // tone_step ≈ 2.13 + Hann mainlobe leakage made the in-between
-    // bins informative; at NFFT=3840 those bins carry pure noise and
-    // a 16-contig sum nearly doubles `t0_ref`, halving sync ratio
-    // and dropping weak qso3 signals (mid/high band → 0 hits).
-    const TONE_STEP_BINS: usize = 2;
+    // Sliding window: carriers at fi and fi+2 share 6 of 7 bins.
+    // allsum[fi] = allsum[fi-2] + row[ia+fi+12] - row[ia+fi-2].
+    // Reduces inner work from 7 adds to 1 add + 1 sub per carrier
+    // after the two seed values. Sequential row reads stay in cache.
+    if n_freq == 0 {
+        return;
+    }
     let row_base = m * spec_n_freq;
     let upper = spec_n_freq - 1;
-    for fi in 0..n_freq {
-        let i_carrier = ia + fi;
-        let mut s: f32 = 0.0;
-        for k in 0..(NTONES - 1) {
-            let bin = (i_carrier + TONE_STEP_BINS * k).min(upper);
-            s += spec[row_base + bin] as f32;
+    let row = &spec[row_base..row_base + spec_n_freq];
+    // Seed prev[0] (even fi=0) and prev[1] (odd fi=1) with full sums.
+    let mut prev = [0.0f32; 2];
+    for parity in 0..2usize {
+        if parity >= n_freq {
+            break;
         }
+        let i_carrier = ia + parity;
+        let mut s = 0.0f32;
+        for k in 0..(NTONES - 1) {
+            let bin = (i_carrier + 2 * k).min(upper);
+            s += row[bin] as f32;
+        }
+        dst[parity * N_TIME + m] = s;
+        prev[parity] = s;
+    }
+    for fi in 2..n_freq {
+        let i_carrier = ia + fi;
+        let drop = (i_carrier - 2).min(upper);
+        let add = (i_carrier + 2 * (NTONES - 2)).min(upper);
+        let p = fi & 1;
+        let s = prev[p] + row[add] as f32 - row[drop] as f32;
         dst[fi * N_TIME + m] = s;
+        prev[p] = s;
     }
 }
 

--- a/embedded-poc/embedded-shared/src/wav_sim.rs
+++ b/embedded-poc/embedded-shared/src/wav_sim.rs
@@ -15,9 +15,7 @@ use core::ptr;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use esp_idf_svc::sys::{
-    configTICK_RATE_HZ, vTaskDelay, xTaskCreatePinnedToCore, QueueHandle_t,
-};
+use esp_idf_svc::sys::{configTICK_RATE_HZ, vTaskDelay, xTaskCreatePinnedToCore, QueueHandle_t};
 
 use crate::pipeline::{send_box, ChunkMsg, CHUNK_LEN};
 

--- a/embedded-poc/m5stack-s3-app/Cargo.toml
+++ b/embedded-poc/m5stack-s3-app/Cargo.toml
@@ -45,7 +45,7 @@ mfsk-core = { path = "../../mfsk-core", default-features = false, features = ["a
 mfsk-ffi-ft8 = { path = "../../mfsk-ffi-ft8", default-features = false, features = ["embedded-fixed-point"] }
 
 # 共有 embedded glue (streaming buffer / esp_dsp_fft / dual_core / Q3i8 LLR)
-embedded-shared = { path = "../embedded-shared" }
+embedded-shared = { path = "../embedded-shared", features = ["aes3"] }
 
 # Board-agnostic app logic (QSO FSM, time sync, TX picker, SNR norm,
 # NVS boot mode, log fanout, WiFi + UDP, UI data + draw routines).

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -834,7 +834,6 @@ pub fn run_log_panel(
             selected_decode_idx,
             latest_slot_seq_snapshot,
         );
-        let mut decoded_redrawn = false;
         if decoded_fp_with_cursor != last_decoded_fp_with_cursor {
             decoded_list::render_with_cursor(
                 &mut display,
@@ -844,21 +843,18 @@ pub fn run_log_panel(
             )
             .ok();
             last_decoded_fp_with_cursor = decoded_fp_with_cursor;
-            decoded_redrawn = true;
         }
 
-        // Menu overlay — render AFTER WF + decoded so the overlay
-        // paints on top of whatever they put down. The menu region
-        // (32, 16) … (132, 84) sits fully inside the WF region
-        // y ∈ [14, 114), so a WF repaint (~80 ms cadence per FFT
-        // pair) would otherwise erase the menu within one or two
-        // ticks. We track both the menu_seq watermark *and* the
-        // WF/decoded redraw flags so the menu re-paints whenever
-        // anything underneath it changed.
+        // Menu overlay — render AFTER WF so the overlay paints on
+        // top of any WF repaint. The menu region (32, 16) … (132,
+        // 84) sits fully inside the WF region y ∈ [14, 114), so a
+        // WF repaint (~80 ms cadence per FFT pair) would otherwise
+        // erase the menu within one or two ticks. The decoded
+        // list (y ∈ [114, …]) does NOT overlap the menu, so its
+        // redraws are irrelevant here (Gemini PR #124 review).
         let menu_seq = menu_snapshot.5;
         let menu_seq_changed = menu_seq != last_menu_seq;
-        let underlying_redrawn = wf_redrawn || decoded_redrawn;
-        if menu_seq_changed || (menu_snapshot.0 && underlying_redrawn) {
+        if menu_seq_changed || (menu_snapshot.0 && wf_redrawn) {
             menu::render(
                 &mut display,
                 menu_snapshot.0,
@@ -869,11 +865,12 @@ pub fn run_log_panel(
                 mode.flipped().label(),
             )
             .ok();
-            // When menu closes, force a full re-render of WF + decoded
-            // next iteration so the overlay's residual pixels go away.
+            // When menu closes, force a full WF re-render next
+            // iteration so the overlay's residual pixels get
+            // wiped. The decoded list doesn't share pixels with
+            // the menu so we don't touch its watermark.
             if menu_seq_changed && !menu_snapshot.0 {
                 last_wf_seq = u32::MAX;
-                last_decoded_fp_with_cursor = (usize::MAX, u32::MAX, None, u32::MAX);
             }
             last_menu_seq = menu_seq;
         }

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -810,6 +810,16 @@ pub fn run_log_panel(
         // wipe in the renderer so it doesn't flicker).
         status_bar::render(&mut display, &status_snapshot).ok();
 
+        // Pre-detect menu close (transition from visible → hidden)
+        // and force a WF repaint in this same iteration so the
+        // overlay's residual pixels get wiped without the 100 ms
+        // one-tick lag a post-WF check would have caused.
+        let menu_seq = menu_snapshot.5;
+        let menu_seq_changed = menu_seq != last_menu_seq;
+        if menu_seq_changed && !menu_snapshot.0 {
+            last_wf_seq = u32::MAX;
+        }
+
         // Waterfall: streams at per-pair cadence. Trigger on
         // `wf_push_seq` so the redraw still fires after the ring
         // saturates at WF_DEPTH (= ~8 s into runtime).
@@ -850,10 +860,7 @@ pub fn run_log_panel(
         // 84) sits fully inside the WF region y ∈ [14, 114), so a
         // WF repaint (~80 ms cadence per FFT pair) would otherwise
         // erase the menu within one or two ticks. The decoded
-        // list (y ∈ [114, …]) does NOT overlap the menu, so its
-        // redraws are irrelevant here (Gemini PR #124 review).
-        let menu_seq = menu_snapshot.5;
-        let menu_seq_changed = menu_seq != last_menu_seq;
+        // list (y ∈ [114, …]) does NOT overlap the menu.
         if menu_seq_changed || (menu_snapshot.0 && wf_redrawn) {
             menu::render(
                 &mut display,
@@ -865,13 +872,6 @@ pub fn run_log_panel(
                 mode.flipped().label(),
             )
             .ok();
-            // When menu closes, force a full WF re-render next
-            // iteration so the overlay's residual pixels get
-            // wiped. The decoded list doesn't share pixels with
-            // the menu so we don't touch its watermark.
-            if menu_seq_changed && !menu_snapshot.0 {
-                last_wf_seq = u32::MAX;
-            }
             last_menu_seq = menu_seq;
         }
 

--- a/embedded-poc/m5stack-s3-app/src/display.rs
+++ b/embedded-poc/m5stack-s3-app/src/display.rs
@@ -810,32 +810,10 @@ pub fn run_log_panel(
         // wipe in the renderer so it doesn't flicker).
         status_bar::render(&mut display, &status_snapshot).ok();
 
-        // Menu overlay — render after WF/decoded so it paints on top.
-        // Tracking last menu_seq to avoid redraw when nothing changed.
-        let menu_seq = menu_snapshot.5;
-        if menu_seq != last_menu_seq {
-            menu::render(
-                &mut display,
-                menu_snapshot.0,
-                menu_snapshot.1,
-                menu_snapshot.2,
-                menu_snapshot.3,
-                menu_snapshot.4,
-                mode.flipped().label(),
-            )
-            .ok();
-            // When menu closes, force a full re-render of WF + decoded
-            // next iteration so the overlay's residual pixels go away.
-            if !menu_snapshot.0 {
-                last_wf_seq = u32::MAX;
-                last_decoded_fp_with_cursor = (usize::MAX, u32::MAX, None, u32::MAX);
-            }
-            last_menu_seq = menu_seq;
-        }
-
         // Waterfall: streams at per-pair cadence. Trigger on
         // `wf_push_seq` so the redraw still fires after the ring
         // saturates at WF_DEPTH (= ~8 s into runtime).
+        let mut wf_redrawn = false;
         if wf_seq != last_wf_seq {
             let wf_refs: heapless::Vec<
                 &mfsk_app_shared::ui::state::WfLine,
@@ -843,6 +821,7 @@ pub fn run_log_panel(
             > = wf_snapshot.iter().collect();
             waterfall::render(&mut display, &wf_refs).ok();
             last_wf_seq = wf_seq;
+            wf_redrawn = true;
         }
 
         // Decoded list: redraw when a new slot's results landed OR
@@ -855,6 +834,7 @@ pub fn run_log_panel(
             selected_decode_idx,
             latest_slot_seq_snapshot,
         );
+        let mut decoded_redrawn = false;
         if decoded_fp_with_cursor != last_decoded_fp_with_cursor {
             decoded_list::render_with_cursor(
                 &mut display,
@@ -864,6 +844,38 @@ pub fn run_log_panel(
             )
             .ok();
             last_decoded_fp_with_cursor = decoded_fp_with_cursor;
+            decoded_redrawn = true;
+        }
+
+        // Menu overlay — render AFTER WF + decoded so the overlay
+        // paints on top of whatever they put down. The menu region
+        // (32, 16) … (132, 84) sits fully inside the WF region
+        // y ∈ [14, 114), so a WF repaint (~80 ms cadence per FFT
+        // pair) would otherwise erase the menu within one or two
+        // ticks. We track both the menu_seq watermark *and* the
+        // WF/decoded redraw flags so the menu re-paints whenever
+        // anything underneath it changed.
+        let menu_seq = menu_snapshot.5;
+        let menu_seq_changed = menu_seq != last_menu_seq;
+        let underlying_redrawn = wf_redrawn || decoded_redrawn;
+        if menu_seq_changed || (menu_snapshot.0 && underlying_redrawn) {
+            menu::render(
+                &mut display,
+                menu_snapshot.0,
+                menu_snapshot.1,
+                menu_snapshot.2,
+                menu_snapshot.3,
+                menu_snapshot.4,
+                mode.flipped().label(),
+            )
+            .ok();
+            // When menu closes, force a full re-render of WF + decoded
+            // next iteration so the overlay's residual pixels go away.
+            if menu_seq_changed && !menu_snapshot.0 {
+                last_wf_seq = u32::MAX;
+                last_decoded_fp_with_cursor = (usize::MAX, u32::MAX, None, u32::MAX);
+            }
+            last_menu_seq = menu_seq;
         }
 
         // TX line: 3-way priority — sync prompt > sync-mark

--- a/embedded-poc/m5stack-s3-app/src/main.rs
+++ b/embedded-poc/m5stack-s3-app/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> ! {
 
     log::info!("=== mfsk-core-m5stack-s3-app boot ===");
     log::info!("phase 0.7c: runtime boot-mode (NVS + KEY1 override + KEY2 long-press)");
-    log::info!("build-stamp 2026-05-17-phase17-qso");
+    log::info!("build-stamp 2026-05-22-phaseD1-aes3-goertzel");
 
     // Global QSO FSM instance. Empty MY_CALL keeps the FSM Idle so
     // the TX scheduler / auto-CQ stays a no-op until cfg.toml provides

--- a/embedded-poc/m5stack-s3/Cargo.toml
+++ b/embedded-poc/m5stack-s3/Cargo.toml
@@ -63,7 +63,7 @@ num-complex = { version = "0.4", default-features = false }
 
 # Shared embedded glue (wav_sim / esp_dsp_fft / dual_core / stage1_inc /
 # internal_pool). Compiled per-target alongside this binary.
-embedded-shared = { path = "../embedded-shared" }
+embedded-shared = { path = "../embedded-shared", features = ["aes3"] }
 
 [build-dependencies]
 embuild = "0.33"

--- a/embedded-poc/m5stack-s3/src/bin/rx_wavsim.rs
+++ b/embedded-poc/m5stack-s3/src/bin/rx_wavsim.rs
@@ -11,14 +11,15 @@ const QSO_WAVS: &[&[u8]] = &[
 ];
 
 fn main() -> ! {
-    // Ship config 2026-05-05 (post Hann→Rect window fix in stage1_inc):
+    // Ship config (post Hann→Rect window fix in stage1_inc):
     //   pass1=30, max_cand=15, q_thresh=DEFAULT_Q_THRESH (=6),
     //   bp_max_iter=DEFAULT_BP_MAX_ITER (=30).
-    // qso3_busy: 6/18 JTDX hits in ~1.30 s post-SlotEnd. Compute-
-    // optimal Pareto across the 9-cfg sweep (logs/s3_rect_sweep_*).
-    // Wider cfgs (45/20, 60/30) recover no extra decodes — N1PJT
-    // HB9CQK at -10 dB is structurally lost without fine_refine_pass1
-    // (192k cd0 FFT, infeasible on Xtensa).
+    // qso3_busy: 6/18 JTDX hits. Compute-optimal Pareto across the
+    // 9-cfg sweep (logs/s3_rect_sweep_*). Wider cfgs (45/20, 60/30)
+    // recover no extra decodes — N1PJT HB9CQK at -10 dB is
+    // structurally lost without fine_refine_pass1 (192k cd0 FFT,
+    // infeasible on Xtensa).
+    // Phase-C (run_speculative_slot) timing: see flash logs.
     embedded_shared::apps::rx_wavsim::run(
         QSO_WAVS,
         30,

--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -139,16 +139,82 @@ pub fn precompute_coarse_allsum_into(
     fill_coarse_allsum(spec, ia, ib, n_freq, dst);
 }
 
-/// Build the 16-bin sliding-window allsum for the carrier-bin range
-/// `[ia..=ib]` into the caller buffer `dst` (length
-/// `n_freq * spec.n_time`, layout `dst[fi * n_time + m]`).
+/// Build the 7-tone-stride-2 allsum for one time slice `m` into `dst`.
 ///
-/// Mirrors the inline precompute inside [`coarse_sync_inner`] —
-/// kept as a separate helper so the embedded port can replicate it
-/// row-by-row in [`stage1_inc`] without depending on private
-/// internals. Computes for **every m**, not just `needed_m`, so
-/// callers can populate cells incrementally with single-row updates
-/// in any order.
+/// Loop order: `m`-outer, `fi`-inner. One time slice (~2 KB at u16)
+/// stays in cache for all carriers instead of striding by `n_freq`
+/// bytes per time step.
+///
+/// Under `fixed-point` (SpecCell = u16, values ≤ 65535): uses a
+/// **sliding window** — carriers at `fi` and `fi+2` share 6 of 7
+/// bins, so `allsum[fi] = allsum[fi-2] + row[ia+fi+12] - row[ia+fi-2]`.
+/// Reduces inner work from 7 adds to 1 add + 1 sub. Intermediate
+/// sums ≤ 7×65535 < 2^19 are exactly representable in f32, so no
+/// drift accumulates.
+///
+/// Without `fixed-point` (SpecCell = f32, host path): direct sum to
+/// avoid rounding drift on large spectrum values that would break the
+/// full-band-allsum-then-slice equivalence test.
+fn fill_allsum_row(spec: &Spectrogram, ia: usize, n_freq: usize, m: usize, dst: &mut [CoarseAcc]) {
+    if n_freq == 0 {
+        return;
+    }
+    let nh1 = spec.n_freq;
+    let upper = nh1 - 1;
+    let n_time = spec.n_time;
+
+    #[cfg(feature = "fixed-point")]
+    {
+        // Sliding window: two independent chains (even / odd fi).
+        let mut prev = [CoarseAcc::default(); 2];
+        for parity in 0..2usize {
+            if parity >= n_freq {
+                break;
+            }
+            let i_carrier = ia + parity;
+            let mut s = CoarseAcc::default();
+            for k in 0..(NTONES - 1) {
+                let bin = (i_carrier + 2 * k).min(upper);
+                s += spec.power_acc(bin, m);
+            }
+            dst[parity * n_time + m] = s;
+            prev[parity] = s;
+        }
+        for fi in 2..n_freq {
+            let i_carrier = ia + fi;
+            let drop = (i_carrier - 2).min(upper);
+            let add = (i_carrier + 2 * (NTONES - 2)).min(upper);
+            let p = fi & 1;
+            #[allow(clippy::unnecessary_cast)]
+            let s = prev[p] + spec.power_acc(add, m) - spec.power_acc(drop, m);
+            dst[fi * n_time + m] = s;
+            prev[p] = s;
+        }
+    }
+
+    #[cfg(not(feature = "fixed-point"))]
+    {
+        // Direct sum: no f32 drift for host tests.
+        for fi in 0..n_freq {
+            let i_carrier = ia + fi;
+            let mut s = CoarseAcc::default();
+            for k in 0..(NTONES - 1) {
+                let bin = (i_carrier + 2 * k).min(upper);
+                s += spec.power_acc(bin, m);
+            }
+            dst[fi * n_time + m] = s;
+        }
+    }
+}
+
+/// Build the 7-tone-stride-2 allsum for the carrier range `[ia..=ib]`
+/// into `dst` (`n_freq * spec.n_time`, layout `dst[fi * n_time + m]`).
+///
+/// Mirrors the inline precompute inside [`coarse_sync_inner`] and
+/// [`stage1_inc::update_one_half`] — kept as a public helper so the
+/// embedded port can replicate it row-by-row without accessing private
+/// internals. Computes **every m** so callers can populate cells
+/// incrementally in any order.
 fn fill_coarse_allsum(
     spec: &Spectrogram,
     ia: usize,
@@ -156,25 +222,10 @@ fn fill_coarse_allsum(
     _n_freq: usize,
     dst: &mut [CoarseAcc],
 ) {
-    let nh1 = spec.n_freq;
-    // WSJT-X `sync8.f90:66` `t0a = sum(s(i:i+nfos*6:nfos, m))` — sums
-    // **7** tones (k=0..6), NOT 8. The Costas array uses `icos7 =
-    // [3,1,4,0,6,5,2]` ⊂ {0..6}; tone 7 is data-only and never a
-    // Costas position. Including tone 7 in the reference sum dilutes
-    // the discriminator with data/noise energy that has no parallel
-    // in WSJT-X — it shifts our normalised sync score relative to
-    // theirs and was a logical implementation diff. NFFT=3840 →
-    // tone_step_bins=2.0 exactly, so single-bin gather per tone.
-    for (fi, i_carrier) in (ia..=ib).enumerate() {
-        let row_off = fi * spec.n_time;
-        for m in 0..spec.n_time {
-            let mut s: CoarseAcc = CoarseAcc::default();
-            for k in 0..(NTONES - 1) {
-                let bin = (i_carrier + 2 * k).min(nh1 - 1);
-                s += spec.power_acc(bin, m);
-            }
-            dst[row_off + m] = s;
-        }
+    let n_freq = ib - ia + 1;
+    // m-outer loop: one time slice (~2 KB u16) stays in cache for all fi.
+    for m in 0..spec.n_time {
+        fill_allsum_row(spec, ia, n_freq, m, dst);
     }
 }
 
@@ -294,25 +345,15 @@ fn coarse_sync_inner(
         owned_allsum = {
             // Sum 7 Costas-tone bins (k=0..NTONES-1; tone 7 is data-only,
             // never a Costas position). Matches WSJT-X `sync8.f90:66` and
-            // the public `fill_coarse_allsum` helper, so the score
-            // formula's `(t0 - t) / (NTONES - 2)` divisor is calibrated:
-            // t0 sums 7 tones, t = 1 Costas-tone bin energy, t0-t = 6
-            // non-Costas tones, divisor = 6 ✓. Pre-fix this loop ran
-            // `0..NTONES` (= 8 tones), which made owned_allsum and
-            // fill_coarse_allsum disagree numerically and broke the
-            // `coarse_sync_with_allsum_matches_internal` /
-            // `coarse_sync_split_with_allsum_*` consistency tests.
+            // the public `fill_coarse_allsum` helper. Only populates
+            // `needed_m` cells — ~60 % of spec.n_time — to save ~40 % of
+            // allsum work; the remaining cells stay at default (0/0.0) and
+            // are never read by the score loop.
+            // Uses the stride-2 sliding window: allsum[fi] = allsum[fi-2]
+            // + row[add] - row[drop], 7× fewer ops per fi after init.
             let mut buf = vec![CoarseAcc::default(); n_freq * spec.n_time];
-            for (fi, i_carrier) in (ia..=ib).enumerate() {
-                let row_off = fi * spec.n_time;
-                for &m in &needed_m {
-                    let mut s: CoarseAcc = CoarseAcc::default();
-                    for k in 0..(NTONES - 1) {
-                        let bin = (i_carrier + 2 * k).min(nh1 - 1);
-                        s += spec.power_acc(bin, m);
-                    }
-                    buf[row_off + m] = s;
-                }
+            for &m in &needed_m {
+                fill_allsum_row(spec, ia, n_freq, m, &mut buf);
             }
             buf
         };

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -704,7 +704,7 @@ pub fn fill_symbol_spectra_goertzel<S: AudioSample>(
         // sequential load that LLVM's unroll + Xtensa FPU pipeline can
         // run at ~1 cycle/tone/sample. Cold path (first/last ~1 symbol
         // per candidate) keeps the original per-sample check.
-        if sym_start >= 0 && sym_start as usize + NSPS <= audio.len() {
+        if sym_start >= 0 && (sym_start as usize) <= audio.len().saturating_sub(NSPS) {
             let base = sym_start as usize;
             for n in 0..NSPS {
                 let sample = audio[base + n].to_i16() as f32;

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -698,21 +698,36 @@ pub fn fill_symbol_spectra_goertzel<S: AudioSample>(
         let mut s_prev = [0.0_f32; NTONES];
         let mut s_prev2 = [0.0_f32; NTONES];
 
-        for n in 0..NSPS {
-            let idx = sym_start + n as i64;
-            let sample = if idx >= 0 && (idx as usize) < audio.len() {
-                audio[idx as usize].to_i16() as f32
-            } else {
-                0.0
-            };
-            // NTONES=8 is `const`; LLVM unrolls this and the 8
-            // resulting fmul/fadd/fsub chains run independently — the
-            // Xtensa FPU's pipeline absorbs ~all of the per-chain
-            // latency in parallel.
-            for tone in 0..NTONES {
-                let s = sample + coeff[tone] * s_prev[tone] - s_prev2[tone];
-                s_prev2[tone] = s_prev[tone];
-                s_prev[tone] = s;
+        // Hot path: entire symbol window lies within audio bounds.
+        // The bounds check (idx >= 0 && idx < audio.len()) can then be
+        // hoisted out of the 1920-iteration inner loop, leaving a clean
+        // sequential load that LLVM's unroll + Xtensa FPU pipeline can
+        // run at ~1 cycle/tone/sample. Cold path (first/last ~1 symbol
+        // per candidate) keeps the original per-sample check.
+        if sym_start >= 0 && sym_start as usize + NSPS <= audio.len() {
+            let base = sym_start as usize;
+            for n in 0..NSPS {
+                let sample = audio[base + n].to_i16() as f32;
+                for tone in 0..NTONES {
+                    let s = sample + coeff[tone] * s_prev[tone] - s_prev2[tone];
+                    s_prev2[tone] = s_prev[tone];
+                    s_prev[tone] = s;
+                }
+            }
+        } else {
+            let audio_len = audio.len() as i64;
+            for n in 0..NSPS {
+                let idx = sym_start + n as i64;
+                let sample = if idx >= 0 && idx < audio_len {
+                    audio[idx as usize].to_i16() as f32
+                } else {
+                    0.0
+                };
+                for tone in 0..NTONES {
+                    let s = sample + coeff[tone] * s_prev[tone] - s_prev2[tone];
+                    s_prev2[tone] = s_prev[tone];
+                    s_prev[tone] = s;
+                }
             }
         }
 

--- a/mfsk-core/src/ft8/decode_block/spectrogram.rs
+++ b/mfsk-core/src/ft8/decode_block/spectrogram.rs
@@ -316,50 +316,112 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
         let row_b = j_b * n_freq;
         // Demux. Modular wrap (NFFT_SPEC=3840 isn't a power of two so
         // `& (NFFT-1)` would alias the high bins). `kn = (NFFT-k) mod
-        // NFFT` collapses k=0 to 0 — DC bin is real, as expected for
-        // real input.
-        for k in 0..n_freq {
-            let kn = if k == 0 { 0 } else { NFFT_SPEC - k };
-            let yk_re = buf[k].re as i32;
-            let yk_im = buf[k].im as i32;
-            let yn_re = buf[kn].re as i32;
-            let yn_im = buf[kn].im as i32;
-            let a_re = (yk_re + yn_re) >> 1;
-            let a_im = (yk_im - yn_im) >> 1;
-            let b_re = (yk_im + yn_im) >> 1;
-            let b_im = (yn_re - yk_re) >> 1;
-            // Square via `unsigned_abs` to dodge the `i32` overflow at
-            // `(-32768)² + (-32768)² = 2^31`, which doesn't fit in i32
-            // (panic in debug, wrap to negative in release). Squaring as
-            // `u32` keeps the sum in 2^31 with one bit to spare —
-            // `>> FP_SPEC_SHIFT` (= 12) lands in u32.
-            // `.min(u16::MAX as u32)` then saturates the u16 cast so
-            // extremely-strong signals (two coincident tones at the
-            // same bin per the FP_SPEC_SHIFT comment) cap at u16::MAX
-            // instead of wrapping to a tiny value. Gemini PR #83 + #100
-            // review.
-            // mag² saturate at u16::MAX. Wrapping `as u16` (the
-            // pre-Phase 1.7.7b behaviour on the embedded path) was a
-            // real bug: very-strong-bin energy overflowed u16 after
-            // `>> FP_SPEC_SHIFT` and aliased to a tiny residue, hiding
-            // strong stations from `coarse_sync`. Both host fixed-point
-            // here and `embedded-shared::stage1_inc` saturate now.
-            // Use `unsigned_abs` so the squares stay in u32 with a bit
-            // to spare for the sum, then `.min(u16::MAX as u32)`.
-            let aru = a_re.unsigned_abs();
-            let aiu = a_im.unsigned_abs();
-            let bru = b_re.unsigned_abs();
-            let biu = b_im.unsigned_abs();
-            let mag2_a = ((aru * aru + aiu * aiu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            let mag2_b = ((bru * bru + biu * biu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            data[row_a + k] = mag2_a as u16;
-            data[row_b + k] = mag2_b as u16;
-            #[cfg(feature = "std")]
-            if jj == 0 && (k == 64 || k == 823) {
-                eprintln!(
-                    "[host spec] pair0 k={k}: yk=({},{}) yn=({},{}) a=({},{}) b=({},{}) mag2_a={mag2_a} mag2_b={mag2_b}",
-                    yk_re, yk_im, yn_re, yn_im, a_re, a_im, b_re, b_im
-                );
+        // NFFT` collapses k=0 to 0 — DC bin is real.
+        //
+        // D4: DC bin hoisted; main loop 4× unrolled to expose
+        // independent multiply chains at opt-level=1. Per-square u32
+        // cast: each square ≤ 2^30 fits in i32; cast before adding so
+        // the sum ≤ 2^31 stays within u32 (avoids i32 panic in debug
+        // for the ±32768 edge case that `unsigned_abs` was guarding).
+
+        // k=0: DC bin (kn=0 → yn=yk)
+        if n_freq > 0 {
+            let r0 = buf[0].re as i32;
+            let i0 = buf[0].im as i32;
+            data[row_a] = ((r0 * r0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            data[row_b] = ((i0 * i0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+        }
+
+        let mut k = 1usize;
+        while k + 4 <= n_freq {
+            let yk0 = buf[k];
+            let yk1 = buf[k + 1];
+            let yk2 = buf[k + 2];
+            let yk3 = buf[k + 3];
+            let yn0 = buf[NFFT_SPEC - k];
+            let yn1 = buf[NFFT_SPEC - k - 1];
+            let yn2 = buf[NFFT_SPEC - k - 2];
+            let yn3 = buf[NFFT_SPEC - k - 3];
+
+            let (a0r, a0i) = (
+                (yk0.re as i32 + yn0.re as i32) >> 1,
+                (yk0.im as i32 - yn0.im as i32) >> 1,
+            );
+            let (b0r, b0i) = (
+                (yk0.im as i32 + yn0.im as i32) >> 1,
+                (yn0.re as i32 - yk0.re as i32) >> 1,
+            );
+            let (a1r, a1i) = (
+                (yk1.re as i32 + yn1.re as i32) >> 1,
+                (yk1.im as i32 - yn1.im as i32) >> 1,
+            );
+            let (b1r, b1i) = (
+                (yk1.im as i32 + yn1.im as i32) >> 1,
+                (yn1.re as i32 - yk1.re as i32) >> 1,
+            );
+            let (a2r, a2i) = (
+                (yk2.re as i32 + yn2.re as i32) >> 1,
+                (yk2.im as i32 - yn2.im as i32) >> 1,
+            );
+            let (b2r, b2i) = (
+                (yk2.im as i32 + yn2.im as i32) >> 1,
+                (yn2.re as i32 - yk2.re as i32) >> 1,
+            );
+            let (a3r, a3i) = (
+                (yk3.re as i32 + yn3.re as i32) >> 1,
+                (yk3.im as i32 - yn3.im as i32) >> 1,
+            );
+            let (b3r, b3i) = (
+                (yk3.im as i32 + yn3.im as i32) >> 1,
+                (yn3.re as i32 - yk3.re as i32) >> 1,
+            );
+
+            data[row_a + k] = (((a0r * a0r) as u32 + (a0i * a0i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k] = (((b0r * b0r) as u32 + (b0i * b0i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_a + k + 1] = (((a1r * a1r) as u32 + (a1i * a1i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k + 1] = (((b1r * b1r) as u32 + (b1i * b1i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_a + k + 2] = (((a2r * a2r) as u32 + (a2i * a2i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k + 2] = (((b2r * b2r) as u32 + (b2i * b2i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_a + k + 3] = (((a3r * a3r) as u32 + (a3i * a3i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k + 3] = (((b3r * b3r) as u32 + (b3i * b3i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+
+            k += 4;
+        }
+        while k < n_freq {
+            let yn = buf[NFFT_SPEC - k];
+            let yk = buf[k];
+            let (ar, ai) = (
+                (yk.re as i32 + yn.re as i32) >> 1,
+                (yk.im as i32 - yn.im as i32) >> 1,
+            );
+            let (br, bi) = (
+                (yk.im as i32 + yn.im as i32) >> 1,
+                (yn.re as i32 - yk.re as i32) >> 1,
+            );
+            data[row_a + k] = (((ar * ar) as u32 + (ai * ai) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k] = (((br * br) as u32 + (bi * bi) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            k += 1;
+        }
+        #[cfg(feature = "std")]
+        if jj == 0 {
+            for ki in [64usize, 823usize] {
+                if ki < n_freq {
+                    eprintln!(
+                        "[host spec] pair0 k={ki}: mag2_a={} mag2_b={}",
+                        data[row_a + ki],
+                        data[row_b + ki]
+                    );
+                }
             }
         }
     }
@@ -375,10 +437,8 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
         for i in 0..n_freq {
             let re = buf[i].re as i32;
             let im = buf[i].im as i32;
-            // Same saturating mag² pattern as the demux loop above.
-            let ru = re.unsigned_abs();
-            let iu = im.unsigned_abs();
-            let mag2 = ((ru * ru + iu * iu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
+            let mag2 =
+                (((re * re) as u32 + (im * im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
             data[row_base + i] = mag2 as u16;
         }
     }


### PR DESCRIPTION
## Summary

- **D4 demux |x|²**: DC-hoist + 4× manual unroll in `spectrogram.rs` and `embedded-shared/stage1_inc.rs`; replaces `unsigned_abs()` with per-square `u32` cast (fixes i32 overflow edge case). Compute-bench stage 1: 1,650 ms → 1,635 ms (−0.9%).
- **rx_wavsim → `run_speculative_slot`**: Migrates bench from the old sequential 3-step pipeline to the same Phase-C speculative runner used by `m5stack-s3-app` / `m5stack-core2-app`. Drops 4 × 30 KB = 120 KB internal DRAM `.bss` (BASIS statics, dead since Phase 1.7.7 Goertzel migration).

## Benchmark results (M5StickS3, qso3_busy)

| Architecture | post-SlotEnd | TX margin (vs 500 ms deadline) |
|---|---|---|
| Old (sequential) | 1,388–1,797 ms | missed by up to 1,297 ms |
| **New (Phase-C)** | **57 ms** | **+443 ms** |

All pass1 candidates (26–27 of 30) fit the audio prefix; early pass2+stage3 completes before SlotEnd. `max_cand_late = 0` so the deferred path is skipped. post-SlotEnd = Slot queue recv latency only.

## Test plan
- [x] `cargo check --release` clean on `m5stack-s3` (zero warnings)
- [x] `cargo clippy` clean (pre-commit hook)
- [x] Flash + capture `rx-wavsim` on M5StickS3 — qso3_busy 7/7 decodes, post_slotend = 57 ms (6 slots)

🤖 Generated with [Claude Code](https://claude.com/claude-code)