### PR TITLE
feat(cores3): Phase 0-Core crate skeleton for M5Stack CoreS3

### DIFF
--- a/embedded-poc/m5stack-cores3-app/.cargo/config.toml
+++ b/embedded-poc/m5stack-cores3-app/.cargo/config.toml
@@ -1,0 +1,15 @@
+[build]
+target = "xtensa-esp32s3-espidf"
+
+[target.'cfg(target_os = "espidf")']
+linker = "ldproxy"
+runner = "espflash flash --monitor"
+rustflags = [ "--cfg",  "espidf_time64"]
+
+[unstable]
+build-std = ["std", "panic_abort"]
+
+[env]
+MCU = "esp32s3"
+ESP_IDF_VERSION = "v5.5.3"
+ESP_IDF_TOOLS_INSTALL_DIR = "global"

--- a/embedded-poc/m5stack-cores3-app/.gitignore
+++ b/embedded-poc/m5stack-cores3-app/.gitignore
@@ -1,0 +1,17 @@
+/target/
+/.embuild/
+Cargo.lock
+
+# Per-session device captures via flash-monitor.sh.
+/logs/
+
+# Build-time WiFi credentials and UDP log target. Created locally;
+# never committed. See cfg-sample.toml for the template.
+cfg.toml
+cfg.toml-*
+
+# build.rs / bootstrap-sdkconfig.sh が CARGO_MANIFEST_DIR の絶対パスで
+# CONFIG_PARTITION_TABLE_CUSTOM_FILENAME を埋め込む生成ファイル。
+sdkconfig.gen.defaults
+
+components_esp32s3.lock

--- a/embedded-poc/m5stack-cores3-app/Cargo.toml
+++ b/embedded-poc/m5stack-cores3-app/Cargo.toml
@@ -1,0 +1,76 @@
+[package]
+name = "mfsk-core-m5stack-cores3-app"
+version = "0.1.0"
+authors = ["Minoru Tomobe <minoru.tomobe@gmail.com>"]
+edition = "2021"
+resolver = "2"
+rust-version = "1.82"
+
+# M5Stack CoreS3 (ESP32-S3, LX7) FT8 controller — main UAC target.
+# Phase B-Core from docs/ROADMAP.md. Shares `mfsk-app-shared` and
+# `embedded-shared` with both sibling app crates. Board-specific layer:
+# AXP2101 + AW9523B PMIC/IO-expander, ILI9342C LCD, FT6336U touch (Phase
+# 6-Core), ES7210 mic + AW88298 speaker (Phase 3-Core), USB-OTG host for
+# IC-705 UAC (Phase 1-Core), BLE CI-V to IC-705 (Phase 2-Core).
+
+[[bin]]
+name = "mfsk-core-m5stack-cores3-app"
+harness = false
+
+[profile.release]
+# Same LX7 LLVM regression workaround as sibling crates: opt-level=1 avoids
+# the f32-select code-gen bug in `mfsk-core::core::pipeline`.
+opt-level = 1
+
+[profile.dev]
+debug = true
+opt-level = 1
+
+[patch.crates-io]
+esp-idf-sys = { git = "https://github.com/esp-rs/esp-idf-sys.git" }
+esp-idf-hal = { git = "https://github.com/esp-rs/esp-idf-hal.git" }
+esp-idf-svc = { git = "https://github.com/esp-rs/esp-idf-svc.git" }
+
+[dependencies]
+log = "0.4"
+anyhow = "1"
+esp-idf-svc = { version = "0.52.1", features = ["critical-section", "embassy-time-driver", "embassy-sync"] }
+esp-idf-hal = "0.46"
+embassy-time = { version = "0.5", features = ["generic-queue-8"] }
+embassy-sync = "0.7"
+heapless = "0.8"
+num-complex = { version = "0.4", default-features = false }
+
+# mfsk-core / FFI: same feature set as the sibling app + bench crates.
+mfsk-core = { path = "../../mfsk-core", default-features = false, features = ["alloc", "std", "ft8", "fft-extern", "fixed-point", "profile-coarse", "nstep-half"] }
+mfsk-ffi-ft8 = { path = "../../mfsk-ffi-ft8", default-features = false, features = ["embedded-fixed-point"] }
+
+# Shared decode-pipeline layer (streaming, dual_core, stage1_inc, esp_dsp_fft).
+embedded-shared = { path = "../embedded-shared", features = ["aes3"] }
+
+# Board-agnostic app logic (QSO FSM, time sync, TX picker, SNR norm,
+# NVS boot mode, log fanout, WiFi + UDP, UI draw routines).
+# CoreS3 has native USB-JTAG (same as StickS3) so enable usb-serial-jtag
+# feature (FanoutLogger gates println! on usb_serial_jtag_is_connected).
+# Phase 1-Core: when UAC host is active, USB-JTAG is consumed — add a
+# runtime guard then rather than disabling the feature here.
+mfsk-app-shared = { path = "../mfsk-app-shared" }
+
+# UI rendering — same as sibling crates.
+embedded-graphics = "0.8"
+mipidsi = "0.8"
+display-interface-spi = "0.5"
+
+[build-dependencies]
+embuild = "0.33"
+toml = "0.8"
+
+# build.rs writes sdkconfig.gen.defaults with the absolute partition CSV
+# path. Run `./bootstrap-sdkconfig.sh` once on a fresh clone.
+[package.metadata.esp-idf-sys]
+esp_idf_sdkconfig_defaults = ["sdkconfig.defaults", "sdkconfig.gen.defaults"]
+
+[[package.metadata.esp-idf-sys.extra_components]]
+remote_component = { name = "espressif/esp-dsp", version = "^1.4" }
+bindings_header = "../bindings_dsp.h"
+bindings_module = "esp_dsp"

--- a/embedded-poc/m5stack-cores3-app/bootstrap-sdkconfig.sh
+++ b/embedded-poc/m5stack-cores3-app/bootstrap-sdkconfig.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Generate sdkconfig.gen.defaults with this checkout's absolute partition
+# CSV path. Required once on a fresh clone (and after moving the repo to
+# a different path). See sibling `m5stack-s3-app/bootstrap-sdkconfig.sh`
+# for rationale.
+set -euo pipefail
+DIR="$(cd "$(dirname "$0")" && pwd)"
+cat > "$DIR/sdkconfig.gen.defaults" <<EOF
+CONFIG_PARTITION_TABLE_CUSTOM_FILENAME="$DIR/partitions.csv"
+EOF
+echo "wrote $DIR/sdkconfig.gen.defaults"

--- a/embedded-poc/m5stack-cores3-app/build.rs
+++ b/embedded-poc/m5stack-cores3-app/build.rs
@@ -1,0 +1,56 @@
+use std::env;
+use std::path::PathBuf;
+
+fn main() {
+    embuild::espidf::sysenv::output();
+
+    // Anchor CONFIG_PARTITION_TABLE_CUSTOM_FILENAME to this checkout's
+    // absolute path — same rationale as the sibling s3-app build.rs.
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").unwrap());
+    let gen_path = manifest_dir.join("sdkconfig.gen.defaults");
+    let partitions_csv = manifest_dir.join("partitions.csv");
+    let body = format!(
+        "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"{}\"\n",
+        partitions_csv.display()
+    );
+    if std::fs::read_to_string(&gen_path).ok().as_deref() != Some(body.as_str()) {
+        std::fs::write(&gen_path, &body)
+            .unwrap_or_else(|e| panic!("write {}: {}", gen_path.display(), e));
+    }
+
+    // cfg.toml (gitignored) carries WiFi credentials + UDP log target.
+    // Absent → empty SSID → WiFi init skipped, binary still boots.
+    let cfg_path = manifest_dir.join("cfg.toml");
+    println!("cargo:rerun-if-changed={}", cfg_path.display());
+
+    let (ssid, psk, pc_ip, port) = if cfg_path.exists() {
+        let txt = std::fs::read_to_string(&cfg_path)
+            .unwrap_or_else(|e| panic!("read {}: {}", cfg_path.display(), e));
+        let v: toml::Value = toml::from_str(&txt)
+            .unwrap_or_else(|e| panic!("parse {}: {}", cfg_path.display(), e));
+        let wifi = v
+            .get("wifi")
+            .and_then(|t| t.as_table())
+            .unwrap_or_else(|| panic!("{} missing [wifi] section", cfg_path.display()));
+        let ssid = wifi.get("ssid").and_then(|s| s.as_str()).unwrap_or("").to_string();
+        let psk = wifi.get("psk").and_then(|s| s.as_str()).unwrap_or("").to_string();
+        let pc_ip = wifi
+            .get("pc_ip")
+            .and_then(|s| s.as_str())
+            .unwrap_or("255.255.255.255")
+            .to_string();
+        let port = wifi
+            .get("port")
+            .and_then(|p| p.as_integer())
+            .map(|p| p as u16)
+            .unwrap_or(9999);
+        (ssid, psk, pc_ip, port)
+    } else {
+        (String::new(), String::new(), "255.255.255.255".to_string(), 9999u16)
+    };
+
+    println!("cargo:rustc-env=WIFI_SSID={ssid}");
+    println!("cargo:rustc-env=WIFI_PSK={psk}");
+    println!("cargo:rustc-env=UDP_LOG_TARGET={pc_ip}");
+    println!("cargo:rustc-env=UDP_LOG_PORT={port}");
+}

--- a/embedded-poc/m5stack-cores3-app/cfg-sample.toml
+++ b/embedded-poc/m5stack-cores3-app/cfg-sample.toml
@@ -1,0 +1,11 @@
+# m5stack-cores3-app build-time configuration template.
+#
+# Copy this file to `cfg.toml` (gitignored) and fill in real credentials
+# for your dev environment. See the sibling `m5stack-s3-app/cfg-sample.toml`
+# for full field documentation.
+
+[wifi]
+ssid = "your-ssid-here"
+psk = "your-passphrase-here"
+pc_ip = "auto"
+port = 9999

--- a/embedded-poc/m5stack-cores3-app/partitions.csv
+++ b/embedded-poc/m5stack-cores3-app/partitions.csv
@@ -1,0 +1,7 @@
+# M5Stack CoreS3 = 16 MB flash. Mirrors the s3-app / Core2-app layout
+# (3 MB factory + 1 MB littlefs); trailing flash is unused for now.
+# Name,     Type, SubType, Offset,  Size
+nvs,        data, nvs,     0x9000,  0x6000
+phy_init,   data, phy,     0xf000,  0x1000
+factory,    app,  factory, 0x10000, 0x330000
+littlefs,   data, spiffs,  0x340000, 0xC0000

--- a/embedded-poc/m5stack-cores3-app/rust-toolchain.toml
+++ b/embedded-poc/m5stack-cores3-app/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "esp"

--- a/embedded-poc/m5stack-cores3-app/sdkconfig.defaults
+++ b/embedded-poc/m5stack-cores3-app/sdkconfig.defaults
@@ -1,0 +1,44 @@
+# M5Stack CoreS3 FT8 controller — sdkconfig defaults (Phase 0-Core).
+#
+# CoreS3-specific vs sibling crates:
+#   1. SPIRAM_MODE_QUAD (CoreS3 has 8 MB Quad PSRAM; StickS3 is Octal).
+#   2. Flash size 16 MB (same as Core2; StickS3 is 8 MB).
+#   3. No USB host / no BLE for Phase 0-Core; both added in Phase 1-Core /
+#      Phase 2-Core respectively.
+#   4. No SPIRAM_MODE_OCT block (unlike s3-app sdkconfig).
+
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=32768
+
+# ── Flash + partition table ──────────────────────────────────────────
+CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="16MB"
+CONFIG_PARTITION_TABLE_CUSTOM=y
+# CONFIG_PARTITION_TABLE_CUSTOM_FILENAME is written by build.rs /
+# bootstrap-sdkconfig.sh with this checkout's absolute CSV path.
+# Run `./bootstrap-sdkconfig.sh` once on a fresh clone.
+
+CONFIG_ESP_SYSTEM_EVENT_TASK_STACK_SIZE=4096
+CONFIG_FREERTOS_IDLE_TASK_STACKSIZE=4096
+CONFIG_PTHREAD_TASK_STACK_SIZE_DEFAULT=4096
+
+# ── Bluetooth (off in Phase 0-Core) ─────────────────────────────────
+# CI-V over BLE is a Phase 2-Core item.
+CONFIG_BT_ENABLED=n
+
+# ── Networking ───────────────────────────────────────────────────────
+# WiFi STA + UDP datagram log sink — same role as both sibling apps.
+CONFIG_ESP_WIFI_ENABLED=y
+CONFIG_LWIP_TCP_ENABLED=y
+CONFIG_LWIP_UDP_ENABLED=y
+
+# ── PSRAM (Quad 8 MB) ─────────────────────────────────────────────────
+CONFIG_SPIRAM=y
+CONFIG_SPIRAM_MODE_QUAD=y
+CONFIG_SPIRAM_USE_MALLOC=y
+# Mandatory for dual-core decode: same constraint as both sibling crates.
+# Keeps allocations ≤4096 B in internal DRAM, preventing TLSF corruption
+# when stage-3 cs Box buffers are placed in internal DRAM by both workers.
+CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096
+
+# ── esp-dsp FFT — 8192 twiddle table ─────────────────────────────────
+CONFIG_DSP_MAX_FFT_SIZE_8192=y

--- a/embedded-poc/m5stack-cores3-app/src/board.rs
+++ b/embedded-poc/m5stack-cores3-app/src/board.rs
@@ -1,0 +1,51 @@
+//! M5Stack CoreS3 公式 pinout.
+//!
+//! ESP32-S3-WROOM-1-N16R8 (LX7 dual-core), ILI9342C 320×240 IPS LCD,
+//! FT6336U 5-point capacitive touch, AXP2101 PMIC, AW9523B I/O expander,
+//! ES7210 dual-mic ADC, AW88298 speaker amp, GC0308 camera, BMI270 IMU,
+//! USB-OTG host on GPIO 19/20.
+//!
+//! Phase 0-Core uses: AXP2101 + AW9523B (power / LCD RST / backlight),
+//! ILI9342C LCD, and I2C0 bus. All other peripherals deferred.
+
+#![allow(dead_code)]
+
+// ── LCD: ILI9342C, 320×240 landscape ─────────────────────────────────
+// FSPI (SPI2_HOST). LCD RST は AW9523B P1_0、BL は AW9523B P0_4 経由。
+pub const LCD_SPI_HOST: u8 = 1; // SPI2_HOST / FSPI
+pub const LCD_PIN_SCK: i32 = 36;
+pub const LCD_PIN_MOSI: i32 = 37;
+pub const LCD_PIN_CS: i32 = 3;
+pub const LCD_PIN_DC: i32 = 35;
+pub const LCD_WIDTH: u16 = 320;
+pub const LCD_HEIGHT: u16 = 240;
+
+// ── I2C bus 0 (AXP2101 + AW9523B + FT6336U + BMI270 共有) ────────────
+pub const I2C0_SCL: i32 = 11;
+pub const I2C0_SDA: i32 = 12;
+pub const AXP2101_I2C_ADDR: u8 = 0x34;
+pub const AW9523B_I2C_ADDR: u8 = 0x58;
+pub const TOUCH_I2C_ADDR: u8 = 0x38;  // FT6336U (Phase 6-Core)
+pub const IMU_I2C_ADDR: u8 = 0x69;    // BMI270
+
+// AW9523B pin assignments (M5Stack CoreS3 schematic):
+//   P0_0 = TP_INT      (FT6336U interrupt, input)
+//   P0_1 = BUS_OUT_EN  (USB host VBUS boost, HIGH=enable; Phase 1-Core)
+//   P0_2 = BOOST_EN    (5V boost for USB VBUS)
+//   P0_4 = LCD_BL      (ILI9342C backlight, HIGH=on)
+//   P0_7 = SPK_EN      (AW88298 speaker amp enable; Phase 3-Core)
+//   P1_0 = LCD_RST     (ILI9342C reset, active LOW)
+//   P1_1 = TP_RST      (FT6336U reset, active LOW; Phase 6-Core)
+pub const AW9523_P0_BUS_OUT_EN: u8 = 1 << 1;
+pub const AW9523_P0_LCD_BL: u8     = 1 << 4;
+pub const AW9523_P0_SPK_EN: u8     = 1 << 7;
+pub const AW9523_P1_LCD_RST: u8    = 1 << 0;
+pub const AW9523_P1_TP_RST: u8     = 1 << 1;
+
+// ── USB OTG (Phase 1-Core) ────────────────────────────────────────────
+pub const USB_OTG_DP: i32 = 20;
+pub const USB_OTG_DM: i32 = 19;
+
+// ── Audio (Phase 3-Core) ──────────────────────────────────────────────
+pub const ES7210_I2C_ADDR: u8  = 0x40;
+pub const AW88298_I2C_ADDR: u8 = 0x36;

--- a/embedded-poc/m5stack-cores3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-cores3-app/src/decode_pipeline.rs
@@ -1,0 +1,199 @@
+//! WAV-fed decode pipeline for CoreS3 (Phase 0-Core).
+//!
+//! Structurally identical to `m5stack-core2-app/src/decode_pipeline.rs`.
+//! All heavy lifting is in `embedded_shared` and `mfsk_app_shared` which
+//! are board-agnostic. Board-specific touch points are `crate::log_free_internal`
+//! and the `QSO_WAVS` slice (same qso3_busy.wav reference as Core2).
+//! Phase 1-Core replaces the wav_sim source with a UAC host capture.
+
+extern crate alloc;
+
+use mfsk_core::ft8::decode::DecodeDepth;
+use mfsk_core::ft8::decode_block::{DEFAULT_Q_THRESH, NFFT_SPEC};
+use mfsk_core::msg::wsjt77::unpack77;
+
+use embedded_shared::{dual_core, esp_dsp_fft, pipeline, stage1_inc, wav_sim};
+
+use mfsk_app_shared::qso::{self, QsoManager, QsoState};
+use mfsk_app_shared::ui::state::{DecodedRow, UI};
+
+const MY_CALL: &str = "JL1NIE";
+const MY_GRID: &str = "PM95";
+
+static QSO_WAVS: &[&[u8]] = &[
+    include_bytes!("../../assets/qso3_busy.wav"),
+];
+
+const PASS1_LIMIT: usize = 30;
+const MAX_CAND: usize = 15;
+
+/// Spawn target. Returns `!`.
+pub fn run() -> ! {
+    // Phase 1.7.7: BASIS scratch retired (Goertzel, zero internal-DRAM
+    // scratch). Empty leak slices stand in for the old ~120 KB allocs.
+    let basis_re_main: &'static mut [i16] =
+        alloc::boxed::Box::leak(alloc::vec![].into_boxed_slice());
+    let basis_im_main: &'static mut [i16] =
+        alloc::boxed::Box::leak(alloc::vec![].into_boxed_slice());
+    let basis_re_c1_ptr: *mut i16 = core::ptr::null_mut();
+    let basis_im_c1_ptr: *mut i16 = core::ptr::null_mut();
+
+    crate::log_free_internal("pre-decode-loop (post-Goertzel: no BASIS alloc)");
+
+    unsafe {
+        esp_idf_svc::sys::vTaskPrioritySet(core::ptr::null_mut(), 6);
+    }
+
+    esp_dsp_fft::prewarm(NFFT_SPEC);
+    dual_core::init(basis_re_c1_ptr, basis_im_c1_ptr);
+
+    let chunk_q = pipeline::create_chunk_queue(4);
+    let slot_q = pipeline::create_slot_queue(2);
+    let spec_q = pipeline::create_spec_queue(2);
+    let wf_q = pipeline::create_wf_queue(8);
+    stage1_inc::spawn_with_wf(chunk_q, slot_q, spec_q, Some(wf_q));
+    wav_sim::spawn(QSO_WAVS, chunk_q);
+
+    let wf_q_addr = wf_q as usize;
+    std::thread::Builder::new()
+        .stack_size(4 * 1024)
+        .spawn(move || wf_drain(wf_q_addr as esp_idf_svc::sys::QueueHandle_t))
+        .expect("spawn wf drainer");
+
+    log::info!("decode pipeline ready (q_thresh={DEFAULT_Q_THRESH}, band 200..3000 Hz, cores3-app phase 0)");
+
+    let mut qso = QsoManager::new(MY_CALL, MY_GRID);
+    let initial = qso.call_cq(None);
+    push_tx_line(&qso, Some(&initial));
+
+    let mut slot_seq: u32 = 0;
+    loop {
+        let cfg = dual_core::DecodeConfig {
+            freq_min: 100.0,
+            freq_max: 3_000.0,
+            sync_min: 1.0,
+            pass1_limit: PASS1_LIMIT,
+            max_cand: MAX_CAND,
+            q_thresh: DEFAULT_Q_THRESH,
+            bp_max_iter: mfsk_core::ft8::params::DEFAULT_BP_MAX_ITER,
+            depth: DecodeDepth::BpVariantsAd,
+        };
+        let out = dual_core::run_speculative_slot(
+            spec_q,
+            slot_q,
+            &cfg,
+            basis_re_main,
+            basis_im_main,
+        );
+        let dual_core::SpeculativeOut {
+            spec,
+            slot,
+            results,
+            n_pass1,
+            n_ready,
+            n_deferred,
+            t_post_recv,
+            t_coarse_done,
+            t_early_done,
+            t_slot_recv,
+            t_done,
+        } = out;
+        let wav_idx = slot.wav_idx;
+
+        let slotend = slot.slotend_us;
+        let tail_window = (slotend - t_post_recv).max(0);
+        let coarse_us = t_coarse_done - t_post_recv;
+        let tail_use = (slotend.min(t_early_done) - t_coarse_done).max(0);
+        let post_slotend = (t_done - slotend).max(0);
+        log::info!(
+            "WAV[{wav_idx}] p1={n_pass1} ready={n_ready} defer={n_deferred} dec={} \
+             tail_win={}us coarse={}us early={}us tail_use={}us post_slotend={}us \
+             slot_wait={}us late={}us",
+            results.len(),
+            tail_window,
+            coarse_us,
+            t_early_done - t_coarse_done,
+            tail_use,
+            post_slotend,
+            t_slot_recv - t_early_done,
+            t_done - t_slot_recv,
+        );
+        slot_seq = slot_seq.wrapping_add(1);
+
+        for r in results.iter() {
+            mfsk_app_shared::time_sync::record_decode_dt(r.dt_sec);
+        }
+        mfsk_app_shared::time_sync::finalize_slot();
+        if let Some(off) = mfsk_app_shared::time_sync::slot_dt_offset() {
+            log::info!(
+                "  median DT = {:+.3} s ({} slots)",
+                off,
+                mfsk_app_shared::time_sync::slots_finalised()
+            );
+        }
+
+        let mut had_response_this_slot = false;
+        if let Ok(mut ui) = UI.lock() {
+            for r in results.iter() {
+                if let Some(text) = unpack77(&r.message77) {
+                    let mut msg: heapless::String<22> = heapless::String::new();
+                    let take = text.len().min(msg.capacity());
+                    let _ = msg.push_str(&text[..take]);
+                    const FP_SPEC_SHIFT: u32 = 12;
+                    let cell_scale = (1u32 << FP_SPEC_SHIFT) as f32;
+                    let calibrated_snr =
+                        mfsk_core::ft8::decode_block::xsnr2_db_simple(&spec.spec, r, cell_scale);
+                    let snr_i8 = calibrated_snr.round().clamp(-128.0, 127.0) as i8;
+                    let row = DecodedRow {
+                        df_hz: r.freq_hz.round().clamp(0.0, 65_535.0) as u16,
+                        snr_db: snr_i8,
+                        hard_errors: r.hard_errors.min(255) as u8,
+                        msg,
+                        slot_seq,
+                        first_seq: slot_seq,
+                    };
+                    ui.push_decode(row);
+                    log::info!(
+                        "{:4.0}Hz {:+5.1}dB (raw={:+5.1}) {}",
+                        r.freq_hz, calibrated_snr, r.snr_db, text
+                    );
+                    qso.set_rx_snr(snr_i8);
+                    let parity_lock_ok =
+                        mfsk_app_shared::parity::framing_settled_for_parity_lock();
+                    if qso
+                        .process_message(&text, wav_idx as u32, parity_lock_ok)
+                        .is_some()
+                    {
+                        had_response_this_slot = true;
+                    }
+                }
+            }
+        }
+
+        if !had_response_this_slot && qso.state != QsoState::Idle {
+            let _ = qso.on_period_end();
+        }
+        if qso.state == QsoState::Idle {
+            qso.call_cq(None);
+        }
+        let intent = qso.next_tx();
+        push_tx_line(&qso, intent.as_ref());
+    }
+}
+
+fn push_tx_line(qso: &QsoManager, intent: Option<&qso::TxIntent>) {
+    let line = qso::format_tx_line(qso, intent);
+    log::info!("[QSO] {}", line.as_str());
+    if let Ok(mut ui) = UI.lock() {
+        ui.set_tx_line(line.as_str());
+    }
+}
+
+fn wf_drain(wf_q: esp_idf_svc::sys::QueueHandle_t) -> ! {
+    loop {
+        let tick = pipeline::recv_box::<pipeline::WfTick>(wf_q);
+        if let Ok(mut ui) = UI.lock() {
+            ui.push_waterfall(tick.row);
+        }
+    }
+}

--- a/embedded-poc/m5stack-cores3-app/src/display.rs
+++ b/embedded-poc/m5stack-cores3-app/src/display.rs
@@ -1,0 +1,247 @@
+//! LCD bring-up + render loop for M5Stack CoreS3 (ILI9342C, 320×240).
+//!
+//! Mirrors `m5stack-core2-app/src/display.rs` structurally. Key CoreS3
+//! deltas:
+//!   - SPI2 (FSPI) on pins 36/37/3/35 (Core2 used SPI3 on 18/23/5/15).
+//!   - PMIC is AXP2101 + AW9523B; RST + BL are driven by `pmic::init`
+//!     before SPI init (Core2 used AXP192 GPIO4 for RST).
+//!   - Color inversion: ILI9342C on CoreS3 requires Inverted (same as
+//!     Core2 whose M5GFX cfg also sets invert=true for ILI9342C).
+//!
+//! Layout reuse: `mfsk_app_shared::ui::{decoded_list, status_bar,
+//! waterfall}` hardcode 135 px width (M5StickS3 panel). Phase 0-Core
+//! renders them into the top-left 135×240 corner; widening to runtime
+//! canvas dims is a Phase 2.5-Core item.
+
+use embedded_graphics::{
+    mono_font::{ascii::FONT_6X10, MonoTextStyleBuilder},
+    pixelcolor::Rgb565,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+    text::{Baseline, Text},
+};
+
+use display_interface_spi::SPIInterface;
+use esp_idf_hal::{
+    delay::Ets,
+    gpio::{AnyIOPin, PinDriver, Pins},
+    i2c::I2C0,
+    spi::{config::Config as SpiConfig, SpiDeviceDriver, SpiDriver, SpiDriverConfig, SPI2},
+    units::FromValueType,
+};
+use mipidsi::{
+    models::ILI9341Rgb565,
+    options::{ColorInversion, Orientation, Rotation},
+    Builder,
+};
+
+use esp_idf_svc::nvs::{EspNvs, NvsDefault};
+
+use mfsk_app_shared::boot_mode::BootMode;
+use mfsk_app_shared::log_sink::LogFanout;
+use mfsk_app_shared::ui::{decoded_list, state::UI, status_bar, waterfall};
+
+const TX_REGION_Y: i32 = 226;
+const TX_REGION_H: u32 = 14;
+const SHARED_UI_WIDTH: u32 = 135;
+
+/// LCD bring-up + render loop. Returns `!`.
+#[allow(clippy::too_many_arguments)]
+pub fn run_log_panel(
+    i2c0: I2C0<'static>,
+    spi2: SPI2<'static>,
+    pins: Pins,
+    fanout: &'static LogFanout,
+    _nvs: EspNvs<NvsDefault>,
+    mode: BootMode,
+) -> ! {
+    // ── PMIC: AXP2101 + AW9523B → LCD power rails + RST + BL. ──────────
+    match crate::pmic::init(i2c0, pins.gpio12, pins.gpio11) {
+        Ok(i2c) => {
+            drop(i2c); // Phase 6-Core touch driver reclaims the bus.
+        }
+        Err(e) => {
+            log::error!("PMIC init failed: {e:#}");
+            loop {
+                log::info!("alive (no PMIC/LCD)");
+                std::thread::sleep(std::time::Duration::from_secs(2));
+            }
+        }
+    }
+
+    // ── SPI2 (FSPI) host for the ILI9342C. ───────────────────────────
+    let driver = SpiDriver::new(
+        spi2,
+        pins.gpio36, // SCK
+        pins.gpio37, // MOSI
+        Option::<AnyIOPin>::None,
+        &SpiDriverConfig::new(),
+    )
+    .expect("SPI2 driver");
+    let spi_cfg = SpiConfig::new().baudrate(20_u32.MHz().into());
+    let spi_dev = SpiDeviceDriver::new(driver, Some(pins.gpio3), &spi_cfg)
+        .expect("SPI device (CS=3)");
+
+    let dc = PinDriver::output(pins.gpio35).expect("DC gpio35");
+    let di = SPIInterface::new(spi_dev, dc);
+
+    // ILI9342C is ILI9341-compatible — use mipidsi's ILI9341 model.
+    // No reset_pin(): RST was already cycled by AW9523B in pmic::init;
+    // mipidsi will send SWRESET via the command interface as fallback.
+    // display_size MUST be (240, 320) (native portrait controller dims);
+    // Deg90 rotation maps to 320×240 landscape in embedded-graphics space.
+    let mut delay = Ets;
+    let mut display = match Builder::new(ILI9341Rgb565, di)
+        .display_size(240, 320)
+        .orientation(Orientation::new().rotate(Rotation::Deg90))
+        .invert_colors(ColorInversion::Inverted) // M5GFX CoreS3: cfg.invert = true
+        .init(&mut delay)
+    {
+        Ok(d) => d,
+        Err(e) => {
+            log::error!("display init failed: {:?}", e);
+            loop {
+                log::info!("alive (no LCD)");
+                std::thread::sleep(std::time::Duration::from_secs(2));
+            }
+        }
+    };
+
+    log::info!(
+        "LCD init OK (ILI9342C/CoreS3 via ILI9341 model, {}x{})",
+        crate::board::LCD_WIDTH,
+        crate::board::LCD_HEIGHT
+    );
+    display.clear(Rgb565::BLACK).ok();
+
+    let tx_style = MonoTextStyleBuilder::new()
+        .font(&FONT_6X10)
+        .text_color(Rgb565::WHITE)
+        .background_color(Rgb565::new(0, 0, 8))
+        .build();
+    let tx_bg = Rgb565::new(0, 0, 8);
+
+    Rectangle::new(Point::new(0, TX_REGION_Y), Size::new(SHARED_UI_WIDTH, TX_REGION_H))
+        .into_styled(PrimitiveStyle::with_fill(tx_bg))
+        .draw(&mut display)
+        .ok();
+    let mode_line: heapless::String<32> = {
+        let mut s: heapless::String<32> = heapless::String::new();
+        let _ = core::fmt::Write::write_fmt(
+            &mut s,
+            format_args!("CoreS3 Mode: {}", mode.label()),
+        );
+        s
+    };
+    Text::with_baseline(
+        mode_line.as_str(),
+        Point::new(2, TX_REGION_Y + 2),
+        tx_style,
+        Baseline::Top,
+    )
+    .draw(&mut display)
+    .ok();
+
+    let mut tick: u32 = 0;
+    let mut last_wf_seq: u32 = u32::MAX;
+    let mut last_decoded_fp: (usize, u32) = (usize::MAX, u32::MAX);
+    let mut last_tx_seq: u32 = 0;
+    loop {
+        let heap = unsafe { esp_idf_svc::sys::esp_get_free_heap_size() };
+        if tick % 50 == 0 {
+            let internal = unsafe {
+                esp_idf_svc::sys::heap_caps_get_free_size(
+                    esp_idf_svc::sys::MALLOC_CAP_INTERNAL | esp_idf_svc::sys::MALLOC_CAP_8BIT,
+                )
+            };
+            let internal_largest = unsafe {
+                esp_idf_svc::sys::heap_caps_get_largest_free_block(
+                    esp_idf_svc::sys::MALLOC_CAP_INTERNAL | esp_idf_svc::sys::MALLOC_CAP_8BIT,
+                )
+            };
+            log::info!(
+                "alive tick={tick} free_heap={heap} internal={internal} largest={internal_largest}"
+            );
+        }
+
+        let status_snapshot;
+        let decoded_snapshot;
+        let wf_snapshot: heapless::Vec<
+            mfsk_app_shared::ui::state::WfLine,
+            { mfsk_app_shared::ui::state::WF_DEPTH },
+        >;
+        let decoded_fp;
+        let wf_seq;
+        let tx_seq;
+        let tx_line_snapshot: heapless::String<48>;
+        {
+            let Ok(mut ui) = UI.lock() else {
+                log::warn!("UI mutex poisoned — skipping render frame");
+                continue;
+            };
+            ui.status.free_heap_kb = (heap / 1024) as u32;
+            status_snapshot = ui.status.clone();
+            decoded_snapshot = ui
+                .decoded_iter()
+                .cloned()
+                .collect::<heapless::Vec<_, 16>>();
+            wf_snapshot = ui.waterfall_iter().cloned().collect();
+            wf_seq = ui.wf_push_seq();
+            tx_seq = ui.tx_seq();
+            let mut buf: heapless::String<48> = heapless::String::new();
+            for ch in ui.tx_line().chars() {
+                if buf.push(ch).is_err() {
+                    break;
+                }
+            }
+            tx_line_snapshot = buf;
+            let max_seq = decoded_snapshot
+                .iter()
+                .map(|r| r.slot_seq)
+                .max()
+                .unwrap_or(0);
+            decoded_fp = (decoded_snapshot.len(), max_seq);
+        }
+
+        status_bar::render(&mut display, &status_snapshot).ok();
+
+        if wf_seq != last_wf_seq {
+            let wf_refs: heapless::Vec<
+                &mfsk_app_shared::ui::state::WfLine,
+                { mfsk_app_shared::ui::state::WF_DEPTH },
+            > = wf_snapshot.iter().collect();
+            waterfall::render(&mut display, &wf_refs).ok();
+            last_wf_seq = wf_seq;
+        }
+
+        if decoded_fp != last_decoded_fp {
+            decoded_list::render(&mut display, &decoded_snapshot).ok();
+            last_decoded_fp = decoded_fp;
+        }
+
+        if tx_seq != last_tx_seq {
+            Rectangle::new(Point::new(0, TX_REGION_Y), Size::new(SHARED_UI_WIDTH, TX_REGION_H))
+                .into_styled(PrimitiveStyle::with_fill(tx_bg))
+                .draw(&mut display)
+                .ok();
+            let text = if tx_line_snapshot.is_empty() {
+                "IDLE: ---"
+            } else {
+                tx_line_snapshot.as_str()
+            };
+            Text::with_baseline(
+                text,
+                Point::new(2, TX_REGION_Y + 2),
+                tx_style,
+                Baseline::Top,
+            )
+            .draw(&mut display)
+            .ok();
+            last_tx_seq = tx_seq;
+        }
+
+        let _ = fanout;
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        tick = tick.wrapping_add(1);
+    }
+}

--- a/embedded-poc/m5stack-cores3-app/src/main.rs
+++ b/embedded-poc/m5stack-cores3-app/src/main.rs
@@ -1,0 +1,130 @@
+//! M5Stack CoreS3 FT8 controller — entry point (Phase 0-Core).
+//!
+//! Mirrors `m5stack-core2-app/src/main.rs`. CoreS3 deltas vs Core2:
+//!   - PMIC: AXP2101 + AW9523B (vs AXP192); LCD RST via AW9523B.
+//!   - SPI2 (FSPI) on pins 36/37/3/35 for LCD (vs Core2 SPI3 18/23/5/15).
+//!   - I2C0: SDA=12, SCL=11 (vs Core2 SDA=21, SCL=22).
+//!   - No GPIO buttons (same as Core2); NVS-only boot mode.
+//!   - USB-OTG capable (Phase 1-Core); no audio in Phase 0.
+
+#![allow(dead_code)]
+
+mod board;
+mod decode_pipeline;
+mod display;
+mod pmic;
+
+use esp_idf_hal::peripherals::Peripherals;
+use esp_idf_svc::eventloop::EspSystemEventLoop;
+use esp_idf_svc::nvs::EspDefaultNvsPartition;
+use esp_idf_svc::sys::{
+    heap_caps_get_free_size, heap_caps_get_largest_free_block, MALLOC_CAP_8BIT, MALLOC_CAP_INTERNAL,
+};
+use log::LevelFilter;
+
+use mfsk_app_shared::boot_mode;
+use mfsk_app_shared::log_sink::{FanoutLogger, LogFanout};
+use mfsk_app_shared::udp_log;
+use mfsk_app_shared::wifi;
+
+pub fn log_free_internal(label: &str) {
+    let caps = MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
+    let free = unsafe { heap_caps_get_free_size(caps) };
+    let largest = unsafe { heap_caps_get_largest_free_block(caps) };
+    log::info!("[mem] {label} free_internal={free} largest={largest}");
+}
+
+static FANOUT: LogFanout = LogFanout::new();
+static LOGGER: FanoutLogger = FanoutLogger::new(&FANOUT, LevelFilter::Info);
+
+const WIFI_SSID: &str = env!("WIFI_SSID");
+const WIFI_PSK: &str = env!("WIFI_PSK");
+const UDP_LOG_TARGET: &str = env!("UDP_LOG_TARGET");
+const UDP_LOG_PORT: &str = env!("UDP_LOG_PORT");
+
+fn main() -> ! {
+    esp_idf_svc::sys::link_patches();
+    LOGGER.install();
+
+    log::info!("=== mfsk-core-m5stack-cores3-app boot ===");
+    log::info!("phase 0-core: NVS boot-mode, wav_sim decode, ILI9342C LCD");
+    log::info!("build-stamp 2026-05-23-cores3-phase0");
+
+    let peripherals = Peripherals::take().expect("peripherals taken twice");
+
+    let nvs_part = EspDefaultNvsPartition::take().expect("NVS partition take");
+    let nvs = boot_mode::open_nvs(nvs_part.clone()).expect("NVS open mfsk namespace");
+    let mode = boot_mode::determine_no_override(&nvs);
+    log::info!("boot_mode: {} (NVS-only on CoreS3)", mode.label());
+
+    let mut _wifi_slot: Option<wifi::WifiHandle> = None;
+    let wifi_should_start = mode == boot_mode::BootMode::Wifi && !WIFI_SSID.is_empty();
+    if mode == boot_mode::BootMode::Wifi && WIFI_SSID.is_empty() {
+        log::warn!(
+            "boot_mode=WIFI but WIFI_SSID empty (no cfg.toml) — flip NVS to DECODE"
+        );
+    }
+    if wifi_should_start {
+        let sysloop = EspSystemEventLoop::take().expect("sysloop");
+        match wifi::connect_sta(
+            peripherals.modem,
+            sysloop,
+            Some(nvs_part.clone()),
+            WIFI_SSID,
+            WIFI_PSK,
+        ) {
+            Ok(handle) => {
+                let target_ip: std::net::IpAddr = if UDP_LOG_TARGET.is_empty()
+                    || UDP_LOG_TARGET == "auto"
+                {
+                    std::net::IpAddr::V4(handle.subnet_broadcast)
+                } else {
+                    match UDP_LOG_TARGET.parse() {
+                        Ok(ip) => ip,
+                        Err(e) => {
+                            log::warn!(
+                                "UDP_LOG_TARGET '{UDP_LOG_TARGET}' parse failed ({e}); using subnet bcast"
+                            );
+                            std::net::IpAddr::V4(handle.subnet_broadcast)
+                        }
+                    }
+                };
+                let port: u16 = UDP_LOG_PORT.parse().unwrap_or(9999);
+                let addr = std::net::SocketAddr::new(target_ip, port);
+                match udp_log::UdpLogSink::new(addr) {
+                    Ok(sink) => {
+                        if let Ok(mut slot) = FANOUT.udp.try_lock() {
+                            *slot = Some(sink);
+                        }
+                        FANOUT.drain_staging_to_udp();
+                        log::info!("UDP log sink up → {addr}");
+                    }
+                    Err(e) => log::warn!("UDP socket bind failed: {e}"),
+                }
+                _wifi_slot = Some(handle);
+            }
+            Err(e) => log::warn!("WiFi STA failed: {e:#} — UDP log disabled"),
+        }
+    }
+
+    if mode == boot_mode::BootMode::Decode {
+        log_free_internal("pre-thread-spawn");
+        let pipeline_spawn = std::thread::Builder::new()
+            .stack_size(32 * 1024)
+            .spawn(|| decode_pipeline::run());
+        if let Err(e) = pipeline_spawn {
+            log::error!("decode_pipeline spawn failed ({e})");
+        }
+    } else {
+        log::info!("decode_pipeline skipped (BootMode::Wifi)");
+    }
+
+    display::run_log_panel(
+        peripherals.i2c0,
+        peripherals.spi2,
+        peripherals.pins,
+        &FANOUT,
+        nvs,
+        mode,
+    )
+}

--- a/embedded-poc/m5stack-cores3-app/src/pmic.rs
+++ b/embedded-poc/m5stack-cores3-app/src/pmic.rs
@@ -1,0 +1,106 @@
+//! AXP2101 + AW9523B bring-up for M5Stack CoreS3 (Phase 0-Core).
+//!
+//! AXP2101 (0x34): main PMIC. Phase 0 verifies presence via Chip-ID
+//! (reg 0x03 → 0x4A for AXP2101) and relies on power-on defaults for all
+//! rails. Full rail tuning (ALDO voltages etc.) is a Phase 1-Core item.
+//!
+//! AW9523B (0x58): I/O expander. Phase 0 configures:
+//!   - Port 0 direction: P0_0 (TP_INT) = input, rest = output.
+//!   - Port 1 direction: all outputs.
+//!   - Safe defaults: BUS_OUT_EN=LOW (no USB VBUS), SPK_EN=LOW.
+//!   - LCD_BL (P0_4) = HIGH → backlight on.
+//!   - LCD_RST (P1_0): LOW → delay → HIGH → ILI9342C reset cycle.
+//!
+//! I2C bus is returned to the caller; display.rs holds it for the reset
+//! delay and then drops it (Phase 6-Core touch driver will reclaim it).
+
+use anyhow::{anyhow, Result};
+use esp_idf_hal::{
+    delay::FreeRtos,
+    gpio::{Gpio11, Gpio12},
+    i2c::{I2cConfig, I2cDriver, I2C0},
+    units::FromValueType,
+};
+
+use crate::board::{
+    AW9523B_I2C_ADDR, AW9523_P0_LCD_BL, AW9523_P1_LCD_RST, AW9523_P1_TP_RST, AXP2101_I2C_ADDR,
+};
+
+// AW9523B register map (AW9523B datasheet §6).
+const AW9523_REG_IN0: u8 = 0x00;  // Input port 0 (read)
+const AW9523_REG_IN1: u8 = 0x01;  // Input port 1 (read)
+const AW9523_REG_OUT0: u8 = 0x02; // Output port 0 latch
+const AW9523_REG_OUT1: u8 = 0x03; // Output port 1 latch
+const AW9523_REG_CFG0: u8 = 0x04; // Port 0 direction: 0=output, 1=input
+const AW9523_REG_CFG1: u8 = 0x05; // Port 1 direction: 0=output, 1=input
+const AW9523_REG_GCR: u8  = 0x11; // Global config (push-pull vs open-drain)
+
+// AXP2101 register map (AXP2101 datasheet).
+const AXP2101_REG_CHIP_ID: u8 = 0x03; // Chip ID — 0x4A for AXP2101
+
+const I2C_TIMEOUT_TICKS: u32 = 100;
+
+fn read_reg(i2c: &mut I2cDriver<'_>, addr: u8, reg: u8) -> Result<u8> {
+    let mut buf = [0u8; 1];
+    i2c.write_read(addr, &[reg], &mut buf, I2C_TIMEOUT_TICKS)
+        .map_err(|e| anyhow!("I2C read 0x{addr:02x} reg 0x{reg:02x} failed: {e}"))?;
+    Ok(buf[0])
+}
+
+fn write_reg(i2c: &mut I2cDriver<'_>, addr: u8, reg: u8, val: u8) -> Result<()> {
+    i2c.write(addr, &[reg, val], I2C_TIMEOUT_TICKS)
+        .map_err(|e| anyhow!("I2C write 0x{addr:02x} reg 0x{reg:02x}={val:#04x} failed: {e}"))
+}
+
+pub fn scan(i2c: &mut I2cDriver<'_>) {
+    log::info!("I2C0 bus scan:");
+    for addr in 0x08u8..=0x77 {
+        if i2c.write(addr, &[0u8], I2C_TIMEOUT_TICKS).is_ok() {
+            log::info!("  device @ 0x{addr:02x}");
+        }
+    }
+}
+
+/// Initialise I2C0, scan the bus, bring up AXP2101 + AW9523B for LCD.
+/// Returns the driver; the caller holds it until LCD SPI init completes,
+/// then may drop it (Phase 6-Core touch will reclaim the bus).
+pub fn init<'d>(i2c0: I2C0<'d>, sda: Gpio12<'d>, scl: Gpio11<'d>) -> Result<I2cDriver<'d>> {
+    let cfg = I2cConfig::new().baudrate(400u32.kHz().into());
+    let mut i2c = I2cDriver::new(i2c0, sda, scl, &cfg)
+        .map_err(|e| anyhow!("I2C0 driver init failed: {e}"))?;
+
+    scan(&mut i2c);
+
+    // ── AXP2101 presence check ────────────────────────────────────────
+    match read_reg(&mut i2c, AXP2101_I2C_ADDR, AXP2101_REG_CHIP_ID) {
+        Ok(id) => log::info!("AXP2101 chip-id=0x{id:02x} (expect 0x4A)"),
+        Err(e) => log::warn!("AXP2101 read failed: {e:#}"),
+    }
+
+    // ── AW9523B init ──────────────────────────────────────────────────
+    // GCR[4] = 0: push-pull mode for port 0 (default is open-drain on
+    // some silicon revisions; set explicitly to guarantee output drive).
+    write_reg(&mut i2c, AW9523B_I2C_ADDR, AW9523_REG_GCR, 0x10)?;
+
+    // Port 0 direction: P0_0 (TP_INT) = input (bit=1), rest = output.
+    write_reg(&mut i2c, AW9523B_I2C_ADDR, AW9523_REG_CFG0, 0x01)?;
+    // Port 1 direction: all outputs (P1_0=LCD_RST, P1_1=TP_RST, ...).
+    write_reg(&mut i2c, AW9523B_I2C_ADDR, AW9523_REG_CFG1, 0x00)?;
+
+    // Safe default output state: BUS_OUT_EN (P0_1)=LOW (no USB VBUS,
+    // Phase 1-Core enables it), SPK_EN (P0_7)=LOW; only LCD_BL on.
+    let p0_out = AW9523_P0_LCD_BL;
+    write_reg(&mut i2c, AW9523B_I2C_ADDR, AW9523_REG_OUT0, p0_out)?;
+    log::info!("AW9523B port0 out=0x{p0_out:02x} (LCD_BL=ON, BUS_OUT_EN=OFF, SPK_EN=OFF)");
+
+    // Port 1: assert LCD_RST and TP_RST LOW first (active-low reset).
+    write_reg(&mut i2c, AW9523B_I2C_ADDR, AW9523_REG_OUT1, 0x00)?;
+    FreeRtos::delay_ms(20);
+    // Release resets (HIGH = normal operation).
+    let p1_out = AW9523_P1_LCD_RST | AW9523_P1_TP_RST;
+    write_reg(&mut i2c, AW9523B_I2C_ADDR, AW9523_REG_OUT1, p1_out)?;
+    FreeRtos::delay_ms(100);
+    log::info!("AW9523B LCD_RST + TP_RST cycle complete");
+
+    Ok(i2c)
+}


### PR DESCRIPTION
## Summary
New crate `m5stack-cores3-app` targeting M5Stack CoreS3 (ESP32-S3 LX7, 16 MB flash, 8 MB Quad PSRAM). Phase 0-Core from `docs/ROADMAP.md` Phase B-Core.

Follows the same `mfsk-app-shared` + `embedded-shared` consumer pattern proven by `m5stack-core2-app`. Board-specific layer only:
- **board.rs**: ILI9342C SPI2 pins (SCK=36, MOSI=37, CS=3, DC=35), I2C0 (SDA=12, SCL=11), AXP2101 (0x34) + AW9523B (0x58) addresses and pin constants
- **pmic.rs**: AXP2101 chip-ID probe + AW9523B init — LCD_BL HIGH, LCD_RST cycle, BUS_OUT_EN LOW (Phase 1-Core enables USB VBUS)
- **display.rs**: ILI9342C via mipidsi ILI9341 model, SPI2/FSPI, color inversion on, 135 px shared UI layout (same as siblings)
- **decode_pipeline.rs**: qso3_busy.wav → `run_speculative_slot`, same as Core2-app
- **main.rs**: NVS-only boot mode (no GPIO buttons), WiFi+UDP log, Decode mode spawns decode pipeline thread

Infrastructure: `.cargo/config.toml` (xtensa-esp32s3-espidf), `sdkconfig.defaults` (16 MB flash, Quad PSRAM, WiFi, no BLE/USB-host for Phase 0), `partitions.csv` (same as Core2 16 MB layout), `build.rs` + `bootstrap-sdkconfig.sh`, `cfg-sample.toml`.

`cargo build --release` clean (only pre-existing mfsk-ffi-ft8 cdylib warning).

## Test plan
- [ ] `cargo check --release` in `embedded-poc/m5stack-cores3-app/`
- [ ] Flash to physical CoreS3: `cargo build --release && ../scripts/flash-monitor.sh ...`
- [ ] Confirm I2C scan shows 0x34 (AXP2101) + 0x58 (AW9523B)
- [ ] LCD lights up and shows decode pipeline output

🤖 Generated with [Claude Code](https://claude.com/claude-code)