### PR TITLE
chore(release): 0.6.6 — cold-start slot bootstrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.6.6 — cold-start slot bootstrap from coarse_sync top-5 DT median
+
+Embedded `m5stack-s3-app` auto-sync previously consumed only
+confirmed-decode DT median, so a cold start (or post-reset) with
+zero confirmed decodes left the slot mis-aligned indefinitely
+("BtnA required" in the log) until the operator intervened —
+defeating the mountain-top "leave the laptop at home" use case
+when the band is quiet for the first slot. WebFT8 faces the same
+constraint with no manual sync available at all.
+
+### Added
+
+- **`mfsk_core::core::sync::bootstrap_dt_median(cands, top_k)`**
+  (public): DT median over the top-`K` highest-score
+  `SyncCandidate`s. Empirically — on `qso3_busy` + `191111`
+  reference captures — `K=5` tracks confirmed-decode DT median
+  within ±70 ms, while `K=10`/`20` wash out into 200–275 ms
+  misses under false-candidate noise. Gated by new integration
+  test `tests/ft8_coarse_sync_bootstrap.rs` (100 ms `|Δ|`
+  budget). Uses `select_nth_unstable_by` for O(N) top-K
+  partition + O(K log K) winner sort.
+
+### Changed
+
+- `embedded-shared::dual_core::SpeculativeOut` gains
+  `bootstrap_dt_med: Option<f32>`, computed in
+  `run_speculative_slot` right after pass1 returns and before
+  the audio-window partition. `n_pass1 == 0` slots get `None`.
+- `m5stack-s3-app/decode_pipeline.rs` auto-sync gains a fourth
+  branch: when `n_dec == 0 && best_n == 0 && bootstrap_dt_med
+  .is_some()`, the helper's value drives the bootstrap shift
+  but `best_n` stays at 0, so the first confirmed-decode slot
+  reclaims the HWM via the existing path. Soft anchor only.
+- `m5stack-core2-app` / `m5stack-cores3-app` / `embedded-shared
+  ::apps::rx_wavsim` consumers thread `bootstrap_dt_med`
+  through as `_` (no slot-drift correction needed in wav_sim
+  mode).
+
+### Fixed
+
+- Stale comment in `m5stack-s3-app/src/audio.rs` claimed the
+  consumed shift hint was "pass1 candidate DT median"; in fact
+  the pre-0.6.6 producer was confirmed-decode median. Corrected.
+
+### Notes for WebFT8
+
+`bootstrap_dt_median` is the same helper WebFT8 calls from its
+cold-start path — no platform-specific wrapping required. Pass
+the raw `Vec<SyncCandidate>` from either
+`decode_block::coarse_sync` or `core::sync::coarse_sync::<Ft8>`.
+
 ## 0.6.5 — crates.io surface refresh (M5StickS3 FT8 controller PoC)
 
 Non-functional patch. Refreshes the project's discoverable surface

--- a/docs/MANUAL_M5STICKS3.md
+++ b/docs/MANUAL_M5STICKS3.md
@@ -375,6 +375,7 @@ The full state machine lives in `embedded-poc/mfsk-app-shared/src/qso.rs`.
 | UDP log not arriving on PC | Subnet broadcast dropped by router, or firewall | Set `pc_ip = "192.168.x.y"` (unicast to your PC) in `cfg.toml`. Open UDP 9999 in the PC firewall. On WSL2 see §4. |
 | Console freezes after a few minutes | USB-CDC host disconnected (chip kept emitting `println!`) | Already fixed in firmware (commit `8b46f4e` gates `println!` on `usb_serial_jtag_is_connected`). If you see it on a fresh build, your tooling is old. |
 | Decoder runs but 0 decodes | Audio level too low / too high; or wrong band on IC-705 | Watch `audio capture+tx tick: NNN B/s rx` log lines — should be 192–196 kB/s sustained for healthy 48 kHz stereo I2S RX. If silent, check mic gain (`embedded-poc/m5stack-s3-app/src/audio.rs` `mic_gain_db`) or radio output level. |
+| First 1-2 slots show `auto-sync (cold bootstrap from coarse_sync top-5, p1=N): DT=…s → +… samples` but no decodes | Cold-start clock skew worse than ±2.5 s tolerance | Expected — the bootstrap is a one-shot anchor from coarse_sync candidates. Once a real decode lands the HWM path takes over. Pre-v0.6.6 firmwares logged `auto-sync (cold): no source — BtnA required` and stayed stuck; update if you still see that. |
 
 ### Log capture conventions
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -303,8 +303,18 @@ in module doc-comments:
   speaker plays back the WAV, TX scheduler is suppressed, LCD shows
   `DEMO MODE — TX OFF`. Deterministic demo safety net when ambient
   acoustic conditions kill the live WebFT8-to-mic path.
+- **Phase 1.7.9 (cold-start auto-sync bootstrap)** — ✅ Done. PR
+  #133 / v0.6.6. Auto-sync gains a fourth branch:
+  `n_dec == 0 && best_n == 0 && bootstrap_dt_med.is_some()` →
+  coarse_sync top-5 DT median drives a one-shot slot shift,
+  `best_n` stays at 0 so the next confirmed-decode slot reclaims
+  HWM. Removes the "BtnA required" cold-start dead-end for
+  no-GPS / no-NTP operation. Helper
+  (`mfsk_core::core::sync::bootstrap_dt_median`) shared with
+  WebFT8, gated by `tests/ft8_coarse_sync_bootstrap.rs`.
 - **Phases 2 / 5 / 6 / TX keying** — Rolled forward to Phase B-Core.
-  Stick frozen after Phase 1.7 demo toggle.
+  Stick frozen after Phase 1.7 demo toggle (1.7.9 is a
+  controller-only auto-sync delta — no new HW surface).
 
 ### Phase B-Core — m5stack-cores3-app (MAIN TARGET, NEW)
 

--- a/embedded-poc/m5stack-s3-app/CLAUDE.md
+++ b/embedded-poc/m5stack-s3-app/CLAUDE.md
@@ -61,9 +61,19 @@ repositioned as the **demo / acoustic-fallback** path:
 - **Phase 1.7.8 (NextMode menu item) — ✅ done**: 4th menu item
   lets the user switch boot mode from within the menu overlay (no
   3-reboot KEY dance). On `feat/demo-mode-qso` (same PR #121 branch).
+- **Phase 1.7.9 (cold-start auto-sync bootstrap) — ✅ done**: PR
+  #133 / v0.6.6. `decode_pipeline.rs` auto-sync gains a fourth
+  branch — when `n_dec == 0 && best_n == 0 && bootstrap_dt_med
+  .is_some()`, coarse_sync top-5 DT median drives a one-shot
+  slot shift while `best_n` stays at 0 (soft anchor; first
+  confirmed-decode slot reclaims HWM via the existing path).
+  Removes the "BtnA required" cold-start dead-end on quiet
+  bands. Helper lives at `mfsk_core::core::sync::bootstrap_dt_median`
+  and is shared with WebFT8.
 - **Phase 1 (UAC), Phase 2 (BLE CI-V), Phase 5 (ADIF), Phase 6
   (buttons), TX keying**: rolled forward to `m5stack-cores3-app`
-  (Phase B-Core in `docs/ROADMAP.md`). **Stick frozen after 1.7.8.**
+  (Phase B-Core in `docs/ROADMAP.md`). **Stick frozen after 1.7.9 —
+  1.7.9 is a controller-side auto-sync delta, no new HW surface.**
 
 The `uac.rs` module (~445 lines) stays in-tree as canonical
 reference; it's cloned verbatim into `m5stack-cores3-app` in Phase

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-core"
-version     = "0.6.5"
+version     = "0.6.6"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 description = "Pure-Rust WSJT-family decoders + synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. Host (rustfft) or no_std embedded (ESP32-S3, RP2350, Cortex-M) via a pluggable FFT backend; fixed-point hot path for FPU-less MCUs. Ships with embedded-poc/m5stack-s3-app, a working M5StickS3 FT8 controller (LCD UI, BLE CI-V to IC-705, acoustic mic, QSO FSM) decoding real on-air signals in ~1.2 s post-SlotEnd on Xtensa LX7."

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-ffi-ft8"
-version     = "0.6.5"
+version     = "0.6.6"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 publish     = false


### PR DESCRIPTION
## Summary

Release bump for the cold-start bootstrap feature merged in #133.

- `mfsk-core` + `mfsk-ffi-ft8` → **0.6.6**
- `CHANGELOG.md`: new 0.6.6 section (Added / Changed / Fixed / Notes for WebFT8)
- `docs/ROADMAP.md`: Phase 1.7.9 entry under Phase B-Stick
- `embedded-poc/m5stack-s3-app/CLAUDE.md`: status block extends through 1.7.9
- `docs/MANUAL_M5STICKS3.md`: troubleshooting row distinguishing the new `cold bootstrap from coarse_sync top-5` log line from the pre-0.6.6 stuck `BtnA required` state

## Release sequence

Per repo policy (CLAUDE.md "Releases — go through CD, never `cargo publish` locally"):
1. Merge this PR into `main`
2. `git checkout main && git pull`
3. `git tag v0.6.6 <merge-sha> && git push origin v0.6.6`
4. Watch the `Release` Actions workflow — it gates on the same-commit CI being green, then publishes to crates.io + builds FFI release artifacts.

## Test plan

- [x] `cargo check -p mfsk-core` (host)
- [x] `cargo publish -p mfsk-core --dry-run --features full` (verifies the bumped manifest + Cargo.lock consistency)
- [ ] Post-merge: `v0.6.6` tag triggers `release.yml`; verify both jobs go green and `crates.io/crates/mfsk-core/0.6.6` appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)