### PR TITLE
fix(fst4): correct NSPS/NDOWN/GFSK_BT + wire missing rvec scramble (#23)

### DIFF
--- a/mfsk-core/src/core/protocol.rs
+++ b/mfsk-core/src/core/protocol.rs
@@ -125,8 +125,10 @@ pub trait ModulationParams: Copy + Default + 'static {
     /// payload is the WSJT-X-transmitted message — but emerges as
     /// nonsense because we never undo the XOR.
     ///
-    /// Default `None` (FT8 / FST4 / others don't scramble); FT4
-    /// overrides to `Some(&FT4_RVEC)`. Length must be 77 when set.
+    /// Default `None` (FT8 / others don't scramble); FT4 and FST4
+    /// both override to the same 77-element `rvec` (WSJT-X
+    /// `genfst4.f90:29-31` uses the identical array to
+    /// `genft4.f90`'s). Length must be 77 when set.
     const INFO_SCRAMBLE_RVEC: Option<&'static [u8]> = None;
 
     /// Window function applied per `NSPS`-sample chunk in

--- a/mfsk-core/src/fst4/decode.rs
+++ b/mfsk-core/src/fst4/decode.rs
@@ -13,19 +13,20 @@ use crate::core::pipeline::{self, FftCache};
 use crate::core::pipeline::DecodeStrictness;
 pub use crate::core::pipeline::{DecodeDepth, DecodeResult};
 
-/// FST4-60A downsample configuration: 12 kHz → 62.5 Hz baseband
-/// (NDOWN = 192), enough for the 4 tones spaced 3.125 Hz apart
-/// (12.5 Hz occupied) plus a generous guard band for the narrow
-/// 60-second slot.
+/// FST4-60A downsample configuration: 12 kHz → 111.11 Hz baseband
+/// (NDOWN = 108, matching WSJT-X `fst4_decode.f90`'s `fs2 = fs/ndown`
+/// for `ntrperiod.eq.60`), enough for the 4 tones spaced 3.0864 Hz
+/// apart (12.35 Hz occupied) plus a generous guard band for the
+/// narrow 60-second slot.
 ///
-/// `fft1_size` = 786 432 (= 2¹⁸ · 3, highly composite, ≥ 720 000
-/// samples that a 60-s slot at 12 kHz contains). `fft2_size` =
-/// fft1 / NDOWN = 4096.
+/// `fft1_size` = 746 496 (= 2¹⁰ · 3⁶, highly composite, ≥ 720 000
+/// samples that a 60-s slot at 12 kHz contains, and an exact multiple
+/// of NDOWN=108). `fft2_size` = fft1 / NDOWN = 6912.
 pub const FST4_60A_DOWNSAMPLE: DownsampleCfg = DownsampleCfg {
     input_rate: 12_000,
-    fft1_size: 786_432,
-    fft2_size: 4_096,
-    tone_spacing_hz: 3.125,
+    fft1_size: 746_496,
+    fft2_size: 6_912,
+    tone_spacing_hz: 12_000.0 / 3_888.0,
     leading_pad_tones: 1.5,
     trailing_pad_tones: 1.5,
     ntones: 4,

--- a/mfsk-core/src/fst4/encode.rs
+++ b/mfsk-core/src/fst4/encode.rs
@@ -2,21 +2,26 @@
 //!
 //! Mirrors `ft4-core::encode` but for the [`Fst4s60`] geometry:
 //! LDPC(240, 101) + CRC-24 over the shared 77-bit WSJT payload,
-//! GFSK with BT = 1.0 and 320 ms symbols.
+//! GFSK with BT = 2.0 and 324 ms symbols.
 
 use super::Fst4s60;
 use crate::core::dsp::gfsk::{GfskCfg, synth_f32, synth_i16};
 use crate::core::{FecCodec, FrameLayout, ModulationParams};
 use crate::fec::Ldpc240_101;
 
-/// FST4-60A GFSK configuration: 12 kHz, 3840 samples/symbol, BT=1.0,
+/// FST4-60A GFSK configuration: 12 kHz, 3888 samples/symbol, BT=2.0,
 /// hmod=1.0, NSPS/8-sample cosine ramp.
+///
+/// Was `samples_per_symbol: 3840, bt: 1.0` — hardcoded independently
+/// of [`ModulationParams`] and never updated to match WSJT-X
+/// `fst4_decode.f90`'s `nsps=3888` / `gen_fst4wave.f90`'s
+/// `gfsk_pulse(2.0,tt)` for `ntrperiod.eq.60` (issue #23 root cause).
 pub const FST4_60A_GFSK: GfskCfg = GfskCfg {
     sample_rate: 12_000.0,
-    samples_per_symbol: 3840,
-    bt: 1.0,
+    samples_per_symbol: 3_888,
+    bt: 2.0,
     hmod: 1.0,
-    ramp_samples: 3840 / 8,
+    ramp_samples: 3_888 / 8,
 };
 
 /// Append the 24-bit CRC used by FST4 (see `mfsk_core::fec::ldpc240_101::crc24`)
@@ -36,8 +41,17 @@ fn append_crc24(message77: &[u8; 77]) -> [u8; 101] {
 }
 
 /// Encode a 77-bit message into the 160-symbol FST4-60A tone sequence.
+///
+/// WSJT-X `genfst4.f90:63` XORs the message with `rvec` before CRC-24 +
+/// LDPC encode; `message_to_tones` transmits the **scrambled** message
+/// bits — same as WSJT-X, so the receive-side CRC verification stays
+/// correct (see [`super::FST4_RVEC`] doc comment).
 pub fn message_to_tones(message77: &[u8; 77]) -> Vec<u8> {
-    let info = append_crc24(message77);
+    let mut scrambled = *message77;
+    for (b, &r) in scrambled.iter_mut().zip(super::FST4_RVEC.iter()) {
+        *b = (*b ^ r) & 1;
+    }
+    let info = append_crc24(&scrambled);
     let codec = Ldpc240_101;
     let mut cw = [0u8; 240];
     codec.encode(&info, &mut cw);
@@ -45,8 +59,8 @@ pub fn message_to_tones(message77: &[u8; 77]) -> Vec<u8> {
 }
 
 /// Synthesise a 12 kHz f32 PCM waveform from an FST4 tone sequence.
-/// Output length is `N_SYMBOLS × NSPS = 160 × 3840 = 614 400` samples
-/// (~51.2 s).
+/// Output length is `N_SYMBOLS × NSPS = 160 × 3888 = 622 080` samples
+/// (~51.84 s).
 pub fn tones_to_f32(itone: &[u8], f0: f32, amplitude: f32) -> Vec<f32> {
     debug_assert_eq!(itone.len(), <Fst4s60 as FrameLayout>::N_SYMBOLS as usize);
     synth_f32(itone, f0, amplitude, &FST4_60A_GFSK)

--- a/mfsk-core/src/fst4/encode.rs
+++ b/mfsk-core/src/fst4/encode.rs
@@ -45,7 +45,7 @@ fn append_crc24(message77: &[u8; 77]) -> [u8; 101] {
 /// WSJT-X `genfst4.f90:63` XORs the message with `rvec` before CRC-24 +
 /// LDPC encode; `message_to_tones` transmits the **scrambled** message
 /// bits — same as WSJT-X, so the receive-side CRC verification stays
-/// correct (see [`super::FST4_RVEC`] doc comment).
+/// correct (see `super::FST4_RVEC`'s doc comment).
 pub fn message_to_tones(message77: &[u8; 77]) -> Vec<u8> {
     let mut scrambled = *message77;
     for (b, &r) in scrambled.iter_mut().zip(super::FST4_RVEC.iter()) {

--- a/mfsk-core/src/fst4/mod.rs
+++ b/mfsk-core/src/fst4/mod.rs
@@ -42,8 +42,8 @@ use crate::msg::Wsjt77Message;
 pub mod decode;
 pub mod encode;
 
-/// FST4-60A: 4-GFSK, 60-second T/R period, 3.125 baud, minimum tone
-/// spacing (12.4 Hz occupied bandwidth). Uses LDPC(240, 101) + CRC-24
+/// FST4-60A: 4-GFSK, 60-second T/R period, 3.0864 baud, minimum tone
+/// spacing (12.35 Hz occupied bandwidth). Uses LDPC(240, 101) + CRC-24
 /// over the same 77-bit WSJT message payload that FT8 / FT4 use.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Fst4s60;
@@ -51,14 +51,25 @@ pub struct Fst4s60;
 impl ModulationParams for Fst4s60 {
     const NTONES: u32 = 4;
     const BITS_PER_SYMBOL: u32 = 2;
-    // Symbol length 320 ms → 3.125 baud → 3.125 Hz tone spacing.
-    const NSPS: u32 = 3_840;
-    const SYMBOL_DT: f32 = 0.32;
-    const TONE_SPACING_HZ: f32 = 3.125;
+    // WSJT-X `fst4_decode.f90`/`fst4sim.f90` (`ntrperiod.eq.60`):
+    // nsps=3888, ndown=108, hmod=1, bt=2.0 (`gen_fst4wave.f90:37`
+    // `gfsk_pulse(2.0,tt)`, unconditional for all FST4 sub-modes).
+    // Symbol length 3888/12000 = 324 ms → baud = 12000/3888 ≈
+    // 3.0864 Hz tone spacing. The previous values here (NSPS=3840,
+    // NDOWN=192, GFSK_BT=1.0, 3.125 Hz) were placeholders that never
+    // got revisited (see git history) — issue #23: they self-decode
+    // fine in the synth roundtrip (encode/decode share the same wrong
+    // constants) but drift ~0.3-0.6 s against real WSJT-X-generated
+    // audio because the wrong NSPS accumulates timing error linearly
+    // across the 160-symbol frame.
+    const NSPS: u32 = 3_888;
+    const SYMBOL_DT: f32 = 3_888.0 / 12_000.0;
+    const TONE_SPACING_HZ: f32 = 12_000.0 / 3_888.0;
     const GRAY_MAP: &'static [u8] = &[0, 1, 3, 2];
-    // BT=1.0 matches the narrow GFSK shaping WSJT-X uses for the
-    // sensitive slow FST4 modes.
-    const GFSK_BT: f32 = 1.0;
+    // BT=2.0 (see NSPS doc comment above) — matches FT8's GFSK_BT,
+    // not FT4's 1.0. The previous BT=1.0 here was wrong (see NSPS
+    // comment).
+    const GFSK_BT: f32 = 2.0;
     const GFSK_HMOD: f32 = 1.0;
     // NFFT window = 2 × NSPS (same convention as FT8) — longer windows
     // don't help FST4-60 because the channel is assumed quasi-static
@@ -66,11 +77,30 @@ impl ModulationParams for Fst4s60 {
     const NFFT_PER_SYMBOL_FACTOR: u32 = 2;
     // Half-symbol coarse grid (matches FT4 practice).
     const NSTEP_PER_SYMBOL: u32 = 2;
-    // 12 000 / 192 = 62.5 Hz baseband — enough for 4-tone signal at
-    // 3.125 Hz spacing plus guard band. Production value may differ;
-    // revisit once decoder is wired.
-    const NDOWN: u32 = 192;
+    // 12 000 / 108 = 111.11 Hz baseband (WSJT-X `fs2`) — enough for
+    // 4-tone signal at 3.0864 Hz spacing plus guard band.
+    const NDOWN: u32 = 108;
+    // WSJT-X `genfst4.f90:63` XORs the 77-bit message with the same
+    // `rvec` sequence FT4 uses (`genft4.f90:64`) before CRC-24 +
+    // LDPC encode; the receiver must undo it after decode
+    // (`fst4_decode.f90` unpack path). This was missing entirely —
+    // CRC-24 still passes on real WSJT-X audio without it (the check
+    // is self-referential: it just confirms LDPC decoded whatever 77
+    // bits were actually sent, scrambled or not), but every decoded
+    // message came out as scrambled garbage instead of a real
+    // callsign. Same root cause bucket as issue #23.
+    const INFO_SCRAMBLE_RVEC: Option<&'static [u8]> = Some(&FST4_RVEC);
 }
+
+/// FST4's 77-bit pre-LDPC scrambler — identical to [`crate::ft4::FT4_RVEC`]
+/// (WSJT-X `genfst4.f90:29-31` uses the same literal array as
+/// `genft4.f90`), duplicated here rather than imported so `fst4` doesn't
+/// pull in the `ft4` feature.
+const FST4_RVEC: [u8; 77] = [
+    0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0,
+    1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
+    1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1,
+];
 
 impl FrameLayout for Fst4s60 {
     const N_DATA: u32 = 120;
@@ -126,8 +156,8 @@ mod tests {
     #[test]
     fn fst4s60_trait_surface() {
         assert_eq!(<Fst4s60 as ModulationParams>::NTONES, 4);
-        assert_eq!(<Fst4s60 as ModulationParams>::NSPS, 3_840);
-        assert!((<Fst4s60 as ModulationParams>::SYMBOL_DT - 0.32).abs() < 1e-6,);
+        assert_eq!(<Fst4s60 as ModulationParams>::NSPS, 3_888);
+        assert!((<Fst4s60 as ModulationParams>::SYMBOL_DT - 0.324).abs() < 1e-6,);
         assert_eq!(<Fst4s60 as FrameLayout>::N_SYMBOLS, 160);
         assert_eq!(<Fst4s60 as FrameLayout>::N_DATA, 120);
         assert_eq!(<Fst4s60 as FrameLayout>::N_SYNC, 40);

--- a/mfsk-core/src/msg/mod.rs
+++ b/mfsk-core/src/msg/mod.rs
@@ -67,14 +67,13 @@ impl MessageCodec for Wsjt77Message {
         // WSJT-X-style (sign-padded two-digit dB string).
         let report = if let Some(g) = &fields.grid {
             g.clone()
-        } else if let Some(r) = fields.report {
+        } else {
+            let r = fields.report?;
             if r >= 0 {
                 format!("+{:02}", r)
             } else {
                 format!("{:03}", r)
             }
-        } else {
-            return None;
         };
         wsjt77::pack77(call1, call2, &report).map(|a| a.to_vec())
     }

--- a/mfsk-core/tests/fst4_wsjtx_samples.rs
+++ b/mfsk-core/tests/fst4_wsjtx_samples.rs
@@ -39,9 +39,6 @@ const FREQ_TOL_HZ: f32 = 4.0;
 const DT_TOL_SEC: f32 = 0.5;
 
 #[test]
-#[ignore = "FST4-60 host path currently 0/1 against WSJT-X golden \
-            (decode_frame returns 0 messages) — run with \
-            `cargo test -- --ignored` to track repair"]
 fn fst4_60_wsjtx_sample_recall_vs_golden() {
     let Some(path) = sample_path() else {
         eprintln!(
@@ -93,4 +90,121 @@ fn fst4_60_wsjtx_sample_recall_vs_golden() {
         hits,
         GOLDEN.len()
     );
+}
+
+/// Diagnostic probe for FST4-60A sync/timing regressions (issue #23's
+/// original root cause: `Fst4s60`'s `NSPS`/`NDOWN`/`GFSK_BT` didn't match
+/// WSJT-X `fst4_decode.f90`, so real-audio decodes drifted ~0.3-0.6 s off
+/// the true frame start even though the synth roundtrip self-decoded
+/// fine). Not a pass/fail gate — mirrors
+/// `jt9::decode::gate_diag::probe_missing_goldens`'s approach: brute-force
+/// scan the (freq, dt) plane around the golden point independent of
+/// `coarse_sync`'s quantised bins, so a future timing bug shows up as a
+/// displaced `nsync` peak instead of a silent `decode_frame` miss. Run
+/// with:
+///   cargo test --test fst4_wsjtx_samples fst4_60_diagnose_golden \
+///       --features fst4,fft-rustfft -- --ignored --nocapture
+#[test]
+#[ignore = "diagnostic probe, not a recall gate — run manually"]
+fn fst4_60_diagnose_golden() {
+    use mfsk_core::core::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::core::equalize::EqMode;
+    use mfsk_core::core::llr::{sync_quality, symbol_spectra};
+    use mfsk_core::core::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
+    use mfsk_core::core::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::core::{FrameLayout, ModulationParams};
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    let Some(path) = sample_path() else {
+        eprintln!("skipping: WSJT-X FST4 sample not found");
+        return;
+    };
+    let audio = read_wsjtx_wav_i16(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let golden = &GOLDEN[0];
+    let ds_rate = 12_000.0 / <Fst4s60 as ModulationParams>::NDOWN as f32;
+    let tx_start = <Fst4s60 as FrameLayout>::TX_START_OFFSET_S;
+    let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+
+    // Brute-force (freq, dt) grid scan around the golden point,
+    // independent of coarse_sync's quantised bins — for each freq
+    // offset, downsample once and sweep dt over a wide window computing
+    // `nsync` directly. A correctly-tuned decoder puts the peak (nsync
+    // near 40/40) right on the golden coordinates; a timing/geometry bug
+    // shows up as a peak displaced by a fraction of a second or more.
+    let mut grid: Vec<(f32, f32, u32)> = Vec::new(); // (freq, dt, nsync)
+    let mut at_golden: Option<u32> = None;
+    for fi in -12..=12i32 {
+        let freq = golden.freq_hz + fi as f32 * 0.25;
+        let cd0 = downsample_cached(&fft_cache, freq, &FST4_60A_DOWNSAMPLE);
+        let i0_lo = ((-1.0 + tx_start) * ds_rate).round() as i32;
+        let i0_hi = ((2.0 + tx_start) * ds_rate).round() as i32;
+        for i0 in i0_lo..=i0_hi {
+            let cs = symbol_spectra::<Fst4s60>(&cd0, i0);
+            let nsync = sync_quality::<Fst4s60>(&cs);
+            let dt = i0 as f32 / ds_rate - tx_start;
+            if (freq - golden.freq_hz).abs() < 0.13 && (dt - golden.dt_sec).abs() < 0.01 {
+                at_golden = Some(nsync);
+            }
+            grid.push((freq, dt, nsync));
+        }
+    }
+    grid.sort_by(|a, b| b.2.cmp(&a.2));
+    eprintln!("brute-force (freq,dt) grid scan, top-10 by nsync (of 40):");
+    for (freq, dt, n) in grid.iter().take(10) {
+        eprintln!("  freq={:8.2} Hz  dt={:+7.3} s  nsync={}", freq, dt, n);
+    }
+    eprintln!(
+        "nsync at golden point (freq={:.1}, dt={:.2}): {:?}  (peak should sit here, not displaced)",
+        golden.freq_hz, golden.dt_sec, at_golden
+    );
+
+    // Cross-check against `coarse_sync` + the real decode path: is there
+    // a candidate inside the golden tolerance window, and does it decode?
+    let candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.0, None, 2000);
+    let mut in_window: Vec<&SyncCandidate> = candidates
+        .iter()
+        .filter(|c| {
+            (c.freq_hz - golden.freq_hz).abs() <= FREQ_TOL_HZ
+                && (c.dt_sec - golden.dt_sec).abs() <= DT_TOL_SEC
+        })
+        .collect();
+    in_window.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    eprintln!(
+        "\ncoarse_sync candidates inside golden tolerance window (freq +-{} Hz, dt +-{} s):",
+        FREQ_TOL_HZ, DT_TOL_SEC
+    );
+    if in_window.is_empty() {
+        eprintln!("  (none — coarse_sync proposes nothing in the golden window at all)");
+        return;
+    }
+    for cand in &in_window {
+        let result = process_candidate_basic::<Fst4s60>(
+            cand,
+            &fft_cache,
+            &FST4_60A_DOWNSAMPLE,
+            DecodeDepth::BpAllOsd,
+            DecodeStrictness::Normal,
+            &[],
+            EqMode::Off,
+            40,
+            0, // sync_q_min=0: bypass the gate, we want to see every attempt
+        );
+        let outcome = match result {
+            Some(r) => {
+                let mut m77 = [0u8; 77];
+                m77.copy_from_slice(&r.info[..77]);
+                format!(
+                    "DECODED hard_errors={} msg={:?}",
+                    r.hard_errors,
+                    unpack77(&m77)
+                )
+            }
+            None => "no decode".to_string(),
+        };
+        eprintln!(
+            "  freq={:8.2} Hz  dt={:+7.3} s  score={:.3}  -> {}",
+            cand.freq_hz, cand.dt_sec, cand.score, outcome
+        );
+    }
 }

--- a/mfsk-core/tests/fst4_wsjtx_samples.rs
+++ b/mfsk-core/tests/fst4_wsjtx_samples.rs
@@ -109,7 +109,7 @@ fn fst4_60_wsjtx_sample_recall_vs_golden() {
 fn fst4_60_diagnose_golden() {
     use mfsk_core::core::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::core::equalize::EqMode;
-    use mfsk_core::core::llr::{sync_quality, symbol_spectra};
+    use mfsk_core::core::llr::{symbol_spectra, sync_quality};
     use mfsk_core::core::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
     use mfsk_core::core::sync::{SyncCandidate, coarse_sync};
     use mfsk_core::core::{FrameLayout, ModulationParams};
@@ -149,7 +149,7 @@ fn fst4_60_diagnose_golden() {
             grid.push((freq, dt, nsync));
         }
     }
-    grid.sort_by(|a, b| b.2.cmp(&a.2));
+    grid.sort_by_key(|c| std::cmp::Reverse(c.2));
     eprintln!("brute-force (freq,dt) grid scan, top-10 by nsync (of 40):");
     for (freq, dt, n) in grid.iter().take(10) {
         eprintln!("  freq={:8.2} Hz  dt={:+7.3} s  nsync={}", freq, dt, n);


### PR DESCRIPTION
## Summary

Root-caused and fixed why FST4-60A recall against the WSJT-X golden
sample (`samples/FST4+FST4W/210115_0058.wav`) was 0/1
(`tests/fst4_wsjtx_samples.rs`, tracked in #23).

- **`Fst4s60`'s modulation parameters were placeholders.** `NSPS=3840`,
  `NDOWN=192`, `GFSK_BT=1.0` never got revisited against WSJT-X — the
  old `NDOWN` comment literally said *"Production value may differ;
  revisit once decoder is wired."* Line-walking WSJT-X's
  `fst4_decode.f90` / `fst4sim.f90` / `gen_fst4wave.f90` for
  `ntrperiod=60` gives the real values: `NSPS=3888`, `NDOWN=108`,
  `BT=2.0`. The wrong `NSPS` accumulated timing error linearly across
  the 160-symbol frame — real audio drifted ~0.3-0.6 s off the true
  frame start. This stayed invisible in the synth roundtrip test
  because encode and decode shared the same wrong constants
  self-consistently.
- **The 77-bit message scramble was never wired for FST4.** WSJT-X
  `genfst4.f90:63` XORs the message with the same `rvec` sequence FT4
  uses, before CRC-24 + LDPC encode
  (`ModulationParams::INFO_SCRAMBLE_RVEC`). FST4 left this `None`.
  CRC-24 still passed on real WSJT-X audio without it — the check is
  self-referential, it just confirms LDPC decoded whatever bits were
  actually sent — but every decode came out as scrambled garbage
  instead of a real callsign.

With both fixed, `fst4_60_wsjtx_sample_recall_vs_golden` recovers the
golden message `CQ N5TM EL29` (dB=-9) with `hard_errors=0`, plus the
WAV's second signal `CQ K9KFR EN71` (dB=16) as a bonus (matches
WSJT-X's own decode of the file, see
`WSJT-X/doc/user_guide/en/images/FST4-1.png`).

## Changes

- `mfsk-core/src/fst4/mod.rs` — `NSPS`/`NDOWN`/`SYMBOL_DT`/
  `TONE_SPACING_HZ`/`GFSK_BT` corrected; `INFO_SCRAMBLE_RVEC` wired to
  a new `FST4_RVEC` (duplicated from `ft4::FT4_RVEC`'s values so
  `fst4` doesn't pull in the `ft4` feature).
- `mfsk-core/src/fst4/decode.rs` — `FST4_60A_DOWNSAMPLE.fft1_size`/
  `fft2_size`/`tone_spacing_hz` updated for the corrected `NDOWN`.
- `mfsk-core/src/fst4/encode.rs` — `FST4_60A_GFSK` corrected (was
  hardcoded independently of `ModulationParams`); `message_to_tones`
  now scrambles before CRC, matching `genfst4.f90`.
- `mfsk-core/src/core/protocol.rs` — doc fix (`INFO_SCRAMBLE_RVEC`
  default comment no longer claims FST4 doesn't scramble).
- `mfsk-core/tests/fst4_wsjtx_samples.rs` — un-ignores the golden
  recall test (matches `ft4_wsjtx_samples.rs`'s no-`#[ignore]`
  convention; skips cleanly when the WSJT-X sample tree is absent),
  adds a permanent `fst4_60_diagnose_golden` diagnostic probe
  (`jt9::gate_diag::probe_missing_goldens`-style (freq, dt) grid scan)
  for any future FST4 sync/timing regression.

## Test plan

- [x] `cargo test -p mfsk-core --lib fst4::` — all pass, including
      `synth_decode_roundtrip_cq_ja1abc` (RUN_FST4_ROUNDTRIP=1)
- [x] `cargo test -p mfsk-core --test fst4_wsjtx_samples --features full -- --ignored` —
      golden recall now 1/1
- [x] `cargo test -p mfsk-core --features full --test '*'` — full
      workspace integration suite, no regressions (exit code 0)
- [ ] CI

Closes #23 (FST4-60A golden lockdown half; FST4-15/FST4W stretch
remains deferred per the issue's original scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)