### PR TITLE
perf(ft8): D4 demux-mag² DC-hoist + 4× unroll; migrate rx_wavsim to run_speculative_slot

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
+++ b/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
@@ -5,9 +5,11 @@
 //! wav_sim → ChunkMsg → stage1_inc → SpecBundle/Slot → main → dual_core
 //! ```
 //!
-//! Stage 2 (`coarse_sync_split_with_allsum`) starts on `SpecBundle`
-//! arrival (≈ 200 ms before SlotEnd), so it overlaps the tail of audio
-//! capture. Post-SlotEnd decode = pass 2 + stage 3 only.
+//! Uses [`dual_core::run_speculative_slot`] — the same Phase-C
+//! speculative runner as `m5stack-s3-app` and `m5stack-core2-app`.
+//! Both the early (audio-tail overlap) and deferred (post-SlotEnd)
+//! decode paths run; the per-slot log shows the Phase-C breakdown so
+//! bench results are directly comparable to production timing.
 //!
 //! Per-target binaries (m5stack-core2 / m5stack-s3) just supply the
 //! WAV byte slices and call `run()`. No target-specific code lives
@@ -15,47 +17,11 @@
 
 extern crate alloc;
 
-use alloc::vec::Vec;
-
-use mfsk_ft8::mfsk_ft8_basis_scratch_len;
-
-use mfsk_core::core::sync::SyncCandidate;
 use mfsk_core::ft8::decode::DecodeDepth;
-use mfsk_core::ft8::decode_block::BASIS_SCRATCH_LEN;
 use mfsk_core::msg::wsjt77::unpack77;
 
 use crate::{dual_core, esp_dsp_fft, pipeline, stage1_inc, wav_sim};
 
-/// Per-core BASIS scratch. 60 KB × 4, internal DRAM `.bss`. Phase 0.7:
-/// both pairs live here so rx_wavsim keeps a single static allocation
-/// strategy; only the m5stack-s3-app runtime heap-allocates so it can
-/// skip the 120 KB worker pair in WiFi mode.
-static mut BASIS_RE: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-static mut BASIS_IM: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-static mut BASIS_RE_C1: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-static mut BASIS_IM_C1: [i16; BASIS_SCRATCH_LEN] = [0; BASIS_SCRATCH_LEN];
-
-fn now_us() -> i64 {
-    unsafe { esp_idf_svc::sys::esp_timer_get_time() }
-}
-
-/// Run the rx_wavsim bench.
-///
-/// * `wavs` — playlist (≥ 1 baked WAV; cycled indefinitely).
-/// * `pass1_limit` — coarse_sync candidate cap (typical 30 for ship
-///   recall floor; raise to 100 to recover one extra borderline weak
-///   signal at ~1.7× post-SlotEnd time on LX7).
-/// * `max_cand` — pass 2 / stage 3 candidate cap (typical 15; raise
-///   to 30 alongside `pass1_limit=100`).
-/// * `q_thresh` — stage-3 `sync_quality` early-reject threshold; pass
-///   [`mfsk_core::ft8::decode_block::DEFAULT_Q_THRESH`] (= 12) for
-///   full recall.
-/// * `bp_max_iter` — stage-3 BP iteration cap per LLR variant. Pass
-///   [`mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER`] (= 30, WSJT-X
-///   reference) for full recall; lower (e.g. 20 / 15) trades weak-
-///   signal recall for post-SlotEnd time. Stage 3 wall-clock scales
-///   roughly linearly with this on cands that exhaust all 4 LLR
-///   variants (≈ half of `max_cand` on busy bands).
 /// One sweep config — applied per-slot when `run_sweep` is used.
 #[derive(Clone, Copy, Debug)]
 pub struct RxSweepCfg {
@@ -95,8 +61,14 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
         mfsk_core::ft8::decode_block::NFFT_SPEC
     );
 
-    let need = mfsk_ft8_basis_scratch_len();
-    assert!(BASIS_SCRATCH_LEN >= need, "BASIS_SCRATCH_LEN too small");
+    // Phase 1.7.7: BASIS scratch retired — Goertzel needs no internal
+    // DRAM scratch. Pass null to dual_core::init; empty slices to
+    // run_speculative_slot. The 4 × 30 KB that used to live here as
+    // `static mut BASIS_*` arrays is now free DRAM.
+    let basis_re_main: &'static mut [i16] =
+        alloc::boxed::Box::leak(alloc::vec![].into_boxed_slice());
+    let basis_im_main: &'static mut [i16] =
+        alloc::boxed::Box::leak(alloc::vec![].into_boxed_slice());
 
     // Bump main task priority above wav_sim (4) and stage1_inc (3).
     unsafe {
@@ -104,11 +76,8 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
     }
 
     esp_dsp_fft::prewarm(mfsk_core::ft8::decode_block::NFFT_SPEC);
+    dual_core::init(core::ptr::null_mut(), core::ptr::null_mut());
 
-    #[allow(static_mut_refs)]
-    unsafe {
-        dual_core::init(BASIS_RE_C1.as_mut_ptr(), BASIS_IM_C1.as_mut_ptr());
-    }
     let chunk_q = pipeline::create_chunk_queue(4);
     let slot_q = pipeline::create_slot_queue(2);
     let spec_q = pipeline::create_spec_queue(2);
@@ -121,118 +90,83 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
     );
     let mut slot_i: usize = 0;
     loop {
-        let cfg = cfgs[slot_i % cfgs.len()];
+        let rx_cfg = cfgs[slot_i % cfgs.len()];
         slot_i = slot_i.wrapping_add(1);
-        // SpecBundle arrives ≈ 200 ms before SlotEnd, so stage 2 runs
-        // in parallel with the tail of capture.
-        let spec = pipeline::recv_box::<pipeline::SpecBundle>(spec_q);
+
         log::info!(
             "─── slot {} cfg pass1={} max_cand={} q={} BP={}",
             slot_i,
-            cfg.pass1_limit,
-            cfg.max_cand,
-            cfg.q_thresh,
-            cfg.bp_max_iter,
+            rx_cfg.pass1_limit,
+            rx_cfg.max_cand,
+            rx_cfg.q_thresh,
+            rx_cfg.bp_max_iter,
         );
-        let t_s2_start = now_us();
-        let pass1 = dual_core::coarse_sync_split_with_allsum(
-            &spec.spec,
-            100.0,
-            3_000.0,
-            1.0,
-            cfg.pass1_limit,
-            &spec.allsum_head,
-            &spec.allsum_tail,
+
+        let dc = dual_core::DecodeConfig {
+            freq_min: 100.0,
+            freq_max: 3_000.0,
+            sync_min: 1.0,
+            pass1_limit: rx_cfg.pass1_limit,
+            max_cand: rx_cfg.max_cand,
+            q_thresh: rx_cfg.q_thresh,
+            bp_max_iter: rx_cfg.bp_max_iter,
+            depth: DecodeDepth::BpVariantsAd,
+        };
+        let out =
+            dual_core::run_speculative_slot(spec_q, slot_q, &dc, basis_re_main, basis_im_main);
+        let dual_core::SpeculativeOut {
+            spec,
+            slot,
+            results,
+            n_pass1,
+            n_ready,
+            n_deferred,
+            t_post_recv,
+            t_coarse_done,
+            t_early_done,
+            t_slot_recv,
+            t_done,
+        } = out;
+
+        let slotend = slot.slotend_us;
+        let inc_us = slot.inc_total_us;
+        let wav_idx = slot.wav_idx;
+        let tail_window = (slotend - t_post_recv).max(0);
+        let coarse_us = t_coarse_done - t_post_recv;
+        let early_us = t_early_done - t_coarse_done;
+        let tail_use = (slotend.min(t_early_done) - t_coarse_done).max(0);
+        let post_slotend = (t_done - slotend).max(0);
+
+        log::info!(
+            "WAV[{wav_idx}] p1={n_pass1} ready={n_ready} defer={n_deferred} dec={} \
+             tail_win={}us coarse={}us early={}us tail_use={}us post_slotend={}us \
+             slot_wait={}us late={}us",
+            results.len(),
+            tail_window,
+            coarse_us,
+            early_us,
+            tail_use,
+            post_slotend,
+            t_slot_recv - t_early_done,
+            t_done - t_slot_recv,
         );
-        let t_s2_end = now_us();
-        drop(spec);
-
-        let slot = pipeline::recv_box::<pipeline::Slot>(slot_q);
-        decode_one_slot(
-            *slot,
-            pass1,
-            t_s2_end - t_s2_start,
-            cfg.max_cand,
-            cfg.q_thresh,
-            cfg.bp_max_iter,
+        log::info!(
+            "  Phase-E: stage1_inc {} us in advance ({}% of capture)",
+            inc_us,
+            (inc_us * 100) / 15_000_000
         );
-    }
-}
 
-fn decode_one_slot(
-    slot: pipeline::Slot,
-    pass1: Vec<SyncCandidate>,
-    stage2_us: i64,
-    max_cand: usize,
-    q_thresh: u32,
-    bp_max_iter: u32,
-) {
-    let wav_idx = slot.wav_idx;
-    let inc_us = slot.inc_total_us;
-    let pass1_n = pass1.len();
-    let post_slot_t0 = now_us();
-
-    log::info!(
-        "rx-wavsim: WAV[{wav_idx}] slot received (audio={} samples, pass1={pass1_n}, q_thresh={q_thresh})",
-        slot.audio_len(),
-    );
-    log::info!(
-        "  stage 2 (during cap): {:>7} us  ({pass1_n} cand)",
-        stage2_us
-    );
-
-    let t2 = now_us();
-    #[allow(static_mut_refs)]
-    let pass2 = unsafe {
-        dual_core::pass2_split(slot.audio(), pass1, max_cand, &mut BASIS_RE, &mut BASIS_IM)
-    };
-    let t3 = now_us();
-    log::info!(
-        "  pass 2:               {:>7} us  → top {}",
-        t3 - t2,
-        pass2.len()
-    );
-
-    let depth = DecodeDepth::BpAll;
-    let t4 = now_us();
-    #[allow(static_mut_refs)]
-    let results = unsafe {
-        dual_core::stage3_split(
-            slot.audio(),
-            pass2,
-            depth,
-            q_thresh,
-            bp_max_iter,
-            &mut BASIS_RE,
-            &mut BASIS_IM,
-        )
-    };
-    let t5 = now_us();
-    log::info!(
-        "  stage 3:              {:>7} us  ({} result(s))",
-        t5 - t4,
-        results.len()
-    );
-    log::info!(
-        "  ─── post-SlotEnd:     {:>7} us = {:.3} s",
-        t5 - post_slot_t0,
-        (t5 - post_slot_t0) as f64 / 1e6
-    );
-    log::info!(
-        "  Phase-E: stage1_inc {} us in advance ({}% of capture)",
-        inc_us,
-        (inc_us * 100) / 15_000_000
-    );
-
-    for (i, r) in results.iter().enumerate() {
-        if let Some(text) = unpack77(&r.message77) {
-            log::info!(
-                "    [{i}]  {:>4.0} Hz  SNR={:>5.1} dB  e={}  '{}'",
-                r.freq_hz,
-                r.snr_db,
-                r.hard_errors,
-                text
-            );
+        for (i, r) in results.iter().enumerate() {
+            if let Some(text) = unpack77(&r.message77) {
+                log::info!(
+                    "    [{i}]  {:>4.0} Hz  SNR={:>5.1} dB  e={}  '{}'",
+                    r.freq_hz,
+                    r.snr_db,
+                    r.hard_errors,
+                    text
+                );
+            }
         }
+        drop(spec);
     }
 }

--- a/embedded-poc/embedded-shared/src/stage1_inc.rs
+++ b/embedded-poc/embedded-shared/src/stage1_inc.rs
@@ -580,36 +580,65 @@ fn compute_pair_into(ctx: &mut WorkerCtx, j_a: usize, j_b: usize) {
     ctx.fft.process(&mut ctx.fft_buf);
 
     // Demux pair → spec rows.
+    // D4: DC bin hoisted (kn=0 special case removed from inner loop);
+    // 4× unrolled main loop; per-square u32 cast avoids i32 addition
+    // overflow at ±32768 edges (each square ≤ 2^30, sum ≤ 2^31 < u32::MAX).
     let row_a = j_a * n_freq;
     let row_b = j_b * n_freq;
     {
         let buf = &ctx.fft_buf;
         let spec = &mut ctx.cur.spec;
-        for k in 0..n_freq {
-            let kn = if k == 0 { 0 } else { NFFT_SPEC - k };
-            let yk_re = buf[k].re as i32;
-            let yk_im = buf[k].im as i32;
-            let yn_re = buf[kn].re as i32;
-            let yn_im = buf[kn].im as i32;
-            let a_re = (yk_re + yn_re) >> 1;
-            let a_im = (yk_im - yn_im) >> 1;
-            let b_re = (yk_im + yn_im) >> 1;
-            let b_im = (yn_re - yk_re) >> 1;
-            // mag² saturate at u16::MAX. Wrapping `as u16` (the
-            // pre-Phase 1.7.7b behaviour) was a real bug: very strong
-            // co-channel bins overflowed u16 after `>> FP_SPEC_SHIFT`
-            // and aliased to a tiny residue, making strong stations
-            // *invisible* to `coarse_sync`. Caught while tracing the
-            // host vs embedded NSTEP divergence — the host fixed-point
-            // path already saturates (`spectrogram.rs::compute_spectrogram`
-            // mag2 sites). Matching it here keeps the two paths
-            // algorithmically identical.
-            let mag2_a =
-                (((a_re * a_re + a_im * a_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            let mag2_b =
-                (((b_re * b_re + b_im * b_im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            spec[row_a + k] = mag2_a as u16;
-            spec[row_b + k] = mag2_b as u16;
+
+        // k=0: DC bin — kn=0 so yn=yk; b = imaginary half-band (zero-phase)
+        if n_freq > 0 {
+            let r0 = buf[0].re as i32;
+            let i0 = buf[0].im as i32;
+            spec[row_a] = ((r0 * r0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b] = ((i0 * i0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+        }
+
+        // k=1..n_freq: kn = NFFT_SPEC - k (no branch needed).
+        // 4× unrolled to expose independent multiply chains to the FPU
+        // pipeline (opt-level=1 does not auto-unroll on Xtensa LX7).
+        let mut k = 1usize;
+        while k + 4 <= n_freq {
+            let yk0 = buf[k];
+            let yk1 = buf[k + 1];
+            let yk2 = buf[k + 2];
+            let yk3 = buf[k + 3];
+            let yn0 = buf[NFFT_SPEC - k];
+            let yn1 = buf[NFFT_SPEC - k - 1];
+            let yn2 = buf[NFFT_SPEC - k - 2];
+            let yn3 = buf[NFFT_SPEC - k - 3];
+
+            let (a0r, a0i) = ((yk0.re as i32 + yn0.re as i32) >> 1, (yk0.im as i32 - yn0.im as i32) >> 1);
+            let (b0r, b0i) = ((yk0.im as i32 + yn0.im as i32) >> 1, (yn0.re as i32 - yk0.re as i32) >> 1);
+            let (a1r, a1i) = ((yk1.re as i32 + yn1.re as i32) >> 1, (yk1.im as i32 - yn1.im as i32) >> 1);
+            let (b1r, b1i) = ((yk1.im as i32 + yn1.im as i32) >> 1, (yn1.re as i32 - yk1.re as i32) >> 1);
+            let (a2r, a2i) = ((yk2.re as i32 + yn2.re as i32) >> 1, (yk2.im as i32 - yn2.im as i32) >> 1);
+            let (b2r, b2i) = ((yk2.im as i32 + yn2.im as i32) >> 1, (yn2.re as i32 - yk2.re as i32) >> 1);
+            let (a3r, a3i) = ((yk3.re as i32 + yn3.re as i32) >> 1, (yk3.im as i32 - yn3.im as i32) >> 1);
+            let (b3r, b3i) = ((yk3.im as i32 + yn3.im as i32) >> 1, (yn3.re as i32 - yk3.re as i32) >> 1);
+
+            spec[row_a + k]     = (((a0r*a0r) as u32 + (a0i*a0i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k]     = (((b0r*b0r) as u32 + (b0i*b0i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_a + k + 1] = (((a1r*a1r) as u32 + (a1i*a1i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k + 1] = (((b1r*b1r) as u32 + (b1i*b1i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_a + k + 2] = (((a2r*a2r) as u32 + (a2i*a2i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k + 2] = (((b2r*b2r) as u32 + (b2i*b2i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_a + k + 3] = (((a3r*a3r) as u32 + (a3i*a3i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k + 3] = (((b3r*b3r) as u32 + (b3i*b3i) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+
+            k += 4;
+        }
+        while k < n_freq {
+            let yn = buf[NFFT_SPEC - k];
+            let yk = buf[k];
+            let (ar, ai) = ((yk.re as i32 + yn.re as i32) >> 1, (yk.im as i32 - yn.im as i32) >> 1);
+            let (br, bi) = ((yk.im as i32 + yn.im as i32) >> 1, (yn.re as i32 - yk.re as i32) >> 1);
+            spec[row_a + k] = (((ar*ar) as u32 + (ai*ai) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            spec[row_b + k] = (((br*br) as u32 + (bi*bi) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            k += 1;
         }
     }
 

--- a/embedded-poc/m5stack-s3/src/bin/rx_wavsim.rs
+++ b/embedded-poc/m5stack-s3/src/bin/rx_wavsim.rs
@@ -11,14 +11,15 @@ const QSO_WAVS: &[&[u8]] = &[
 ];
 
 fn main() -> ! {
-    // Ship config 2026-05-05 (post Hann→Rect window fix in stage1_inc):
+    // Ship config (post Hann→Rect window fix in stage1_inc):
     //   pass1=30, max_cand=15, q_thresh=DEFAULT_Q_THRESH (=6),
     //   bp_max_iter=DEFAULT_BP_MAX_ITER (=30).
-    // qso3_busy: 6/18 JTDX hits in ~1.30 s post-SlotEnd. Compute-
-    // optimal Pareto across the 9-cfg sweep (logs/s3_rect_sweep_*).
-    // Wider cfgs (45/20, 60/30) recover no extra decodes — N1PJT
-    // HB9CQK at -10 dB is structurally lost without fine_refine_pass1
-    // (192k cd0 FFT, infeasible on Xtensa).
+    // qso3_busy: 6/18 JTDX hits. Compute-optimal Pareto across the
+    // 9-cfg sweep (logs/s3_rect_sweep_*). Wider cfgs (45/20, 60/30)
+    // recover no extra decodes — N1PJT HB9CQK at -10 dB is
+    // structurally lost without fine_refine_pass1 (192k cd0 FFT,
+    // infeasible on Xtensa).
+    // Phase-C (run_speculative_slot) timing: see flash logs.
     embedded_shared::apps::rx_wavsim::run(
         QSO_WAVS,
         30,

--- a/mfsk-core/src/ft8/decode_block/spectrogram.rs
+++ b/mfsk-core/src/ft8/decode_block/spectrogram.rs
@@ -316,50 +316,112 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
         let row_b = j_b * n_freq;
         // Demux. Modular wrap (NFFT_SPEC=3840 isn't a power of two so
         // `& (NFFT-1)` would alias the high bins). `kn = (NFFT-k) mod
-        // NFFT` collapses k=0 to 0 — DC bin is real, as expected for
-        // real input.
-        for k in 0..n_freq {
-            let kn = if k == 0 { 0 } else { NFFT_SPEC - k };
-            let yk_re = buf[k].re as i32;
-            let yk_im = buf[k].im as i32;
-            let yn_re = buf[kn].re as i32;
-            let yn_im = buf[kn].im as i32;
-            let a_re = (yk_re + yn_re) >> 1;
-            let a_im = (yk_im - yn_im) >> 1;
-            let b_re = (yk_im + yn_im) >> 1;
-            let b_im = (yn_re - yk_re) >> 1;
-            // Square via `unsigned_abs` to dodge the `i32` overflow at
-            // `(-32768)² + (-32768)² = 2^31`, which doesn't fit in i32
-            // (panic in debug, wrap to negative in release). Squaring as
-            // `u32` keeps the sum in 2^31 with one bit to spare —
-            // `>> FP_SPEC_SHIFT` (= 12) lands in u32.
-            // `.min(u16::MAX as u32)` then saturates the u16 cast so
-            // extremely-strong signals (two coincident tones at the
-            // same bin per the FP_SPEC_SHIFT comment) cap at u16::MAX
-            // instead of wrapping to a tiny value. Gemini PR #83 + #100
-            // review.
-            // mag² saturate at u16::MAX. Wrapping `as u16` (the
-            // pre-Phase 1.7.7b behaviour on the embedded path) was a
-            // real bug: very-strong-bin energy overflowed u16 after
-            // `>> FP_SPEC_SHIFT` and aliased to a tiny residue, hiding
-            // strong stations from `coarse_sync`. Both host fixed-point
-            // here and `embedded-shared::stage1_inc` saturate now.
-            // Use `unsigned_abs` so the squares stay in u32 with a bit
-            // to spare for the sum, then `.min(u16::MAX as u32)`.
-            let aru = a_re.unsigned_abs();
-            let aiu = a_im.unsigned_abs();
-            let bru = b_re.unsigned_abs();
-            let biu = b_im.unsigned_abs();
-            let mag2_a = ((aru * aru + aiu * aiu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            let mag2_b = ((bru * bru + biu * biu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
-            data[row_a + k] = mag2_a as u16;
-            data[row_b + k] = mag2_b as u16;
-            #[cfg(feature = "std")]
-            if jj == 0 && (k == 64 || k == 823) {
-                eprintln!(
-                    "[host spec] pair0 k={k}: yk=({},{}) yn=({},{}) a=({},{}) b=({},{}) mag2_a={mag2_a} mag2_b={mag2_b}",
-                    yk_re, yk_im, yn_re, yn_im, a_re, a_im, b_re, b_im
-                );
+        // NFFT` collapses k=0 to 0 — DC bin is real.
+        //
+        // D4: DC bin hoisted; main loop 4× unrolled to expose
+        // independent multiply chains at opt-level=1. Per-square u32
+        // cast: each square ≤ 2^30 fits in i32; cast before adding so
+        // the sum ≤ 2^31 stays within u32 (avoids i32 panic in debug
+        // for the ±32768 edge case that `unsigned_abs` was guarding).
+
+        // k=0: DC bin (kn=0 → yn=yk)
+        if n_freq > 0 {
+            let r0 = buf[0].re as i32;
+            let i0 = buf[0].im as i32;
+            data[row_a] = ((r0 * r0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+            data[row_b] = ((i0 * i0) as u32 >> FP_SPEC_SHIFT).min(u16::MAX as u32) as u16;
+        }
+
+        let mut k = 1usize;
+        while k + 4 <= n_freq {
+            let yk0 = buf[k];
+            let yk1 = buf[k + 1];
+            let yk2 = buf[k + 2];
+            let yk3 = buf[k + 3];
+            let yn0 = buf[NFFT_SPEC - k];
+            let yn1 = buf[NFFT_SPEC - k - 1];
+            let yn2 = buf[NFFT_SPEC - k - 2];
+            let yn3 = buf[NFFT_SPEC - k - 3];
+
+            let (a0r, a0i) = (
+                (yk0.re as i32 + yn0.re as i32) >> 1,
+                (yk0.im as i32 - yn0.im as i32) >> 1,
+            );
+            let (b0r, b0i) = (
+                (yk0.im as i32 + yn0.im as i32) >> 1,
+                (yn0.re as i32 - yk0.re as i32) >> 1,
+            );
+            let (a1r, a1i) = (
+                (yk1.re as i32 + yn1.re as i32) >> 1,
+                (yk1.im as i32 - yn1.im as i32) >> 1,
+            );
+            let (b1r, b1i) = (
+                (yk1.im as i32 + yn1.im as i32) >> 1,
+                (yn1.re as i32 - yk1.re as i32) >> 1,
+            );
+            let (a2r, a2i) = (
+                (yk2.re as i32 + yn2.re as i32) >> 1,
+                (yk2.im as i32 - yn2.im as i32) >> 1,
+            );
+            let (b2r, b2i) = (
+                (yk2.im as i32 + yn2.im as i32) >> 1,
+                (yn2.re as i32 - yk2.re as i32) >> 1,
+            );
+            let (a3r, a3i) = (
+                (yk3.re as i32 + yn3.re as i32) >> 1,
+                (yk3.im as i32 - yn3.im as i32) >> 1,
+            );
+            let (b3r, b3i) = (
+                (yk3.im as i32 + yn3.im as i32) >> 1,
+                (yn3.re as i32 - yk3.re as i32) >> 1,
+            );
+
+            data[row_a + k] = (((a0r * a0r) as u32 + (a0i * a0i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k] = (((b0r * b0r) as u32 + (b0i * b0i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_a + k + 1] = (((a1r * a1r) as u32 + (a1i * a1i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k + 1] = (((b1r * b1r) as u32 + (b1i * b1i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_a + k + 2] = (((a2r * a2r) as u32 + (a2i * a2i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k + 2] = (((b2r * b2r) as u32 + (b2i * b2i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_a + k + 3] = (((a3r * a3r) as u32 + (a3i * a3i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k + 3] = (((b3r * b3r) as u32 + (b3i * b3i) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+
+            k += 4;
+        }
+        while k < n_freq {
+            let yn = buf[NFFT_SPEC - k];
+            let yk = buf[k];
+            let (ar, ai) = (
+                (yk.re as i32 + yn.re as i32) >> 1,
+                (yk.im as i32 - yn.im as i32) >> 1,
+            );
+            let (br, bi) = (
+                (yk.im as i32 + yn.im as i32) >> 1,
+                (yn.re as i32 - yk.re as i32) >> 1,
+            );
+            data[row_a + k] = (((ar * ar) as u32 + (ai * ai) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            data[row_b + k] = (((br * br) as u32 + (bi * bi) as u32) >> FP_SPEC_SHIFT)
+                .min(u16::MAX as u32) as u16;
+            k += 1;
+        }
+        #[cfg(feature = "std")]
+        if jj == 0 {
+            for ki in [64usize, 823usize] {
+                if ki < n_freq {
+                    eprintln!(
+                        "[host spec] pair0 k={ki}: mag2_a={} mag2_b={}",
+                        data[row_a + ki],
+                        data[row_b + ki]
+                    );
+                }
             }
         }
     }
@@ -375,10 +437,8 @@ pub fn compute_spectrogram<S: AudioSample>(audio: &[S], max_freq_hz: f32) -> Spe
         for i in 0..n_freq {
             let re = buf[i].re as i32;
             let im = buf[i].im as i32;
-            // Same saturating mag² pattern as the demux loop above.
-            let ru = re.unsigned_abs();
-            let iu = im.unsigned_abs();
-            let mag2 = ((ru * ru + iu * iu) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
+            let mag2 =
+                (((re * re) as u32 + (im * im) as u32) >> FP_SPEC_SHIFT).min(u16::MAX as u32);
             data[row_base + i] = mag2 as u16;
         }
     }


### PR DESCRIPTION
Rebased onto main after D3 (#130) squash-merge. Two new commits.

## Summary
- D4: demux-mag², DC-hoist, 4× loop unroll in coarse_sync hot path
- rx_wavsim: migrate bench to `dual_core::run_speculative_slot` (Phase-C)

## Predecessors
- #127 (Phase D1 _aes3_ + D2' Goertzel)
- #130 (D3 allsum sliding window)

## Benchmark (S3 qso3_busy, Phase-C)
- post_slotend = 57 ms (all slots complete before SlotEnd)
- tail_use = early_us (full early decode in audio tail)
- 7 decodes, FT8 TX margin ~443 ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)