### PR TITLE
fix(ci): add parallel to full feature so coarse_sync par-path is tested

### DIFF
--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -26,7 +26,7 @@ std          = ["alloc"]
 alloc        = []
 
 # Aggregate features.
-full         = ["std", "fft-rustfft", "ft8", "ft4", "fst4", "wspr", "jt9", "jt65", "q65", "packet-bytes", "uvpacket"]
+full         = ["std", "fft-rustfft", "ft8", "ft4", "fst4", "wspr", "jt9", "jt65", "q65", "packet-bytes", "uvpacket", "parallel"]
 
 # FFT backend selection. `mfsk-core::core::fft::FftPlanner` is the
 # trait every decode-side caller talks to; one of these features must


### PR DESCRIPTION
## Problem

`full` feature did not include `parallel`, so all CI runs with `--features full` compiled only the `#[cfg(not(feature = "parallel"))]` serial branch of `coarse_sync`. The rayon-parallelised loops added in #139 were never exercised in CI.

## Fix

One-line addition: `"parallel"` appended to the `full` feature list in `mfsk-core/Cargo.toml`.

## Impact

- All `cargo test --features full` runs (default suite, recall suites, feature-matrix) now exercise the parallel `coarse_sync` path
- `full` still implies `std`, so `parallel = ["std", "dep:rayon"]` is satisfied without pulling in extra transitive deps beyond rayon

🤖 Generated with [Claude Code](https://claude.com/claude-code)