### PR TITLE
chore(release): 0.7.0 — FST4 all sub-modes + coarse_sync parallelisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,60 @@
 # Changelog
 
+## 0.7.0 — FST4 all sub-modes + coarse_sync parallelisation (#23, #139)
+
+### Added
+
+- **FST4-15, FST4-30, FST4-120, FST4-300** sub-modes (`Fst4s15`, `Fst4s30`,
+  `Fst4s120`, `Fst4s300`) via the `fst4_submode!` macro.  All 5 FST4 periods
+  now decode against WSJT-X `fst4sim`-generated signals (#138).
+  Per-mode constants verified against `fst4_decode.f90` / `fst4sim.f90`:
+
+  | Sub-mode | NSPS  | NDOWN | TX_START_OFFSET_S |
+  |----------|-------|-------|-------------------|
+  | FST4-15  | 720   | 18    | 0.5 s             |
+  | FST4-30  | 1 680 | 42    | 1.0 s             |
+  | FST4-60  | 3 888 | 108   | 1.0 s             |
+  | FST4-120 | 8 200 | 205   | 1.0 s             |
+  | FST4-300 | 21 504| 512   | 1.0 s             |
+
+- **Generic FST4 decode API**: `decode_frame_for::<P>(audio, cfg, freq_min,
+  freq_max, sync_min, max_cand)` — one function covers all sub-modes.
+
+- **`coarse_sync` parallelisation** under `--features parallel` (#139).
+  Three serial `fi`-loops (sync2d construction, per-bin peak reduction,
+  candidate NMS) replaced with rayon equivalents.  Serial path unchanged
+  when the feature is absent.  Measured on a 12-core host during the FST4-300
+  CCIR sweep (1 120 files): wall-clock ~3 min 44 s, CPU utilisation ≈8×.
+  FST4-300 benefits most (n_freq ≈ 5 200 bins vs FT8's ≈ 464); FT8 and all
+  other protocols that call `coarse_sync<P>` also gain proportionally.
+
+- **fst4sim test infrastructure** (`scripts/`):
+  - `build_fst4sim.sh` — builds WSJT-X's `fst4sim` Fortran binary (gfortran
+    + FFTW3) for use as a golden signal source.
+  - `gen_fst4_sim_wavs.sh` — one AWGN WAV per sub-mode at −5 dB.
+  - `gen_fst4_sweep_wavs.sh` — full SNR × fading matrix (5 modes × 4 ITU-R
+    Watterson channels × SNR sweep × 10 trials = 1 120 WAVs).
+
+### Tests
+
+- `tests/fst4_sim_roundtrip.rs` — all 5 sub-modes decode `fst4sim` −5 dB
+  AWGN signals; all pass.
+- `tests/fst4_sweep.rs` (`#[ignore]`) — SNR sweep benchmark with recall
+  table output.  Parallelises the 10 trials per cell when `parallel` is set.
+
+  Selected sensitivity results (50 % recall threshold, 10 trials/cell):
+
+  | Mode     | AWGN   | ccir_good | ccir_moderate | ccir_poor |
+  |----------|--------|-----------|---------------|-----------|
+  | FST4-15  | −17 dB | −17 dB    | −15 dB        | −15 dB    |
+  | FST4-30  | −20 dB | −20 dB    | −20 dB        | −20 dB    |
+  | FST4-60  | −24 dB | −24 dB    | −20 dB        | −20 dB    |
+  | FST4-120 | −26 dB | −26 dB    | −25 dB        | −24 dB    |
+  | FST4-300 | −30 dB | −30 dB    | −28 dB        | −22 dB    |
+
+  Channels: `ccir_good` = fdop 0.1 Hz / del 0.5 ms,
+  `ccir_moderate` = 0.5 / 1.0, `ccir_poor` = 1.0 / 2.0 (ITU-R Watterson).
+
 ## 0.6.8 — fix FST4-60A decode (#23): wrong NSPS/NDOWN/GFSK_BT + missing message scramble
 
 `Fst4s60`'s modulation parameters were never-revisited placeholders:

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-core"
-version     = "0.6.8"
+version     = "0.7.0"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 description = "Pure-Rust WSJT-family decoders + synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. Host (rustfft) or no_std embedded (ESP32-S3, RP2350, Cortex-M) via a pluggable FFT backend; fixed-point hot path for FPU-less MCUs. Ships with embedded-poc/m5stack-s3-app, a working M5StickS3 FT8 controller (LCD UI, BLE CI-V to IC-705, acoustic mic, QSO FSM) decoding real on-air signals in ~1.2 s post-SlotEnd on Xtensa LX7."

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-ffi-ft8"
-version     = "0.6.8"
+version     = "0.7.0"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 publish     = false
@@ -53,7 +53,7 @@ embedded-fixed-point = [
 embedded-runtime = []
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.6.2", default-features = false }
+mfsk-core = { path = "../mfsk-core", version = "0.7.0", default-features = false }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/mfsk-ffi/Cargo.toml
+++ b/mfsk-ffi/Cargo.toml
@@ -11,7 +11,7 @@ name       = "mfsk"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.6", features = ["full"] }
+mfsk-core = { path = "../mfsk-core", version = "0.7", features = ["full"] }
 
 [build-dependencies]
 cbindgen = "0.29"


### PR DESCRIPTION
## Summary

- Bump `mfsk-core` and `mfsk-ffi-ft8` to **0.7.0**
- Update `mfsk-ffi` dependency constraint to `0.7`
- CHANGELOG entry for 0.7.0

## What's in 0.7.0

**#138** FST4-15/30/120/300 sub-modes — all 5 FST4 periods now decoded, verified against `fst4sim` golden signals across AWGN and ITU-R Watterson HF channels.

**#139** `coarse_sync` parallelisation — `fi`-loops in `sync.rs` use rayon under `--features parallel`; ≈8× CPU utilisation on 12-core host, FST4-300 benefits most (n_freq ≈ 5 200 bins).

## Test plan

- [x] `cargo check` clean at 0.7.0
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)