### PR TITLE
chore(ci): pre-push fmt+clippy hook + drop redundant Build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,10 +364,6 @@ jobs:
         if: steps.gate.outputs.should_run == 'true'
         uses: Swatinem/rust-cache@v2
 
-      - name: Build (full)
-        if: steps.gate.outputs.should_run == 'true'
-        run: cargo build -p mfsk-core --features full --release
-
       - name: Run suite
         if: steps.gate.outputs.should_run == 'true'
         env:

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Install the project's git hooks into .git/hooks/.
+# Run once after cloning:  bash scripts/install-hooks.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+install_hook() {
+  local name="$1" target="$2"
+  local hook_path="$HOOKS_DIR/$name"
+  cat > "$hook_path" <<EOF
+#!/usr/bin/env bash
+exec "\$(git rev-parse --show-toplevel)/$target" "\$@"
+EOF
+  chmod +x "$hook_path"
+  echo "  installed $name → $target"
+}
+
+echo "Installing git hooks for mfsk-core…"
+install_hook pre-push scripts/pre-push-check.sh
+echo "Done."

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Pre-push quality gate — mirrors what CI's rustfmt+clippy job checks.
+# Install once with:  scripts/install-hooks.sh
+set -euo pipefail
+
+echo "► cargo fmt --check"
+cargo fmt --check
+
+echo "► cargo clippy (full features, tests)"
+cargo clippy --workspace --all-targets --features full --no-deps -- \
+  -D warnings -D clippy::perf
+
+echo "✓ pre-push checks passed"


### PR DESCRIPTION
## Problem

Two issues surfaced during #138 review iteration:

1. **No local gate before push** — three separate pushes were needed to fix rustfmt then clippy then rustfmt-again, triggering three CI runs per iteration.
2. **Redundant `Build (full)` step** — each `test` matrix job ran `cargo build --release` explicitly before `Run suite`, but `cargo test --release` already compiles. Double build per suite with no benefit.

## Fix

### Pre-push hook (`scripts/pre-push-check.sh`)
Mirrors the CI `rustfmt + clippy` job exactly. Catches style issues before they reach GitHub.

Install once after clone:
```sh
bash scripts/install-hooks.sh
```

### Drop `Build (full)` step from test matrix
`cargo test --release` builds implicitly; the preceding `cargo build --release` was pure overhead. `rust-cache` still populates the cache on the first compilation inside `cargo test`.

## Test plan

- [x] pre-push hook fires on `git push` and blocks on fmt/clippy errors
- [ ] CI green with `Build (full)` step removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)