### PR TITLE
perf(ft8): D3 allsum sliding window + m-outer loop order

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/compute_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/compute_bench.rs
@@ -175,9 +175,8 @@ fn ffi_smoke_one(slot: &[i16]) {
     if !results.items.is_null() {
         let items = unsafe { core::slice::from_raw_parts(results.items, results.len) };
         for (i, r) in items.iter().enumerate() {
-            let bytes: &[u8] = unsafe {
-                core::slice::from_raw_parts(r.text.as_ptr() as *const u8, r.text.len())
-            };
+            let bytes: &[u8] =
+                unsafe { core::slice::from_raw_parts(r.text.as_ptr() as *const u8, r.text.len()) };
             let n = bytes.iter().position(|&b| b == 0).unwrap_or(bytes.len());
             let text = core::str::from_utf8(&bytes[..n]).unwrap_or("<bad utf8>");
             log::info!(
@@ -215,9 +214,8 @@ fn decode_one(slot: &[i16], max_cand: usize, _dt_grid: u8, _df_grid: u8, _q_thre
 
     let t_pass2 = now_us();
     #[allow(static_mut_refs)]
-    let pass2 = unsafe {
-        dual_core::pass2_split(slot, pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM)
-    };
+    let pass2 =
+        unsafe { dual_core::pass2_split(slot, pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM) };
     let t_pass2_end = now_us();
     log::info!(
         "  pass 2 (re-rank):     {:>8} us  → top {} by sync_quality_block0",

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -35,8 +35,8 @@ use core::ptr;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use esp_idf_svc::sys::{
-    xQueueGenericCreate, xQueueGenericSend, xQueueReceive, xTaskCreatePinnedToCore,
-    xTaskGetCoreID, QueueHandle_t,
+    xQueueGenericCreate, xQueueGenericSend, xQueueReceive, xTaskCreatePinnedToCore, xTaskGetCoreID,
+    QueueHandle_t,
 };
 
 use alloc::boxed::Box;
@@ -51,7 +51,7 @@ use mfsk_core::ft8::decode_block::{
 };
 
 use crate::internal_pool::{CS_SCRATCH_MAIN, CS_SCRATCH_WORKER};
-use crate::pipeline::{self, SpecBundle, Slot};
+use crate::pipeline::{self, Slot, SpecBundle};
 
 /// One slot's Phase-C output. Both apps consume it identically:
 /// `spec` for `xsnr2_db_simple`, `slot` for `wav_idx` /
@@ -384,13 +384,8 @@ extern "C" fn worker_main(_arg: *mut core::ffi::c_void) {
                 let basis_im = unsafe {
                     core::slice::from_raw_parts_mut(BASIS_IM_C1.get(), BASIS_SCRATCH_LEN)
                 };
-                let result = refine_candidates_into(
-                    audio_slice,
-                    cands,
-                    max_cand,
-                    basis_re,
-                    basis_im,
-                );
+                let result =
+                    refine_candidates_into(audio_slice, cands, max_cand, basis_re, basis_im);
                 let raw = Box::into_raw(Box::new(result));
                 unsafe { queue_send_ptr(PASS2_RESULT_Q.get(), raw) };
             }
@@ -470,7 +465,9 @@ pub fn init(re_c1: *mut i16, im_c1: *mut i16) {
         BASIS_RE_C1.set(re_c1);
         BASIS_IM_C1.set(im_c1);
         JOB_Q.set(queue_create(core::mem::size_of::<*mut Job>()));
-        PASS2_RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<RefinedCandidate>>()));
+        PASS2_RESULT_Q.set(queue_create(
+            core::mem::size_of::<*mut Vec<RefinedCandidate>>(),
+        ));
         STAGE3_RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<DecodeResult>>()));
         COARSE_RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<SyncCandidate>>()));
 
@@ -542,8 +539,7 @@ pub fn coarse_sync_split_with_allsum(
     });
     unsafe { queue_send_ptr(JOB_Q.get(), Box::into_raw(job)) };
 
-    let mut local =
-        coarse_sync_with_allsum(spec, freq_min, mid, sync_min, max_cand, allsum_head);
+    let mut local = coarse_sync_with_allsum(spec, freq_min, mid, sync_min, max_cand, allsum_head);
 
     let worker_ptr = unsafe { queue_recv_ptr::<Vec<SyncCandidate>>(COARSE_RESULT_Q.get()) };
     let worker = unsafe { *Box::from_raw(worker_ptr) };

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -282,9 +282,7 @@ impl Fft for MixedRadix3840Fft {
     fn process(&self, buf: &mut [Complex32]) {
         const N: usize = mfsk_core::core::dsp::fft_mixed_3840::N;
         assert_eq!(buf.len(), N, "3840 FFT input length mismatch");
-        let buf_arr: &mut [Complex32; N] = buf
-            .try_into()
-            .expect("buf.len() == N already asserted");
+        let buf_arr: &mut [Complex32; N] = buf.try_into().expect("buf.len() == N already asserted");
 
         // Inner 256-pt forward FFT via esp-dsp asm path. Mirrors
         // `EspDspFft::process` but specialised to len=256.
@@ -478,8 +476,7 @@ impl Fft16 for MixedRadix3840Sc16Fft {
         }
 
         // ── Step 3+4: convert to f32, twiddle, run 15-pt PFA per column.
-        let mut m: alloc::vec::Vec<Complex32> =
-            alloc::vec![Complex32::new(0.0, 0.0); N];
+        let mut m: alloc::vec::Vec<Complex32> = alloc::vec![Complex32::new(0.0, 0.0); N];
         for (i, c) in rows.iter().enumerate() {
             m[i] = Complex32::new(c.re as f32, c.im as f32) * self.twiddles[i];
         }

--- a/embedded-poc/embedded-shared/src/pipeline.rs
+++ b/embedded-poc/embedded-shared/src/pipeline.rs
@@ -9,9 +9,7 @@ use alloc::boxed::Box;
 use alloc::vec::Vec;
 use core::ptr;
 
-use esp_idf_svc::sys::{
-    xQueueGenericCreate, xQueueGenericSend, xQueueReceive, QueueHandle_t,
-};
+use esp_idf_svc::sys::{xQueueGenericCreate, xQueueGenericSend, xQueueReceive, QueueHandle_t};
 
 const PD_PASS: i32 = 1;
 const QUEUE_SEND_TO_BACK: i32 = 0;
@@ -310,13 +308,7 @@ pub fn try_send_box<T>(q: QueueHandle_t, boxed: Box<T>) -> Result<(), Box<T>> {
 /// stage1_inc to discard its in-progress spec.
 pub fn try_recv_box<T>(q: QueueHandle_t) -> Option<Box<T>> {
     let mut raw: *mut T = ptr::null_mut();
-    let r = unsafe {
-        xQueueReceive(
-            q,
-            (&mut raw as *mut *mut T) as *mut core::ffi::c_void,
-            0,
-        )
-    };
+    let r = unsafe { xQueueReceive(q, (&mut raw as *mut *mut T) as *mut core::ffi::c_void, 0) };
     if r == PD_PASS {
         debug_assert!(!raw.is_null());
         Some(unsafe { Box::from_raw(raw) })

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -16,9 +16,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use esp_idf_svc::sys::{
-    esp_timer_get_time, xTaskCreatePinnedToCore, QueueHandle_t,
-};
+use esp_idf_svc::sys::{esp_timer_get_time, xTaskCreatePinnedToCore, QueueHandle_t};
 
 use mfsk_core::core::fft::{Fft16, FftPlanner16};
 use num_complex::Complex;
@@ -37,7 +35,10 @@ const NTONES: usize = 8;
 // candidates land in the wrong frequency bins and the entire slot
 // silently produces zero results (recall=0). Keep `assert!` below.
 const NFFT_SPEC: usize = mfsk_core::ft8::decode_block::NFFT_SPEC;
-const _: () = assert!(NFFT_SPEC == 3_840, "stage1_inc NFFT_SPEC must match mfsk_core (3840)");
+const _: () = assert!(
+    NFFT_SPEC == 3_840,
+    "stage1_inc NFFT_SPEC must match mfsk_core (3840)"
+);
 const FP_SPEC_SHIFT: u32 = 12;
 const TONE_SPACING_HZ: f32 = 6.25;
 const SAMPLE_RATE_HZ: f32 = 12_000.0;
@@ -332,7 +333,10 @@ pub fn spawn_with_wf(
             1, // APP_CPU
         )
     };
-    assert_eq!(r, PD_PASS, "xTaskCreatePinnedToCore(stage1_inc) failed: {r}");
+    assert_eq!(
+        r, PD_PASS,
+        "xTaskCreatePinnedToCore(stage1_inc) failed: {r}"
+    );
     log::info!(
         "stage1_inc: spawned (APP_CPU prio 6 — preempts dsp_worker); n_time={} n_pairs={} n_freq={}",
         N_TIME,
@@ -351,7 +355,10 @@ extern "C" fn worker_main(arg: *mut c_void) {
             ChunkMsg::Samples(samples) => {
                 ingest_samples(ctx, &samples);
             }
-            ChunkMsg::SlotEnd { wav_idx, total_samples } => {
+            ChunkMsg::SlotEnd {
+                wav_idx,
+                total_samples,
+            } => {
                 finalize_slot(ctx, wav_idx, total_samples);
             }
             ChunkMsg::SlotResetMark => {
@@ -597,10 +604,10 @@ fn compute_pair_into(ctx: &mut WorkerCtx, j_a: usize, j_b: usize) {
             // path already saturates (`spectrogram.rs::compute_spectrogram`
             // mag2 sites). Matching it here keeps the two paths
             // algorithmically identical.
-            let mag2_a = (((a_re * a_re + a_im * a_im) as u32) >> FP_SPEC_SHIFT)
-                .min(u16::MAX as u32);
-            let mag2_b = (((b_re * b_re + b_im * b_im) as u32) >> FP_SPEC_SHIFT)
-                .min(u16::MAX as u32);
+            let mag2_a =
+                (((a_re * a_re + a_im * a_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
+            let mag2_b =
+                (((b_re * b_re + b_im * b_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
             spec[row_a + k] = mag2_a as u16;
             spec[row_b + k] = mag2_b as u16;
         }
@@ -642,10 +649,11 @@ fn decimate_pair_to_wf(
     let row_b = j_b * n_freq;
     let mut out = [0u8; crate::pipeline::WF_ROW_LEN];
     for col in 0..crate::pipeline::WF_ROW_LEN {
-        let f0 = WF_FREQ_LO_HZ + (col as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ)
-            / crate::pipeline::WF_ROW_LEN as f32;
-        let f1 = WF_FREQ_LO_HZ + ((col + 1) as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ)
-            / crate::pipeline::WF_ROW_LEN as f32;
+        let f0 = WF_FREQ_LO_HZ
+            + (col as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ) / crate::pipeline::WF_ROW_LEN as f32;
+        let f1 = WF_FREQ_LO_HZ
+            + ((col + 1) as f32) * (WF_FREQ_HI_HZ - WF_FREQ_LO_HZ)
+                / crate::pipeline::WF_ROW_LEN as f32;
         let bin_lo = (f0 / df).floor() as usize;
         let bin_hi = ((f1 / df).ceil() as usize).min(n_freq);
         if bin_hi <= bin_lo {
@@ -696,26 +704,42 @@ fn update_one_half(
     dst: &mut [f32],
 ) {
     // 7-tone gather at 2-bin step — matches WSJT-X `sync8.f90:66`
-    // (k=0..6; tone 7 is data-only, never a Costas position) and
-    // `coarse_sync_inner`'s score-formula divisor `(NTONES - 2) = 6`.
+    // (k=0..6; tone 7 is data-only, never a Costas position).
+    // NFFT=3840 → tone_step_bins=2.0 exactly → single-bin gather.
     //
-    // NFFT=3840 → tone_step_bins = 2.0 exactly. The earlier 16-bin
-    // contiguous sliding window matched the NFFT=4096 era when
-    // tone_step ≈ 2.13 + Hann mainlobe leakage made the in-between
-    // bins informative; at NFFT=3840 those bins carry pure noise and
-    // a 16-contig sum nearly doubles `t0_ref`, halving sync ratio
-    // and dropping weak qso3 signals (mid/high band → 0 hits).
-    const TONE_STEP_BINS: usize = 2;
+    // Sliding window: carriers at fi and fi+2 share 6 of 7 bins.
+    // allsum[fi] = allsum[fi-2] + row[ia+fi+12] - row[ia+fi-2].
+    // Reduces inner work from 7 adds to 1 add + 1 sub per carrier
+    // after the two seed values. Sequential row reads stay in cache.
+    if n_freq == 0 {
+        return;
+    }
     let row_base = m * spec_n_freq;
     let upper = spec_n_freq - 1;
-    for fi in 0..n_freq {
-        let i_carrier = ia + fi;
-        let mut s: f32 = 0.0;
-        for k in 0..(NTONES - 1) {
-            let bin = (i_carrier + TONE_STEP_BINS * k).min(upper);
-            s += spec[row_base + bin] as f32;
+    let row = &spec[row_base..row_base + spec_n_freq];
+    // Seed prev[0] (even fi=0) and prev[1] (odd fi=1) with full sums.
+    let mut prev = [0.0f32; 2];
+    for parity in 0..2usize {
+        if parity >= n_freq {
+            break;
         }
+        let i_carrier = ia + parity;
+        let mut s = 0.0f32;
+        for k in 0..(NTONES - 1) {
+            let bin = (i_carrier + 2 * k).min(upper);
+            s += row[bin] as f32;
+        }
+        dst[parity * N_TIME + m] = s;
+        prev[parity] = s;
+    }
+    for fi in 2..n_freq {
+        let i_carrier = ia + fi;
+        let drop = (i_carrier - 2).min(upper);
+        let add = (i_carrier + 2 * (NTONES - 2)).min(upper);
+        let p = fi & 1;
+        let s = prev[p] + row[add] as f32 - row[drop] as f32;
         dst[fi * N_TIME + m] = s;
+        prev[p] = s;
     }
 }
 

--- a/embedded-poc/embedded-shared/src/wav_sim.rs
+++ b/embedded-poc/embedded-shared/src/wav_sim.rs
@@ -15,9 +15,7 @@ use core::ptr;
 use alloc::boxed::Box;
 use alloc::vec::Vec;
 
-use esp_idf_svc::sys::{
-    configTICK_RATE_HZ, vTaskDelay, xTaskCreatePinnedToCore, QueueHandle_t,
-};
+use esp_idf_svc::sys::{configTICK_RATE_HZ, vTaskDelay, xTaskCreatePinnedToCore, QueueHandle_t};
 
 use crate::pipeline::{send_box, ChunkMsg, CHUNK_LEN};
 

--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -139,16 +139,82 @@ pub fn precompute_coarse_allsum_into(
     fill_coarse_allsum(spec, ia, ib, n_freq, dst);
 }
 
-/// Build the 16-bin sliding-window allsum for the carrier-bin range
-/// `[ia..=ib]` into the caller buffer `dst` (length
-/// `n_freq * spec.n_time`, layout `dst[fi * n_time + m]`).
+/// Build the 7-tone-stride-2 allsum for one time slice `m` into `dst`.
 ///
-/// Mirrors the inline precompute inside [`coarse_sync_inner`] —
-/// kept as a separate helper so the embedded port can replicate it
-/// row-by-row in [`stage1_inc`] without depending on private
-/// internals. Computes for **every m**, not just `needed_m`, so
-/// callers can populate cells incrementally with single-row updates
-/// in any order.
+/// Loop order: `m`-outer, `fi`-inner. One time slice (~2 KB at u16)
+/// stays in cache for all carriers instead of striding by `n_freq`
+/// bytes per time step.
+///
+/// Under `fixed-point` (SpecCell = u16, values ≤ 65535): uses a
+/// **sliding window** — carriers at `fi` and `fi+2` share 6 of 7
+/// bins, so `allsum[fi] = allsum[fi-2] + row[ia+fi+12] - row[ia+fi-2]`.
+/// Reduces inner work from 7 adds to 1 add + 1 sub. Intermediate
+/// sums ≤ 7×65535 < 2^19 are exactly representable in f32, so no
+/// drift accumulates.
+///
+/// Without `fixed-point` (SpecCell = f32, host path): direct sum to
+/// avoid rounding drift on large spectrum values that would break the
+/// full-band-allsum-then-slice equivalence test.
+fn fill_allsum_row(spec: &Spectrogram, ia: usize, n_freq: usize, m: usize, dst: &mut [CoarseAcc]) {
+    if n_freq == 0 {
+        return;
+    }
+    let nh1 = spec.n_freq;
+    let upper = nh1 - 1;
+    let n_time = spec.n_time;
+
+    #[cfg(feature = "fixed-point")]
+    {
+        // Sliding window: two independent chains (even / odd fi).
+        let mut prev = [CoarseAcc::default(); 2];
+        for parity in 0..2usize {
+            if parity >= n_freq {
+                break;
+            }
+            let i_carrier = ia + parity;
+            let mut s = CoarseAcc::default();
+            for k in 0..(NTONES - 1) {
+                let bin = (i_carrier + 2 * k).min(upper);
+                s += spec.power_acc(bin, m);
+            }
+            dst[parity * n_time + m] = s;
+            prev[parity] = s;
+        }
+        for fi in 2..n_freq {
+            let i_carrier = ia + fi;
+            let drop = (i_carrier - 2).min(upper);
+            let add = (i_carrier + 2 * (NTONES - 2)).min(upper);
+            let p = fi & 1;
+            #[allow(clippy::unnecessary_cast)]
+            let s = prev[p] + spec.power_acc(add, m) - spec.power_acc(drop, m);
+            dst[fi * n_time + m] = s;
+            prev[p] = s;
+        }
+    }
+
+    #[cfg(not(feature = "fixed-point"))]
+    {
+        // Direct sum: no f32 drift for host tests.
+        for fi in 0..n_freq {
+            let i_carrier = ia + fi;
+            let mut s = CoarseAcc::default();
+            for k in 0..(NTONES - 1) {
+                let bin = (i_carrier + 2 * k).min(upper);
+                s += spec.power_acc(bin, m);
+            }
+            dst[fi * n_time + m] = s;
+        }
+    }
+}
+
+/// Build the 7-tone-stride-2 allsum for the carrier range `[ia..=ib]`
+/// into `dst` (`n_freq * spec.n_time`, layout `dst[fi * n_time + m]`).
+///
+/// Mirrors the inline precompute inside [`coarse_sync_inner`] and
+/// [`stage1_inc::update_one_half`] — kept as a public helper so the
+/// embedded port can replicate it row-by-row without accessing private
+/// internals. Computes **every m** so callers can populate cells
+/// incrementally in any order.
 fn fill_coarse_allsum(
     spec: &Spectrogram,
     ia: usize,
@@ -156,25 +222,10 @@ fn fill_coarse_allsum(
     _n_freq: usize,
     dst: &mut [CoarseAcc],
 ) {
-    let nh1 = spec.n_freq;
-    // WSJT-X `sync8.f90:66` `t0a = sum(s(i:i+nfos*6:nfos, m))` — sums
-    // **7** tones (k=0..6), NOT 8. The Costas array uses `icos7 =
-    // [3,1,4,0,6,5,2]` ⊂ {0..6}; tone 7 is data-only and never a
-    // Costas position. Including tone 7 in the reference sum dilutes
-    // the discriminator with data/noise energy that has no parallel
-    // in WSJT-X — it shifts our normalised sync score relative to
-    // theirs and was a logical implementation diff. NFFT=3840 →
-    // tone_step_bins=2.0 exactly, so single-bin gather per tone.
-    for (fi, i_carrier) in (ia..=ib).enumerate() {
-        let row_off = fi * spec.n_time;
-        for m in 0..spec.n_time {
-            let mut s: CoarseAcc = CoarseAcc::default();
-            for k in 0..(NTONES - 1) {
-                let bin = (i_carrier + 2 * k).min(nh1 - 1);
-                s += spec.power_acc(bin, m);
-            }
-            dst[row_off + m] = s;
-        }
+    let n_freq = ib - ia + 1;
+    // m-outer loop: one time slice (~2 KB u16) stays in cache for all fi.
+    for m in 0..spec.n_time {
+        fill_allsum_row(spec, ia, n_freq, m, dst);
     }
 }
 
@@ -294,25 +345,15 @@ fn coarse_sync_inner(
         owned_allsum = {
             // Sum 7 Costas-tone bins (k=0..NTONES-1; tone 7 is data-only,
             // never a Costas position). Matches WSJT-X `sync8.f90:66` and
-            // the public `fill_coarse_allsum` helper, so the score
-            // formula's `(t0 - t) / (NTONES - 2)` divisor is calibrated:
-            // t0 sums 7 tones, t = 1 Costas-tone bin energy, t0-t = 6
-            // non-Costas tones, divisor = 6 ✓. Pre-fix this loop ran
-            // `0..NTONES` (= 8 tones), which made owned_allsum and
-            // fill_coarse_allsum disagree numerically and broke the
-            // `coarse_sync_with_allsum_matches_internal` /
-            // `coarse_sync_split_with_allsum_*` consistency tests.
+            // the public `fill_coarse_allsum` helper. Only populates
+            // `needed_m` cells — ~60 % of spec.n_time — to save ~40 % of
+            // allsum work; the remaining cells stay at default (0/0.0) and
+            // are never read by the score loop.
+            // Uses the stride-2 sliding window: allsum[fi] = allsum[fi-2]
+            // + row[add] - row[drop], 7× fewer ops per fi after init.
             let mut buf = vec![CoarseAcc::default(); n_freq * spec.n_time];
-            for (fi, i_carrier) in (ia..=ib).enumerate() {
-                let row_off = fi * spec.n_time;
-                for &m in &needed_m {
-                    let mut s: CoarseAcc = CoarseAcc::default();
-                    for k in 0..(NTONES - 1) {
-                        let bin = (i_carrier + 2 * k).min(nh1 - 1);
-                        s += spec.power_acc(bin, m);
-                    }
-                    buf[row_off + m] = s;
-                }
+            for &m in &needed_m {
+                fill_allsum_row(spec, ia, n_freq, m, &mut buf);
             }
             buf
         };


### PR DESCRIPTION
Rebased onto main after #127 squash-merge. Single new commit (D3 perf work).

## Summary
- Allsum sliding window optimisation for coarse_sync
- m-outer loop order change for better cache locality

## Predecessor
- #127 (Phase D1 _aes3_ FFT + D2' Goertzel, now on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)