### PR TITLE
chore(release): 0.7.1 — README restructure for crates.io / GitHub discoverability (#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## 0.7.1 — README restructure for crates.io / GitHub discoverability (#144)
+
+Non-functional patch. No source code modifications, no new features,
+no bug fixes — pure docs, published solely to refresh the crate's
+displayed README on crates.io (crates.io/docs.rs render a snapshot
+taken at publish time and don't pick up GitHub-only changes):
+
+- `README.md` reordered so a first-time visitor hits the overview,
+  supported-protocol table, and a copy-pasteable Quick Start example
+  before any design discussion.
+- New DSP-pipeline Architecture diagram (Audio → FFT → Candidate
+  Search → Sync → Demodulation → FEC → Decoded Message), kept
+  separate from the existing trait-stack diagram (now under Design
+  Philosophy).
+- Design Philosophy expanded with an explicit "why a `Protocol`
+  trait" section (shared vs. protocol-specific, zero-cost
+  monomorphisation) and the "Why Rust" rationale.
+- Added a Performance summary, a Comparison-with-WSJT-X table, and
+  an FAQ.
+- Detailed reference material (attribution, modules, FFI, contributing,
+  full status/recall tables) moved below License into a "Reference"
+  section so the top of the file stays short.
+
 ## 0.7.0 — FST4 all sub-modes + coarse_sync parallelisation (#23, #139)
 
 ### Added

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-core"
-version     = "0.7.0"
+version     = "0.7.1"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 description = "Pure-Rust WSJT-family decoders + synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. Host (rustfft) or no_std embedded (ESP32-S3, RP2350, Cortex-M) via a pluggable FFT backend; fixed-point hot path for FPU-less MCUs. Ships with embedded-poc/m5stack-s3-app, a working M5StickS3 FT8 controller (LCD UI, BLE CI-V to IC-705, acoustic mic, QSO FSM) decoding real on-air signals in ~1.2 s post-SlotEnd on Xtensa LX7."

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-ffi-ft8"
-version     = "0.7.0"
+version     = "0.7.1"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 publish     = false
@@ -53,7 +53,7 @@ embedded-fixed-point = [
 embedded-runtime = []
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.7.0", default-features = false }
+mfsk-core = { path = "../mfsk-core", version = "0.7.1", default-features = false }
 
 [build-dependencies]
 cbindgen = "0.29"


### PR DESCRIPTION
## Summary
- Non-functional patch release. No source code changes — bumps `mfsk-core` (and its FFI sibling `mfsk-ffi-ft8`, which tracks the same version) to `0.7.1` purely to refresh the README that crates.io/docs.rs display, since that's a snapshot taken at publish time and doesn't pick up GitHub-only changes (#144 merged the README restructure into `main` without a version bump).
- `CHANGELOG.md` gets a `0.7.1` entry summarizing the README changes, following the same "non-functional patch" precedent as `0.6.5`.

## Test plan
- [x] `cargo check --features full` — builds clean at `mfsk-core v0.7.1`
- [x] CI (fmt/clippy/rustdoc/tests/publish dry-run) will gate this PR before merge
- Pushing the matching `v0.7.1` tag after merge triggers `release.yml` to publish to crates.io per this repo's CD process (see `CLAUDE.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Rm4V6Fcf4GMCczny58QhiE


---
_Generated by [Claude Code](https://claude.ai/code/session_01Rm4V6Fcf4GMCczny58QhiE)_