### PR TITLE
feat(ft8): coarse_sync top-5 DT median as cold-start bootstrap

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
+++ b/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
@@ -121,6 +121,7 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
             n_pass1,
             n_ready,
             n_deferred,
+            bootstrap_dt_med: _,
             t_post_recv,
             t_coarse_done,
             t_early_done,

--- a/embedded-poc/embedded-shared/src/dual_core.rs
+++ b/embedded-poc/embedded-shared/src/dual_core.rs
@@ -43,7 +43,7 @@ use alloc::boxed::Box;
 use alloc::vec;
 use alloc::vec::Vec;
 
-use mfsk_core::core::sync::SyncCandidate;
+use mfsk_core::core::sync::{bootstrap_dt_median, SyncCandidate};
 use mfsk_core::ft8::decode::{DecodeDepth, DecodeResult};
 use mfsk_core::ft8::decode_block::{
     coarse_sync, process_candidates_into_with_cs_scratch_tuned, refine_candidates_into,
@@ -64,6 +64,13 @@ pub struct SpeculativeOut {
     pub n_pass1: usize,
     pub n_ready: usize,
     pub n_deferred: usize,
+    /// DT median over the top-5 highest-score pass1 candidates.
+    /// `None` if pass1 was empty. Used by the controller's auto-sync
+    /// path as a cold-start fallback when zero confirmed decodes
+    /// land — empirically lines up with the confirmed-decode median
+    /// to within ±70 ms on reference fixtures, gated by the
+    /// `ft8_coarse_sync_bootstrap` integration test.
+    pub bootstrap_dt_med: Option<f32>,
     /// `esp_timer_get_time()` right after `recv_box::<SpecBundle>` returns.
     pub t_post_recv: i64,
     /// after `coarse_sync_split_with_allsum`.
@@ -133,6 +140,7 @@ pub fn run_speculative_slot(
     let t_coarse_done = unsafe { esp_timer_get_time() };
 
     let n_pass1 = pass1.len();
+    let bootstrap_dt_med = bootstrap_dt_median(&pass1, 5);
     let snap_fill = spec.audio_len();
     // Partition by audio-window fit only.
     //
@@ -227,6 +235,7 @@ pub fn run_speculative_slot(
         n_pass1,
         n_ready,
         n_deferred,
+        bootstrap_dt_med,
         t_post_recv,
         t_coarse_done,
         t_early_done,

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -112,6 +112,7 @@ pub fn run() -> ! {
             n_pass1,
             n_ready,
             n_deferred,
+            bootstrap_dt_med: _,
             t_post_recv,
             t_coarse_done,
             t_early_done,

--- a/embedded-poc/m5stack-cores3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-cores3-app/src/decode_pipeline.rs
@@ -105,6 +105,7 @@ pub fn run_with_source<F: FnOnce(QueueHandle_t)>(source_spawn: F) -> ! {
             n_pass1,
             n_ready,
             n_deferred,
+            bootstrap_dt_med: _,
             t_post_recv,
             t_coarse_done,
             t_early_done,

--- a/embedded-poc/m5stack-s3-app/src/audio.rs
+++ b/embedded-poc/m5stack-s3-app/src/audio.rs
@@ -660,8 +660,9 @@ pub fn capture_thread(mut i2s: I2sDriver<'static, I2sRx>) -> ! {
                             }),
                         );
                         // Consume the latest bootstrap shift hint
-                        // from decode_pipeline (pass1 candidate DT
-                        // median). Apply once as a one-shot adjustment
+                        // from decode_pipeline (confirmed-decode DT
+                        // median, gated on N>HWM). Apply once as a
+                        // one-shot adjustment
                         // to the next slot length; the producer side
                         // posts 0 in steady state so this is idempotent.
                         let shift = mfsk_app_shared::time_sync::take_bootstrap_slot_shift_12k();

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -230,6 +230,7 @@ where
             n_pass1,
             n_ready,
             n_deferred,
+            bootstrap_dt_med,
             t_post_recv,
             t_coarse_done,
             t_early_done,
@@ -407,6 +408,26 @@ where
                 MAX_SHIFT_SAMPLES as f32 / 12000.0
             );
             best_n = n_dec;
+        } else if n_dec == 0 && best_n == 0 && bootstrap_dt_med.is_some() {
+            // Cold start (or post-reset) with 0 confirmed decodes —
+            // fall back to coarse_sync top-5 DT median. Gated by
+            // `ft8_coarse_sync_bootstrap` test (mfsk-core): top-5
+            // median tracks confirmed median to within ±70 ms on the
+            // reference WAVs. Soft anchor only — best_n stays 0 so
+            // the next confirmed-decode slot takes over via the HWM
+            // update path above.
+            let med = bootstrap_dt_med.unwrap();
+            let shift_samples: i32 = if med.abs() < ALIGN_OK_SEC {
+                0
+            } else {
+                (med * 12000.0).round() as i32
+            };
+            let shift_samples = shift_samples.clamp(-MAX_SHIFT_SAMPLES, MAX_SHIFT_SAMPLES);
+            mfsk_app_shared::time_sync::set_bootstrap_slot_shift_12k(shift_samples);
+            log::info!(
+                "  auto-sync (cold bootstrap from coarse_sync top-5, p1={n_pass1}): DT={:+.3}s → {:+} samples",
+                med, shift_samples,
+            );
         } else if post_sync {
             mfsk_app_shared::time_sync::set_bootstrap_slot_shift_12k(0);
             if n_dec > 0 {

--- a/mfsk-core/src/core/sync.rs
+++ b/mfsk-core/src/core/sync.rs
@@ -48,7 +48,11 @@ pub fn bootstrap_dt_median(cands: &[SyncCandidate], top_k: usize) -> Option<f32>
         return None;
     }
     let mut sorted: Vec<&SyncCandidate> = cands.iter().collect();
-    sorted.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(core::cmp::Ordering::Equal));
+    sorted.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(core::cmp::Ordering::Equal)
+    });
     let mut dts: Vec<f32> = sorted.iter().take(top_k).map(|c| c.dt_sec).collect();
     dts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
     let n = dts.len();

--- a/mfsk-core/src/core/sync.rs
+++ b/mfsk-core/src/core/sync.rs
@@ -31,6 +31,34 @@ pub struct SyncCandidate {
     pub score: f32,
 }
 
+/// DT median of the top-`top_k` highest-score coarse-sync candidates.
+///
+/// Used to bootstrap slot alignment when zero confirmed decodes are
+/// available (cold start, or a deep-fade slot). Empirically — on
+/// reference qso3_busy / WSJT-X 191111 captures — the top-5 candidate
+/// DT median lands within ±70 ms of the confirmed-decode DT median,
+/// while top-10/20 wash out under false-candidate noise (see
+/// `mfsk-core/tests/ft8_coarse_sync_bootstrap.rs`).
+///
+/// `cands` does not need to be sorted; callers pass the raw output of
+/// `decode_block::coarse_sync` or `core::sync::coarse_sync`. Returns
+/// `None` if `cands` is empty or `top_k == 0`.
+pub fn bootstrap_dt_median(cands: &[SyncCandidate], top_k: usize) -> Option<f32> {
+    if cands.is_empty() || top_k == 0 {
+        return None;
+    }
+    let mut sorted: Vec<&SyncCandidate> = cands.iter().collect();
+    sorted.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(core::cmp::Ordering::Equal));
+    let mut dts: Vec<f32> = sorted.iter().take(top_k).map(|c| c.dt_sec).collect();
+    dts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+    let n = dts.len();
+    Some(if n % 2 == 1 {
+        dts[n / 2]
+    } else {
+        0.5 * (dts[n / 2 - 1] + dts[n / 2])
+    })
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Per-protocol DSP parameter bundle (all derived from P at compile time)
 // ──────────────────────────────────────────────────────────────────────────

--- a/mfsk-core/src/core/sync.rs
+++ b/mfsk-core/src/core/sync.rs
@@ -47,14 +47,21 @@ pub fn bootstrap_dt_median(cands: &[SyncCandidate], top_k: usize) -> Option<f32>
     if cands.is_empty() || top_k == 0 {
         return None;
     }
-    let mut sorted: Vec<&SyncCandidate> = cands.iter().collect();
-    sorted.sort_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(core::cmp::Ordering::Equal)
-    });
-    let mut dts: Vec<f32> = sorted.iter().take(top_k).map(|c| c.dt_sec).collect();
-    dts.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+    // O(N) top-K partition via `select_nth_unstable_by`, then
+    // O(K log K) sort of just the K winners. Saves ~N log N vs full
+    // sort; for N≈200 / K=5 / one call per slot the saving is sub-µs,
+    // but the cost is identical to the naïve approach so we take it.
+    let mut refs: Vec<&SyncCandidate> = cands.iter().collect();
+    let k = top_k.min(refs.len());
+    if k < refs.len() {
+        refs.select_nth_unstable_by(k - 1, |a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(core::cmp::Ordering::Equal)
+        });
+    }
+    let mut dts: Vec<f32> = refs[..k].iter().map(|c| c.dt_sec).collect();
+    dts.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
     let n = dts.len();
     Some(if n % 2 == 1 {
         dts[n / 2]

--- a/mfsk-core/tests/ft8_coarse_sync_bootstrap.rs
+++ b/mfsk-core/tests/ft8_coarse_sync_bootstrap.rs
@@ -23,7 +23,7 @@
 
 use std::path::Path;
 
-use mfsk_core::core::sync::{bootstrap_dt_median, SyncCandidate};
+use mfsk_core::core::sync::{SyncCandidate, bootstrap_dt_median};
 use mfsk_core::ft8::decode::DecodeDepth;
 use mfsk_core::ft8::decode_block::{coarse_sync, compute_spectrogram, decode_block};
 
@@ -59,8 +59,7 @@ fn check_one(label: &str, wav_path: &str) {
 
     let dt_conf = median(decodes.iter().map(|r| r.dt_sec).collect())
         .expect("reference WAVs all have ≥1 confirmed decode");
-    let dt_boot_k5 =
-        bootstrap_dt_median(&cands, 5).expect("coarse_sync returned no candidates");
+    let dt_boot_k5 = bootstrap_dt_median(&cands, 5).expect("coarse_sync returned no candidates");
     let dt_boot_k10 = bootstrap_dt_median(&cands, 10);
     let dt_boot_k20 = bootstrap_dt_median(&cands, 20);
 

--- a/mfsk-core/tests/ft8_coarse_sync_bootstrap.rs
+++ b/mfsk-core/tests/ft8_coarse_sync_bootstrap.rs
@@ -1,0 +1,105 @@
+//! Bootstrap-from-coarse-sync DT median feasibility + correctness gate.
+//!
+//! Issue context: embedded `decode_pipeline.rs` currently feeds
+//! confirmed-decode DT median into `set_bootstrap_slot_shift_12k`,
+//! so cold-start with 0 confirmed decodes leaves the slot mis-aligned
+//! ("BtnA required"). WebFT8 wants to do better — bootstrap slot
+//! alignment from raw `coarse_sync` candidate DTs while
+//! N_confirmed = 0.
+//!
+//! `core::sync::bootstrap_dt_median(&cands, K=5)` is the published
+//! helper both consumers use. This test gates K=5 |Δ| < 100 ms vs
+//! the confirmed-decode DT median on three reference recordings —
+//! one busy band (15 decodes) and two sparse JTDX captures (4-5
+//! decodes). The K=5 cutoff is empirical: K=10+ washes out under
+//! false-candidate noise (see informational K=10/20 print-outs).
+//!
+//! Run:
+//! ```sh
+//! cargo test --release -p mfsk-core --features full \
+//!     --test ft8_coarse_sync_bootstrap -- --nocapture
+//! ```
+#![cfg(feature = "fft-rustfft")]
+
+use std::path::Path;
+
+use mfsk_core::core::sync::{bootstrap_dt_median, SyncCandidate};
+use mfsk_core::ft8::decode::DecodeDepth;
+use mfsk_core::ft8::decode_block::{coarse_sync, compute_spectrogram, decode_block};
+
+#[allow(dead_code)]
+mod common;
+
+use common::load_wav_i16;
+
+fn median(mut xs: Vec<f32>) -> Option<f32> {
+    if xs.is_empty() {
+        return None;
+    }
+    xs.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let n = xs.len();
+    Some(if n % 2 == 1 {
+        xs[n / 2]
+    } else {
+        0.5 * (xs[n / 2 - 1] + xs[n / 2])
+    })
+}
+
+/// K=5 |Δ| budget vs confirmed-decode median. Empirical worst case on
+/// the three reference WAVs is ~68 ms; 100 ms gives a small safety
+/// margin without admitting K=10's ~225-275 ms misses.
+const BOOTSTRAP_MAX_DELTA_SEC: f32 = 0.100;
+
+fn check_one(label: &str, wav_path: &str) {
+    let audio = load_wav_i16(Path::new(wav_path));
+    let spec = compute_spectrogram(&audio, 3_000.0);
+
+    let cands: Vec<SyncCandidate> = coarse_sync(&spec, 100.0, 3_000.0, 1.0, 200);
+    let decodes = decode_block(&audio, 100.0, 3_000.0, 1.0, DecodeDepth::BpAllOsd, 30);
+
+    let dt_conf = median(decodes.iter().map(|r| r.dt_sec).collect())
+        .expect("reference WAVs all have ≥1 confirmed decode");
+    let dt_boot_k5 =
+        bootstrap_dt_median(&cands, 5).expect("coarse_sync returned no candidates");
+    let dt_boot_k10 = bootstrap_dt_median(&cands, 10);
+    let dt_boot_k20 = bootstrap_dt_median(&cands, 20);
+
+    let diff = (dt_conf - dt_boot_k5).abs();
+    println!(
+        "{label:<22} N_conf={:>2}  conf_dt={:+.3}s  K5={:+.3}s  |Δ|={:.3}s  \
+         (K10={:+.3?} K20={:+.3?})",
+        decodes.len(),
+        dt_conf,
+        dt_boot_k5,
+        diff,
+        dt_boot_k10,
+        dt_boot_k20,
+    );
+
+    assert!(
+        diff < BOOTSTRAP_MAX_DELTA_SEC,
+        "{label}: K=5 bootstrap DT off by {:.3}s vs confirmed (budget {:.3}s) — \
+         coarse_sync top-5 no longer correlates with truth on this fixture",
+        diff,
+        BOOTSTRAP_MAX_DELTA_SEC
+    );
+}
+
+#[test]
+fn bootstrap_dt_median_top5_matches_confirmed() {
+    check_one("qso3_busy.wav", asset_path!("qso3_busy.wav"));
+    check_one("191111_110130.wav", asset_path!("191111_110130.wav"));
+    check_one("191111_110200.wav", asset_path!("191111_110200.wav"));
+}
+
+#[test]
+fn bootstrap_dt_median_handles_empty_and_zero_k() {
+    assert!(bootstrap_dt_median(&[], 5).is_none());
+    let dummy = vec![SyncCandidate {
+        freq_hz: 1000.0,
+        dt_sec: 0.3,
+        score: 2.0,
+    }];
+    assert!(bootstrap_dt_median(&dummy, 0).is_none());
+    assert_eq!(bootstrap_dt_median(&dummy, 5).unwrap(), 0.3);
+}


### PR DESCRIPTION
## Summary

- Publish `mfsk_core::core::sync::bootstrap_dt_median(cands, top_k)` — DT median over top-K highest-score `SyncCandidate`s. Gated by new `tests/ft8_coarse_sync_bootstrap.rs`: K=5 tracks confirmed-decode median within ±70 ms on qso3_busy + 191111 captures (budget asserted at 100 ms; K=10/20 wash out into 200-275 ms misses under false-candidate noise).
- Embedded: `SpeculativeOut.bootstrap_dt_med` computed in `run_speculative_slot`. `m5stack-s3-app` auto-sync gains a fourth branch — when `n_dec == 0 && best_n == 0 && bootstrap_dt_med.is_some()`, apply the shift but keep `best_n = 0` so the next confirmed-decode slot reclaims HWM via the existing path. Core2 / CoreS3 / rx_wavsim consumers thread the field through as `_` (no slot-drift correction in wav_sim mode).
- Drop the stale `pass1 candidate DT median` comment in `audio.rs:663` — the producer was already confirmed-decode median, the comment was a leftover from an earlier design.

## Why

Before this PR: cold start with 0 confirmed decodes left the slot mis-aligned indefinitely ("BtnA required" log) until the operator intervened. The mountain-top use case (laptop at home) makes manual sync impractical. WebFT8 has the same constraint with no manual sync available at all. The helper lives in `mfsk-core` so both consumers share one implementation and one CI gate.

## Test plan

- [x] `cargo test --release -p mfsk-core --features full --test ft8_coarse_sync_bootstrap` passes (K=5 |Δ| worst-case 0.067s vs 0.100s budget)
- [x] `cargo build -p mfsk-core` (host)
- [x] `cargo check --release` for `m5stack-s3-app` (xtensa-esp32s3-espidf)
- [x] `cargo check --release` for `m5stack-core2-app` (xtensa-esp32-espidf)
- [ ] Flash `m5stack-s3-app` and observe `auto-sync (cold bootstrap from coarse_sync top-5, p1=...): DT=...s → ... samples` in the first slot, then HWM reclaim on the next decode slot
- [ ] WebFT8 reuse — call `mfsk_core::core::sync::bootstrap_dt_median` from JS-side bootstrap path

`m5stack-cores3-app` build needs `./bootstrap-sdkconfig.sh` rerun for unrelated partitions.csv generation; the destructure-pattern change there is mechanically identical to core2-app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)