### PR TITLE
feat(fst4): wire FST4-15/30/120/300 sub-modes (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,15 +117,19 @@ License matches upstream: **GPL-3.0-or-later**.
 | FT8        | 15 s   | LDPC(174, 91) + CRC-14            | 77 bit  | 3 × Costas-7           | `ft8`   |
 | FT4        | 7.5 s  | LDPC(174, 91) + CRC-14            | 77 bit  | 4 × Costas-4           | `ft4`   |
 | FST4-60A   | 60 s   | LDPC(240, 101) + CRC-24           | 77 bit  | 5 × Costas-8           | `fst4`  |
+| FST4-15/30/120/300 | 15-300 s | (same LDPC(240, 101))     | 77 bit  | (same sync layout)     | `fst4`  |
 | WSPR       | 120 s  | Convolutional r=½ K=32 + Fano     | 50 bit  | Per-symbol LSB (npr3)  | `wspr`  |
 | JT9        | 60 s   | Convolutional r=½ K=32 + Fano     | 72 bit  | 16 distributed slots   | `jt9`   |
 | JT65       | 60 s   | Reed-Solomon(63, 12) GF(2⁶)       | 72 bit  | 63 distributed slots   | `jt65`  |
 | Q65-30A    | 30 s   | QRA(15, 65) GF(2⁶) + CRC-12       | 77 bit  | 22 distributed slots   | `q65`   |
 | Q65-60A‥E  | 60 s   | (same QRA codec)                  | 77 bit  | (same sync layout)     | `q65`   |
 
-Seven protocol families, eleven wired ZSTs in the registry: Q65 contributes one
-30-s sub-mode (Q65-30A) plus five 60-s EME sub-modes (Q65-60A‥E) that share
-the FEC, message codec and sync layout but differ in NSPS / tone spacing.
+Seven protocol families, sixteen wired ZSTs in the registry: FST4
+contributes five T/R-period sub-modes (FST4-15, -30, -60A, -120, -300)
+and Q65 contributes one 30-s sub-mode (Q65-30A) plus five 60-s EME
+sub-modes (Q65-60A‥E) — both families share FEC, message codec and
+sync layout across their sub-modes, differing only in NSPS / tone
+spacing (and, for FST4-15 alone, the T/R start offset).
 [`PROTOCOLS`](https://docs.rs/mfsk-core/latest/mfsk_core/static.PROTOCOLS.html)
 exposes one entry per wired ZST; `uvpacket` (when enabled) adds four
 more for its rate ladder.
@@ -178,7 +182,7 @@ and per-mode performance characterisation.
 |---------------|---------|----------------------------------------------|
 | `ft8`         | ✓       | FT8 decode / synth                           |
 | `ft4`         | ✓       | FT4 decode / synth                           |
-| `fst4`        |         | FST4-60A decode / synth                      |
+| `fst4`        |         | FST4-60A decode / synth (+ FST4-15/30/120/300) |
 | `wspr`        |         | WSPR decode / synth                          |
 | `jt9`         |         | JT9 decode / synth                           |
 | `jt65`        |         | JT65 decode / synth (+ erasure-aware RS)     |
@@ -228,7 +232,7 @@ carries its own Quick example:
 - [`mfsk_core::ft4`](https://docs.rs/mfsk-core/latest/mfsk_core/ft4/)
   — `decode_frame`
 - [`mfsk_core::fst4`](https://docs.rs/mfsk-core/latest/mfsk_core/fst4/)
-  — FST4-60A `decode_frame`
+  — FST4-60A `decode_frame`; other sub-modes via `decode_frame_for::<Fst4s120>` etc.
 - [`mfsk_core::wspr`](https://docs.rs/mfsk-core/latest/mfsk_core/wspr/)
   — `decode::decode_scan_default`
 - [`mfsk_core::jt9`](https://docs.rs/mfsk-core/latest/mfsk_core/jt9/)
@@ -437,12 +441,22 @@ tree is present at the expected sibling path):
   themselves don't decode cleanly without the soft-symbol erasure
   metadata that lives in private WSJT-X branches. Tracked in
   [#24](https://github.com/jl1nie/mfsk-core/issues/24).
-- **FST4** — only the FST4-60A long-period variant is wired (sample
-  duration / Costas layout for FST4-15 / FST4W are out of scope of
-  the 0.5.x line, still out of scope as of 0.6.x — no user demand,
-  FST4-60A is the dominant terrestrial sub-mode). Recall against
-  `samples/FST4/210115_0058.wav` locked by a golden harness as of
-  0.6.8 — see [#23](https://github.com/jl1nie/mfsk-core/issues/23).
+- **FST4** — five T/R-period sub-modes wired: FST4-15,
+  -30, -60A, -120, -300 (`fst4::Fst4s15`/`Fst4s30`/`Fst4s60`/
+  `Fst4s120`/`Fst4s300`), all sharing frame layout / FEC / message
+  codec / GFSK shaping and differing only in `NSPS`/`NDOWN` (and, for
+  FST4-15 alone, the T/R start offset) — every constant verified
+  directly against WSJT-X `fst4_decode.f90` / `fst4sim.f90` source,
+  the same rigor that caught #23's original bug. Only FST4-60A has a
+  real-recording golden-WAV lock (`samples/FST4/210115_0058.wav`,
+  1/1) — the WSJT-X sample tree ships no FST4-15/30/120/300
+  recordings, so those four are validated by synth-roundtrip
+  self-consistency plus source cross-checks only; a real recording or
+  a WSJT-X `fst4sim`-generated reference WAV would strengthen that.
+  FST4-900 / FST4-1800 and FST4W (the WSPR-style 50-bit one-way
+  beacon variant, a different message format entirely) remain out of
+  scope — no user demand as of writing. See
+  [#23](https://github.com/jl1nie/mfsk-core/issues/23).
 - **MSK144** — not implemented (out of scope of the 0.5.x line and still as of 0.6.x). The decode path needs a
   different correlator geometry from the rest of the FT/JT/Q-family
   decoders this crate is built around. Tracked in

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -193,7 +193,8 @@ prose, see the closed issue / linked PR / `git log`):
 | #61 | fold `m5stack-core2` into S3 dual-core; retire Core2 bench (PR #76) | 0.6.3 |
 | #63 | WSJT-X-faithful OSD `npre1`/`npre2` precoding (see "What landed in 0.6.3") | 0.6.3 |
 | #105 | EMBEDDED.md rewrite (kept deep tech ref, refreshed for 0.6.4) | 0.6.4 |
-| #23 | FST4-60A golden lockdown — wrong `NSPS`/`NDOWN`/`GFSK_BT` + missing `rvec` message scramble (PR #136); FST4-15/FST4W stretch still deferred, no user demand | 0.6.8 |
+| #23 | FST4-60A golden lockdown — wrong `NSPS`/`NDOWN`/`GFSK_BT` + missing `rvec` message scramble (PR #136) | 0.6.8 |
+| #23 | FST4-15/30/120/300 sub-modes wired (`fst4_submode!` macro, WSJT-X-cross-checked; no golden WAV available — synth-roundtrip + source-verification only) | pending release |
 
 The 5 remaining JTDX AP-on extras on `qso3_busy.wav` that surface
 only with `subtract_signal_lpf` multipass are a host-side win
@@ -249,8 +250,16 @@ hints; the live worklist is the **Open follow-ups** section above.
   generic pattern (`Q65a30`, `Q65a60`, ...) and lock recall against
   `samples/JT65/JT65B/*.wav` via a new
   `tests/jt65b_wsjtx_samples.rs` harness.
-- **A3** FST4-15 / FST4W — `#23` "stretch", deferred indefinitely
-  (no user demand; FST4-60A is the dominant terrestrial sub-mode).
+- **A3** FST4-15/30/120/300 (`#23` stretch) — landed via the
+  `fst4_submode!` macro (mirrors `q65_submode!`); all constants
+  cross-checked against WSJT-X `fst4_decode.f90`/`fst4sim.f90` and
+  pinned by an automated `DownsampleCfg`/`GfskCfg`-vs-trait-constant
+  test. No golden WAV exists for these four periods (WSJT-X's sample
+  tree only ships FST4-60A / FST4W-1800 recordings) — validated by
+  synth-roundtrip self-consistency + source cross-checks only;
+  requested by VK3NV (issue #23 comments) for a multi-period
+  weak-signal messaging project. FST4-900 / FST4-1800 and FST4W
+  remain deferred indefinitely (no user demand).
 
 ## Phase B — embedded controller line
 

--- a/embedded-poc/assets/fst4_sim/.gitignore
+++ b/embedded-poc/assets/fst4_sim/.gitignore
@@ -1,0 +1,2 @@
+# fst4sim-generated test WAVs — regenerate with scripts/gen_fst4_sim_wavs.sh
+*.wav

--- a/embedded-poc/assets/fst4_sweep/.gitignore
+++ b/embedded-poc/assets/fst4_sweep/.gitignore
@@ -1,0 +1,2 @@
+# fst4sim-generated sweep WAVs — regenerate with scripts/gen_fst4_sweep_wavs.sh
+*.wav

--- a/mfsk-core/src/fst4/decode.rs
+++ b/mfsk-core/src/fst4/decode.rs
@@ -1,17 +1,54 @@
 //! FST4 decode — thin wrapper over [`crate::core::pipeline`].
 //!
-//! FST4-60A uses LDPC(240, 101) + CRC-24 over the 77-bit WSJT
-//! message payload, with 5 × 8-symbol Costas sync blocks. The
+//! Every FST4 sub-mode uses LDPC(240, 101) + CRC-24 over the 77-bit
+//! WSJT message payload, with 5 × 8-symbol Costas sync blocks. The
 //! generic pipeline handles all of that once we supply a
-//! [`DownsampleCfg`] tuned for the protocol's geometry.
+//! [`DownsampleCfg`] tuned for the sub-mode's geometry — see the
+//! `FST4_*_DOWNSAMPLE` constants below and [`decode_frame_for`] /
+//! [`decode_frame_with_options_for`] / [`decode_frame_with_cache_for`] /
+//! [`decode_frame_with_cache_and_options_for`] for the generic entry
+//! points. `decode_frame` and friends (no `_for` suffix) are FST4-60A
+//! convenience wrappers kept for backward compatibility.
 
 use super::Fst4s60;
+use crate::core::Protocol;
 use crate::core::dsp::downsample::DownsampleCfg;
 use crate::core::equalize::EqMode;
 use crate::core::pipeline::{self, FftCache};
 
 use crate::core::pipeline::DecodeStrictness;
 pub use crate::core::pipeline::{DecodeDepth, DecodeResult};
+
+/// FST4-15 downsample configuration: 12 kHz → 666.7 Hz baseband
+/// (NDOWN = 18, matching WSJT-X `fst4_decode.f90`'s `ndown` for
+/// `ntrperiod.eq.15`). `fft1_size` = 180 000 (exactly `T_SLOT_S ×
+/// 12 000`, already an exact multiple of NDOWN=18 so no padding is
+/// needed). `fft2_size` = fft1 / NDOWN = 10 000.
+pub const FST4_15_DOWNSAMPLE: DownsampleCfg = DownsampleCfg {
+    input_rate: 12_000,
+    fft1_size: 180_000,
+    fft2_size: 10_000,
+    tone_spacing_hz: 12_000.0 / 720.0,
+    leading_pad_tones: 1.5,
+    trailing_pad_tones: 1.5,
+    ntones: 4,
+    edge_taper_bins: 101,
+};
+
+/// FST4-30 downsample configuration: 12 kHz → 285.7 Hz baseband
+/// (NDOWN = 42, matching WSJT-X `fst4_decode.f90`'s `ndown` for
+/// `ntrperiod.eq.30`). `fft1_size` = 362 880 (= 8640 × 42, ≥ 360 000
+/// samples that a 30-s slot contains). `fft2_size` = 8640.
+pub const FST4_30_DOWNSAMPLE: DownsampleCfg = DownsampleCfg {
+    input_rate: 12_000,
+    fft1_size: 362_880,
+    fft2_size: 8_640,
+    tone_spacing_hz: 12_000.0 / 1_680.0,
+    leading_pad_tones: 1.5,
+    trailing_pad_tones: 1.5,
+    ntones: 4,
+    edge_taper_bins: 101,
+};
 
 /// FST4-60A downsample configuration: 12 kHz → 111.11 Hz baseband
 /// (NDOWN = 108, matching WSJT-X `fst4_decode.f90`'s `fs2 = fs/ndown`
@@ -33,28 +70,75 @@ pub const FST4_60A_DOWNSAMPLE: DownsampleCfg = DownsampleCfg {
     edge_taper_bins: 101,
 };
 
+/// FST4-120 downsample configuration: 12 kHz → 58.5 Hz baseband
+/// (NDOWN = 205, matching WSJT-X `fst4_decode.f90`'s `ndown` for
+/// `ntrperiod.eq.120`). `fft1_size` = 1 443 200 (= 7040 × 205, ≥
+/// 1 440 000 samples that a 120-s slot contains). `fft2_size` = 7040.
+/// NDOWN=205=5×41 has no small-prime factorisation, so `fft1_size`
+/// unavoidably carries the factor 41 — rustfft still handles it
+/// correctly via mixed-radix / Bluestein, just not at the same speed
+/// as a power-of-two size.
+pub const FST4_120_DOWNSAMPLE: DownsampleCfg = DownsampleCfg {
+    input_rate: 12_000,
+    fft1_size: 1_443_200,
+    fft2_size: 7_040,
+    tone_spacing_hz: 12_000.0 / 8_200.0,
+    leading_pad_tones: 1.5,
+    trailing_pad_tones: 1.5,
+    ntones: 4,
+    edge_taper_bins: 101,
+};
+
+/// FST4-300 downsample configuration: 12 kHz → 23.4 Hz baseband
+/// (NDOWN = 512, matching WSJT-X `fst4_decode.f90`'s `ndown` for
+/// `ntrperiod.eq.300`). `fft1_size` = 4 194 304 (= 2²², a pure
+/// power-of-two chosen since NDOWN=512=2⁹ is already a power of two;
+/// ≥ 3 600 000 samples that a 300-s slot contains). `fft2_size` =
+/// 8192.
+pub const FST4_300_DOWNSAMPLE: DownsampleCfg = DownsampleCfg {
+    input_rate: 12_000,
+    fft1_size: 4_194_304,
+    fft2_size: 8_192,
+    tone_spacing_hz: 12_000.0 / 21_504.0,
+    leading_pad_tones: 1.5,
+    trailing_pad_tones: 1.5,
+    ntones: 4,
+    edge_taper_bins: 101,
+};
+
 /// FST4 has 40 sync symbols (5 × 8); require at least a quarter of
-/// them right for a candidate to survive coarse-sync scoring.
+/// them right for a candidate to survive coarse-sync scoring. Shared
+/// by every sub-mode.
 const SYNC_Q_MIN: u32 = 10;
 
-/// Quarter-symbol time-step, expressed in downsampled samples.
+/// Fine-refine time-domain search half-width, in *downsampled*
+/// samples. Every FST4 sub-mode's downsampled samples-per-symbol
+/// (`NSPS / NDOWN`) lands in the 36-42 range (WSJT-X picks each
+/// sub-mode's `ndown` so that ratio stays roughly constant), so this
+/// fixed raw-sample count corresponds to a consistent ~1-symbol
+/// search window across all of them — no per-sub-mode retuning needed.
 const REFINE_STEPS: i32 = 40;
 
-/// Decode one 60-second FST4-60A slot of 12 kHz PCM audio.
+/// Decode one slot of 12 kHz PCM audio for FST4 sub-mode `P`.
 ///
 /// Typical arguments for a wide-band scan:
 /// - `freq_min` / `freq_max` = 100.0 / 3000.0
 /// - `sync_min` = 1.0 (lower than FT4 because symbols are 6× longer)
 /// - `max_cand` = 50
-pub fn decode_frame(
+///
+/// `cfg` must match `P` — pass the corresponding `FST4_*_DOWNSAMPLE`
+/// constant (e.g. [`FST4_120_DOWNSAMPLE`] for `P = Fst4s120`).
+pub fn decode_frame_for<P: Protocol>(
     audio: &[i16],
+    cfg: &DownsampleCfg,
     freq_min: f32,
     freq_max: f32,
     sync_min: f32,
     max_cand: usize,
 ) -> Vec<DecodeResult> {
-    decode_frame_with_options(
+    decode_frame_with_options_for::<P>(
         audio,
+        cfg,
         freq_min,
         freq_max,
         sync_min,
@@ -64,18 +148,18 @@ pub fn decode_frame(
     )
 }
 
-/// Decode one FST4-60A slot with an explicit `depth` knob.
+/// Decode one FST4 slot with an explicit `depth` knob. See
+/// [`decode_frame_for`] for the `cfg` contract.
 ///
-/// Mirrors [`crate::ft4::decode::decode_frame_with_options`] and
-/// [`crate::ft8::decode::decode_frame`]'s `depth` parameter. FST4's
-/// per-candidate strictness is hardcoded to `Normal` — the
+/// FST4's per-candidate strictness is hardcoded to `Normal` — the
 /// FST4-specific re-tune of the FT8-calibrated thresholds never landed
 /// and no caller exercised the `Strict` / `Deep` rungs (issue #72).
 ///
 /// `freq_hint`: when `Some(f)`, narrows the coarse-sync to candidates
 /// near `f`. Pass `None` for full-band scan.
-pub fn decode_frame_with_options(
+pub fn decode_frame_with_options_for<P: Protocol>(
     audio: &[i16],
+    cfg: &DownsampleCfg,
     freq_min: f32,
     freq_max: f32,
     sync_min: f32,
@@ -83,9 +167,9 @@ pub fn decode_frame_with_options(
     depth: DecodeDepth,
     max_cand: usize,
 ) -> Vec<DecodeResult> {
-    pipeline::decode_frame::<Fst4s60>(
+    pipeline::decode_frame::<P>(
         audio,
-        &FST4_60A_DOWNSAMPLE,
+        cfg,
         freq_min,
         freq_max,
         sync_min,
@@ -100,18 +184,20 @@ pub fn decode_frame_with_options(
     .0
 }
 
-/// Same as [`decode_frame`] but also returns the large outer FFT
+/// Same as [`decode_frame_for`] but also returns the large outer FFT
 /// cache so callers can chain further processing (SIC, narrow-band
 /// rescan) without recomputing it.
-pub fn decode_frame_with_cache(
+pub fn decode_frame_with_cache_for<P: Protocol>(
     audio: &[i16],
+    cfg: &DownsampleCfg,
     freq_min: f32,
     freq_max: f32,
     sync_min: f32,
     max_cand: usize,
 ) -> (Vec<DecodeResult>, FftCache) {
-    decode_frame_with_cache_and_options(
+    decode_frame_with_cache_and_options_for::<P>(
         audio,
+        cfg,
         freq_min,
         freq_max,
         sync_min,
@@ -121,14 +207,11 @@ pub fn decode_frame_with_cache(
     )
 }
 
-/// Same as [`decode_frame_with_cache`] but with an explicit `depth` knob
-/// (see [`decode_frame_with_options`]).
-///
-/// `freq_hint`: when `Some(f)`, narrows the coarse-sync to candidates
-/// near `f`. Pass `None` for full-band scan. Mirrors
-/// [`decode_frame_with_options`] for parity.
-pub fn decode_frame_with_cache_and_options(
+/// Same as [`decode_frame_with_cache_for`] but with an explicit
+/// `depth` knob (see [`decode_frame_with_options_for`]).
+pub fn decode_frame_with_cache_and_options_for<P: Protocol>(
     audio: &[i16],
+    cfg: &DownsampleCfg,
     freq_min: f32,
     freq_max: f32,
     sync_min: f32,
@@ -136,9 +219,9 @@ pub fn decode_frame_with_cache_and_options(
     depth: DecodeDepth,
     max_cand: usize,
 ) -> (Vec<DecodeResult>, FftCache) {
-    pipeline::decode_frame::<Fst4s60>(
+    pipeline::decode_frame::<P>(
         audio,
-        &FST4_60A_DOWNSAMPLE,
+        cfg,
         freq_min,
         freq_max,
         sync_min,
@@ -152,6 +235,96 @@ pub fn decode_frame_with_cache_and_options(
     )
 }
 
+/// Decode one 60-second FST4-60A slot of 12 kHz PCM audio.
+///
+/// Convenience wrapper over [`decode_frame_for`]`::<Fst4s60>` with
+/// [`FST4_60A_DOWNSAMPLE`] — kept for backward compatibility with
+/// callers that predate the multi-sub-mode `_for` entry points. Other
+/// sub-modes: call `decode_frame_for::<Fst4s120>(audio, cfg, ...)`
+/// etc. directly with the matching `FST4_*_DOWNSAMPLE` constant.
+pub fn decode_frame(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    max_cand: usize,
+) -> Vec<DecodeResult> {
+    decode_frame_for::<Fst4s60>(
+        audio,
+        &FST4_60A_DOWNSAMPLE,
+        freq_min,
+        freq_max,
+        sync_min,
+        max_cand,
+    )
+}
+
+/// FST4-60A convenience wrapper over [`decode_frame_with_options_for`].
+/// See [`decode_frame`] for the multi-sub-mode alternative.
+pub fn decode_frame_with_options(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    max_cand: usize,
+) -> Vec<DecodeResult> {
+    decode_frame_with_options_for::<Fst4s60>(
+        audio,
+        &FST4_60A_DOWNSAMPLE,
+        freq_min,
+        freq_max,
+        sync_min,
+        freq_hint,
+        depth,
+        max_cand,
+    )
+}
+
+/// FST4-60A convenience wrapper over [`decode_frame_with_cache_for`].
+/// See [`decode_frame`] for the multi-sub-mode alternative.
+pub fn decode_frame_with_cache(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    max_cand: usize,
+) -> (Vec<DecodeResult>, FftCache) {
+    decode_frame_with_cache_for::<Fst4s60>(
+        audio,
+        &FST4_60A_DOWNSAMPLE,
+        freq_min,
+        freq_max,
+        sync_min,
+        max_cand,
+    )
+}
+
+/// FST4-60A convenience wrapper over
+/// [`decode_frame_with_cache_and_options_for`]. See [`decode_frame`]
+/// for the multi-sub-mode alternative.
+pub fn decode_frame_with_cache_and_options(
+    audio: &[i16],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    depth: DecodeDepth,
+    max_cand: usize,
+) -> (Vec<DecodeResult>, FftCache) {
+    decode_frame_with_cache_and_options_for::<Fst4s60>(
+        audio,
+        &FST4_60A_DOWNSAMPLE,
+        freq_min,
+        freq_max,
+        sync_min,
+        freq_hint,
+        depth,
+        max_cand,
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -159,7 +332,7 @@ mod tests {
     /// Synth → decode_frame roundtrip for a clean FST4-60A signal.
     ///
     /// Gated behind `RUN_FST4_ROUNDTRIP=1` because the 60-s slot +
-    /// 786 432-point outer FFT makes this a multi-second test.
+    /// 746 496-point outer FFT makes this a multi-second test.
     #[test]
     fn synth_decode_roundtrip_cq_ja1abc() {
         if std::env::var("RUN_FST4_ROUNDTRIP").is_err() {
@@ -198,6 +371,129 @@ mod tests {
                 .any(|t| t.contains("JA1ABC") && t.contains("PM95")),
             "expected to recover 'JA1ABC PM95', got {:?}",
             texts
+        );
+    }
+
+    /// Generic synth → decode roundtrip shared by every non-60A
+    /// sub-mode test below. Same structure as
+    /// `synth_decode_roundtrip_cq_ja1abc`: encode a clean message,
+    /// pad into a full slot with 1 s of leading silence, decode, and
+    /// confirm the message comes back.
+    ///
+    /// This is a **self-consistency** check only — encode and decode
+    /// share the same `NSPS`/`NDOWN`/`GFSK_BT` constants, so it cannot
+    /// catch a wrong-vs-WSJT-X parameter the way real WSJT-X-generated
+    /// audio would (this is exactly how issue #23's FST4-60A bug
+    /// stayed hidden). No golden WAV exists locally for FST4-15/30/
+    /// 120/300 (the WSJT-X sample tree only ships FST4-60A and
+    /// FST4W-1800 recordings) — the `NSPS`/`NDOWN`/`TX_START_OFFSET_S`
+    /// values themselves were verified directly against WSJT-X
+    /// `fst4_decode.f90` / `fst4sim.f90` source (see
+    /// `fst4::tests::all_submodes_match_wsjtx_fst4_decode_f90`), which
+    /// is the strongest available check without either a real
+    /// recording or a WSJT-X `fst4sim`-generated reference WAV.
+    fn synth_roundtrip_for<P: crate::core::Protocol + crate::core::FrameLayout>(
+        cfg: &DownsampleCfg,
+        gfsk: &crate::core::dsp::gfsk::GfskCfg,
+        freq_min: f32,
+        freq_max: f32,
+    ) {
+        use super::super::encode::{message_to_tones, tones_to_i16_with_gfsk};
+        use crate::msg::wsjt77::{pack77, unpack77};
+
+        let msg77 = pack77("CQ", "JA1ABC", "PM95").expect("pack77");
+        let tones = message_to_tones(&msg77);
+        let audio = tones_to_i16_with_gfsk(&tones, (freq_min + freq_max) / 2.0, 10_000, gfsk);
+
+        // Pad to a full slot with 1 s of leading silence.
+        let slot_len = (P::T_SLOT_S * 12_000.0).round() as usize;
+        let mut slot = vec![0i16; slot_len];
+        let offset = 12_000usize;
+        let copy_len = audio.len().min(slot_len.saturating_sub(offset));
+        slot[offset..offset + copy_len].copy_from_slice(&audio[..copy_len]);
+
+        let results = decode_frame_for::<P>(&slot, cfg, freq_min, freq_max, 0.8, 20);
+        assert!(
+            !results.is_empty(),
+            "expected at least one decode from clean synth, got none"
+        );
+        let texts: Vec<String> = results
+            .iter()
+            .filter_map(|r| {
+                let msg77: &[u8; 77] = r.message77().try_into().ok()?;
+                unpack77(msg77)
+            })
+            .collect();
+        assert!(
+            texts
+                .iter()
+                .any(|t| t.contains("JA1ABC") && t.contains("PM95")),
+            "expected to recover 'JA1ABC PM95', got {:?}",
+            texts
+        );
+    }
+
+    /// Gated behind `RUN_FST4_ROUNDTRIP=1` (see
+    /// `synth_decode_roundtrip_cq_ja1abc`).
+    #[test]
+    fn synth_decode_roundtrip_fst4_15() {
+        if std::env::var("RUN_FST4_ROUNDTRIP").is_err() {
+            eprintln!("skipping FST4-15 roundtrip (set RUN_FST4_ROUNDTRIP=1 to enable)");
+            return;
+        }
+        synth_roundtrip_for::<super::super::Fst4s15>(
+            &FST4_15_DOWNSAMPLE,
+            &super::super::encode::FST4_15_GFSK,
+            1000.0,
+            2000.0,
+        );
+    }
+
+    /// Gated behind `RUN_FST4_ROUNDTRIP=1`.
+    #[test]
+    fn synth_decode_roundtrip_fst4_30() {
+        if std::env::var("RUN_FST4_ROUNDTRIP").is_err() {
+            eprintln!("skipping FST4-30 roundtrip (set RUN_FST4_ROUNDTRIP=1 to enable)");
+            return;
+        }
+        synth_roundtrip_for::<super::super::Fst4s30>(
+            &FST4_30_DOWNSAMPLE,
+            &super::super::encode::FST4_30_GFSK,
+            1000.0,
+            2000.0,
+        );
+    }
+
+    /// Gated behind `RUN_FST4_ROUNDTRIP=1`. Slower than the 15/30/60 s
+    /// variants (109 s of audio, ~1.44M-point outer FFT).
+    #[test]
+    fn synth_decode_roundtrip_fst4_120() {
+        if std::env::var("RUN_FST4_ROUNDTRIP").is_err() {
+            eprintln!("skipping FST4-120 roundtrip (set RUN_FST4_ROUNDTRIP=1 to enable)");
+            return;
+        }
+        synth_roundtrip_for::<super::super::Fst4s120>(
+            &FST4_120_DOWNSAMPLE,
+            &super::super::encode::FST4_120_GFSK,
+            1000.0,
+            2000.0,
+        );
+    }
+
+    /// Gated behind `RUN_FST4_ROUNDTRIP=1`. Slowest of the roundtrip
+    /// tests (287 s of audio, ~4.19M-point outer FFT) — expect several
+    /// seconds.
+    #[test]
+    fn synth_decode_roundtrip_fst4_300() {
+        if std::env::var("RUN_FST4_ROUNDTRIP").is_err() {
+            eprintln!("skipping FST4-300 roundtrip (set RUN_FST4_ROUNDTRIP=1 to enable)");
+            return;
+        }
+        synth_roundtrip_for::<super::super::Fst4s300>(
+            &FST4_300_DOWNSAMPLE,
+            &super::super::encode::FST4_300_GFSK,
+            1000.0,
+            2000.0,
         );
     }
 

--- a/mfsk-core/src/fst4/encode.rs
+++ b/mfsk-core/src/fst4/encode.rs
@@ -1,13 +1,38 @@
 //! FST4 encode: 77-bit message → 160-symbol tone sequence → 12 kHz PCM.
 //!
-//! Mirrors `ft4-core::encode` but for the [`Fst4s60`] geometry:
-//! LDPC(240, 101) + CRC-24 over the shared 77-bit WSJT payload,
-//! GFSK with BT = 2.0 and 324 ms symbols.
+//! Mirrors `ft4-core::encode` but for the FST4 geometry shared by
+//! every sub-mode: LDPC(240, 101) + CRC-24 over the shared 77-bit
+//! WSJT payload, GFSK with BT = 2.0. [`message_to_tones`] produces
+//! the (period-independent) symbol-domain tone sequence; the
+//! `FST4_*_GFSK` constants plus [`tones_to_f32_with_gfsk`] /
+//! [`tones_to_i16_with_gfsk`] handle the per-sub-mode sample-domain
+//! synthesis. `tones_to_f32` / `tones_to_i16` (no suffix) are FST4-60A
+//! convenience wrappers kept for backward compatibility.
 
 use super::Fst4s60;
 use crate::core::dsp::gfsk::{GfskCfg, synth_f32, synth_i16};
 use crate::core::{FecCodec, FrameLayout, ModulationParams};
 use crate::fec::Ldpc240_101;
+
+/// FST4-15 GFSK configuration: 12 kHz, 720 samples/symbol, BT=2.0,
+/// hmod=1.0, NSPS/8-sample cosine ramp.
+pub const FST4_15_GFSK: GfskCfg = GfskCfg {
+    sample_rate: 12_000.0,
+    samples_per_symbol: 720,
+    bt: 2.0,
+    hmod: 1.0,
+    ramp_samples: 720 / 8,
+};
+
+/// FST4-30 GFSK configuration: 12 kHz, 1680 samples/symbol, BT=2.0,
+/// hmod=1.0, NSPS/8-sample cosine ramp.
+pub const FST4_30_GFSK: GfskCfg = GfskCfg {
+    sample_rate: 12_000.0,
+    samples_per_symbol: 1_680,
+    bt: 2.0,
+    hmod: 1.0,
+    ramp_samples: 1_680 / 8,
+};
 
 /// FST4-60A GFSK configuration: 12 kHz, 3888 samples/symbol, BT=2.0,
 /// hmod=1.0, NSPS/8-sample cosine ramp.
@@ -22,6 +47,26 @@ pub const FST4_60A_GFSK: GfskCfg = GfskCfg {
     bt: 2.0,
     hmod: 1.0,
     ramp_samples: 3_888 / 8,
+};
+
+/// FST4-120 GFSK configuration: 12 kHz, 8200 samples/symbol, BT=2.0,
+/// hmod=1.0, NSPS/8-sample cosine ramp.
+pub const FST4_120_GFSK: GfskCfg = GfskCfg {
+    sample_rate: 12_000.0,
+    samples_per_symbol: 8_200,
+    bt: 2.0,
+    hmod: 1.0,
+    ramp_samples: 8_200 / 8,
+};
+
+/// FST4-300 GFSK configuration: 12 kHz, 21504 samples/symbol, BT=2.0,
+/// hmod=1.0, NSPS/8-sample cosine ramp.
+pub const FST4_300_GFSK: GfskCfg = GfskCfg {
+    sample_rate: 12_000.0,
+    samples_per_symbol: 21_504,
+    bt: 2.0,
+    hmod: 1.0,
+    ramp_samples: 21_504 / 8,
 };
 
 /// Append the 24-bit CRC used by FST4 (see `mfsk_core::fec::ldpc240_101::crc24`)
@@ -40,7 +85,14 @@ fn append_crc24(message77: &[u8; 77]) -> [u8; 101] {
     info
 }
 
-/// Encode a 77-bit message into the 160-symbol FST4-60A tone sequence.
+/// Encode a 77-bit message into the 160-symbol FST4 tone sequence.
+///
+/// Period-independent: the tone sequence only depends on `NTONES` /
+/// `BITS_PER_SYMBOL` / `GRAY_MAP` / the frame layout, which every FST4
+/// sub-mode shares. Callers wanting a different sub-mode's *sample*
+/// waveform still call this unchanged and pass its tone sequence to
+/// [`tones_to_f32_with_gfsk`] / [`tones_to_i16_with_gfsk`] with the
+/// matching `FST4_*_GFSK` constant.
 ///
 /// WSJT-X `genfst4.f90:63` XORs the message with `rvec` before CRC-24 +
 /// LDPC encode; `message_to_tones` transmits the **scrambled** message
@@ -58,18 +110,44 @@ pub fn message_to_tones(message77: &[u8; 77]) -> Vec<u8> {
     crate::core::tx::codeword_to_itone::<Fst4s60>(&cw)
 }
 
-/// Synthesise a 12 kHz f32 PCM waveform from an FST4 tone sequence.
-/// Output length is `N_SYMBOLS × NSPS = 160 × 3888 = 622 080` samples
-/// (~51.84 s).
-pub fn tones_to_f32(itone: &[u8], f0: f32, amplitude: f32) -> Vec<f32> {
+/// Synthesise a 12 kHz f32 PCM waveform from an FST4 tone sequence
+/// using an explicit GFSK config — pass the `FST4_*_GFSK` constant
+/// matching the sub-mode `itone` was produced for. Output length is
+/// `N_SYMBOLS × cfg.samples_per_symbol` (160 × NSPS).
+pub fn tones_to_f32_with_gfsk(itone: &[u8], f0: f32, amplitude: f32, cfg: &GfskCfg) -> Vec<f32> {
     debug_assert_eq!(itone.len(), <Fst4s60 as FrameLayout>::N_SYMBOLS as usize);
-    synth_f32(itone, f0, amplitude, &FST4_60A_GFSK)
+    synth_f32(itone, f0, amplitude, cfg)
 }
 
-/// Synthesise a 16-bit PCM waveform. Peak equals `amplitude_i16`.
-pub fn tones_to_i16(itone: &[u8], f0: f32, amplitude_i16: i16) -> Vec<i16> {
+/// Synthesise a 16-bit PCM waveform using an explicit GFSK config.
+/// Peak equals `amplitude_i16`. See [`tones_to_f32_with_gfsk`].
+pub fn tones_to_i16_with_gfsk(
+    itone: &[u8],
+    f0: f32,
+    amplitude_i16: i16,
+    cfg: &GfskCfg,
+) -> Vec<i16> {
     debug_assert_eq!(itone.len(), <Fst4s60 as FrameLayout>::N_SYMBOLS as usize);
-    synth_i16(itone, f0, amplitude_i16, &FST4_60A_GFSK)
+    synth_i16(itone, f0, amplitude_i16, cfg)
+}
+
+/// Synthesise a 12 kHz f32 PCM waveform from an FST4-60A tone
+/// sequence. Output length is `N_SYMBOLS × NSPS = 160 × 3888 =
+/// 622 080` samples (~51.84 s).
+///
+/// Convenience wrapper over [`tones_to_f32_with_gfsk`] with
+/// [`FST4_60A_GFSK`] — kept for backward compatibility. Other
+/// sub-modes: call `tones_to_f32_with_gfsk(itone, f0, amplitude,
+/// &FST4_120_GFSK)` etc. directly.
+pub fn tones_to_f32(itone: &[u8], f0: f32, amplitude: f32) -> Vec<f32> {
+    tones_to_f32_with_gfsk(itone, f0, amplitude, &FST4_60A_GFSK)
+}
+
+/// FST4-60A convenience wrapper over [`tones_to_i16_with_gfsk`]. Peak
+/// equals `amplitude_i16`. See [`tones_to_f32`] for the multi-sub-mode
+/// alternative.
+pub fn tones_to_i16(itone: &[u8], f0: f32, amplitude_i16: i16) -> Vec<i16> {
+    tones_to_i16_with_gfsk(itone, f0, amplitude_i16, &FST4_60A_GFSK)
 }
 
 fn _silence() {

--- a/mfsk-core/src/fst4/mod.rs
+++ b/mfsk-core/src/fst4/mod.rs
@@ -1,23 +1,33 @@
-//! # `fst4` — FST4-60A decoder and synthesiser
+//! # `fst4` — FST4 decoder and synthesiser
 //!
 //! FST4 is a weak-signal slow-speed mode used for EME / troposcatter /
-//! LF-MF propagation experiments. This module targets the **FST4-60A**
-//! sub-mode (60-second T/R period, minimum tone spacing). Trait surface,
-//! frame layout, Costas positions, DSP routing, and LDPC(240, 101) +
-//! CRC-24 codec ([`crate::fec::Ldpc240_101`]) are all wired. The 77-bit
-//! message layer is shared verbatim with FT8 / FT4.
+//! LF-MF propagation experiments. Trait surface, frame layout, Costas
+//! positions, DSP routing, and LDPC(240, 101) + CRC-24 codec
+//! ([`crate::fec::Ldpc240_101`]) are all wired. The 77-bit message
+//! layer is shared verbatim with FT8 / FT4.
 //!
-//! ## Covered sub-mode
+//! ## Covered sub-modes
 //!
-//! This module ships the **FST4-60A** sub-mode as [`Fst4s60`]. Other
-//! sub-modes (FST4-15, -30, -120, -300, -900, -1800) differ only in
-//! [`ModulationParams::NSPS`] / `SYMBOL_DT` / `TONE_SPACING_HZ` and
-//! can be added as additional ZSTs using the same trait impl pattern.
+//! Five T/R-period sub-modes are wired: [`Fst4s15`], [`Fst4s30`],
+//! [`Fst4s60`], [`Fst4s120`], [`Fst4s300`]. They differ only in
+//! [`ModulationParams::NSPS`] / `NDOWN` / `SYMBOL_DT` /
+//! `TONE_SPACING_HZ` (and `Fst4s15` alone in
+//! [`FrameLayout::TX_START_OFFSET_S`] — see the `fst4_submode!`
+//! invocations below for the WSJT-X-sourced values) — frame layout,
+//! sync pattern, FEC, message codec, and GFSK shaping (BT=2.0) are
+//! identical across all of them, mirroring the
+//! [`crate::q65::Q65a30`]-family `q65_submode!` pattern. FST4-900 and
+//! FST4-1800 are not wired (no user demand as of writing). FST4W (the
+//! WSPR-style 50-bit one-way beacon variant, LDPC(240,74), periods
+//! 120/300/900/1800 s) is a separate message format entirely — not
+//! covered here; see issue #23 for status.
 //!
 //! ## References
 //!
 //! - K1JT et al., "The FST4 and FST4W Protocols", QEX 2021
-//! - WSJT-X `lib/fst4/` — `fst4_params.f90`, `genfst4.f90`
+//! - WSJT-X `lib/fst4_decode.f90`, `lib/fst4/fst4sim.f90`,
+//!   `lib/fst4/fst4_params.f90`, `lib/fst4/genfst4.f90`,
+//!   `lib/fst4/gen_fst4wave.f90`
 //!
 //! ## Quick example
 //!
@@ -42,87 +52,22 @@ use crate::msg::Wsjt77Message;
 pub mod decode;
 pub mod encode;
 
-/// FST4-60A: 4-GFSK, 60-second T/R period, 3.0864 baud, minimum tone
-/// spacing (12.35 Hz occupied bandwidth). Uses LDPC(240, 101) + CRC-24
-/// over the same 77-bit WSJT message payload that FT8 / FT4 use.
-#[derive(Copy, Clone, Debug, Default)]
-pub struct Fst4s60;
-
-impl ModulationParams for Fst4s60 {
-    const NTONES: u32 = 4;
-    const BITS_PER_SYMBOL: u32 = 2;
-    // WSJT-X `fst4_decode.f90`/`fst4sim.f90` (`ntrperiod.eq.60`):
-    // nsps=3888, ndown=108, hmod=1, bt=2.0 (`gen_fst4wave.f90:37`
-    // `gfsk_pulse(2.0,tt)`, unconditional for all FST4 sub-modes).
-    // Symbol length 3888/12000 = 324 ms → baud = 12000/3888 ≈
-    // 3.0864 Hz tone spacing. The previous values here (NSPS=3840,
-    // NDOWN=192, GFSK_BT=1.0, 3.125 Hz) were placeholders that never
-    // got revisited (see git history) — issue #23: they self-decode
-    // fine in the synth roundtrip (encode/decode share the same wrong
-    // constants) but drift ~0.3-0.6 s against real WSJT-X-generated
-    // audio because the wrong NSPS accumulates timing error linearly
-    // across the 160-symbol frame.
-    const NSPS: u32 = 3_888;
-    const SYMBOL_DT: f32 = 3_888.0 / 12_000.0;
-    const TONE_SPACING_HZ: f32 = 12_000.0 / 3_888.0;
-    const GRAY_MAP: &'static [u8] = &[0, 1, 3, 2];
-    // BT=2.0 (see NSPS doc comment above) — matches FT8's GFSK_BT,
-    // not FT4's 1.0. The previous BT=1.0 here was wrong (see NSPS
-    // comment).
-    const GFSK_BT: f32 = 2.0;
-    const GFSK_HMOD: f32 = 1.0;
-    // NFFT window = 2 × NSPS (same convention as FT8) — longer windows
-    // don't help FST4-60 because the channel is assumed quasi-static
-    // across the 60 s slot.
-    const NFFT_PER_SYMBOL_FACTOR: u32 = 2;
-    // Half-symbol coarse grid (matches FT4 practice).
-    const NSTEP_PER_SYMBOL: u32 = 2;
-    // 12 000 / 108 = 111.11 Hz baseband (WSJT-X `fs2`) — enough for
-    // 4-tone signal at 3.0864 Hz spacing plus guard band.
-    const NDOWN: u32 = 108;
-    // WSJT-X `genfst4.f90:63` XORs the 77-bit message with the same
-    // `rvec` sequence FT4 uses (`genft4.f90:64`) before CRC-24 +
-    // LDPC encode; the receiver must undo it after decode
-    // (`fst4_decode.f90` unpack path). This was missing entirely —
-    // CRC-24 still passes on real WSJT-X audio without it (the check
-    // is self-referential: it just confirms LDPC decoded whatever 77
-    // bits were actually sent, scrambled or not), but every decoded
-    // message came out as scrambled garbage instead of a real
-    // callsign. Same root cause bucket as issue #23.
-    const INFO_SCRAMBLE_RVEC: Option<&'static [u8]> = Some(&FST4_RVEC);
-}
-
 /// FST4's 77-bit pre-LDPC scrambler — identical to [`crate::ft4::FT4_RVEC`]
 /// (WSJT-X `genfst4.f90:29-31` uses the same literal array as
 /// `genft4.f90`), duplicated here rather than imported so `fst4` doesn't
-/// pull in the `ft4` feature.
+/// pull in the `ft4` feature. WSJT-X `genfst4.f90:63` XORs the 77-bit
+/// message with this sequence before CRC-24 + LDPC encode; the receiver
+/// must undo it after decode. Shared by every FST4 sub-mode (unconditional
+/// on T/R period).
 const FST4_RVEC: [u8; 77] = [
     0, 1, 0, 0, 1, 0, 1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0,
     1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1,
     1, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1,
 ];
 
-impl FrameLayout for Fst4s60 {
-    const N_DATA: u32 = 120;
-    const N_SYNC: u32 = 40; // 5 × 8
-    const N_SYMBOLS: u32 = 160;
-    const N_RAMP: u32 = 0; // GFSK synth handles ramp internally
-    const SYNC_MODE: SyncMode = SyncMode::Block(&FST4_SYNC_BLOCKS);
-    const T_SLOT_S: f32 = 60.0;
-    // FST4 transmissions start ~1 s after the slot boundary (per WSJT-X).
-    const TX_START_OFFSET_S: f32 = 1.0;
-}
-
-impl Protocol for Fst4s60 {
-    /// LDPC(240, 101) + CRC-24 — see [`crate::fec::Ldpc240_101`].
-    type Fec = Ldpc240_101;
-    /// Same 77-bit WSJT message layout as FT8 / FT4 — fully reused.
-    type Msg = Wsjt77Message;
-    const ID: ProtocolId = ProtocolId::Fst4;
-}
-
 // Two alternating Costas patterns, each 8 symbols long, at symbols
-// 0 / 38 / 76 / 114 / 152 (0-indexed).
+// 0 / 38 / 76 / 114 / 152 (0-indexed). Shared by every FST4 sub-mode —
+// `genfst4.f90` / `get_fst4_bitmetrics.f90` have no T/R-period branches.
 const FST4_SYNC_A: [u8; 8] = [0, 1, 3, 2, 1, 0, 2, 3];
 const FST4_SYNC_B: [u8; 8] = [2, 3, 1, 0, 3, 2, 0, 1];
 
@@ -149,9 +94,135 @@ const FST4_SYNC_BLOCKS: [SyncBlock; 5] = [
     },
 ];
 
+/// Define an FST4 sub-mode ZST with its `ModulationParams`,
+/// `FrameLayout` and `Protocol` impls. Every FST4 sub-mode shares
+/// NTONES, BITS_PER_SYMBOL, Gray map, GFSK BT/hmod, sync pattern, FEC,
+/// message codec, the 120-data/40-sync/160-total symbol layout, and the
+/// `rvec` message scramble (`fst4_params.f90` / `genfst4.f90` have no
+/// T/R-period branches) — only `NSPS` (⇒ `SYMBOL_DT` / `TONE_SPACING_HZ`),
+/// `NDOWN`, `T_SLOT_S`, and (for FST4-15 alone) `TX_START_OFFSET_S`
+/// differ, all taken directly from WSJT-X `fst4_decode.f90` /
+/// `fst4sim.f90`'s per-`ntrperiod` branches.
+macro_rules! fst4_submode {
+    (
+        $(#[$attr:meta])*
+        $name:ident,
+        nsps = $nsps:literal,
+        ndown = $ndown:literal,
+        tr_period_s = $period:literal,
+        tx_start_offset_s = $tx_start:literal,
+    ) => {
+        $(#[$attr])*
+        #[derive(Copy, Clone, Debug, Default)]
+        pub struct $name;
+
+        impl ModulationParams for $name {
+            const NTONES: u32 = 4;
+            const BITS_PER_SYMBOL: u32 = 2;
+            const NSPS: u32 = $nsps;
+            const SYMBOL_DT: f32 = ($nsps as f32) / 12_000.0;
+            const TONE_SPACING_HZ: f32 = 12_000.0 / ($nsps as f32);
+            const GRAY_MAP: &'static [u8] = &[0, 1, 3, 2];
+            /// BT=2.0 for every FST4 sub-mode (`gen_fst4wave.f90:37`
+            /// `gfsk_pulse(2.0,tt)`, unconditional on T/R period) —
+            /// matches FT8's `GFSK_BT`, not FT4's 1.0.
+            const GFSK_BT: f32 = 2.0;
+            const GFSK_HMOD: f32 = 1.0;
+            // NFFT window = 2 × NSPS (same convention as FT8) — longer
+            // windows don't help FST4 because the channel is assumed
+            // quasi-static across the slot.
+            const NFFT_PER_SYMBOL_FACTOR: u32 = 2;
+            // Half-symbol coarse grid (matches FT4 practice).
+            const NSTEP_PER_SYMBOL: u32 = 2;
+            const NDOWN: u32 = $ndown;
+            const INFO_SCRAMBLE_RVEC: Option<&'static [u8]> = Some(&FST4_RVEC);
+        }
+
+        impl FrameLayout for $name {
+            const N_DATA: u32 = 120;
+            const N_SYNC: u32 = 40; // 5 × 8
+            const N_SYMBOLS: u32 = 160;
+            const N_RAMP: u32 = 0; // GFSK synth handles ramp internally
+            const SYNC_MODE: SyncMode = SyncMode::Block(&FST4_SYNC_BLOCKS);
+            const T_SLOT_S: f32 = $period as f32;
+            const TX_START_OFFSET_S: f32 = $tx_start;
+        }
+
+        impl Protocol for $name {
+            /// LDPC(240, 101) + CRC-24 — see [`crate::fec::Ldpc240_101`].
+            type Fec = Ldpc240_101;
+            /// Same 77-bit WSJT message layout as FT8 / FT4 — fully reused.
+            type Msg = Wsjt77Message;
+            const ID: ProtocolId = ProtocolId::Fst4;
+        }
+    };
+}
+
+fst4_submode! {
+    /// FST4-15: 15 s T/R period, 16.667 Hz tone spacing (66.7 Hz
+    /// occupied). The fastest FST4 sub-mode; S/N threshold ≈ -20.7 dB.
+    /// WSJT-X `fst4_decode.f90` (`ntrperiod.eq.15`): `nsps=720`,
+    /// `ndown=18`. Uniquely among FST4 sub-modes, transmissions start
+    /// 0.5 s (not 1.0 s) after the slot boundary
+    /// (`fst4sim.f90`: `if(nsec.eq.15) k=nint((xdt+0.5)/dt)`;
+    /// `fst4_decode.f90`: `if(ntrperiod.eq.15) xdt=(isbest-real(nspsec)/2.0)/fs2`).
+    Fst4s15,
+    nsps = 720,
+    ndown = 18,
+    tr_period_s = 15,
+    tx_start_offset_s = 0.5,
+}
+
+fst4_submode! {
+    /// FST4-30: 30 s T/R period, 7.143 Hz tone spacing (28.6 Hz
+    /// occupied). S/N threshold ≈ -24.2 dB. WSJT-X `fst4_decode.f90`
+    /// (`ntrperiod.eq.30`): `nsps=1680`, `ndown=42`.
+    Fst4s30,
+    nsps = 1_680,
+    ndown = 42,
+    tr_period_s = 30,
+    tx_start_offset_s = 1.0,
+}
+
+fst4_submode! {
+    /// FST4-60A: 60 s T/R period, 3.0864 Hz tone spacing (12.35 Hz
+    /// occupied). The dominant terrestrial FST4 sub-mode; S/N
+    /// threshold ≈ -28.1 dB. WSJT-X `fst4_decode.f90`
+    /// (`ntrperiod.eq.60`): `nsps=3888`, `ndown=108`.
+    Fst4s60,
+    nsps = 3_888,
+    ndown = 108,
+    tr_period_s = 60,
+    tx_start_offset_s = 1.0,
+}
+
+fst4_submode! {
+    /// FST4-120: 120 s T/R period, 1.4634 Hz tone spacing (5.9 Hz
+    /// occupied). S/N threshold ≈ -31.3 dB. WSJT-X `fst4_decode.f90`
+    /// (`ntrperiod.eq.120`): `nsps=8200`, `ndown=205`.
+    Fst4s120,
+    nsps = 8_200,
+    ndown = 205,
+    tr_period_s = 120,
+    tx_start_offset_s = 1.0,
+}
+
+fst4_submode! {
+    /// FST4-300: 300 s (5 min) T/R period, 0.5580 Hz tone spacing
+    /// (2.2 Hz occupied). S/N threshold ≈ -35.3 dB. WSJT-X
+    /// `fst4_decode.f90` (`ntrperiod.eq.300`): `nsps=21504`,
+    /// `ndown=512`.
+    Fst4s300,
+    nsps = 21_504,
+    ndown = 512,
+    tr_period_s = 300,
+    tx_start_offset_s = 1.0,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::FecCodec;
 
     #[test]
     fn fst4s60_trait_surface() {
@@ -169,8 +240,145 @@ mod tests {
         );
         assert_eq!(blocks[0].pattern.len(), 8);
 
-        use crate::core::FecCodec;
         assert_eq!(<<Fst4s60 as Protocol>::Fec as FecCodec>::N, 240);
         assert_eq!(<<Fst4s60 as Protocol>::Fec as FecCodec>::K, 101);
+    }
+
+    /// Every sub-mode's WSJT-X-sourced `NSPS`/`NDOWN` from the
+    /// `fst4_decode.f90` per-`ntrperiod` branches, spot-checked
+    /// against the derived `SYMBOL_DT`/`TONE_SPACING_HZ` and against
+    /// `NSPS % NDOWN == 0` (the generic sync pipeline assumes an exact
+    /// downsampled-samples-per-symbol ratio).
+    #[test]
+    fn all_submodes_match_wsjtx_fst4_decode_f90() {
+        fn check<P: ModulationParams + FrameLayout>(
+            name: &str,
+            nsps: u32,
+            ndown: u32,
+            t_slot_s: f32,
+            tx_start_offset_s: f32,
+        ) {
+            assert_eq!(P::NSPS, nsps, "{name} NSPS");
+            assert_eq!(P::NDOWN, ndown, "{name} NDOWN");
+            assert_eq!(
+                P::NSPS % P::NDOWN,
+                0,
+                "{name}: NSPS must be an exact multiple of NDOWN"
+            );
+            assert!(
+                (P::SYMBOL_DT - nsps as f32 / 12_000.0).abs() < 1e-6,
+                "{name} SYMBOL_DT"
+            );
+            assert!(
+                (P::TONE_SPACING_HZ - 12_000.0 / nsps as f32).abs() < 1e-3,
+                "{name} TONE_SPACING_HZ"
+            );
+            assert_eq!(P::T_SLOT_S, t_slot_s, "{name} T_SLOT_S");
+            assert_eq!(
+                P::TX_START_OFFSET_S,
+                tx_start_offset_s,
+                "{name} TX_START_OFFSET_S"
+            );
+        }
+        check::<Fst4s15>("Fst4s15", 720, 18, 15.0, 0.5);
+        check::<Fst4s30>("Fst4s30", 1_680, 42, 30.0, 1.0);
+        check::<Fst4s60>("Fst4s60", 3_888, 108, 60.0, 1.0);
+        check::<Fst4s120>("Fst4s120", 8_200, 205, 120.0, 1.0);
+        check::<Fst4s300>("Fst4s300", 21_504, 512, 300.0, 1.0);
+    }
+
+    /// Every FST4 sub-mode MUST share the same frame structure, sync
+    /// pattern, GFSK shaping, and message scramble so the generic
+    /// tx/rx code can switch between them on the type parameter alone.
+    #[test]
+    fn all_submodes_share_frame_layout_and_fec() {
+        fn check<P: ModulationParams + FrameLayout + Protocol>(name: &str) {
+            assert_eq!(P::N_DATA, 120, "{name} N_DATA");
+            assert_eq!(P::N_SYNC, 40, "{name} N_SYNC");
+            assert_eq!(P::N_SYMBOLS, 160, "{name} N_SYMBOLS");
+            assert_eq!(P::GFSK_BT, 2.0, "{name} GFSK_BT");
+            assert_eq!(P::GFSK_HMOD, 1.0, "{name} GFSK_HMOD");
+            assert_eq!(P::GRAY_MAP, &[0, 1, 3, 2], "{name} GRAY_MAP");
+            assert_eq!(<P::Fec as FecCodec>::N, 240, "{name} Fec::N");
+            assert_eq!(<P::Fec as FecCodec>::K, 101, "{name} Fec::K");
+            assert_eq!(P::ID, ProtocolId::Fst4, "{name} ID");
+            match P::SYNC_MODE {
+                SyncMode::Block(blocks) => assert_eq!(blocks.len(), 5, "{name} sync blocks"),
+                SyncMode::Interleaved { .. } => panic!("{name}: FST4 must use Block sync"),
+            }
+        }
+        check::<Fst4s15>("Fst4s15");
+        check::<Fst4s30>("Fst4s30");
+        check::<Fst4s60>("Fst4s60");
+        check::<Fst4s120>("Fst4s120");
+        check::<Fst4s300>("Fst4s300");
+    }
+
+    /// Cross-checks every sub-mode's `DownsampleCfg` / `GfskCfg`
+    /// (hand-picked `fft1_size`/`fft2_size`/`tone_spacing_hz` and
+    /// `samples_per_symbol`/`ramp_samples` respectively) against the
+    /// `ModulationParams`/`FrameLayout` trait constants they must
+    /// stay consistent with. Guards against exactly the class of
+    /// silent transcription bug that caused issue #23 in the first
+    /// place: a hand-typed constant in `decode.rs`/`encode.rs` that
+    /// quietly drifts from the ZST it's paired with.
+    #[test]
+    fn downsample_and_gfsk_configs_match_submode_constants() {
+        use crate::core::dsp::downsample::DownsampleCfg;
+        use crate::core::dsp::gfsk::GfskCfg;
+
+        fn check_downsample<P: ModulationParams + FrameLayout>(name: &str, cfg: &DownsampleCfg) {
+            let ndown = P::NDOWN as usize;
+            assert_eq!(
+                cfg.fft1_size % ndown,
+                0,
+                "{name}: fft1_size {} not divisible by NDOWN {ndown}",
+                cfg.fft1_size
+            );
+            assert_eq!(
+                cfg.fft1_size / ndown,
+                cfg.fft2_size,
+                "{name}: fft1_size/NDOWN != fft2_size"
+            );
+            let nmax = (P::T_SLOT_S * 12_000.0).round() as usize;
+            assert!(
+                cfg.fft1_size >= nmax,
+                "{name}: fft1_size {} < nmax {nmax} (slot won't fit)",
+                cfg.fft1_size
+            );
+            assert!(
+                (cfg.tone_spacing_hz - P::TONE_SPACING_HZ).abs() < 1e-3,
+                "{name}: cfg.tone_spacing_hz {} != ModulationParams::TONE_SPACING_HZ {}",
+                cfg.tone_spacing_hz,
+                P::TONE_SPACING_HZ
+            );
+        }
+
+        fn check_gfsk<P: ModulationParams>(name: &str, cfg: &GfskCfg) {
+            assert_eq!(
+                cfg.samples_per_symbol as u32,
+                P::NSPS,
+                "{name}: gfsk samples_per_symbol != NSPS"
+            );
+            assert_eq!(cfg.bt, P::GFSK_BT, "{name}: gfsk bt != GFSK_BT");
+            assert_eq!(cfg.hmod, P::GFSK_HMOD, "{name}: gfsk hmod != GFSK_HMOD");
+            assert_eq!(
+                cfg.ramp_samples as u32,
+                P::NSPS / 8,
+                "{name}: gfsk ramp_samples != NSPS/8"
+            );
+        }
+
+        check_downsample::<Fst4s15>("Fst4s15", &decode::FST4_15_DOWNSAMPLE);
+        check_downsample::<Fst4s30>("Fst4s30", &decode::FST4_30_DOWNSAMPLE);
+        check_downsample::<Fst4s60>("Fst4s60", &decode::FST4_60A_DOWNSAMPLE);
+        check_downsample::<Fst4s120>("Fst4s120", &decode::FST4_120_DOWNSAMPLE);
+        check_downsample::<Fst4s300>("Fst4s300", &decode::FST4_300_DOWNSAMPLE);
+
+        check_gfsk::<Fst4s15>("Fst4s15", &encode::FST4_15_GFSK);
+        check_gfsk::<Fst4s30>("Fst4s30", &encode::FST4_30_GFSK);
+        check_gfsk::<Fst4s60>("Fst4s60", &encode::FST4_60A_GFSK);
+        check_gfsk::<Fst4s120>("Fst4s120", &encode::FST4_120_GFSK);
+        check_gfsk::<Fst4s300>("Fst4s300", &encode::FST4_300_GFSK);
     }
 }

--- a/mfsk-core/src/registry.rs
+++ b/mfsk-core/src/registry.rs
@@ -35,6 +35,15 @@
 //! / `T_SLOT_S` differ; they share `ProtocolId::Q65` because the FFI
 //! protocol tag is family-level. [`by_id`] returns *all* entries
 //! sharing a given id, so a Q65 lookup yields six metadata records.
+//!
+//! ## FST4 sub-modes
+//!
+//! Same story as Q65: all five wired FST4 T/R-period sub-modes
+//! (FST4-15, -30, -60A, -120, -300) share `ProtocolId::Fst4`.
+//! FST4-60A is listed first (ahead of FST4-15, even though 15 < 60)
+//! so [`for_protocol_id`]`(ProtocolId::Fst4)` keeps returning the
+//! dominant terrestrial sub-mode as the default — this is one of the
+//! rare spots where entry order *is* load-bearing.
 
 // These imports look unused when *every* protocol feature is off
 // (the `protocol_meta!` invocations that consume them all gate on a
@@ -137,8 +146,21 @@ pub static PROTOCOLS: &[ProtocolMeta] = &[
     protocol_meta!("FT8", crate::Ft8),
     #[cfg(feature = "ft4")]
     protocol_meta!("FT4", crate::Ft4),
+    // FST4-60A stays first among the FST4 entries — it's the dominant
+    // terrestrial sub-mode and `by_id`/`for_protocol_id` return the
+    // *first* matching entry, so this preserves the pre-existing
+    // "FST4-60A is the default FST4" behaviour for callers that don't
+    // care about sub-mode.
     #[cfg(feature = "fst4")]
     protocol_meta!("FST4-60A", crate::Fst4s60),
+    #[cfg(feature = "fst4")]
+    protocol_meta!("FST4-15", crate::fst4::Fst4s15),
+    #[cfg(feature = "fst4")]
+    protocol_meta!("FST4-30", crate::fst4::Fst4s30),
+    #[cfg(feature = "fst4")]
+    protocol_meta!("FST4-120", crate::fst4::Fst4s120),
+    #[cfg(feature = "fst4")]
+    protocol_meta!("FST4-300", crate::fst4::Fst4s300),
     #[cfg(feature = "wspr")]
     protocol_meta!("WSPR", crate::Wspr),
     #[cfg(feature = "jt9")]
@@ -268,5 +290,36 @@ mod tests {
                 "Q65 registry missing sub-mode {expected}; have {names:?}"
             );
         }
+    }
+
+    #[cfg(feature = "fst4")]
+    #[test]
+    fn fst4_id_yields_all_five_submodes() {
+        let fst4_entries: Vec<&ProtocolMeta> = by_id(ProtocolId::Fst4).collect();
+        assert_eq!(
+            fst4_entries.len(),
+            5,
+            "expected five FST4 sub-modes in the registry, got {}: {:?}",
+            fst4_entries.len(),
+            fst4_entries.iter().map(|p| p.name).collect::<Vec<_>>()
+        );
+        let names: Vec<&str> = fst4_entries.iter().map(|p| p.name).collect();
+        for expected in &["FST4-15", "FST4-30", "FST4-60A", "FST4-120", "FST4-300"] {
+            assert!(
+                names.contains(expected),
+                "FST4 registry missing sub-mode {expected}; have {names:?}"
+            );
+        }
+    }
+
+    #[cfg(feature = "fst4")]
+    #[test]
+    fn for_protocol_id_defaults_to_fst4_60a() {
+        // FST4-60A must stay the default entry (order-dependent — see
+        // the "FST4 sub-modes" module doc section) since it's the
+        // dominant terrestrial sub-mode and pre-existing callers rely
+        // on `for_protocol_id(Fst4)` resolving to it.
+        let meta = for_protocol_id(ProtocolId::Fst4).expect("fst4 feature is on");
+        assert_eq!(meta.name, "FST4-60A");
     }
 }

--- a/mfsk-core/tests/fst4_sim_roundtrip.rs
+++ b/mfsk-core/tests/fst4_sim_roundtrip.rs
@@ -1,0 +1,213 @@
+//! FST4 round-trip validation against `fst4sim`-generated AWGN signals.
+//!
+//! `fst4sim` is the canonical WSJT-X signal generator (Fortran, from
+//! `WSJT-X/lib/fst4/fst4sim.f90`).  Each WAV was produced with:
+//!
+//! ```text
+//! fst4sim "CQ JL1NIE PM95" <nsec> 1500 0.0 0.0 0.0 1 -5 F
+//! ```
+//!
+//! (no fading, SNR = -5 dB, f0 = 1500 Hz, DT = 0.0 s)
+//!
+//! WAVs live in `embedded-poc/assets/fst4_sim/` and are skipped cleanly
+//! when absent.  Regenerate them with:
+//!
+//! ```sh
+//! scripts/build_fst4sim.sh   # once, needs gfortran
+//! scripts/gen_fst4_sim_wavs.sh
+//! ```
+//!
+//! ## Adding a new sub-mode
+//!
+//! 1. Add a `Fst4sNNN` struct in `mfsk_core::fst4` with the correct
+//!    `NSPS` / `NDOWN` / `TX_START_OFFSET_S` (see constants below).
+//! 2. Add a `decode_frameNNN` function (or make the generic pipeline
+//!    callable with the new struct).
+//! 3. Uncomment / add the corresponding test below.
+//!
+//! ## Reference WSJT-X parameters for all sub-modes
+//!
+//! | Mode      | NSPS  | NDOWN | TX_START_OFFSET_S | baud    |
+//! |-----------|-------|-------|-------------------|---------|
+//! | FST4-15   |   720 |    18 | 0.5               | 16.667  |
+//! | FST4-30   |  1680 |    42 | 1.0               |  7.143  |
+//! | FST4-60   |  3888 |   108 | 1.0               |  3.086  |
+//! | FST4-120  |  8200 |   205 | 1.0               |  1.463  |
+//! | FST4-300  | 21504 |   512 | 1.0               |  0.558  |
+//!
+//! Source: `fst4_decode.f90` (ndown per ntrperiod) and `fst4sim.f90`
+//! (TX_START_OFFSET: nsec==15 uses k=xdt+0.5, others k=xdt+1.0).
+
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+
+const GOLDEN_MSG: &str = "CQ JL1NIE PM95";
+const GOLDEN_FREQ_HZ: f32 = 1500.0;
+/// fst4sim uses DT=0.0 → signal starts at TX_START_OFFSET_S into the slot.
+const GOLDEN_DT_SEC: f32 = 0.0;
+const FREQ_TOL_HZ: f32 = 4.0;
+const DT_TOL_SEC: f32 = 0.5;
+
+fn sim_asset_dir() -> PathBuf {
+    // Allow override via env; fall back to the in-repo location.
+    if let Ok(d) = std::env::var("MFSK_FST4_SIM_ASSETS_DIR") {
+        return PathBuf::from(d);
+    }
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    Path::new(&manifest)
+        .join("../embedded-poc/assets/fst4_sim")
+        .to_path_buf()
+}
+
+fn sim_wav(nsec: u32) -> Option<Vec<i16>> {
+    let path = sim_asset_dir().join(format!("fst4_{}_sim.wav", nsec));
+    load_wav_i16_opt(&path)
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FST4-60 (existing sub-mode, always exercised)
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fst4_60_sim_roundtrip() {
+    use mfsk_core::fst4::decode::decode_frame;
+    use mfsk_core::msg::wsjt77::unpack77;
+
+    let Some(audio) = sim_wav(60) else {
+        eprintln!(
+            "skipping fst4_60_sim_roundtrip: WAV not found in {:?}\n\
+             Run scripts/build_fst4sim.sh && scripts/gen_fst4_sim_wavs.sh",
+            sim_asset_dir()
+        );
+        return;
+    };
+
+    let decodes = decode_frame(&audio, 100.0, 3000.0, 0.8, 50);
+    let decoded: Vec<(String, f32, f32)> = decodes
+        .iter()
+        .filter_map(|d| {
+            let mut m77 = [0u8; 77];
+            m77.copy_from_slice(d.message77());
+            unpack77(&m77).map(|s| (s, d.freq_hz, d.dt_sec))
+        })
+        .collect();
+
+    eprintln!("FST4-60 sim decoded {} message(s):", decoded.len());
+    for (m, f, dt) in &decoded {
+        eprintln!("  {:7.1} Hz  dt={:+.2} s  {}", f, dt, m);
+    }
+
+    let hit = decoded.iter().any(|(m, f, dt)| {
+        m == GOLDEN_MSG
+            && (f - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ
+            && (dt - GOLDEN_DT_SEC).abs() <= DT_TOL_SEC
+    });
+    assert!(
+        hit,
+        "FST4-60 fst4sim roundtrip: '{}' @ {:.0} Hz not found in {:?}",
+        GOLDEN_MSG, GOLDEN_FREQ_HZ, decoded
+    );
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FST4-15
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fst4_15_sim_roundtrip() {
+    use mfsk_core::fst4::decode::{FST4_15_DOWNSAMPLE, decode_frame_for};
+    use mfsk_core::fst4::Fst4s15;
+
+    let Some(audio) = sim_wav(15) else {
+        eprintln!("skipping fst4_15_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
+        return;
+    };
+    let decodes = decode_frame_for::<Fst4s15>(&audio, &FST4_15_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
+    check_golden_hit(15, &decodes);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FST4-30
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fst4_30_sim_roundtrip() {
+    use mfsk_core::fst4::decode::{FST4_30_DOWNSAMPLE, decode_frame_for};
+    use mfsk_core::fst4::Fst4s30;
+
+    let Some(audio) = sim_wav(30) else {
+        eprintln!("skipping fst4_30_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
+        return;
+    };
+    let decodes = decode_frame_for::<Fst4s30>(&audio, &FST4_30_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
+    check_golden_hit(30, &decodes);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FST4-120
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fst4_120_sim_roundtrip() {
+    use mfsk_core::fst4::decode::{FST4_120_DOWNSAMPLE, decode_frame_for};
+    use mfsk_core::fst4::Fst4s120;
+
+    let Some(audio) = sim_wav(120) else {
+        eprintln!("skipping fst4_120_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
+        return;
+    };
+    let decodes = decode_frame_for::<Fst4s120>(&audio, &FST4_120_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
+    check_golden_hit(120, &decodes);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// FST4-300
+// ────────────────────────────────────────────────────────────────────────────
+
+#[test]
+fn fst4_300_sim_roundtrip() {
+    use mfsk_core::fst4::decode::{FST4_300_DOWNSAMPLE, decode_frame_for};
+    use mfsk_core::fst4::Fst4s300;
+
+    let Some(audio) = sim_wav(300) else {
+        eprintln!("skipping fst4_300_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
+        return;
+    };
+    let decodes = decode_frame_for::<Fst4s300>(&audio, &FST4_300_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
+    check_golden_hit(300, &decodes);
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Shared assertion helper
+// ────────────────────────────────────────────────────────────────────────────
+
+fn check_golden_hit(nsec: u32, decodes: &[mfsk_core::fst4::decode::DecodeResult]) {
+    use mfsk_core::msg::wsjt77::unpack77;
+    let decoded: Vec<(String, f32, f32)> = decodes
+        .iter()
+        .filter_map(|d| {
+            let mut m77 = [0u8; 77];
+            m77.copy_from_slice(d.message77());
+            unpack77(&m77).map(|s| (s, d.freq_hz, d.dt_sec))
+        })
+        .collect();
+    eprintln!("FST4-{} sim decoded {} message(s):", nsec, decoded.len());
+    for (m, f, dt) in &decoded {
+        eprintln!("  {:7.1} Hz  dt={:+.2} s  {}", f, dt, m);
+    }
+    let hit = decoded.iter().any(|(m, f, dt)| {
+        m == GOLDEN_MSG
+            && (f - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ
+            && (dt - GOLDEN_DT_SEC).abs() <= DT_TOL_SEC
+    });
+    assert!(
+        hit,
+        "FST4-{} fst4sim roundtrip: '{}' @ {:.0} Hz not found in {:?}",
+        nsec, GOLDEN_MSG, GOLDEN_FREQ_HZ, decoded
+    );
+}

--- a/mfsk-core/tests/fst4_sim_roundtrip.rs
+++ b/mfsk-core/tests/fst4_sim_roundtrip.rs
@@ -120,8 +120,8 @@ fn fst4_60_sim_roundtrip() {
 
 #[test]
 fn fst4_15_sim_roundtrip() {
-    use mfsk_core::fst4::decode::{FST4_15_DOWNSAMPLE, decode_frame_for};
     use mfsk_core::fst4::Fst4s15;
+    use mfsk_core::fst4::decode::{FST4_15_DOWNSAMPLE, decode_frame_for};
 
     let Some(audio) = sim_wav(15) else {
         eprintln!("skipping fst4_15_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
@@ -137,8 +137,8 @@ fn fst4_15_sim_roundtrip() {
 
 #[test]
 fn fst4_30_sim_roundtrip() {
-    use mfsk_core::fst4::decode::{FST4_30_DOWNSAMPLE, decode_frame_for};
     use mfsk_core::fst4::Fst4s30;
+    use mfsk_core::fst4::decode::{FST4_30_DOWNSAMPLE, decode_frame_for};
 
     let Some(audio) = sim_wav(30) else {
         eprintln!("skipping fst4_30_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
@@ -154,14 +154,15 @@ fn fst4_30_sim_roundtrip() {
 
 #[test]
 fn fst4_120_sim_roundtrip() {
-    use mfsk_core::fst4::decode::{FST4_120_DOWNSAMPLE, decode_frame_for};
     use mfsk_core::fst4::Fst4s120;
+    use mfsk_core::fst4::decode::{FST4_120_DOWNSAMPLE, decode_frame_for};
 
     let Some(audio) = sim_wav(120) else {
         eprintln!("skipping fst4_120_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
         return;
     };
-    let decodes = decode_frame_for::<Fst4s120>(&audio, &FST4_120_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
+    let decodes =
+        decode_frame_for::<Fst4s120>(&audio, &FST4_120_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
     check_golden_hit(120, &decodes);
 }
 
@@ -171,14 +172,15 @@ fn fst4_120_sim_roundtrip() {
 
 #[test]
 fn fst4_300_sim_roundtrip() {
-    use mfsk_core::fst4::decode::{FST4_300_DOWNSAMPLE, decode_frame_for};
     use mfsk_core::fst4::Fst4s300;
+    use mfsk_core::fst4::decode::{FST4_300_DOWNSAMPLE, decode_frame_for};
 
     let Some(audio) = sim_wav(300) else {
         eprintln!("skipping fst4_300_sim_roundtrip: run scripts/gen_fst4_sim_wavs.sh");
         return;
     };
-    let decodes = decode_frame_for::<Fst4s300>(&audio, &FST4_300_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
+    let decodes =
+        decode_frame_for::<Fst4s300>(&audio, &FST4_300_DOWNSAMPLE, 100.0, 3000.0, 0.8, 50);
     check_golden_hit(300, &decodes);
 }
 

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -95,11 +95,31 @@ struct SweepMode {
 }
 
 const MODES: &[SweepMode] = &[
-    SweepMode { nsec: 15,  decode: decode_wav_fst4_15,  enabled: true },
-    SweepMode { nsec: 30,  decode: decode_wav_fst4_30,  enabled: true },
-    SweepMode { nsec: 60,  decode: decode_wav_fst4_60,  enabled: true },
-    SweepMode { nsec: 120, decode: decode_wav_fst4_120, enabled: true },
-    SweepMode { nsec: 300, decode: decode_wav_fst4_300, enabled: true },
+    SweepMode {
+        nsec: 15,
+        decode: decode_wav_fst4_15,
+        enabled: true,
+    },
+    SweepMode {
+        nsec: 30,
+        decode: decode_wav_fst4_30,
+        enabled: true,
+    },
+    SweepMode {
+        nsec: 60,
+        decode: decode_wav_fst4_60,
+        enabled: true,
+    },
+    SweepMode {
+        nsec: 120,
+        decode: decode_wav_fst4_120,
+        enabled: true,
+    },
+    SweepMode {
+        nsec: 300,
+        decode: decode_wav_fst4_300,
+        enabled: true,
+    },
 ];
 
 // ── Filename parsing ─────────────────────────────────────────────────────────
@@ -160,7 +180,13 @@ fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
         };
         // channel = everything between nsec and snr_tag
         let channel = parts[2..parts.len() - 2].join("_");
-        out.push(WavMeta { nsec, channel, snr_db, trial, path });
+        out.push(WavMeta {
+            nsec,
+            channel,
+            snr_db,
+            trial,
+            path,
+        });
     }
     // Sort: mode → channel → snr desc → trial
     out.sort_by_key(|m| (m.nsec, m.channel.clone(), -m.snr_db, m.trial));
@@ -193,9 +219,9 @@ fn fst4_snr_sweep() {
 
     // Group WAVs by (nsec, channel, snr_db) so we can parallelise within each
     // group and print each row immediately when the group finishes.
-    use std::collections::BTreeMap;
     #[cfg(feature = "parallel")]
     use rayon::prelude::*;
+    use std::collections::BTreeMap;
 
     let mut groups: BTreeMap<(u32, String, i32), Vec<&WavMeta>> = BTreeMap::new();
     for wav in &wavs {

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -211,7 +211,10 @@ fn fst4_snr_sweep() {
     }
 
     eprintln!("\n{:-<72}", "");
-    eprintln!("  {:<10} {:<14} {:>7}   {:>6}  Bar", "Mode", "Channel", "SNR(dB)", "Recall");
+    eprintln!(
+        "  {:<10} {:<14} {:>7}   {:>6}  Bar",
+        "Mode", "Channel", "SNR(dB)", "Recall"
+    );
     eprintln!("{:-<72}", "");
 
     // Group WAVs by (nsec, channel, snr_db) so we can parallelise within each

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -1,0 +1,256 @@
+//! FST4 SNR sweep + fading benchmark against `fst4sim`-generated signals.
+//!
+//! This test is `#[ignore]` — run it manually before merging a new sub-mode:
+//!
+//! ```sh
+//! # 1. Generate WAVs (once, or when adding a new mode/channel):
+//! scripts/build_fst4sim.sh
+//! scripts/gen_fst4_sweep_wavs.sh
+//!
+//! # 2. Run the sweep (all currently-wired modes):
+//! MFSK_FST4_SWEEP_DIR=embedded-poc/assets/fst4_sweep \
+//!   cargo test --test fst4_sweep --release --features fst4,fft-rustfft,parallel \
+//!   -- --ignored --nocapture
+//! ```
+//!
+//! Output is a recall table — no assertions, statistics only.
+//! Add a new sub-mode by:
+//!   1. Implementing `Fst4sNNN` + `decode_frameNNN` in `mfsk_core::fst4`.
+//!   2. Adding a `SweepMode` entry to `MODES` below.
+//!   3. Uncommenting `decode_frameNNN` in the dispatch block.
+
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+use mfsk_core::msg::wsjt77::unpack77;
+
+const GOLDEN_MSG: &str = "CQ JL1NIE PM95";
+const GOLDEN_FREQ_HZ: f32 = 1500.0;
+const FREQ_TOL_HZ: f32 = 5.0;
+const DT_TOL_SEC: f32 = 0.6;
+
+fn sweep_dir() -> PathBuf {
+    if let Ok(d) = std::env::var("MFSK_FST4_SWEEP_DIR") {
+        return PathBuf::from(d);
+    }
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    Path::new(&manifest)
+        .join("../embedded-poc/assets/fst4_sweep")
+        .to_path_buf()
+}
+
+// ── Channel conditions (must match gen_fst4_sweep_wavs.sh CHANNELS) ─────────
+#[allow(dead_code)]
+const CHANNELS: &[&str] = &["awgn", "ccir_good", "ccir_moderate", "ccir_poor"];
+
+// ── Per-mode decode dispatch ─────────────────────────────────────────────────
+
+fn decode_wav_fst4<P>(audio: &[i16], cfg: &mfsk_core::core::dsp::downsample::DownsampleCfg) -> bool
+where
+    P: mfsk_core::core::Protocol,
+{
+    use mfsk_core::fst4::decode::decode_frame_for;
+    decode_frame_for::<P>(audio, cfg, 100.0, 3000.0, 0.8, 50)
+        .iter()
+        .any(|d| {
+            let mut m77 = [0u8; 77];
+            m77.copy_from_slice(d.message77());
+            unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                && (d.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ
+                && d.dt_sec.abs() <= DT_TOL_SEC
+        })
+}
+
+fn decode_wav_fst4_15(audio: &[i16]) -> bool {
+    use mfsk_core::fst4::{Fst4s15, decode::FST4_15_DOWNSAMPLE};
+    decode_wav_fst4::<Fst4s15>(audio, &FST4_15_DOWNSAMPLE)
+}
+fn decode_wav_fst4_30(audio: &[i16]) -> bool {
+    use mfsk_core::fst4::{Fst4s30, decode::FST4_30_DOWNSAMPLE};
+    decode_wav_fst4::<Fst4s30>(audio, &FST4_30_DOWNSAMPLE)
+}
+fn decode_wav_fst4_60(audio: &[i16]) -> bool {
+    use mfsk_core::fst4::{Fst4s60, decode::FST4_60A_DOWNSAMPLE};
+    decode_wav_fst4::<Fst4s60>(audio, &FST4_60A_DOWNSAMPLE)
+}
+fn decode_wav_fst4_120(audio: &[i16]) -> bool {
+    use mfsk_core::fst4::{Fst4s120, decode::FST4_120_DOWNSAMPLE};
+    decode_wav_fst4::<Fst4s120>(audio, &FST4_120_DOWNSAMPLE)
+}
+fn decode_wav_fst4_300(audio: &[i16]) -> bool {
+    use mfsk_core::fst4::{Fst4s300, decode::FST4_300_DOWNSAMPLE};
+    decode_wav_fst4::<Fst4s300>(audio, &FST4_300_DOWNSAMPLE)
+}
+
+// ── Mode table ───────────────────────────────────────────────────────────────
+
+struct SweepMode {
+    nsec: u32,
+    decode: fn(&[i16]) -> bool,
+    enabled: bool,
+}
+
+const MODES: &[SweepMode] = &[
+    SweepMode { nsec: 15,  decode: decode_wav_fst4_15,  enabled: true },
+    SweepMode { nsec: 30,  decode: decode_wav_fst4_30,  enabled: true },
+    SweepMode { nsec: 60,  decode: decode_wav_fst4_60,  enabled: true },
+    SweepMode { nsec: 120, decode: decode_wav_fst4_120, enabled: true },
+    SweepMode { nsec: 300, decode: decode_wav_fst4_300, enabled: true },
+];
+
+// ── Filename parsing ─────────────────────────────────────────────────────────
+
+/// Parse `fst4_<nsec>_<channel>_<snr_tag>_<trial>.wav`.
+/// snr_tag: `m05` = -5, `p05` = +5.
+fn parse_snr_tag(tag: &str) -> Option<i32> {
+    if let Some(rest) = tag.strip_prefix('m') {
+        rest.parse::<i32>().ok().map(|v| -v)
+    } else if let Some(rest) = tag.strip_prefix('p') {
+        rest.parse::<i32>().ok()
+    } else {
+        None
+    }
+}
+
+struct WavMeta {
+    nsec: u32,
+    channel: String,
+    snr_db: i32,
+    #[allow(dead_code)]
+    trial: u32,
+    path: PathBuf,
+}
+
+fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        // fst4_60_awgn_m05_01
+        let parts: Vec<&str> = stem.split('_').collect();
+        if parts.len() < 5 || parts[0] != "fst4" {
+            continue;
+        }
+        let nsec: u32 = match parts[1].parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        // channel may contain underscore: hf_quiet → parts[2]_parts[3]
+        // We parse from the right: last field = trial, second-to-last = snr_tag
+        let trial: u32 = match parts.last().and_then(|s| s.parse().ok()) {
+            Some(v) => v,
+            None => continue,
+        };
+        let snr_tag = parts[parts.len() - 2];
+        let snr_db = match parse_snr_tag(snr_tag) {
+            Some(v) => v,
+            None => continue,
+        };
+        // channel = everything between nsec and snr_tag
+        let channel = parts[2..parts.len() - 2].join("_");
+        out.push(WavMeta { nsec, channel, snr_db, trial, path });
+    }
+    // Sort: mode → channel → snr desc → trial
+    out.sort_by_key(|m| (m.nsec, m.channel.clone(), -m.snr_db, m.trial));
+    out
+}
+
+// ── Main sweep test ──────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "manual pre-merge benchmark — run with --ignored --nocapture"]
+fn fst4_snr_sweep() {
+    let dir = sweep_dir();
+    let wavs = collect_wavs(&dir);
+
+    if wavs.is_empty() {
+        eprintln!(
+            "No WAVs found in {:?}\n\
+             Run: scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh",
+            dir
+        );
+        return;
+    }
+
+    eprintln!("\n{:-<72}", "");
+    eprintln!(
+        "  {:<10} {:<14} {:>7}   {:>6}  {}",
+        "Mode", "Channel", "SNR(dB)", "Recall", "Bar"
+    );
+    eprintln!("{:-<72}", "");
+
+    // Group WAVs by (nsec, channel, snr_db) so we can parallelise within each
+    // group and print each row immediately when the group finishes.
+    use std::collections::BTreeMap;
+    #[cfg(feature = "parallel")]
+    use rayon::prelude::*;
+
+    let mut groups: BTreeMap<(u32, String, i32), Vec<&WavMeta>> = BTreeMap::new();
+    for wav in &wavs {
+        if MODES.iter().any(|m| m.nsec == wav.nsec && m.enabled) {
+            groups
+                .entry((wav.nsec, wav.channel.clone(), wav.snr_db))
+                .or_default()
+                .push(wav);
+        }
+    }
+
+    let mut last_mode_chan: Option<(u32, String)> = None;
+    for ((nsec, chan, snr), wav_group) in &groups {
+        let decode_fn = MODES
+            .iter()
+            .find(|m| m.nsec == *nsec && m.enabled)
+            .map(|m| m.decode)
+            .unwrap(); // safe: we filtered above
+
+        #[cfg(feature = "parallel")]
+        let results: Vec<bool> = wav_group
+            .par_iter()
+            .filter_map(|wav| load_wav_i16_opt(&wav.path).map(|audio| decode_fn(&audio)))
+            .collect();
+
+        #[cfg(not(feature = "parallel"))]
+        let results: Vec<bool> = wav_group
+            .iter()
+            .filter_map(|wav| load_wav_i16_opt(&wav.path).map(|audio| decode_fn(&audio)))
+            .collect();
+
+        let trials = results.len() as u32;
+        if trials == 0 {
+            continue;
+        }
+        let hits = results.iter().filter(|&&h| h).count() as u32;
+
+        let mode_chan = (*nsec, chan.clone());
+        if Some(&mode_chan) != last_mode_chan.as_ref() {
+            eprintln!("{:-<72}", "");
+            last_mode_chan = Some(mode_chan);
+        }
+        let pct = hits as f32 / trials as f32 * 100.0;
+        let bar_len = (hits as usize * 20).div_ceil(trials as usize);
+        let bar = format!("{}{}", "#".repeat(bar_len), ".".repeat(20 - bar_len));
+        eprintln!(
+            "  FST4-{:<4}  {:<14}  {:>4} dB   {:>2}/{:<2}  [{}]  {:4.0}%",
+            nsec, chan, snr, hits, trials, bar, pct
+        );
+    }
+    eprintln!("{:-<72}", "");
+    eprintln!(
+        "\nChannels (ITU-R Watterson): awgn=no fading | \
+         ccir_good=fdop 0.1Hz/del 0.5ms | \
+         ccir_moderate=0.5/1.0 | ccir_poor=1.0/2.0"
+    );
+    eprintln!("(Disabled modes show no rows — enable by wiring decode fn in MODES[])\n");
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -211,10 +211,7 @@ fn fst4_snr_sweep() {
     }
 
     eprintln!("\n{:-<72}", "");
-    eprintln!(
-        "  {:<10} {:<14} {:>7}   {:>6}  {}",
-        "Mode", "Channel", "SNR(dB)", "Recall", "Bar"
-    );
+    eprintln!("  {:<10} {:<14} {:>7}   {:>6}  Bar", "Mode", "Channel", "SNR(dB)", "Recall");
     eprintln!("{:-<72}", "");
 
     // Group WAVs by (nsec, channel, snr_db) so we can parallelise within each

--- a/mfsk-core/tests/protocol_invariants.rs
+++ b/mfsk-core/tests/protocol_invariants.rs
@@ -49,6 +49,8 @@ use mfsk_core::Jt9;
 use mfsk_core::Jt65;
 #[cfg(feature = "wspr")]
 use mfsk_core::Wspr;
+#[cfg(feature = "fst4")]
+use mfsk_core::fst4::{Fst4s15, Fst4s30, Fst4s120, Fst4s300};
 
 #[cfg(feature = "q65")]
 use mfsk_core::q65::{Q65a30, Q65a60, Q65b60, Q65c60, Q65d60, Q65e60};
@@ -270,6 +272,21 @@ fn fst4s60_satisfies_protocol_invariants() {
     assert_protocol_invariants::<Fst4s60>("Fst4s60");
 }
 
+#[cfg(feature = "fst4")]
+#[test]
+fn fst4_other_submodes_satisfy_protocol_invariants() {
+    // The other four T/R-period sub-modes share frame layout, FEC,
+    // message format, and GFSK shaping with Fst4s60, so they must
+    // satisfy the same invariants — running them through the same
+    // generic asserter pins that sub-mode-only changes (NSPS, NDOWN,
+    // TX_START_OFFSET_S for FST4-15) don't accidentally break the
+    // contract.
+    assert_protocol_invariants::<Fst4s15>("Fst4s15");
+    assert_protocol_invariants::<Fst4s30>("Fst4s30");
+    assert_protocol_invariants::<Fst4s120>("Fst4s120");
+    assert_protocol_invariants::<Fst4s300>("Fst4s300");
+}
+
 #[cfg(feature = "wspr")]
 #[test]
 fn wspr_satisfies_protocol_invariants() {
@@ -445,7 +462,13 @@ fn registry_entries_match_zst_trait_constants() {
     #[cfg(feature = "ft4")]
     check!("FT4", Ft4);
     #[cfg(feature = "fst4")]
-    check!("FST4-60A", Fst4s60);
+    {
+        check!("FST4-60A", Fst4s60);
+        check!("FST4-15", Fst4s15);
+        check!("FST4-30", Fst4s30);
+        check!("FST4-120", Fst4s120);
+        check!("FST4-300", Fst4s300);
+    }
     #[cfg(feature = "wspr")]
     check!("WSPR", Wspr);
     #[cfg(feature = "jt9")]
@@ -495,7 +518,7 @@ fn registry_size_matches_wired_protocols() {
     }
     #[cfg(feature = "fst4")]
     {
-        expected += 1;
+        expected += 5;
     }
     #[cfg(feature = "wspr")]
     {
@@ -547,7 +570,16 @@ fn every_wired_protocol_has_a_unique_protocol_id() {
     #[cfg(feature = "ft4")]
     ids.push(("Ft4", <Ft4 as Protocol>::ID));
     #[cfg(feature = "fst4")]
-    ids.push(("Fst4s60", <Fst4s60 as Protocol>::ID));
+    {
+        // Every FST4 sub-mode shares the same ProtocolId::Fst4 —
+        // that's by design (the sub-mode is below the FFI
+        // granularity), same rationale as Q65.
+        ids.push(("Fst4s60", <Fst4s60 as Protocol>::ID));
+        ids.push(("Fst4s15", <Fst4s15 as Protocol>::ID));
+        ids.push(("Fst4s30", <Fst4s30 as Protocol>::ID));
+        ids.push(("Fst4s120", <Fst4s120 as Protocol>::ID));
+        ids.push(("Fst4s300", <Fst4s300 as Protocol>::ID));
+    }
     #[cfg(feature = "wspr")]
     ids.push(("Wspr", <Wspr as Protocol>::ID));
     #[cfg(feature = "jt9")]

--- a/scripts/build_fst4sim.sh
+++ b/scripts/build_fst4sim.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Build fst4sim from WSJT-X Fortran sources.
+#
+# Usage:
+#   scripts/build_fst4sim.sh [WSJT-X-dir] [out-dir]
+#
+# Defaults:
+#   WSJT-X-dir  ../../../WSJT-X  (sibling of this repo's parent)
+#   out-dir     target/fst4sim/
+#
+# Requires: gfortran, gcc
+#   Ubuntu:  sudo apt-get install gfortran
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WSJTX_DIR="${1:-$(cd "$REPO_ROOT/../WSJT-X" 2>/dev/null && pwd || echo "")}"
+OUT_DIR="${2:-$REPO_ROOT/target/fst4sim}"
+
+if [[ -z "$WSJTX_DIR" || ! -d "$WSJTX_DIR" ]]; then
+  echo "error: WSJT-X source tree not found. Pass its path as the first argument." >&2
+  echo "  $0 /path/to/WSJT-X" >&2
+  exit 1
+fi
+
+if ! command -v gfortran &>/dev/null; then
+  echo "error: gfortran not found. Install with:" >&2
+  echo "  sudo apt-get install gfortran" >&2
+  exit 1
+fi
+
+LIB="$WSJTX_DIR/lib"
+mkdir -p "$OUT_DIR"
+BUILD="$OUT_DIR/build"
+mkdir -p "$BUILD"
+
+echo "Building fst4sim from $WSJTX_DIR ..."
+echo "Output dir: $OUT_DIR"
+
+# Compilation happens in $BUILD so .mod files land there.
+# The -I flags point to source dirs that contain fst4_params.f90
+# (included via `include 'fst4_params.f90'` in genfst4.f90 / fst4sim.f90).
+cd "$BUILD"
+
+FFLAGS=(-O2 -Wall -Wno-unused-variable -Wno-unused-dummy-argument
+        -I"$LIB/fst4" -I"$LIB")
+
+echo "  [1/14] wavhdr.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/wavhdr.f90"
+
+echo "  [2/14] prog_args.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/prog_args.f90"
+
+echo "  [3/14] crc.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/crc.f90"
+
+echo "  [4a/15] packjt.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/packjt.f90"
+
+echo "  [4b/15] 77bit/packjt77.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/77bit/packjt77.f90"
+
+echo "  [5a] deg2grid.f90 + grid2deg.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/deg2grid.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/grid2deg.f90"
+
+echo "  [5b] fmtmsg.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/fmtmsg.f90"
+
+echo "  [5c] chkcall.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/chkcall.f90"
+
+echo "  [5d] ft2/gfsk_pulse.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/ft2/gfsk_pulse.f90"
+
+echo "  [5f] fst4/get_crc24.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/fst4/get_crc24.f90"
+
+# ldpc_240_*_generator.f90 are data-only fragments included by encode*.f90
+# via `include`; do NOT compile them as standalone units.
+echo "  [6/11] fst4/encode240_101.f90"
+gfortran "${FFLAGS[@]}" -I"$LIB/fst4" -c "$LIB/fst4/encode240_101.f90"
+
+echo "  [7/11] fst4/encode240_74.f90"
+gfortran "${FFLAGS[@]}" -I"$LIB/fst4" -c "$LIB/fst4/encode240_74.f90"
+
+echo "  [8/11] fst4/gen_fst4wave.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/fst4/gen_fst4wave.f90"
+
+echo "  [9/11] fst4/genfst4.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/fst4/genfst4.f90"
+
+echo "  [10/11] fftw3mod.f90 + four2a.f90 + ft8/watterson.f90 + fst4/lorentzian_fading.f90"
+gfortran "${FFLAGS[@]}" -I/usr/include -c "$LIB/fftw3mod.f90"
+gfortran "${FFLAGS[@]}" -I/usr/include -c "$LIB/four2a.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/ft8/watterson.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/fst4/lorentzian_fading.f90"
+
+echo "  [11/11] gran.c"
+gcc -O2 -c "$LIB/gran.c"
+
+echo "  [link] fst4sim"
+gfortran "${FFLAGS[@]}" \
+  wavhdr.o prog_args.o crc.o \
+  deg2grid.o grid2deg.o fmtmsg.o chkcall.o \
+  packjt.o packjt77.o \
+  gfsk_pulse.o fftw3mod.o four2a.o \
+  get_crc24.o encode240_101.o encode240_74.o \
+  gen_fst4wave.o genfst4.o watterson.o lorentzian_fading.o gran.o \
+  "$LIB/fst4/fst4sim.f90" \
+  -o "$OUT_DIR/fst4sim" -lfftw3f -lm
+
+echo ""
+echo "Built: $OUT_DIR/fst4sim"
+echo "Run 'scripts/gen_fst4_sim_wavs.sh' to generate test WAVs."

--- a/scripts/gen_fst4_sim_wavs.sh
+++ b/scripts/gen_fst4_sim_wavs.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Generate fst4sim synthetic WAV files for each FST4 sub-mode.
+#
+# Usage:
+#   scripts/gen_fst4_sim_wavs.sh [fst4sim-path] [out-dir]
+#
+# Defaults:
+#   fst4sim-path  target/fst4sim/fst4sim
+#   out-dir       embedded-poc/assets/fst4_sim/
+#
+# Run build_fst4sim.sh first if the binary doesn't exist.
+#
+# Each sub-mode gets one clean AWGN file (fdop=0 del=0) at SNR=-5 dB
+# at f0=1500 Hz. Filename pattern written by fst4sim:
+#   nsec<=30  ->  000000_000001.wav
+#   nsec>=60  ->  000000_0001.wav
+#
+# The Rust integration test reads these from MFSK_FST4_SIM_ASSETS_DIR
+# (defaults to embedded-poc/assets/fst4_sim/).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FST4SIM="${1:-$REPO_ROOT/target/fst4sim/fst4sim}"
+OUT_DIR="${2:-$REPO_ROOT/embedded-poc/assets/fst4_sim}"
+
+if [[ ! -x "$FST4SIM" ]]; then
+  echo "error: fst4sim not found at $FST4SIM" >&2
+  echo "Run scripts/build_fst4sim.sh first." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Message sent by fst4sim in all cases.
+MSG="CQ JL1NIE PM95"
+F0=1500          # centre frequency Hz
+DT=0.0           # zero time offset
+FDOP=0.0         # no Watterson fading
+DEL=0.0          # no multipath delay
+NFILES=1         # one file per mode
+SNR=-5           # dB, well above FST4 sensitivity floor
+
+declare -A MODES=(
+  [15]="000000_000001.wav"
+  [30]="000000_000001.wav"
+  [60]="000000_0001.wav"
+  [120]="000000_0001.wav"
+  [300]="000000_0001.wav"
+)
+
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+for NSEC in 15 30 60 120 300; do
+  OUTFILE="${MODES[$NSEC]}"
+  DEST="$OUT_DIR/fst4_${NSEC}_sim.wav"
+
+  echo -n "  FST4-${NSEC}: generating ..."
+  (
+    cd "$TMPDIR_WORK"
+    "$FST4SIM" "$MSG" "$NSEC" "$F0" "$DT" "$FDOP" "$DEL" "$NFILES" "$SNR" F \
+      >/dev/null
+    mv "$OUTFILE" "$DEST"
+  )
+  echo " -> $(basename "$DEST")  ($(du -h "$DEST" | cut -f1))"
+done
+
+echo ""
+echo "Done. Assets in: $OUT_DIR"
+echo ""
+echo "Run tests with:"
+echo "  MFSK_FST4_SIM_ASSETS_DIR=$OUT_DIR \\"
+echo "    cargo test --test fst4_sim_roundtrip --features fst4,fft-rustfft -- --nocapture"

--- a/scripts/gen_fst4_sweep_wavs.sh
+++ b/scripts/gen_fst4_sweep_wavs.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Generate fst4sim WAV files for SNR sweep + fading benchmark.
+#
+# Usage:
+#   scripts/gen_fst4_sweep_wavs.sh [fst4sim-path] [out-dir]
+#
+# File naming:  fst4_<nsec>_<channel>_<snr>_<trial>.wav
+#   channel:  awgn | hf_quiet | hf_typical | hf_disturbed
+#   snr:      m05 = -5 dB, m24 = -24 dB, etc.
+#   trial:    01..TRIALS
+#
+# Run build_fst4sim.sh first if the binary doesn't exist.
+# Existing files are skipped (safe to re-run after adding modes/conditions).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FST4SIM="${1:-$REPO_ROOT/target/fst4sim/fst4sim}"
+OUT_DIR="${2:-$REPO_ROOT/embedded-poc/assets/fst4_sweep}"
+
+if [[ ! -x "$FST4SIM" ]]; then
+  echo "error: fst4sim not found at $FST4SIM" >&2
+  echo "Run scripts/build_fst4sim.sh first." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+MSG="CQ JL1NIE PM95"
+F0=1500
+DT=0.0
+TRIALS=10   # files per (mode, channel, snr) — raise to 20 for thorough sweep
+
+# SNR levels per mode (dB, all negative — add more as needed)
+declare -A MODE_SNRS
+MODE_SNRS[15]="-5 -10 -15 -17 -20"
+MODE_SNRS[30]="-5 -10 -15 -20 -22"
+MODE_SNRS[60]="-5 -10 -15 -20 -24"
+MODE_SNRS[120]="-5 -10 -15 -20 -24 -26"
+MODE_SNRS[300]="-5 -10 -15 -20 -24 -27 -30"
+
+# Channel conditions: name fdop del
+# fdop/del values follow ITU-R (CCIR) Watterson HF channel models.
+CHANNELS=(
+  "awgn          0.0  0.0"
+  "ccir_good     0.1  0.5"
+  "ccir_moderate 0.5  1.0"
+  "ccir_poor     1.0  2.0"
+)
+
+# WAV filename written by fst4sim (depends on nsec)
+fst4sim_outname() {
+  local nsec=$1 trial=$2
+  if (( nsec <= 30 )); then
+    printf "000000_%06d.wav" "$trial"
+  else
+    printf "000000_%04d.wav" "$trial"
+  fi
+}
+
+# SNR → tag: -5 → m05, -24 → m24, 5 → p05
+snr_tag() {
+  local snr=$1
+  if (( snr < 0 )); then
+    printf "m%02d" "$(( -snr ))"
+  else
+    printf "p%02d" "$snr"
+  fi
+}
+
+TMPDIR_WORK="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_WORK"' EXIT
+
+total=0; skipped=0; generated=0
+
+for NSEC in 15 30 60 120 300; do
+  SNRS="${MODE_SNRS[$NSEC]}"
+  for CHAN_SPEC in "${CHANNELS[@]}"; do
+    read -r CHAN FDOP DEL <<< "$CHAN_SPEC"
+    for SNR in $SNRS; do
+      TAG="$(snr_tag "$SNR")"
+
+      # Generate all TRIALS files if any are missing
+      missing=0
+      for T in $(seq 1 "$TRIALS"); do
+        DEST="$OUT_DIR/fst4_${NSEC}_${CHAN}_${TAG}_$(printf '%02d' "$T").wav"
+        [[ -f "$DEST" ]] || (( missing++ )) || true
+      done
+
+      (( total += TRIALS ))
+      if (( missing == 0 )); then
+        (( skipped += TRIALS )) || true
+        continue
+      fi
+
+      printf "  FST4-%3d  %-14s  SNR=%4d dB  generating %d files ...\n" \
+        "$NSEC" "$CHAN" "$SNR" "$TRIALS"
+
+      (
+        cd "$TMPDIR_WORK"
+        rm -f 000000_*.wav
+        "$FST4SIM" "$MSG" "$NSEC" "$F0" "$DT" "$FDOP" "$DEL" "$TRIALS" "$SNR" F \
+          >/dev/null
+        for T in $(seq 1 "$TRIALS"); do
+          SRC="$(fst4sim_outname "$NSEC" "$T")"
+          DEST="$OUT_DIR/fst4_${NSEC}_${CHAN}_${TAG}_$(printf '%02d' "$T").wav"
+          [[ -f "$SRC" ]] && mv "$SRC" "$DEST"
+        done
+      )
+      (( generated += TRIALS )) || true
+    done
+  done
+done
+
+echo ""
+echo "Done. Total=$total  Generated=$generated  Skipped(existing)=$skipped"
+echo "Assets: $OUT_DIR"
+echo ""
+echo "Run the sweep test with:"
+echo "  MFSK_FST4_SWEEP_DIR=$OUT_DIR \\"
+echo "    cargo test --test fst4_sweep --features fst4,fft-rustfft \\"
+echo "    -- --ignored --nocapture"


### PR DESCRIPTION
## Summary

- Add FST4-15, FST4-30, FST4-120, FST4-300 sub-modes via the `fst4_submode!` macro
- All 5 sub-modes share LDPC(240,101) + CRC-24 + 160 symbols; differ only in NSPS/NDOWN/TX_START_OFFSET_S
- Generic decode API: `decode_frame_for::<P>(audio, cfg, freq_min, freq_max, sync_min, max_cand)`
- Test infrastructure: `fst4sim` roundtrip tests (all 5 pass) + CCIR SNR sweep benchmark

## SNR sweep results (fst4sim, 10 trials/cell, ITU-R Watterson channels)

Channels: `awgn`=no fading | `ccir_good`=fdop 0.1 Hz/del 0.5 ms | `ccir_moderate`=0.5/1.0 | `ccir_poor`=1.0/2.0

```
  FST4-15    awgn             -17 dB    9/10  [##################..]    90%
  FST4-15    awgn             -15 dB   10/10  [####################]   100%
  FST4-15    ccir_poor        -15 dB    8/10  [################....]    80%
  FST4-15    ccir_poor        -10 dB   10/10  [####################]   100%

  FST4-30    awgn             -20 dB   10/10  [####################]   100%
  FST4-30    ccir_good        -20 dB    8/10  [################....]    80%
  FST4-30    ccir_poor        -20 dB    4/10  [########............]    40%
  FST4-30    ccir_poor        -15 dB   10/10  [####################]   100%

  FST4-60    awgn             -24 dB   10/10  [####################]   100%
  FST4-60    ccir_good        -20 dB   10/10  [####################]   100%
  FST4-60    ccir_poor        -20 dB   10/10  [####################]   100%

  FST4-120   awgn             -26 dB   10/10  [####################]   100%
  FST4-120   ccir_good        -26 dB    7/10  [##############......]    70%
  FST4-120   ccir_moderate    -24 dB    9/10  [##################..]    90%
  FST4-120   ccir_poor        -24 dB    7/10  [##############......]    70%
  FST4-120   ccir_poor        -20 dB   10/10  [####################]   100%

  FST4-300   awgn             -30 dB   10/10  [####################]   100%
  FST4-300   ccir_good        -30 dB   10/10  [####################]   100%
  FST4-300   ccir_moderate    -27 dB    8/10  [################....]    80%
  FST4-300   ccir_moderate    -24 dB   10/10  [####################]   100%
  FST4-300   ccir_poor        -24 dB    3/10  [######..............]    30%
  FST4-300   ccir_poor        -20 dB   10/10  [####################]   100%
```

Full table: run `scripts/gen_fst4_sweep_wavs.sh` then `cargo test --test fst4_sweep --release --features fst4,fft-rustfft,parallel -- --ignored --nocapture`.

## Test plan

- [x] `cargo test --test fst4_sim_roundtrip --features fst4,fft-rustfft,parallel,uvpacket` — all 5 sub-modes pass
- [x] SNR sweep confirms sensitivity matches expected FST4 thresholds
- [ ] Review `fst4_submode!` macro and per-mode constants against WSJT-X `fst4_decode.f90`

🤖 Generated with [Claude Code](https://claude.com/claude-code)