### PR TITLE
chore(release): 0.6.7 — fix coarse_sync wasm32 runtime panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## 0.6.7 — fix coarse_sync wasm32 runtime panic
+
+0.6.6 left `std::time::Instant::now()` calls in `coarse_sync` gated
+only by `feature = "std"` (3 timestamps + a final diagnostic block).
+Any consumer building for `wasm32-unknown-unknown` with the default
+`std` feature panicked the first time stage-2 ran — `Instant::now` is
+unimplemented on that target. `webft8` and any future WASM PWA
+consumer were affected; embedded (esp-idf) was not because esp-idf
+provides a working clock.
+
+### Fixed
+
+- **`coarse_sync.rs`**: the 4 timestamp reads + the `eprintln!`
+  diagnostic block are now gated on `#[cfg(feature = "profile-coarse")]`
+  rather than `#[cfg(feature = "std")]`. WASM builds without
+  `profile-coarse` (the normal case — feature is off by default)
+  compile the timing code out entirely and no longer touch
+  `Instant::now`.
+
+### Removed
+
+- `MFSK_PROFILE_COARSE` env-var dispatch in `coarse_sync` (added in
+  `#130` as a host convenience to flip profiling without rebuild, but
+  never exercised by any in-tree script, test, or CI job — the same
+  diagnostic is reachable via `--features profile-coarse`). Embedded
+  apps already enabled the feature flag directly, so their serial-log
+  output is unchanged.
+
+### Notes
+
+- `mfsk-ffi-ft8` bumped to 0.6.7 in lock-step (no behavioral change in
+  the FFI itself — it tracks `mfsk-core` so users see matching version
+  numbers in release artifacts).
+
 ## 0.6.6 — cold-start slot bootstrap from coarse_sync top-5 DT median
 
 Embedded `m5stack-s3-app` auto-sync previously consumed only

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ and per-mode performance characterisation.
 | `fft-rustfft` | ✓       | Default host FFT backend (`rustfft`, requires `std`) |
 | `fft-extern`  |         | Pluggable FFT trait — caller binary supplies an `FftPlanner` impl (esp-dsp on ESP32-S3, CMSIS-DSP on RP2350, …) |
 | `fixed-point` |         | Embedded integer pipeline: u16 spectrogram + i16 DFT + Q11i16 LLR + integer NMS BP (see *Status* below for the Q3i8 → Q11i16 step taken in 0.6.2 / 0.6.3 for recall) |
-| `profile-coarse` |      | Always-on coarse_sync sub-stage profiling (host has `MFSK_PROFILE_COARSE` env var alternative) |
+| `profile-coarse` |      | Always-on coarse_sync sub-stage profiling (do not enable on `wasm32-unknown-unknown` — `Instant::now` panics) |
 
 ## Quick example
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ and per-mode performance characterisation.
 | `fft-rustfft` | ✓       | Default host FFT backend (`rustfft`, requires `std`) |
 | `fft-extern`  |         | Pluggable FFT trait — caller binary supplies an `FftPlanner` impl (esp-dsp on ESP32-S3, CMSIS-DSP on RP2350, …) |
 | `fixed-point` |         | Embedded integer pipeline: u16 spectrogram + i16 DFT + Q11i16 LLR + integer NMS BP (see *Status* below for the Q3i8 → Q11i16 step taken in 0.6.2 / 0.6.3 for recall) |
-| `profile-coarse` |      | Always-on coarse_sync sub-stage profiling (do not enable on `wasm32-unknown-unknown` — `Instant::now` panics) |
+| `profile-coarse` |      | Always-on coarse_sync sub-stage profiling (automatically disabled on `wasm32-unknown-unknown` to prevent panics) |
 
 ## Quick example
 

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -78,8 +78,8 @@ nstep-half   = []
 # breakdown (allsum / score / dedupe+sort / total μs) to stderr after
 # every `coarse_sync` call. Only useful when investigating stage-2
 # wall-clock — adds 4 timestamp reads per call, negligible cost. Off by
-# default; enabling on `wasm32-unknown-unknown` will panic at runtime
-# (`Instant::now` is unimplemented), so leave disabled for WASM.
+# default; automatically disabled on `wasm32-unknown-unknown` at compile
+# time to prevent runtime panics (`Instant::now` is unimplemented).
 profile-coarse = ["std"]
 
 # Lightweight modes — embedded-port-clean. `fft-rustfft` (host) or

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-core"
-version     = "0.6.6"
+version     = "0.6.7"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 description = "Pure-Rust WSJT-family decoders + synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. Host (rustfft) or no_std embedded (ESP32-S3, RP2350, Cortex-M) via a pluggable FFT backend; fixed-point hot path for FPU-less MCUs. Ships with embedded-poc/m5stack-s3-app, a working M5StickS3 FT8 controller (LCD UI, BLE CI-V to IC-705, acoustic mic, QSO FSM) decoding real on-air signals in ~1.2 s post-SlotEnd on Xtensa LX7."
@@ -74,11 +74,12 @@ fixed-point  = ["nstep-half"]
 # dep so it can simulate embedded byte-for-byte.
 nstep-half   = []
 
-# Always-on coarse_sync sub-stage profiling. Same output as setting
-# `MFSK_PROFILE_COARSE=1` on host, but works on embedded targets where
-# the env var is not reachable. Only useful when investigating stage-2
-# wall-clock breakdown — adds 4 timestamp reads per `coarse_sync` call,
-# negligible cost.
+# Always-on coarse_sync sub-stage profiling. Emits `[coarse_sync prof]`
+# breakdown (allsum / score / dedupe+sort / total μs) to stderr after
+# every `coarse_sync` call. Only useful when investigating stage-2
+# wall-clock — adds 4 timestamp reads per call, negligible cost. Off by
+# default; enabling on `wasm32-unknown-unknown` will panic at runtime
+# (`Instant::now` is unimplemented), so leave disabled for WASM.
 profile-coarse = ["std"]
 
 # Lightweight modes — embedded-port-clean. `fft-rustfft` (host) or

--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -258,7 +258,10 @@ fn coarse_sync_inner(
     let mut sync2d = vec![0.0f32; n_freq * n_lag];
     let idx = |fi: usize, lag: i32| fi * n_lag + (lag + jz) as usize;
     let ratio_eps = ratio_eps();
-    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
+    #[cfg(all(
+        feature = "profile-coarse",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ))]
     let t_setup = std::time::Instant::now();
 
     // **Single-bin tone gather**. NFFT=3840 → tone_step_bins = 2.0
@@ -357,7 +360,10 @@ fn coarse_sync_inner(
         };
         &owned_allsum
     };
-    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
+    #[cfg(all(
+        feature = "profile-coarse",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ))]
     let t_allsum = std::time::Instant::now();
 
     // Three identical Costas arrays at symbol positions 0, 36, 72.
@@ -452,7 +458,10 @@ fn coarse_sync_inner(
             sync2d[idx(fi, lag)] = sync_all.max(sync_tail);
         }
     }
-    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
+    #[cfg(all(
+        feature = "profile-coarse",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ))]
     let t_score = std::time::Instant::now();
 
     const MLAG: i32 = 10;
@@ -571,7 +580,10 @@ fn coarse_sync_inner(
         }
     }
     let cands = out;
-    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
+    #[cfg(all(
+        feature = "profile-coarse",
+        not(all(target_arch = "wasm32", target_os = "unknown"))
+    ))]
     {
         let t_end = std::time::Instant::now();
         let allsum_us = (t_allsum - t_setup).as_micros();

--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -258,7 +258,7 @@ fn coarse_sync_inner(
     let mut sync2d = vec![0.0f32; n_freq * n_lag];
     let idx = |fi: usize, lag: i32| fi * n_lag + (lag + jz) as usize;
     let ratio_eps = ratio_eps();
-    #[cfg(feature = "profile-coarse")]
+    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
     let t_setup = std::time::Instant::now();
 
     // **Single-bin tone gather**. NFFT=3840 → tone_step_bins = 2.0
@@ -357,7 +357,7 @@ fn coarse_sync_inner(
         };
         &owned_allsum
     };
-    #[cfg(feature = "profile-coarse")]
+    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
     let t_allsum = std::time::Instant::now();
 
     // Three identical Costas arrays at symbol positions 0, 36, 72.
@@ -452,7 +452,7 @@ fn coarse_sync_inner(
             sync2d[idx(fi, lag)] = sync_all.max(sync_tail);
         }
     }
-    #[cfg(feature = "profile-coarse")]
+    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
     let t_score = std::time::Instant::now();
 
     const MLAG: i32 = 10;
@@ -571,7 +571,7 @@ fn coarse_sync_inner(
         }
     }
     let cands = out;
-    #[cfg(feature = "profile-coarse")]
+    #[cfg(all(feature = "profile-coarse", not(all(target_arch = "wasm32", target_os = "unknown"))))]
     {
         let t_end = std::time::Instant::now();
         let allsum_us = (t_allsum - t_setup).as_micros();

--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -258,9 +258,7 @@ fn coarse_sync_inner(
     let mut sync2d = vec![0.0f32; n_freq * n_lag];
     let idx = |fi: usize, lag: i32| fi * n_lag + (lag + jz) as usize;
     let ratio_eps = ratio_eps();
-    #[cfg(feature = "std")]
-    let prof = cfg!(feature = "profile-coarse") || std::env::var("MFSK_PROFILE_COARSE").is_ok();
-    #[cfg(feature = "std")]
+    #[cfg(feature = "profile-coarse")]
     let t_setup = std::time::Instant::now();
 
     // **Single-bin tone gather**. NFFT=3840 → tone_step_bins = 2.0
@@ -359,7 +357,7 @@ fn coarse_sync_inner(
         };
         &owned_allsum
     };
-    #[cfg(feature = "std")]
+    #[cfg(feature = "profile-coarse")]
     let t_allsum = std::time::Instant::now();
 
     // Three identical Costas arrays at symbol positions 0, 36, 72.
@@ -454,7 +452,7 @@ fn coarse_sync_inner(
             sync2d[idx(fi, lag)] = sync_all.max(sync_tail);
         }
     }
-    #[cfg(feature = "std")]
+    #[cfg(feature = "profile-coarse")]
     let t_score = std::time::Instant::now();
 
     const MLAG: i32 = 10;
@@ -573,8 +571,8 @@ fn coarse_sync_inner(
         }
     }
     let cands = out;
-    #[cfg(feature = "std")]
-    if prof {
+    #[cfg(feature = "profile-coarse")]
+    {
         let t_end = std::time::Instant::now();
         let allsum_us = (t_allsum - t_setup).as_micros();
         let score_us = (t_score - t_allsum).as_micros();

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-ffi-ft8"
-version     = "0.6.6"
+version     = "0.6.7"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 publish     = false


### PR DESCRIPTION
## Summary

- 0.6.6 left `std::time::Instant::now()` calls in `coarse_sync` gated only by `feature = "std"` (3 timestamps + a final `eprintln!` block). Any consumer building for `wasm32-unknown-unknown` with the default `std` feature panicked the first time stage-2 ran — `Instant::now` is unimplemented on that target.
- Move the gate from `feature = "std"` → `feature = "profile-coarse"` (the feature that actually consumes the timestamps). WASM builds without `profile-coarse` (the normal case, default-off) compile the timing code out entirely. Embedded apps already enable `profile-coarse` directly so serial-log output is unchanged.
- Drop the `MFSK_PROFILE_COARSE` env-var dispatch path added in #130 — no in-tree script / test / CI job referenced it, and `--features profile-coarse` reaches the same diagnostic.
- `mfsk-core` + `mfsk-ffi-ft8` → 0.6.7. CHANGELOG drafted (Fixed / Removed / Notes).

## Test plan

- [x] `cargo check` (default features) — green on 0.6.7
- [x] `cargo check --features profile-coarse` — green (embedded-app feature set)
- [x] `cargo check --target wasm32-unknown-unknown --no-default-features --features "std,ft8,fft-rustfft"` — green (this is the build that panicked at runtime on 0.6.6)
- [x] `cargo check -p mfsk-ffi-ft8` — green
- [ ] CI green on this branch
- [ ] After merge: tag `v0.6.7` against merge SHA → `release.yml` publishes mfsk-core to crates.io + attaches mfsk-ffi-ft8 prebuilt artifacts to the GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)