### PR TITLE
chore(release): 0.6.8 — FST4-60A golden lockdown (#23)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## 0.6.8 — fix FST4-60A decode (#23): wrong NSPS/NDOWN/GFSK_BT + missing message scramble
+
+`Fst4s60`'s modulation parameters were never-revisited placeholders:
+`NSPS=3840`, `NDOWN=192`, `GFSK_BT=1.0` (the old `NDOWN` comment
+literally said *"Production value may differ; revisit once decoder
+is wired"*). Line-walking WSJT-X's `fst4_decode.f90` /
+`fst4sim.f90` / `gen_fst4wave.f90` for `ntrperiod=60` gives the real
+values: `NSPS=3888`, `NDOWN=108`, `BT=2.0`. The wrong `NSPS`
+accumulated timing error linearly across the 160-symbol frame, so
+real audio drifted ~0.3-0.6 s off the true frame start — invisible
+in the synth roundtrip test because encode and decode shared the
+same wrong constants self-consistently.
+
+Separately, FST4 never wired up the 77-bit `rvec` pre-LDPC scramble
+that WSJT-X's `genfst4.f90:63` applies (same sequence FT4 uses).
+CRC-24 still passed on real WSJT-X audio without it — the check is
+self-referential, it just confirms LDPC decoded whatever bits were
+actually sent — but every decode came out as scrambled garbage
+instead of a real callsign.
+
+### Fixed
+
+- **`fst4/mod.rs`**: `NSPS`/`NDOWN`/`SYMBOL_DT`/`TONE_SPACING_HZ`/
+  `GFSK_BT` corrected to match WSJT-X; `ModulationParams::
+  INFO_SCRAMBLE_RVEC` wired to a new `FST4_RVEC` constant (same
+  values as `ft4::FT4_RVEC`, duplicated so `fst4` doesn't pull in
+  the `ft4` feature).
+- **`fst4/decode.rs`**: `FST4_60A_DOWNSAMPLE`'s `fft1_size` /
+  `fft2_size` / `tone_spacing_hz` updated for the corrected `NDOWN`.
+- **`fst4/encode.rs`**: `FST4_60A_GFSK` corrected (was hardcoded
+  independently of `ModulationParams` and never updated in lockstep);
+  `message_to_tones` now scrambles the message before CRC-24, matching
+  `genfst4.f90`.
+
+### Tests
+
+- `tests/fst4_wsjtx_samples.rs::fst4_60_wsjtx_sample_recall_vs_golden`
+  now recovers the golden message `CQ N5TM EL29` (dB=-9) against the
+  WSJT-X reference WAV, plus the same recording's second signal
+  `CQ K9KFR EN71` (dB=16) as a bonus. Un-ignored (was skipping with
+  "decode_frame returns 0 messages" since the test was added).
+- Adds `fst4_60_diagnose_golden`, a permanent diagnostic probe
+  (`jt9::gate_diag::probe_missing_goldens`-style (freq, dt) grid scan)
+  for any future FST4 sync/timing regression.
+
+### Notes
+
+- `mfsk-ffi-ft8` bumped to 0.6.8 in lock-step (FST4 isn't in its FFI
+  surface — the crate only wraps FT8 — so this is a version-number
+  sync only, no behavioral change).
+
 ## 0.6.7 — fix coarse_sync wasm32 runtime panic
 
 0.6.6 left `std::time::Instant::now()` calls in `coarse_sync` gated

--- a/README.md
+++ b/README.md
@@ -426,7 +426,7 @@ tree is present at the expected sibling path):
 | `JT9/130418_1742.wav` (5 frames)    | **5 / 5**   | full WSJT-X-faithful softsym pipeline (afc9 + chkss2 + xx0 mettab + sync9 collapse) |
 | `MSK144/181211_120500.wav` (n/a)    | —           | not implemented — [#25](https://github.com/jl1nie/mfsk-core/issues/25) |
 | `JT65/*` (n/a)                      | —           | golden harness pending — [#24](https://github.com/jl1nie/mfsk-core/issues/24) |
-| `FST4/210115_0058.wav` (1 frame)    | —           | golden harness pending — [#23](https://github.com/jl1nie/mfsk-core/issues/23) |
+| `FST4/210115_0058.wav` (1 frame)    | **1 / 1**   | fixed NSPS/NDOWN/BT + rvec message scramble (0.6.8, [#23](https://github.com/jl1nie/mfsk-core/issues/23)) |
 
 #### Known limitations / quirks
 
@@ -439,9 +439,10 @@ tree is present at the expected sibling path):
   [#24](https://github.com/jl1nie/mfsk-core/issues/24).
 - **FST4** — only the FST4-60A long-period variant is wired (sample
   duration / Costas layout for FST4-15 / FST4W are out of scope of
-  the 0.5.x line, still out of scope as of 0.6.x). Recall against `samples/FST4/210115_0058.wav` is
-  not yet locked by a golden harness — tracked in
-  [#23](https://github.com/jl1nie/mfsk-core/issues/23).
+  the 0.5.x line, still out of scope as of 0.6.x — no user demand,
+  FST4-60A is the dominant terrestrial sub-mode). Recall against
+  `samples/FST4/210115_0058.wav` locked by a golden harness as of
+  0.6.8 — see [#23](https://github.com/jl1nie/mfsk-core/issues/23).
 - **MSK144** — not implemented (out of scope of the 0.5.x line and still as of 0.6.x). The decode path needs a
   different correlator geometry from the rest of the FT/JT/Q-family
   decoders this crate is built around. Tracked in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -163,8 +163,6 @@ to a 0.7.x design pass.
 
 Currently open GitHub issues (state:open as of 2026-05-18):
 
-- **#23** — FST4-60A golden lockdown (host); FST4-15 / FST4W
-  stretch. Carried forward from the post-0.5.12 "Phase A1".
 - **#24** — JT65B golden lockdown + erasure-metadata path.
   Carried forward from the post-0.5.12 "Phase A2".
 - **#25** — MSK144 decode path. Community-contribution invitation;
@@ -195,6 +193,7 @@ prose, see the closed issue / linked PR / `git log`):
 | #61 | fold `m5stack-core2` into S3 dual-core; retire Core2 bench (PR #76) | 0.6.3 |
 | #63 | WSJT-X-faithful OSD `npre1`/`npre2` precoding (see "What landed in 0.6.3") | 0.6.3 |
 | #105 | EMBEDDED.md rewrite (kept deep tech ref, refreshed for 0.6.4) | 0.6.4 |
+| #23 | FST4-60A golden lockdown — wrong `NSPS`/`NDOWN`/`GFSK_BT` + missing `rvec` message scramble (PR #136); FST4-15/FST4W stretch still deferred, no user demand | 0.6.8 |
 
 The 5 remaining JTDX AP-on extras on `qso3_busy.wav` that surface
 only with `subtract_signal_lpf` multipass are a host-side win
@@ -239,11 +238,12 @@ hints; the live worklist is the **Open follow-ups** section above.
 
 (A0 / A0' both closed in v0.6.x — see the closed-issues table above.)
 
-- **A1** FST4-60A (`#23`) — `tests/fst4_wsjtx_samples.rs` is `#[ignore]`d
-  with "decode_frame returns 0 messages"; root-cause line-walk of
-  `WSJT-X/lib/fst4_decode.f90` against `mfsk-core/src/fst4/decode.rs`
-  still pending. Probe template:
-  `mfsk-core/src/jt9/decode.rs::gate_diag::probe_missing_goldens`.
+- **A1** FST4-60A (`#23`) — closed in 0.6.8 (PR #136). Root cause was
+  `Fst4s60`'s `NSPS`/`NDOWN`/`GFSK_BT` being never-revisited
+  placeholders (wrong vs. `WSJT-X/lib/fst4_decode.f90` /
+  `fst4sim.f90` / `gen_fst4wave.f90`) plus a missing `rvec` pre-LDPC
+  message scramble; `tests/fst4_wsjtx_samples.rs` is un-ignored and
+  recovers the golden decode.
 - **A2** JT65 (`#24`) — current implementation is JT65A; WSJT-X
   ships JT65B samples. Add a `Jt65b` ZST mirroring the Q65 sub-mode
   generic pattern (`Q65a30`, `Q65a60`, ...) and lock recall against

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-core"
-version     = "0.6.7"
+version     = "0.6.8"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 description = "Pure-Rust WSJT-family decoders + synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. Host (rustfft) or no_std embedded (ESP32-S3, RP2350, Cortex-M) via a pluggable FFT backend; fixed-point hot path for FPU-less MCUs. Ships with embedded-poc/m5stack-s3-app, a working M5StickS3 FT8 controller (LCD UI, BLE CI-V to IC-705, acoustic mic, QSO FSM) decoding real on-air signals in ~1.2 s post-SlotEnd on Xtensa LX7."

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-ffi-ft8"
-version     = "0.6.7"
+version     = "0.6.8"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 publish     = false


### PR DESCRIPTION
## Summary

Release-prep follow-up to #136 (merged into `main` as `8dba773`):
version bump to 0.6.8 + CHANGELOG/README/ROADMAP updates reflecting
the FST4-60A fix (issue #23 closed).

- `mfsk-core/Cargo.toml`, `mfsk-ffi-ft8/Cargo.toml` — `0.6.7` → `0.6.8`
  (kept in lock-step per project convention; `mfsk-ffi-ft8` itself is
  unaffected code-wise, it's FT8-only).
- `CHANGELOG.md` — new 0.6.8 entry.
- `docs/ROADMAP.md` — #23 moved from "Open follow-ups" to the closed
  table; Phase A1 section updated.
- `README.md` — FST4 golden-recall table row + "Known limitations"
  paragraph updated from "pending" to closed/1-1.

No source code changes.

## Test plan

- [x] `cargo build -p mfsk-core --features full`
- [x] `cargo fmt --all -- --check`
- [ ] CI

After merge: tag the merge commit `v0.6.8` and push per
`CLAUDE.md`'s release sequence to trigger the `Release` workflow
(crates.io publish + `mfsk-ffi-ft8` binary tarballs + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)