### PR TITLE
fix(ft4): close AWGN sensitivity gap to WSJT-X (issue #72)

### DIFF
--- a/docs/notes/FT4_BENCHMARK.ja.md
+++ b/docs/notes/FT4_BENCHMARK.ja.md
@@ -1,0 +1,255 @@
+# FT4 感度ベンチマーク — 環境セットアップ
+
+クリーンチェックアウトから FT4 の AWGN/フェージング SNR スイープ
+(`tests/ft4_sweep.rs`) を再現する手順。[#146](https://github.com/jl1nie/mfsk-core/issues/146)
+向けに構築した FST4 の手法 ([`FST4_BENCHMARK.ja.md`](FST4_BENCHMARK.ja.md))
+をそのまま踏襲したもので、
+[#72](https://github.com/jl1nie/mfsk-core/issues/72) の
+`DecodeStrictness` 再較正に使う。FT4 は現状 `DecodeStrictness::Normal`
+決め打ちで、閾値の数値自体は FT8 の較正値をコピペしただけのまま
+一度も FT4 用に調整されていない。
+
+パイプライン全体は: **WSJT-X Fortran ソース → `ft4sim` バイナリ →
+ディスク上の WAV コーパス → `cargo test --ignored` が WAV を読んで
+recall テーブルを出力**。ビルド時に一度だけ WSJT-X ソースに触れる以外、
+テスト実行時にネットワークは不要。
+
+## 1. 前提パッケージ
+
+| 要件 | Ubuntu/Debian パッケージ | 用途 |
+|---|---|---|
+| `gfortran` | `gfortran` | `ft4sim.f90` + 依存ライブラリのコンパイル |
+| `gcc` / `g++` | `build-essential` | `gran.c`, `sgran.c`, `init_random_seed.c`, `crc14.cpp` のコンパイル |
+| `libboost-dev` | `libboost-dev` | `crc14.cpp` が `boost::augmented_crc` を使用 |
+| FFTW (単精度) | `libfftw3-dev` | `-lfftw3f` でリンク |
+| WSJT-X ソースツリー | — (下記参照) | `lib/ft4/*.f90` を提供 |
+
+```sh
+sudo apt-get install gfortran build-essential libboost-dev libfftw3-dev
+```
+
+**WSJT-X ソース。** `scripts/build_ft4sim.sh` は `lib/` サブツリーのみ
+必要（Qt ビルドや `cmake` は不要）— `ft4/ft4sim.f90` シミュレータが
+入っている WSJT-X チェックアウトならどれでも動く:
+
+```sh
+git clone https://github.com/jl1nie/WSJT-X.git ../WSJT-X
+```
+
+リポジトリルートの `CLAUDE.md` のテスト用パス規則に従い、このチェック
+アウトへの絶対パスを決め打ちしないこと — `build_ft4sim.sh` は明示引数
+として受け取り、デフォルトは `../WSJT-X`（本リポジトリの兄弟ディレクトリ）
+という規約だけを使う。
+
+## 2. `ft4sim` をビルド
+
+```sh
+scripts/build_ft4sim.sh [/path/to/WSJT-X] [out-dir]
+# デフォルト: WSJT-X-dir = ../WSJT-X（本リポジトリの兄弟）, out-dir = target/ft4sim/
+```
+
+`target/ft4sim/ft4sim` を生成。FT4 は FT8 の `encode174_91`
+(LDPC(174,91)) をそのまま再利用する（`genft4.f90` が直接呼ぶ）ため、
+`build_fst4sim.sh` が既にコンパイルしている共有 lib サブツリー
+（`wavhdr`、`packjt77`、`watterson`、`fftw3mod`/`four2a`）に FT4 固有の
+コンパイル単位 2 つ（`genft4.f90`、`gen_ft4wave.f90`）を足すだけで済む。
+加えて `crc14.cpp`（Boost ベースの CRC-14、C++）と `sgran.c` /
+`init_random_seed.c`（乱数シード）が必要 — `fst4sim` はこれらを使わない
+（FST4 は CRC-24 を使い `sgran` も呼ばない）。
+
+ビルドの動作確認:
+
+```sh
+target/ft4sim/ft4sim "CQ JL1NIE PM95" 1500 0.0 0.0 0.0 1 -15
+ls 000000_*.wav   # -15 dB の 7.5 秒 AWGN トライアル 1 件
+```
+
+（`ft4sim` の CLI には T/R 周期引数がない — `fst4sim` と違い FT4 に
+サブモードはないため: `message f0 DT fdop del nfiles snr` の位置引数 7 個。）
+
+## 3. WAV コーパスの生成
+
+```sh
+scripts/gen_ft4_sweep_wavs.sh [ft4sim-path] [out-dir]
+# デフォルト: ft4sim-path = target/ft4sim/ft4sim
+#           out-dir      = embedded-poc/assets/ft4_sweep/
+```
+
+4 種のチャネル条件（`awgn`、`ccir_good`、`ccir_moderate`、`ccir_poor`）
+× `SNRS` グリッド × `TRIALS` 回（デフォルト 20）。
+`gen_fst4_sweep_wavs.sh` と同じくインクリメンタル — グリッドを広げて
+再実行しても不足分だけ生成する。
+
+デフォルトの `SNRS` グリッド（-5〜-23 dB）は、FT4 の公称 WSJT-X AWGN
+閾値である約 **-17.5 dB**（2500 Hz 基準帯域幅、FT8 の -21 dB と比較 —
+FT4 は 7.5 秒という短いスロットと少ない FEC インターリーブと引き換えに
+感度を犠牲にしている）を挟むように設定。実測の 50% クロス点が想定より
+弱ければ、FST4 #146 のグリッド打ち切り (censoring) の教訓に従いさらに
+深いグリッドへ拡張すること。
+
+## 4. スイープの実行
+
+```sh
+MFSK_FT4_SWEEP_DIR=embedded-poc/assets/ft4_sweep \
+  cargo test --test ft4_sweep --release \
+  --features ft4,fft-rustfft,parallel,uvpacket \
+  -- --ignored --nocapture
+```
+
+`uvpacket` が必要なのは `mod common` 経由で取り込まれる
+`tests/common/channel.rs` が無条件に `mfsk_core::uvpacket` を import
+するため — FT4 自体とは無関係。
+
+出力はチャネル × SNR セルごとの recall テーブルのみ（pass/fail の
+assertion はなし、あくまで測定ツール）。
+
+### 実測値 2026-07-18（このコーパス/シード、`DecodeStrictness::Normal`）
+
+隣接グリッド点間の線形補間による 50% クロス点:
+
+| チャネル | 50% クロス点(概算) |
+|---|---:|
+| AWGN | ≈ -15.5 dB |
+| CCIR good | ≈ -14.7 dB |
+| CCIR moderate | ≈ -14.3 dB |
+| CCIR poor | ≈ -13.7 dB |
+
+いずれも公称値 -17.5 dB より約 2 dB 弱い。まだ根本原因は特定していない
+— `ft4sim` の SNR 規約の問題、実装側の本物のギャップ（#146 と同種の
+調査候補）、あるいは公称値自体が別の指標を指している可能性のいずれか。
+今回はこれ以上追わずここに記録するに留める。今後着手する際は
+`FST4_BENCHMARK.ja.md` 6 節の「直す前に診断する」順序に従うこと。
+
+## 5. `DecodeStrictness` の probe (issue #72)
+
+同ファイル内の `ft4_strictness_probe` は `core::pipeline::decode_frame`
+を `Strict` / `Normal` / `Deep` それぞれで直接叩き、上記スイープで
+判明した部分 recall のセルについて「golden recall」（実際に送信された
+メッセージと一致）と「any-msg recall」（golden かどうか問わず CRC を
+通った decode 全て — このテストでは各トライアルの真の内容が既知なので
+false-accept 膨張の代理指標になる）の両方を出す。
+
+```sh
+MFSK_FT4_SWEEP_DIR=embedded-poc/assets/ft4_sweep \
+  cargo test --test ft4_sweep --release --features ft4,fft-rustfft,parallel,uvpacket \
+  ft4_strictness_probe -- --ignored --nocapture
+```
+
+**2026-07-18 実測の知見:** 「未較正のコピペだからおそらく効かない」
+という想定に反し、このノブは FT4 に対して no-op ではない。AWGN では
+効果は小さいが、フェージング下では無視できない — 例えば
+`ccir_poor` -13 dB: Strict 9/20 → Normal 14/20 → Deep 16/20 (golden
+recall)。ただし `Deep` はいくつかのセルで "any-msg" が "golden" より
+速く増える（`ccir_moderate` -16 dB: golden 1→2、any-msg 1→4）—
+Deep の追加 decode の一部は false-accept であり、本物の感度向上ではない。
+これは FT8 のオリジナル較正コメントが述べていた
+sensitivity/false-positive のトレードオフそのもので、FT4 では今回まで
+未検証だった。
+
+まとめ: 現状デフォルトの `Normal` は既に妥当な落とし所にある —
+実利用上重要なフェージングセル（`ccir_poor` -13 dB では Deep の
+7-decode 分の gain のうち 5 を確保）で `Strict → Deep` の実質的な
+gain の大半を捉えつつ、`Deep` の最悪の false-accept 増加は避けている。
+今回で未解決なのは、FT8 からコピペした数値ではなく FT4 固有に較正した
+閾値なら、`Deep` の FP コストなしに `Normal` を上回れるか、という点 —
+これには既存の 3 段階の named level だけでなく `osd_max_errors` /
+`osd_score_min` の数値そのものを振る sweep が必要。
+
+## 6. 数値の再較正 (issue #72, 2026-07-18)
+
+`core::pipeline::process_candidate_basic` 内の
+`strictness.osd_score_min()` / `strictness.osd_max_errors()` 呼び出し
+箇所を追跡したところ、両方とも `!is_fst4` の条件下でのみ実行される
+ことが判明 — つまり **FST4 はこれらの値を一切使わない**（#146 の
+fix）。実際には `core::pipeline::DecodeStrictness` の数値は FT4 専用
+になっている。これは `Normal` の再較正が FST4 の（別途調整済みの）
+recall に対して回帰リスクゼロであることを意味し、単に特性を測定する
+だけでなく実際に数値を動かす道を開いた。
+
+手動で sweep: 候補値を編集 → `ft4_strictness_probe` を部分 recall の
+8 セルに対して再実行 → any-msg が golden より速く増えない（= 新たな
+false-accept が出ない）範囲で golden recall が上がっていれば採用、
+そうでなければ破棄。
+
+- `osd_score_min`: `2.2 → 1.8`。`2.0` で 3 セル改善（新規 FP ほぼ
+  なし）、`1.8` でさらに 2 セル改善。`1.6` まで下げると golden の
+  伸びはゼロで false-accept だけ増えた — `1.8` が上限。
+- `osd_max_errors`: `(depth3, depth4, other) = (26, 30, 29) →
+  (28, 30, 31)`。`(29, 31, 32)` は同一結果（それ以上動かす利点なし）、
+  `(30, 33, 33)` は golden 増加ゼロで false-accept が 2 件増加 —
+  `(28, 30, 31)` が上限。
+
+フルスイープへの効果（Normal、変更前→変更後）:
+
+| チャネル | -17 dB | -16 dB | -15 dB | -14 dB | -13 dB |
+|---|---:|---:|---:|---:|---:|
+| AWGN | 0%→10% | 20%→20% | 85%→85% | 95%→95% | 95%→95% |
+| CCIR good | 5%→10% | 20%→20% | 40%→45% | 90%→100% | 90%→90% |
+| CCIR moderate | 5%→10% | 5%→5% | 30%→40% | 70%→70% | 95%→95% |
+| CCIR poor | 0%→0% | 10%→15% | 20%→25% | 45%→50% | 70%→75% |
+
+小幅かつ単調な改善で、どこにも regression なし（ゲートを緩めるだけ
+なので recall は維持か増加のみ）— dB スケールの跳躍ではなく、実質的
+だが漸進的な gain。`core::pipeline::DecodeStrictness::{osd_max_errors,
+osd_score_min}` に反映済み。`Strict`/`Deep` の数値は未変更（現状どの
+呼び出し元も使っていない、FT8 からの未検証コピーのまま）。
+
+## 7. Coherent full-slot Δt search (`ft4_sync_search`, 2026-07-18)
+
+上記の `DecodeStrictness` チューニングとは別に、`sync4d.f90`/
+`ft4_decode.f90` に対する WSJT-X 忠実性監査で判明: `core::sync::coarse_sync`
+の広域(±2.5s) Δt 探索は **non-coherent**（パワースペクトラムのbin）
+なのに対し、WSJT-X 本家の広域 Δt 探索（`isync=1`、3セグメントで
+各350〜450サンプル）は **coherent**（複素Costas相関）。
+`tests/ft4_coherent_wide_search_diag.rs` で実測確認: CCIR フェージング
+下では `coarse_sync` の non-coherent な選択が真のピークから0.5〜2.4秒
+もずれることがあり、旧来のローカル `sync2d_refine`（±20 downsampled
+samples ≈ ±30ms）の範囲外——それでも真のピークの coherent スコアの
+方が一貫して高い。AWGN では影響なし（non-coherent のずれは16ms以内
+に収まり、旧refineの範囲内）。
+
+修正: `core::sync2d::ft4_sync_search`、WSJT-Xの`isync=1`/`isync=2`
+ループを模した coherent full-slot Δt 探索（±12Hz/3Hz の coarse ×
+絶対座標`[-344, 1012]` downsampled-sample窓・step4、その後±4Hz/1Hz ×
+±5サンプルの fine）で `sync2d_refine`/`Sync2dConfig::for_ft4` を置換
+（FST4は#146で既に同等の`fst4_sync_search`を獲得済み）。
+
+**最初の実装はネットでregressionでした**（クリーンなAWGNですらrecall
+低下）— 実際に起きた罠として記録しておく価値がある: Δt探索を広げると、
+**真の信号自身の周波数近傍にある`coarse_sync`候補が、より多く独立に
+正当で自己無矛盾なCostasロックに到達してしまう**（ノイズではない —
+`sync_quality`も、独自に実装したWSJT-X `nsync_qual`相当のbit-metric
+ゲートも、どちらも高スコアを出すことを確認済み）。試して破棄した対策:
+(a) dedup時にhard_errors最小の重複を残す — 逆効果、hard_errorsは位置
+精度と相関しない。(b) `nsync_qual`相当の追加ゲート — WSJT-X自身の
+ゲート設計はここには適用できないと判明。WSJT-Xの「1周波数ピークに
+つき1候補」というシンプルな構造は、そもそもこの種の近接重複候補を
+生まないので、そのゲートは元々こういう候補を裁定するために作られた
+ものではなかった。
+
+**本当の根本原因**: `DecodeResult.freq_hz`が精密化前の`cand.freq_hz`
+から設定されており、`refined.freq_hz`ではなかった——潜在バグ。以前
+無害だったのは、旧来の狭いローカルrefineが元々真値に近い候補しか
+補正しなかったから。広域探索で遠く離れた候補も成功するようになり、
+それぞれが古い`cand.freq_hz`をそのまま報告し続けた——recallの問題
+ではなくreport層のバグだった。`process_candidate_basic`内の3箇所の
+`DecodeResult`構築を全て`refined.freq_hz`に修正。dedupの
+sync_score-tie-breakは残した（正しく報告されるようになった今では
+ほぼ見た目上の意味しか持たないが、精密化が完全に収束しない稀なケース
+のために有効）。
+
+### 実測値 2026-07-18（6節の`DecodeStrictness`のみのbaseline比）
+
+| チャネル | -17 dB | -16 dB | -15 dB | -14 dB | -13 dB |
+|---|---:|---:|---:|---:|---:|
+| AWGN | 10%→20% | 20%→30% | 85%→100% | 95%→95% | 95%→100% |
+| CCIR good | 10%→20% | 20%→40% | 45%→65% | 100%→100% | 90%→95% |
+| CCIR moderate | 10%→10% | 5%→5% | 40%→50% | 70%→80% | 95%→95% |
+| CCIR poor | 0%→0% | 15%→20% | 25%→35% | 50%→55% | 75%→80% |
+
+50%クロス点の改善（線形補間）: AWGN ≈+0.2dB、CCIR good ≈+0.7dB、
+CCIR moderate ≈+0.3dB、CCIR poor ≈+0.25dB。CCIR poor -5dB
+（100%→95%、1トライアル分）以外に regression なし——20トライアル/
+セルのサンプリングノイズの範囲内。フル非ignoredテストスイート
+（`cargo test --release --features full`）と
+`ft4_wsjtx_sample_recall_vs_golden`で全green確認済み。

--- a/docs/notes/FT4_BENCHMARK.md
+++ b/docs/notes/FT4_BENCHMARK.md
@@ -1,0 +1,542 @@
+# FT4 sensitivity benchmark — environment setup
+
+How to reproduce the FT4 AWGN/fading SNR sweep (`tests/ft4_sweep.rs`) from
+a clean checkout on any machine. This mirrors the FST4 methodology in
+[`FST4_BENCHMARK.md`](FST4_BENCHMARK.md) (built for
+[#146](https://github.com/jl1nie/mfsk-core/issues/146)) and feeds the
+`DecodeStrictness` recalibration tracked in
+[#72](https://github.com/jl1nie/mfsk-core/issues/72) — FT4 currently
+hardcodes `DecodeStrictness::Normal` with threshold numbers copy-pasted
+from the FT8 calibration, never re-tuned for FT4's own SNR/OSD behaviour.
+
+The whole pipeline is: **WSJT-X Fortran source → `ft4sim` binary → WAV
+corpus on disk → `cargo test --ignored` reads the WAVs and prints a
+recall table.** Nothing here needs network access at test time — only
+the one-time build step touches WSJT-X source.
+
+## 1. Prerequisites
+
+| Requirement | Ubuntu/Debian package | Purpose |
+|---|---|---|
+| `gfortran` | `gfortran` | compiles `ft4sim.f90` + supporting lib |
+| `gcc` / `g++` | `build-essential` | compiles `gran.c`, `sgran.c`, `init_random_seed.c`, `crc14.cpp` |
+| `libboost-dev` | `libboost-dev` | `crc14.cpp` uses `boost::augmented_crc` |
+| FFTW single-precision | `libfftw3-dev` | linked as `-lfftw3f` |
+| WSJT-X source tree | — (see below) | provides `lib/ft4/*.f90` |
+
+```sh
+sudo apt-get install gfortran build-essential libboost-dev libfftw3-dev
+```
+
+**WSJT-X source.** `scripts/build_ft4sim.sh` only needs the `lib/`
+subtree (no Qt build, no `cmake` step) — any WSJT-X checkout with the
+`ft4/ft4sim.f90` simulator works, including the upstream tree:
+
+```sh
+git clone https://github.com/jl1nie/WSJT-X.git ../WSJT-X
+```
+
+Per the repo-root `CLAUDE.md` test-fixture-path rule, never hardcode an
+absolute path to this checkout — `build_ft4sim.sh` takes it as an
+explicit argument (falling back to the `../WSJT-X` sibling-of-repo-root
+convention only as a default).
+
+## 2. Build `ft4sim`
+
+```sh
+scripts/build_ft4sim.sh [/path/to/WSJT-X] [out-dir]
+# defaults: WSJT-X-dir = ../WSJT-X (sibling of this repo), out-dir = target/ft4sim/
+```
+
+Produces `target/ft4sim/ft4sim`. FT4 reuses FT8's `encode174_91`
+LDPC(174,91) codec (`genft4.f90` calls it directly), so this build adds
+only two FT4-specific compile units (`genft4.f90`, `gen_ft4wave.f90`) on
+top of the same shared lib subtree `build_fst4sim.sh` already compiles
+(`wavhdr`, `packjt77`, `watterson`, `fftw3mod`/`four2a`). It additionally
+needs `crc14.cpp` (Boost-based CRC-14, C++) + `sgran.c` /
+`init_random_seed.c` (RNG seeding) — `fst4sim` doesn't need these because
+FST4 uses CRC-24 and never calls `sgran`.
+
+Sanity-check the build:
+
+```sh
+target/ft4sim/ft4sim "CQ JL1NIE PM95" 1500 0.0 0.0 0.0 1 -15
+ls 000000_*.wav   # one 7.5 s AWGN trial at -15 dB
+```
+
+(`ft4sim`'s CLI has no T/R-period argument — unlike `fst4sim`, FT4 has
+no sub-modes: `message f0 DT fdop del nfiles snr`, 7 positional args.)
+
+## 3. Generate the WAV corpus
+
+```sh
+scripts/gen_ft4_sweep_wavs.sh [ft4sim-path] [out-dir]
+# defaults: ft4sim-path = target/ft4sim/ft4sim
+#           out-dir     = embedded-poc/assets/ft4_sweep/
+```
+
+Covers 4 channel conditions (`awgn`, `ccir_good`, `ccir_moderate`,
+`ccir_poor`) × the `SNRS` grid × `TRIALS` repeats (default 20). Same
+idempotent/incremental behaviour as `gen_fst4_sweep_wavs.sh` — widening
+the grid and re-running only tops up missing cells.
+
+The default `SNRS` grid (`-5` down to `-23` dB) straddles FT4's
+published WSJT-X AWGN threshold of about **-17.5 dB** (2500 Hz ref BW;
+compare FT8's -21 dB — FT4 trades sensitivity for the shorter 7.5 s slot
+and less FEC interleaving). Extend the grid deeper if the measured 50%
+crossing turns out weaker than expected, per the FST4 #146
+grid-censoring lesson.
+
+## 4. Run the sweep
+
+```sh
+MFSK_FT4_SWEEP_DIR=embedded-poc/assets/ft4_sweep \
+  cargo test --test ft4_sweep --release \
+  --features ft4,fft-rustfft,parallel,uvpacket \
+  -- --ignored --nocapture
+```
+
+`uvpacket` is only required because `tests/common/channel.rs` (pulled in
+via `mod common`) unconditionally imports `mfsk_core::uvpacket` —
+unrelated to FT4 itself.
+
+Output is a plain recall table (decodes / trials per channel × SNR
+cell) — no pass/fail assertions, this is a measurement tool.
+
+### Measured 2026-07-18 (this corpus/seed, `DecodeStrictness::Normal`)
+
+50% crossing, linear-interpolated between adjacent grid points:
+
+| Channel | ~50% crossing |
+|---|---:|
+| AWGN | ≈ -15.5 dB |
+| CCIR good | ≈ -14.7 dB |
+| CCIR moderate | ≈ -14.3 dB |
+| CCIR poor | ≈ -13.7 dB |
+
+All about 2 dB worse than the -17.5 dB published figure. Not yet
+root-caused — could be `ft4sim`'s SNR convention, a genuine pipeline
+gap (candidate for the same style of investigation as #146), or the
+published number itself referring to a different metric. Flagged here
+rather than chased further in this pass; see section 6 of
+`FST4_BENCHMARK.md` for the diagnose-before-fixing order to use if this
+gets picked up.
+
+## 5. `DecodeStrictness` probe (issue #72)
+
+`ft4_strictness_probe` (same file) drives `core::pipeline::decode_frame`
+directly with each of `Strict` / `Normal` / `Deep` across a handful of
+partial-recall cells identified by the sweep above, and reports both
+"golden" recall (matches the known transmitted message) and "any-msg"
+recall (any CRC-passing decode, golden or not — a proxy for false-accept
+inflation, since every trial's true content is known here).
+
+```sh
+MFSK_FT4_SWEEP_DIR=embedded-poc/assets/ft4_sweep \
+  cargo test --test ft4_sweep --release --features ft4,fft-rustfft,parallel,uvpacket \
+  ft4_strictness_probe -- --ignored --nocapture
+```
+
+**Measured 2026-07-18 finding:** the knob is *not* a no-op for FT4,
+contrary to the assumption that an uncalibrated copy-paste "probably
+doesn't matter." Effect size is small in AWGN but substantial under
+fading — e.g. `ccir_poor` at -13 dB: Strict 9/20 → Normal 14/20 → Deep
+16/20 golden recall. But `Deep` also grows "any-msg" faster than
+"golden" in several cells (`ccir_moderate` -16 dB: golden 1→2, any-msg
+1→4), i.e. some of Deep's extra decodes are false-accepts, not real
+sensitivity gain — the same sensitivity/false-positive trade-off the
+original FT8 calibration comment describes, just unverified for FT4
+until now.
+
+Net: `Normal` (today's hardcoded default) already sits at a reasonable
+point — it captures most of `Strict → Deep`'s real gain in the fading
+cells that matter (`ccir_poor` -13 dB captures 5 of Deep's 7-decode
+gain) without `Deep`'s worst false-accept growth. The open question
+this doesn't yet answer is whether FT4-*specific* threshold numbers
+(rather than the FT8-copied ones) could beat `Normal` without `Deep`'s
+FP cost — that needs a numeric sweep over `osd_max_errors` /
+`osd_score_min` values, not just the three existing named levels.
+
+## 6. Numeric retune (issue #72, 2026-07-18)
+
+Traced `strictness.osd_score_min()` / `strictness.osd_max_errors()` call
+sites in `core::pipeline::process_candidate_basic`: both are gated
+behind `!is_fst4`, so **FST4 bypasses these values entirely** (the #146
+fix) — in practice `core::pipeline::DecodeStrictness`'s numbers are
+FT4-exclusive. This means retuning `Normal` carries zero regression
+risk against FST4's separately-tuned recall, clearing the way to
+actually move the numbers instead of just characterising them.
+
+Swept by hand: edit a candidate value, rerun `ft4_strictness_probe`
+against the 8 partial-recall cells, keep the change if golden recall
+went up without any-msg growing faster than golden (i.e. no new
+false-accepts), discard otherwise.
+
+- `osd_score_min`: `2.2 → 1.8`. `2.0` gained 3 cells with ~0 new FPs;
+  `1.8` gained 2 more cells cleanly; `1.6` gained nothing further and
+  only added false-accepts — `1.8` is the ceiling.
+- `osd_max_errors`: `(depth3, depth4, other) = (26, 30, 29) → (28, 30, 31)`.
+  `(29, 31, 32)` gave identical results (no benefit to going further);
+  `(30, 33, 33)` added 2 false-accepts with zero additional golden
+  recall — `(28, 30, 31)` is the ceiling.
+
+Net effect on the full sweep (Normal, before → after):
+
+| Channel | -17 dB | -16 dB | -15 dB | -14 dB | -13 dB |
+|---|---:|---:|---:|---:|---:|
+| AWGN | 0%→10% | 20%→20% | 85%→85% | 95%→95% | 95%→95% |
+| CCIR good | 5%→10% | 20%→20% | 40%→45% | 90%→100% | 90%→90% |
+| CCIR moderate | 5%→10% | 5%→5% | 30%→40% | 70%→70% | 95%→95% |
+| CCIR poor | 0%→0% | 10%→15% | 20%→25% | 45%→50% | 70%→75% |
+
+Modest, monotonic, no regressions anywhere (loosening a gate can only
+hold or increase recall) — a real but incremental gain, not a dB-scale
+jump. Landed in `core::pipeline::DecodeStrictness::{osd_max_errors,
+osd_score_min}`; `Strict`/`Deep` numbers untouched (still the original
+unverified FT8 copy — no current caller exercises them).
+
+## 7. Coherent full-slot Δt search (`ft4_sync_search`, 2026-07-18)
+
+Separately from the `DecodeStrictness` tuning above, a WSJT-X
+faithfulness audit of `sync4d.f90`/`ft4_decode.f90` against our FT4 sync
+pipeline found that `core::sync::coarse_sync`'s wide (±2.5 s) Δt search
+is *non-coherent* (magnitude-squared spectrogram bins) while WSJT-X's
+own wide Δt search (`isync=1`, ~350-450 samples/segment × 3 segments) is
+*coherent* (complex Costas correlation). `tests/ft4_coherent_wide_search_diag.rs`
+confirmed the consequence empirically: under CCIR fading, `coarse_sync`'s
+non-coherent pick can land 0.5-2.4 s from the true peak — far outside
+the old local `sync2d_refine` (±20 downsampled samples ≈ ±30 ms) — even
+though the true peak's *coherent* score was consistently higher. AWGN
+was not affected (non-coherent gap stayed under ~16 ms, within the old
+refine's reach).
+
+Fix: `core::sync2d::ft4_sync_search`, a coherent full-slot Δt search
+mirroring WSJT-X's `isync=1`/`isync=2` loops (±12 Hz/3 Hz coarse ×
+absolute `[-344, 1012]` downsampled-sample window step 4, then ±4 Hz/1 Hz
+× ±5 samples fine), replacing `sync2d_refine`/`Sync2dConfig::for_ft4` for
+FT4 (FST4 already had the equivalent `fst4_sync_search` from #146).
+
+**First attempt was a net regression** (recall dropped even in clean
+AWGN) — worth recording since it's a real trap: widening the Δt search
+lets *more* of a real signal's own frequency-neighbour `coarse_sync`
+candidates independently reach a genuine, self-consistent Costas lock
+(not noise — confirmed both `sync_quality` and a from-scratch WSJT-X
+`nsync_qual`-equivalent bit-metric gate score these highly). Tried and
+discarded: (a) preferring the lowest-`hard_errors` duplicate on dedup —
+worse, hard_errors doesn't correlate with position accuracy; (b) the
+extra `nsync_qual`-style gate — proved WSJT-X's own gate design doesn't
+apply here, since WSJT-X's simpler 1-candidate-per-frequency-peak
+architecture doesn't generate these near-duplicate candidates in the
+first place, so its gates were never meant to arbitrate between them.
+
+**Actual root cause**: `DecodeResult.freq_hz` was being set from the
+*pre-refinement* `cand.freq_hz`, not `refined.freq_hz` — a latent bug,
+harmless before because the old narrow local refine only ever corrected
+candidates that started close to the truth anyway. The wide search let
+far-off candidates succeed too, each still reporting its own stale
+`cand.freq_hz` — a report-layer bug, not a recall one. Fixed all three
+`DecodeResult` construction sites in `process_candidate_basic` to use
+`refined.freq_hz`; kept the dedup-by-`sync_score` tie-break (now mostly
+cosmetic, since duplicates converge on nearly the same refined position
+once reported correctly).
+
+### Measured 2026-07-18 (vs section 6's `DecodeStrictness`-only baseline)
+
+| Channel | -17 dB | -16 dB | -15 dB | -14 dB | -13 dB |
+|---|---:|---:|---:|---:|---:|
+| AWGN | 10%→20% | 20%→30% | 85%→100% | 95%→95% | 95%→100% |
+| CCIR good | 10%→20% | 20%→40% | 45%→65% | 100%→100% | 90%→95% |
+| CCIR moderate | 10%→10% | 5%→5% | 40%→50% | 70%→80% | 95%→95% |
+| CCIR poor | 0%→0% | 15%→20% | 25%→35% | 50%→55% | 75%→80% |
+
+50%-crossing improvement (linear-interpolated): AWGN ≈+0.2 dB, CCIR
+good ≈+0.7 dB, CCIR moderate ≈+0.3 dB, CCIR poor ≈+0.25 dB. No
+regressions except CCIR poor -5 dB (100%→95%, one trial — within
+sampling noise for 20 trials/cell). Verified against the full
+non-ignored test suite (`cargo test --release --features full`) and
+`ft4_wsjtx_sample_recall_vs_golden` — all green.
+
+## 8. `nsync>=18` OSD-depth gate — real bug, confirmed not the AWGN gap (issue #72, 2026-07-18)
+
+Following section 6's own "diagnose before fixing" principle (and the
+identical rule in this file's sibling `FST4_BENCHMARK.md` §6): before
+touching any more numbers, built `ft4_diag_weak_trials`
+(`tests/ft4_sweep.rs`, mirrors `fst4_diag_weak_trials`) to trace
+`coarse_sync` + `process_candidate_basic` directly on individual AWGN
+trials straddling the post-section-7 ≈-15.7 dB crossing, rather than
+guessing at a WSJT-X-vs-ours diff and re-running the full sweep to check.
+
+**coarse_sync isn't the bottleneck at the crossing.** Across the -17..-14
+dB AWGN cells (80 trials), only 8/20 (-17 dB) and 6/20 (-16 dB) trials had
+no near-golden-frequency candidate at all — the dominant failure mode
+(10/20 at both -17 dB and -16 dB) was a candidate found at the exact true
+freq/dt, with a `coarse_sync` score in the same range as successful
+trials, that still failed inside `process_candidate_basic`.
+
+**Found while instrumenting that path**: `sync_quality`'s FT4 output
+(`nsync`) is capped at `N_SYNC = 16` (4 Costas blocks × 4 symbols each,
+`ft4/mod.rs:98`) — confirmed empirically, values across ~140 measured
+candidates topped out at 16 and clustered 10-16 regardless of decode
+success. But `process_candidate_basic`'s OSD depth-escalation gates
+(`core/pipeline.rs`) checked `nsync >= 18` for both the depth-3 rung and
+the depth-4 Top-K rescue — a threshold calibrated against FT8's
+`N_SYNC = 21` (12/21, 18/21), copy-pasted as literals rather than scaled
+per protocol. **18 is mathematically unreachable when the ceiling is 16**:
+FT4 candidates could never get anything past OSD depth-2, silently
+dropping the entire depth-3/depth-4 escalation tier — the same
+copy-paste-from-FT8 pattern issue #72 already named for `DecodeStrictness`,
+just in a different gate.
+
+Fixed in `core/pipeline.rs`: `osd_attempt_min`/`osd_depth3_min` now scale
+by `P::N_SYNC` using the ratio FT8's original 12/21 and 18/21 imply
+(→ 9/14 for FT4's `N_SYNC=16`), gated on `P::ID == Ft4` so FT8
+(`N_SYNC=21` — formula reproduces 12/18 exactly, byte-identical) and FST4
+(already separately tuned, issue #146) are untouched.
+
+**Re-verified narrow (AWGN only, -17..-14 dB, real `decode_frame` via
+`ft4_snr_sweep`, not the diagnostic's simplified candidate loop)**: 4/20,
+6/20, 20/20, 19/20 — **byte-identical** to section 7's post-tuning
+baseline (20%, 30%, 100%, 95%). `ft4_diag_weak_trials` traced individual
+`nsync>=14` trials that now correctly escalate to OSD depth-3
+(confirmed via temporary tracing, since removed) and still fail — these
+are genuinely SNR-limited, not depth-limited. Full non-ignored suite +
+`ft4_wsjtx_sample_recall_vs_golden` (6/6) green.
+
+**Verdict**: real, worth keeping (it's a genuine protocol-scale bug, and
+untested corners — CCIR fading, busy-band multi-signal — weren't ruled
+out), but **confirmed not the explanation for the ~1.8 dB AWGN gap**.
+Exactly the kind of result section 6 warned about: a plausible-sounding,
+source-verified diff that a full re-sweep shows didn't move the needle.
+The two remaining open candidates from the original audit — (1) no
+WSJT-X-style early `smax`-based candidate reject before bitmetrics are
+computed at all, (2) unclear whether `ft4_sync_search` replicates
+WSJT-X's 3-segment Δt search with monotonicity gating — are still
+un-investigated.
+
+## 9. `ft4_sync_search` scorer was non-coherent within each Costas block (issue #72, 2026-07-18) — ~1 dB AWGN gain
+
+Prompted by a direct question about whether the `score` semantics feeding
+`ft4_sync_search` and the `osd_score_min` gate actually mean the same
+thing as WSJT-X's — the right question to ask before trusting section 8's
+"scorer is faithful" note, which turned out to have only checked the
+*outer* structure.
+
+`ft4_sync_search`'s doc comment claimed the scorer matched `sync4d.f90`'s
+`sync = p(z1)+p(z2)+p(z3)+p(z4)` "exactly." True at the outermost level
+(4 Costas blocks, magnitude-summed, non-coherent block-to-block) — but
+re-reading `sync4d.f90` line-by-line (not just the final formula) shows
+each `z_k` is **one coherent dot product spanning all 4 symbols of block
+k** (`z1=sum(cd0(i1:i1+4*NSS-1:2)*conjg(csync2))`, a single complex
+accumulator built from a reference that concatenates all 4 symbols'
+waveforms back-to-back). `ft4_sync_search` instead called
+`score_costas_block` — which correlates **each symbol separately**, takes
+`.norm_sqr()` (power) of each, and power-sums the 4 symbols. Non-coherent
+combining across N=4 samples loses ~sqrt(4) ≈ 3 dB of discrimination vs
+one coherent N=4 correlation — the identical mechanism already diagnosed
+and fixed for FST4 (`project_fst4_coherent_sync` memory, issue #146):
+`fst4_sync_search` already carries the correct machinery
+(`make_costas_ref_continuous` + `score_flat_coherent`, one flat reference
+per block, correlated once, magnitude taken) — it just hadn't been wired
+up for FT4's block-by-block loop.
+
+Cross-checked against `sync8d.f90` (FT8) to confirm `score_costas_block`
+itself isn't wrong: FT8's own combining really is per-symbol,
+non-coherent, power-summed (`sync = sync + p(z1)+p(z2)+p(z3)` inside a
+loop over each of the 7 Costas symbol positions, `p(z)` with no sqrt —
+pure power) — `score_costas_block` is faithful *for FT8*, just wrong when
+reused for FT4's genuinely different (per-block-coherent) combining
+style. Fix scoped to `ft4_sync_search` alone (`core/sync2d.rs`): swapped
+`make_costas_ref`/`score_costas_block` for
+`make_costas_ref_continuous`/`score_flat_coherent`, reusing the exact
+helpers `fst4_sync_search` already uses. `score_costas_block` itself,
+`sync2d_refine` (shared by other protocols), and FT8's own fine-sync are
+untouched.
+
+**Measured** (`ft4_snr_sweep`, `--ignored --nocapture`, AWGN -20..-13 dB
++ all 3 CCIR channels -18..-12 dB, real `decode_frame`, not the diag
+harness):
+
+| Channel | -18 dB | -17 dB | -16 dB | -15 dB | -14 dB | -13 dB |
+|---|---:|---:|---:|---:|---:|---:|
+| AWGN | 0%→0% | 20%→40% | 30%→75% | 100%→100% | 95%→100% | —→100% |
+| CCIR good | —→10% | 20%→45% | 40%→60% | 65%→95% | 100%→100% | 95%→95% |
+| CCIR moderate | —→5% | 10%→10% | 5%→35% | 40%→65% | 70%→95% | 95%→95% |
+| CCIR poor | —→0% | 0%→0% | 15%→25% | 25%→50% | 50%→75% | 75%→90% |
+
+(AWGN -20/-19/-18 dB stayed at 0% both before and after — crossing sits
+safely inside the grid, not pinned at the floor.)
+
+50%-crossing (linear-interpolated): **AWGN -15.7→-16.7 dB (+1.0 dB)**,
+CCIR good -15.6→-16.7 dB (+1.1 dB), CCIR moderate -15.0→-15.5 dB
+(+0.5 dB), CCIR poor -14.25→-15.0 dB (+0.75 dB). No regressions anywhere
+in the swept range. This is the single largest AWGN gain of the whole
+issue #72 investigation — more than half of the ~1.8 dB gap against
+WSJT-X's published -17.5 dB closed in one fix (residual gap now ≈0.8 dB).
+Fading channels gained less than AWGN, consistent with coherent
+combining being partially undermined by channel decorrelation over the
+4-symbol block span — a plausible, not yet separately verified,
+explanation.
+
+`ft4_wsjtx_sample_recall_vs_golden`: still 6/6, and the busy WSJT-X
+sample WAV now yields 13 total CRC-passing decodes (was 11) — the two
+new ones have well-formed callsign/grid/report fields, consistent with
+recovering genuine weak signals rather than new false-accepts. Full
+non-ignored suite green (350+ tests, 0 failed).
+
+Reinforces the section 8 lesson from the opposite direction: don't stop
+verifying a "matches WSJT-X" claim at the outermost formula when the
+question is specifically about numerical/scale fidelity — the bug was
+one level deeper than the code comment had actually checked.
+
+## 10. BP/OSD decode strength — mostly ruled out, one faithfulness fix, null on AWGN (issue #72, 2026-07-18)
+
+With the sync-side fixes (sections 8-9) landed, checked whether the
+residual ≈0.8 dB AWGN gap is instead a decode-strength issue (LDPC
+BP/OSD weaker than WSJT-X's `decode174_91`) — the general concern
+`project_wsjtx_compliance_audit.md` flagged as "BP algorithm (tanh-product
+vs min-sum NMS) — the biggest general gap."
+
+**BP algorithm: already faithful on host, concern doesn't apply here.**
+`fec::ldpc::bp::FecOpts::default()` sets `bp_kind: BpKind::SumProduct`
+(`core/protocol.rs:384`) — the true log-domain tanh/atanh belief
+propagation (`tov = 2·atanh(−∏tanh(−toc/2))`), matching WSJT-X's
+`bpdecode174_91.f90:101,107-110` algebraically. `BpKind::NormalizedMinSum`/
+`OffsetMinSum` exist in the same module but are only used by the embedded
+fixed-point path (`bp_decode_generic_nms`, doc'd as embedded-only in
+`bp.rs`) — not exercised by any host test, including this whole AWGN
+sweep. The compliance-audit concern is real for the embedded path but
+doesn't explain anything measured here.
+
+**OSD barely gets exercised.** Extended `ft4_diag_weak_trials` to print
+`DecodeResult.pass` (which LLR variant / BP vs OSD rescue) and
+`hard_errors`. Across 45 successful near-crossing decodes (AWGN
+-18..-15 dB): 43 succeeded on plain BP (pass 0/1/2, no OSD needed), only
+2 needed OSD depth-3 rescue (pass 5), and OSD depth-2/4 (pass 4, or the
+Top-K path) never fired at all. `nsync` and `score` are both attempted
+(`osd@9=true`) for nearly every one of the 17 failing candidates in the
+same trace, and their values heavily overlap successes' — no separation
+visible, consistent with genuinely SNR-limited failures rather than a
+gating artifact.
+
+**Found and fixed one real BP parameter mismatch, but it's null on AWGN.**
+Checked WSJT-X's own `max_iterations` (BP iteration budget) per protocol:
+`ft8b.f90:96` and `fst4/decode240_101.f90:27` both use 30 (matching our
+shared `bp_max_iter: 30` hardcoded in `core/pipeline.rs`), but
+`ft4_decode.f90:194` uses **40** — FT4 is the outlier, not FT8/FST4.
+Scoped the fix to `P::ID == Ft4` (same pattern as sections 8-9), leaving
+FT8/FST4 byte-identical. Re-verified narrow (AWGN -19..-14 dB): **byte-
+identical** to section 9's post-fix baseline (40%/75%/100%/100%) — BP
+convergence isn't iteration-budget-limited in this range; candidates
+either converge well under 30 iterations or don't converge regardless of
+budget. Kept anyway (zero cost, now byte-faithful to WSJT-X, and may
+matter for fading/busy-band cases this narrow AWGN check didn't cover).
+
+**Verdict**: BP/OSD strength is not the source of the residual AWGN gap.
+The algorithm is already WSJT-X-faithful on host, OSD's marginal
+contribution here is too small (~4% of successes) to be hiding a large
+effect, and the one real parameter gap found doesn't move AWGN recall.
+`ft4_wsjtx_sample_recall_vs_golden` still 6/6, full non-ignored suite and
+`-D clippy::perf` green. The two candidates from section 8's closing
+notes — WSJT-X's early `smax`-based candidate reject before bitmetrics,
+and the 3-segment Δt-search structure — remain the most likely places
+left to look for the remaining ≈0.8 dB.
+
+## 11. 3-segment Δt-search retry — implemented, measured, reverted (issue #72, 2026-07-18)
+
+WSJT-X's `ft4_decode.f90` `iseg=1,2,3` loop doesn't just *find* a position
+more thoroughly than a single collapsed pass — it can attempt a **decode**
+at up to 3 different Δt positions per candidate (segment 1 `[108,560]`
+always tried first if `smax≥1.2`; segments 2/3 tried too, but only if
+their own `smax` beats segment 1's). `ft4_sync_search`'s single collapsed
+full-window pass (section 9) picks one global-best position and decodes
+once — in principle vulnerable to a higher-scoring spurious position
+elsewhere in the wider union window beating the true signal's own
+(lower-scoring but genuine) position at low SNR.
+
+Built `ft4_sync_search_window` (`core/sync2d.rs`, `ft4_sync_search` now a
+thin wrapper over it with the full `[-344,1012]` union) to let a
+diagnostic replicate WSJT-X's literal per-segment search, and
+`ft4_diag_segment_retry` (`tests/ft4_sweep.rs`) to check, for every
+currently-failing candidate, whether decoding at segment 1's position
+alone (not the collapsed global best) would have succeeded.
+
+**First pass over-reported dramatically**: 10/17 "rescues." Implemented
+the fix in `process_candidate_basic` (FT4-only 3-segment loop replacing
+the single collapsed call) and re-verified with the real `ft4_snr_sweep`
+— **byte-identical** to the pre-fix baseline, 0 movement. The diagnostic
+was wrong, not the theory: `try_decode_at` tried OSD unconditionally
+without the `hard_errors ≥ osd_max_errors` rejection gate real OSD
+results go through, so it was accepting exactly the kind of over-
+corrected, low-confidence codeword that gate exists to reject. Fixed the
+diagnostic to apply the same gate and check the decoded message against
+`GOLDEN_MSG` (not just "CRC passed") — corrected result: **0/17
+rescues**, matching the real sweep exactly. Reverted the
+`process_candidate_basic` segment loop back to the single collapsed
+pass (avoids 3x the search/decode cost per FT4 candidate for zero
+measured benefit); kept `ft4_sync_search_window` since it's harmless,
+reusable, and the diagnostic (`ft4_diag_segment_retry`) is worth keeping
+for future re-checks under CCIR fading or busy-band, where a spurious
+competing peak is more plausible than in clean AWGN.
+
+Lesson, stated plainly: a diagnostic that skips a real production gate to
+"give a hypothesis its best chance" can manufacture a false positive
+large enough to look like the answer. Re-verifying against the *actual*
+production code path (not just a simplified stand-in) — this file's
+recurring theme since section 6 — caught it before any code shipped on
+the strength of the flawed number.
+
+## 12. `osd_score_min` gate on the wrong (stale) score — real fix, ~0.5 dB further AWGN gain (issue #72, 2026-07-18)
+
+While building section 11's diagnostic, printing `cand.score` alongside
+decode outcomes surfaced a separate, real issue: `cand.score` is
+`coarse_sync`'s non-coherent score — a different, unrelated quantity
+from the coherent score `ft4_sync_search` computes (the one section 9
+fixed to be WSJT-X-faithful). `strictness.osd_score_min()` (`1.8`) was
+tuned in section 6 against `cand.score`, back before the coherent score
+existed as a separate quantity, and `process_candidate_basic`'s
+OSD-attempt gate (`core/pipeline.rs`) still checks `cand.score`, not the
+coherent one.
+
+Measured directly (`ft4_diag_weak_trials`, 17 currently-failing
+near-crossing AWGN candidates): **13/17 (76%) have `cand.score < 1.8`**
+and so never even attempt OSD — plain BP already failed, and that's the
+only rung they ever get. All 17 clear WSJT-X's own `syncmin=1.2` easily
+(the coherent score, correctly computed) — these are unambiguously real
+signals, not noise the gate is protecting against.
+
+WSJT-X's own FT4 decoder has no OSD-attempt score gate at all —
+`decode174_91` runs BP and OSD together in one call, governed by
+`ndepth`/`maxosd`, never by a score check. Section 8's FST4 bypass
+(`is_fst4`) already exists for the identical symptom, found during #146:
+"every real candidate's coarse-sync score sat below `osd_score_min`
+(blocking OSD entirely)." Extended the same bypass to FT4
+(`bypass_osd_score_min = is_fst4 || P::ID == Ft4`), keeping
+`osd_max_errors` (a genuine hard-error ceiling, not a stale-quantity
+gate) as the false-accept safety net — unlike FST4, which bypasses both.
+
+**Measured** (`ft4_snr_sweep`, real `decode_frame`):
+
+| Channel | -19 | -18 | -17 | -16 | -15 | -14 | -13 |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| AWGN | 0%→0% | 0%→15% | 40%→60% | 75%→80% | 100%→100% | 100%→100% | 100%→100% |
+| CCIR good | —→0% | 10%→15% | 45%→65% | 60%→75% | 95%→95% | 100%→100% | 95%→95% |
+| CCIR moderate | —→5% | 5%→15% | 10%→15% | 35%→40% | 65%→80% | 95%→100% | 95%→95% |
+| CCIR poor | —→0% | 0%→0% | 0%→0% | 25%→55% | 50%→60% | 75%→85% | 90%→90% |
+
+No regressions anywhere. 50%-crossing (linear-interpolated): **AWGN
+-16.7→-17.2 dB (+0.5 dB)** — WSJT-X's published -17.5 dB gap now only
+≈0.3 dB. CCIR good -16.7→-17.3 dB (+0.6 dB), CCIR moderate -15.5→-15.75 dB
+(+0.25 dB), CCIR poor -15.0→-16.1 dB (+1.1 dB, the biggest single-channel
+gain — the poor-fading trials evidently had the most candidates sitting
+in the blocked `cand.score<1.8` band).
+
+`ft4_wsjtx_sample_recall_vs_golden`: still 6/6, still 13 total decodes
+(no new false-accepts on the real sample — the `osd_max_errors` gate
+still in place is doing its job). Full non-ignored suite and
+`-D clippy::perf` green.
+
+**Cumulative issue #72 AWGN result**: -15.5 dB (pre-tuning) → -17.2 dB
+(now), essentially closing the gap to WSJT-X's published -17.5 dB. Three
+real, WSJT-X-source-verified fixes contributed (sections 6, 9, 12); two
+plausible-looking candidates were built, measured, and correctly
+discarded (sections 8, 11) rather than shipped on faith.

--- a/embedded-poc/assets/ft4_sweep/.gitignore
+++ b/embedded-poc/assets/ft4_sweep/.gitignore
@@ -1,0 +1,2 @@
+# ft4sim-generated sweep WAVs — regenerate with scripts/gen_ft4_sweep_wavs.sh
+*.wav

--- a/mfsk-core/src/core/pipeline.rs
+++ b/mfsk-core/src/core/pipeline.rs
@@ -41,6 +41,16 @@ pub enum DecodeDepth {
 }
 
 /// Decode strictness: trades off sensitivity vs false-positive rate.
+///
+/// `process_candidate_basic` bypasses both `osd_score_min` and
+/// `osd_max_errors` for FST4 (see the `is_fst4` gate below — issue #146:
+/// WSJT-X's own FST4 decoder has no such gates), so in practice these
+/// numbers are FT4-exclusive. `Normal` (FT4's hardcoded strictness,
+/// issue #72) was retuned 2026-07-18 against a `ft4sim` AWGN/CCIR sweep
+/// (`docs/notes/FT4_BENCHMARK.md`) — no longer a placeholder copy of the
+/// FT8 calibration. `Strict`/`Deep` are unused by any current caller but
+/// kept for the API shape; their numbers are the original FT8-copied
+/// values, unverified for FT4.
 #[derive(Debug, Clone, Copy, PartialEq, Default)]
 pub enum DecodeStrictness {
     Strict,
@@ -50,16 +60,23 @@ pub enum DecodeStrictness {
 }
 
 impl DecodeStrictness {
-    /// Upper bound on `hard_errors` for non-AP OSD decode. Same calibration
-    /// as the FT8 implementation; FT4/FST4 can re-tune later.
+    /// Upper bound on `hard_errors` for non-AP OSD decode.
+    ///
+    /// `Normal`'s values were retuned for FT4 (issue #72, 2026-07-18) by
+    /// sweeping against `ft4sim`-generated AWGN/CCIR WAVs and picking the
+    /// loosest thresholds that gained real (golden-message) recall without
+    /// also growing false-accepts (any CRC-passing decode beyond the golden
+    /// one) — see the `ft4_strictness_probe` test and
+    /// `docs/notes/FT4_BENCHMARK.md` section 5 for the measurements.
+    /// `Strict`/`Deep` remain the original FT8-copied placeholders.
     pub fn osd_max_errors(self, osd_depth: u8) -> u32 {
         match (self, osd_depth) {
             (Self::Strict, 3) => 20,
             (Self::Strict, 4) => 24,
             (Self::Strict, _) => 22,
-            (Self::Normal, 3) => 26,
+            (Self::Normal, 3) => 28,
             (Self::Normal, 4) => 30,
-            (Self::Normal, _) => 29,
+            (Self::Normal, _) => 31,
             (Self::Deep, 3) => 30,
             (Self::Deep, 4) => 36,
             (Self::Deep, _) => 40,
@@ -67,10 +84,12 @@ impl DecodeStrictness {
     }
 
     /// Minimum coarse-sync score to enter OSD fallback.
+    ///
+    /// `Normal` retuned alongside `osd_max_errors` above (issue #72).
     pub fn osd_score_min(self) -> f32 {
         match self {
             Self::Strict => 3.0,
-            Self::Normal => 2.2,
+            Self::Normal => 1.8,
             Self::Deep => 2.0,
         }
     }
@@ -154,189 +173,188 @@ pub fn process_candidate_basic<P: Protocol>(
         }
     }
 
-    // FT4 uses the WSJT-X-faithful 2-D `sync2d_refine` (`sync4d.f90`
-    // constants: coarse ±12 Hz/3 Hz × ±20/4 samples; fine ±4 Hz/1 Hz ×
-    // ±5 samples).  Bit-identical to the old `sync4d_refine`; critical for
-    // sub-bin signals like W9JA (520.0 Hz, midway between our 5.21-Hz bins)
-    // in the WSJT-X golden WAV.
-    //
-    // FST4 uses `fst4_sync_search`: faithful port of WSJT-X
-    // `fst4_decode.f90:879-925`.  Coarse pass sweeps ±1.5 s (full slot)
-    // so the winner is always near the true peak; fine pass ±7×0.02·baud ×
-    // ±4 samples locks in.  Previous local-window approach (Sync2dConfig
-    // ±10 samples) caused regression because noise peaks at the window edge
-    // displaced the fine pass outside reach of the true position.
-    //
-    // FT8 keeps the generic time-only `refine_candidate` path; it has its
-    // own 3-stage refine wired separately in `ft8/decode.rs`.
-    let (refined, i_start): (SyncCandidate, i32) =
-        if P::ID == super::ProtocolId::Ft4 || P::ID == super::ProtocolId::Fst4 {
-            let s2 = if P::ID == super::ProtocolId::Fst4 {
-                super::sync2d::fst4_sync_search::<P>(&cd0, cand)
-            } else {
-                let cfg = super::sync2d::Sync2dConfig::for_ft4();
-                super::sync2d::sync2d_refine::<P>(&cd0, cand, &cfg)
-            };
-            let df_hz = s2.freq_hz - cand.freq_hz;
-            cd0 = super::sync2d::freq_shift_cd0(&cd0, df_hz, ds_rate);
-            let i_start: i32 = s2.i0;
-            let refined = SyncCandidate {
-                freq_hz: s2.freq_hz,
-                dt_sec: (s2.i0 as f32) / ds_rate - tx_start,
-                score: s2.score,
-            };
-            (refined, i_start)
-        } else {
-            let refined = refine_candidate::<P>(&cd0, cand, refine_steps);
-            let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as i32;
-            (refined, i_start)
-        };
-
-    let cs_raw = symbol_spectra::<P>(&cd0, i_start);
-    let nsync = sync_quality::<P>(&cs_raw);
-    if nsync <= sync_q_min {
-        return None;
-    }
-
-    let per_block = fine_sync_power_per_block::<P>(&cd0, i_start);
-    let sync_cv = if !per_block.is_empty() {
-        let n = per_block.len() as f32;
-        let mean = per_block.iter().sum::<f32>() / n;
-        if mean > f32::EPSILON {
-            let var = per_block.iter().map(|&x| (x - mean).powi(2)).sum::<f32>() / n;
-            var.sqrt() / mean
-        } else {
-            0.0
-        }
-    } else {
-        0.0
-    };
-
     let _ = ntones;
     let _ = n_sym;
-    let decode = |cs: &[Complex<f32>]| -> Option<DecodeResult> {
-        let mut llr_set = compute_llr::<P, f32>(cs);
-        // RX half of the optional bit interleaver: if the protocol
-        // declares an interleave table, permute each LLR vector from
-        // channel-bit order into codeword-bit order before BP/OSD.
-        // No-op for protocols with `CODEWORD_INTERLEAVE = None`
-        // (FT4/FT8/FST4/etc) — same call site, byte-identical result.
-        deinterleave_llr_set::<P>(&mut llr_set);
-        // llre (nsym=P::LLR_NSYM_MID, e.g. FST4's nsym=4 rung — see
-        // `ModulationParams::LLR_NSYM_MID`) is empty for every protocol
-        // that doesn't set LLR_NSYM_MID, so this is a Vec instead of a
-        // fixed array only to make that slot conditional; no behaviour
-        // change for FT8/FT4/etc.
-        let mut variants: Vec<(&Vec<f32>, u8)> = Vec::with_capacity(5);
-        variants.push((&llr_set.llra, 0u8));
-        variants.push((&llr_set.llrb, 1));
-        if !llr_set.llre.is_empty() {
-            variants.push((&llr_set.llre, 6));
-        }
-        variants.push((&llr_set.llrc, 2));
-        variants.push((&llr_set.llrd, 3));
+    // BP iteration budget: WSJT-X's `ft8b.f90:96` and `fst4/decode240_101.f90:27`
+    // both use `max_iterations=30`, but `ft4_decode.f90:194` uses 40 — FT4 is
+    // the outlier, not the other two. Scoped to `P::ID == Ft4` (issue #72,
+    // discovered while checking whether BP/OSD strength explains the residual
+    // AWGN gap after `docs/notes/FT4_BENCHMARK.md` section 9) so FT8/FST4 stay
+    // byte-identical.
+    let bp_max_iter: u32 = if P::ID == super::ProtocolId::Ft4 {
+        40
+    } else {
+        30
+    };
+    let cd0_base = cd0;
 
-        let fec = P::Fec::default();
-        let bp_opts = FecOpts {
-            bp_max_iter: 30,
-            osd_depth: 0,
-            ap_mask: None,
-            // Thread the protocol's message-codec verifier so CRC-bearing
-            // protocols (FT8/FT4/FST4 → Wsjt77 → CRC-14) keep their
-            // existing reject-on-CRC-fail behaviour. uvpacket-style
-            // codecs that override `verify_info = |_| true` accept any
-            // parity-converged candidate.
-            verify_info: Some(<P::Msg as MessageCodec>::verify_info),
-            ..FecOpts::default()
+    // Attempt a full decode (symbol_spectra -> nsync gate -> BP -> OSD) at
+    // one explicit `(freq_hz, i0, score)` position. Factored out of the
+    // single-position call below so FT4 can retry it at up to 3 positions
+    // (see the segment loop further down) without duplicating the LLR/BP/
+    // OSD logic.
+    let try_position = |freq_hz: f32, i0: i32, score: f32| -> Option<DecodeResult> {
+        let df_hz = freq_hz - cand.freq_hz;
+        let cd0 = super::sync2d::freq_shift_cd0(&cd0_base, df_hz, ds_rate);
+        let refined = SyncCandidate {
+            freq_hz,
+            dt_sec: (i0 as f32) / ds_rate - tx_start,
+            score,
         };
 
-        for (llr, pass_id) in &variants {
-            if let Some(mut r) = fec.decode_soft(llr, &bp_opts) {
-                let itone = encode_tones_for_snr::<P>(&r.info, &fec);
-                let snr_db = compute_snr_db::<P>(cs, &itone);
-                // FT4 pre-LDPC scramble (WSJT-X `genft4.f90:64`): undo
-                // the rvec XOR before presenting the 77-bit payload.
-                descramble_info::<P>(&mut r.info);
-                return Some(DecodeResult {
-                    info: r.info.into_boxed_slice(),
-                    freq_hz: cand.freq_hz,
-                    dt_sec: refined.dt_sec,
-                    hard_errors: r.hard_errors,
-                    sync_score: refined.score,
-                    pass: *pass_id,
-                    sync_cv,
-                    snr_db,
-                });
-            }
+        let cs_raw = symbol_spectra::<P>(&cd0, i0);
+        let nsync = sync_quality::<P>(&cs_raw);
+        if nsync <= sync_q_min {
+            return None;
         }
 
-        // WSJT-X's own FST4 decoder (`fst4_decode.f90`) has neither of
-        // the gates below: `decode240_101` is called unconditionally
-        // after BP fails (no coarse-sync-score pre-filter), and its
-        // only acceptance test is `nharderrors.ge.0 .and.
-        // unpk77_success` (`fst4_decode.f90:570`) — i.e. "OSD
-        // converged to a CRC-24-verified codeword", full stop, no
-        // upper bound on how many bits OSD had to flip to get there.
-        // `osd_score_min`/`osd_max_errors` are FT8-calibrated
-        // (doc'd as "can re-tune later", issue #72) and were never
-        // re-tuned for FST4: near its own sensitivity threshold,
-        // every real candidate's coarse-sync score sat below
-        // `osd_score_min` (blocking OSD entirely) and every OSD
-        // result that *did* run had a CRC-verified hard-error count
-        // above `osd_max_errors` (rejected despite being provably
-        // correct) — issue #146. Bypass both for FST4 to match
-        // WSJT-X: attempt OSD whenever plain BP fails (still gated on
-        // `nsync` the same as every other protocol), and trust the
-        // CRC-24 verification inside `decode_soft` alone.
-        let is_fst4 = P::ID == super::ProtocolId::Fst4;
-        if depth == DecodeDepth::BpAllOsd
-            && nsync >= 12
-            && (is_fst4 || cand.score >= strictness.osd_score_min())
-        {
-            let freq_dup = known
-                .iter()
-                .any(|r| (r.freq_hz - cand.freq_hz).abs() < 20.0);
-            if !freq_dup {
-                let osd_depth: u8 = if nsync >= 18 { 3 } else { 2 };
-                let osd_opts = FecOpts {
-                    bp_max_iter: 30,
-                    osd_depth: osd_depth as u32,
-                    ap_mask: None,
-                    verify_info: Some(<P::Msg as MessageCodec>::verify_info),
-                    ..FecOpts::default()
-                };
-                for (llr, _) in &variants {
-                    if let Some(mut r) = fec.decode_soft(llr, &osd_opts) {
-                        if !is_fst4 && r.hard_errors >= strictness.osd_max_errors(osd_depth) {
-                            continue;
-                        }
-                        let itone = encode_tones_for_snr::<P>(&r.info, &fec);
-                        let snr_db = compute_snr_db::<P>(cs, &itone);
-                        descramble_info::<P>(&mut r.info);
-                        return Some(DecodeResult {
-                            info: r.info.into_boxed_slice(),
-                            freq_hz: cand.freq_hz,
-                            dt_sec: refined.dt_sec,
-                            hard_errors: r.hard_errors,
-                            sync_score: refined.score,
-                            pass: if osd_depth == 3 { 5 } else { 4 },
-                            sync_cv,
-                            snr_db,
-                        });
-                    }
+        let per_block = fine_sync_power_per_block::<P>(&cd0, i0);
+        let sync_cv = if !per_block.is_empty() {
+            let n = per_block.len() as f32;
+            let mean = per_block.iter().sum::<f32>() / n;
+            if mean > f32::EPSILON {
+                let var = per_block.iter().map(|&x| (x - mean).powi(2)).sum::<f32>() / n;
+                var.sqrt() / mean
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+
+        let decode = |cs: &[Complex<f32>]| -> Option<DecodeResult> {
+            let mut llr_set = compute_llr::<P, f32>(cs);
+            // RX half of the optional bit interleaver: if the protocol
+            // declares an interleave table, permute each LLR vector from
+            // channel-bit order into codeword-bit order before BP/OSD.
+            // No-op for protocols with `CODEWORD_INTERLEAVE = None`
+            // (FT4/FT8/FST4/etc) — same call site, byte-identical result.
+            deinterleave_llr_set::<P>(&mut llr_set);
+            // llre (nsym=P::LLR_NSYM_MID, e.g. FST4's nsym=4 rung — see
+            // `ModulationParams::LLR_NSYM_MID`) is empty for every protocol
+            // that doesn't set LLR_NSYM_MID, so this is a Vec instead of a
+            // fixed array only to make that slot conditional; no behaviour
+            // change for FT8/FT4/etc.
+            let mut variants: Vec<(&Vec<f32>, u8)> = Vec::with_capacity(5);
+            variants.push((&llr_set.llra, 0u8));
+            variants.push((&llr_set.llrb, 1));
+            if !llr_set.llre.is_empty() {
+                variants.push((&llr_set.llre, 6));
+            }
+            variants.push((&llr_set.llrc, 2));
+            variants.push((&llr_set.llrd, 3));
+
+            let fec = P::Fec::default();
+            let bp_opts = FecOpts {
+                bp_max_iter,
+                osd_depth: 0,
+                ap_mask: None,
+                // Thread the protocol's message-codec verifier so CRC-bearing
+                // protocols (FT8/FT4/FST4 → Wsjt77 → CRC-14) keep their
+                // existing reject-on-CRC-fail behaviour. uvpacket-style
+                // codecs that override `verify_info = |_| true` accept any
+                // parity-converged candidate.
+                verify_info: Some(<P::Msg as MessageCodec>::verify_info),
+                ..FecOpts::default()
+            };
+
+            for (llr, pass_id) in &variants {
+                if let Some(mut r) = fec.decode_soft(llr, &bp_opts) {
+                    let itone = encode_tones_for_snr::<P>(&r.info, &fec);
+                    let snr_db = compute_snr_db::<P>(cs, &itone);
+                    // FT4 pre-LDPC scramble (WSJT-X `genft4.f90:64`): undo
+                    // the rvec XOR before presenting the 77-bit payload.
+                    descramble_info::<P>(&mut r.info);
+                    return Some(DecodeResult {
+                        info: r.info.into_boxed_slice(),
+                        freq_hz: refined.freq_hz,
+                        dt_sec: refined.dt_sec,
+                        hard_errors: r.hard_errors,
+                        sync_score: refined.score,
+                        pass: *pass_id,
+                        sync_cv,
+                        snr_db,
+                    });
                 }
-                // OSD depth-4 Top-K pruning gated on high sync quality.
-                if nsync >= 18 {
-                    let osd4_opts = FecOpts {
-                        bp_max_iter: 30,
-                        osd_depth: 4,
+            }
+
+            // WSJT-X's own FST4 decoder (`fst4_decode.f90`) has neither of
+            // the gates below: `decode240_101` is called unconditionally
+            // after BP fails (no coarse-sync-score pre-filter), and its
+            // only acceptance test is `nharderrors.ge.0 .and.
+            // unpk77_success` (`fst4_decode.f90:570`) — i.e. "OSD
+            // converged to a CRC-24-verified codeword", full stop, no
+            // upper bound on how many bits OSD had to flip to get there.
+            // `osd_score_min`/`osd_max_errors` are FT8-calibrated
+            // (doc'd as "can re-tune later", issue #72) and were never
+            // re-tuned for FST4: near its own sensitivity threshold,
+            // every real candidate's coarse-sync score sat below
+            // `osd_score_min` (blocking OSD entirely) and every OSD
+            // result that *did* run had a CRC-verified hard-error count
+            // above `osd_max_errors` (rejected despite being provably
+            // correct) — issue #146. Bypass both for FST4 to match
+            // WSJT-X: attempt OSD whenever plain BP fails (still gated on
+            // `nsync` the same as every other protocol), and trust the
+            // CRC-24 verification inside `decode_soft` alone.
+            let is_fst4 = P::ID == super::ProtocolId::Fst4;
+            // FT4 hit the identical `osd_score_min` symptom FST4 already
+            // worked around: `cand.score` is `coarse_sync`'s non-coherent
+            // score (unrelated to the coherent `ft4_sync_search` score
+            // computed above), and `1.8` was tuned against it back when
+            // that was the only score in play (section 5/6). Empirically
+            // confirmed (`ft4_diag_weak_trials`, issue #72,
+            // `docs/notes/FT4_BENCHMARK.md` section 12): 13/17 currently-
+            // failing near-crossing AWGN candidates have `cand.score <
+            // 1.8` and so never even attempt OSD, despite all 17 clearing
+            // WSJT-X's own `syncmin=1.2` easily (real signals, not
+            // noise). WSJT-X's own FT4 decoder has no OSD-attempt score
+            // gate at all either (`decode174_91` runs BP+OSD together,
+            // governed by `ndepth`, not by a score check) — bypass
+            // `osd_score_min` for FT4 too, same as FST4, keeping
+            // `osd_max_errors` (a real hard-error ceiling, not a stale-
+            // quantity gate) as the false-accept safety net.
+            let bypass_osd_score_min = is_fst4 || P::ID == super::ProtocolId::Ft4;
+            // The `12`/`18` OSD depth-escalation gates below were calibrated
+            // against FT8's `N_SYNC=21` (3 blocks x 7-symbol Costas): 12/21
+            // ~ attempt-OSD-at-all, 18/21 ~ escalate to depth-3/depth-4.
+            // FT4's `N_SYNC=16` (4 blocks x 4-symbol Costas) is smaller —
+            // `nsync` can never reach 18 there (empirically confirmed via
+            // `ft4_diag_weak_trials`, issue #72: even -14dB AWGN decodes
+            // topped out around 15/16), so depth-3 OSD and the depth-4 Top-K
+            // rescue were silently dead code for every FT4 candidate. Scale
+            // by the same ratio the FT8 numbers imply, applied to FT4's own
+            // `N_SYNC` (16 * 12/21 ~ 9, 16 * 18/21 ~ 14) — reproduces 12/18
+            // exactly for FT8 (`P::N_SYNC == 21`) and leaves FST4 untouched
+            // (gated on `P::ID`, not a blanket formula, since FST4's
+            // depth-escalation threshold was already tuned separately,
+            // issue #146).
+            let (osd_attempt_min, osd_depth3_min) = if P::ID == super::ProtocolId::Ft4 {
+                (
+                    (12.0 * P::N_SYNC as f32 / 21.0).round() as u32,
+                    (18.0 * P::N_SYNC as f32 / 21.0).round() as u32,
+                )
+            } else {
+                (12, 18)
+            };
+            if depth == DecodeDepth::BpAllOsd
+                && nsync >= osd_attempt_min
+                && (bypass_osd_score_min || cand.score >= strictness.osd_score_min())
+            {
+                let freq_dup = known
+                    .iter()
+                    .any(|r| (r.freq_hz - cand.freq_hz).abs() < 20.0);
+                if !freq_dup {
+                    let osd_depth: u8 = if nsync >= osd_depth3_min { 3 } else { 2 };
+                    let osd_opts = FecOpts {
+                        bp_max_iter,
+                        osd_depth: osd_depth as u32,
                         ap_mask: None,
                         verify_info: Some(<P::Msg as MessageCodec>::verify_info),
                         ..FecOpts::default()
                     };
                     for (llr, _) in &variants {
-                        if let Some(mut r) = fec.decode_soft(llr, &osd4_opts) {
-                            if !is_fst4 && r.hard_errors >= strictness.osd_max_errors(4) {
+                        if let Some(mut r) = fec.decode_soft(llr, &osd_opts) {
+                            if !is_fst4 && r.hard_errors >= strictness.osd_max_errors(osd_depth) {
                                 continue;
                             }
                             let itone = encode_tones_for_snr::<P>(&r.info, &fec);
@@ -344,31 +362,97 @@ pub fn process_candidate_basic<P: Protocol>(
                             descramble_info::<P>(&mut r.info);
                             return Some(DecodeResult {
                                 info: r.info.into_boxed_slice(),
-                                freq_hz: cand.freq_hz,
+                                freq_hz: refined.freq_hz,
                                 dt_sec: refined.dt_sec,
                                 hard_errors: r.hard_errors,
                                 sync_score: refined.score,
-                                pass: 13,
+                                pass: if osd_depth == 3 { 5 } else { 4 },
                                 sync_cv,
                                 snr_db,
                             });
                         }
                     }
+                    // OSD depth-4 Top-K pruning gated on high sync quality.
+                    if nsync >= osd_depth3_min {
+                        let osd4_opts = FecOpts {
+                            bp_max_iter,
+                            osd_depth: 4,
+                            ap_mask: None,
+                            verify_info: Some(<P::Msg as MessageCodec>::verify_info),
+                            ..FecOpts::default()
+                        };
+                        for (llr, _) in &variants {
+                            if let Some(mut r) = fec.decode_soft(llr, &osd4_opts) {
+                                if !is_fst4 && r.hard_errors >= strictness.osd_max_errors(4) {
+                                    continue;
+                                }
+                                let itone = encode_tones_for_snr::<P>(&r.info, &fec);
+                                let snr_db = compute_snr_db::<P>(cs, &itone);
+                                descramble_info::<P>(&mut r.info);
+                                return Some(DecodeResult {
+                                    info: r.info.into_boxed_slice(),
+                                    freq_hz: refined.freq_hz,
+                                    dt_sec: refined.dt_sec,
+                                    hard_errors: r.hard_errors,
+                                    sync_score: refined.score,
+                                    pass: 13,
+                                    sync_cv,
+                                    snr_db,
+                                });
+                            }
+                        }
+                    }
                 }
             }
-        }
 
-        None
+            None
+        };
+
+        match eq_mode {
+            EqMode::Off => decode(&cs_raw),
+            EqMode::Local => {
+                let mut cs_eq = cs_raw.clone();
+                equalize_local::<P>(&mut cs_eq);
+                decode(&cs_eq)
+            }
+        }
     };
 
-    match eq_mode {
-        EqMode::Off => decode(&cs_raw),
-        EqMode::Local => {
-            let mut cs_eq = cs_raw.clone();
-            equalize_local::<P>(&mut cs_eq);
-            decode(&cs_eq)
-        }
-    }
+    // FT4 uses `ft4_sync_search`: a coherent full-slot Δt search (WSJT-X
+    // `ft4_decode.f90` isync=1/2 + `sync4d.f90` scorer). A literal port of
+    // WSJT-X's `iseg=1,2,3` per-segment retry structure (try up to 3
+    // different Δt positions, not just the single global best) was
+    // implemented and measured here — empirically ruled out, not just
+    // unimplemented: `ft4_diag_segment_retry` (`tests/ft4_sweep.rs`,
+    // issue #72, `docs/notes/FT4_BENCHMARK.md` section 11) found 0/17
+    // rescues once the diagnostic was corrected to apply the same
+    // `hard_errors >= osd_max_errors` gate and golden-message check
+    // production does — an earlier uncorrected pass had over-reported
+    // 10/17 by skipping that gate. Reverted to the single collapsed pass
+    // to avoid 3x the search/decode cost for zero measured benefit.
+    //
+    // FST4 uses `fst4_sync_search`: faithful port of WSJT-X
+    // `fst4_decode.f90:879-925`. Coarse pass sweeps ±1.5 s (full slot) so
+    // the winner is always near the true peak; fine pass ±7×0.02·baud ×
+    // ±4 samples locks in. Previous local-window approach (Sync2dConfig
+    // ±10 samples) caused regression because noise peaks at the window
+    // edge displaced the fine pass outside reach of the true position.
+    //
+    // FT8 (and everything else) keeps the generic time-only
+    // `refine_candidate` path; FT8 has its own 3-stage refine wired
+    // separately in `ft8/decode.rs`.
+    let (freq_hz, i0, score) = if P::ID == super::ProtocolId::Ft4 {
+        let s2 = super::sync2d::ft4_sync_search::<P>(&cd0_base, cand);
+        (s2.freq_hz, s2.i0, s2.score)
+    } else if P::ID == super::ProtocolId::Fst4 {
+        let s2 = super::sync2d::fst4_sync_search::<P>(&cd0_base, cand);
+        (s2.freq_hz, s2.i0, s2.score)
+    } else {
+        let refined = refine_candidate::<P>(&cd0_base, cand, refine_steps);
+        let i_start = ((refined.dt_sec + tx_start) * ds_rate).round() as i32;
+        (refined.freq_hz, i_start, refined.score)
+    };
+    try_position(freq_hz, i0, score)
 }
 
 /// Deinterleave each of the four LLR variants from channel-bit order to
@@ -474,10 +558,23 @@ pub fn decode_frame<P: Protocol>(
         })
         .collect();
 
+    // Dedup by decoded message, keeping the candidate with the highest
+    // `sync_score` (the post-refine coherent Costas correlation) rather
+    // than the first-processed one. `coarse_sync`'s NMS can keep more
+    // than one (freq, dt) candidate per frequency bin, and more than one
+    // can independently reach a self-consistent Costas lock on the same
+    // real signal (not noise — both land in the same place after
+    // `ft4_sync_search`'s refine). This is now mostly cosmetic
+    // (`DecodeResult.freq_hz`/`dt_sec` come from the *refined* position,
+    // not the raw candidate, so duplicates converge on nearly the same
+    // reported values) but keeps the tie-break meaningful for the rare
+    // case where refinement doesn't fully converge.
     let mut results: Vec<DecodeResult> = Vec::new();
     for r in raw {
-        if !results.iter().any(|x| x.info == r.info) {
-            results.push(r);
+        match results.iter_mut().find(|x| x.info == r.info) {
+            Some(existing) if r.sync_score > existing.sync_score => *existing = r,
+            Some(_) => {}
+            None => results.push(r),
         }
     }
     (results, fft_cache)

--- a/mfsk-core/src/core/pipeline.rs
+++ b/mfsk-core/src/core/pipeline.rs
@@ -328,11 +328,13 @@ pub fn process_candidate_basic<P: Protocol>(
             // (gated on `P::ID`, not a blanket formula, since FST4's
             // depth-escalation threshold was already tuned separately,
             // issue #146).
+            // Integer round-to-nearest (`(A + B/2) / B`) instead of the
+            // f32 `.round()` this originally used — same result for
+            // FT4's `N_SYNC=16` (9/14 either way), no float ops on a
+            // path embedded/no_std builds also compile (Gemini PR
+            // review).
             let (osd_attempt_min, osd_depth3_min) = if P::ID == super::ProtocolId::Ft4 {
-                (
-                    (12.0 * P::N_SYNC as f32 / 21.0).round() as u32,
-                    (18.0 * P::N_SYNC as f32 / 21.0).round() as u32,
-                )
+                ((12 * P::N_SYNC + 10) / 21, (18 * P::N_SYNC + 10) / 21)
             } else {
                 (12, 18)
             };

--- a/mfsk-core/src/core/sync2d.rs
+++ b/mfsk-core/src/core/sync2d.rs
@@ -378,7 +378,7 @@ pub fn fst4_sync_search<P: Protocol>(
 /// large — even though the true peak's *coherent* score was consistently
 /// higher than whatever the non-coherent stage picked instead.
 ///
-/// **Scorer**: `score_flat_coherent` per FT4 Costas block (4 blocks:
+/// **Scorer**: one coherent dot product per FT4 Costas block (4 blocks:
 /// symbols 0, 33, 66, 99), magnitude-summed across blocks — matches
 /// `sync4d.f90`'s `sync = p(z1)+p(z2)+p(z3)+p(z4)` (`p(z)=|z*fac|`,
 /// magnitude not power) where each `z_k` is itself ONE coherent dot
@@ -386,15 +386,20 @@ pub fn fst4_sync_search<P: Protocol>(
 /// (`z1=sum(cd0(i1:i1+4*NSS-1:2)*conjg(csync2))`, `sync4d.f90:64`) — i.e.
 /// coherent *within* each block, magnitude-summed (non-coherent) *across*
 /// the 4 blocks, the same combining style [`fst4_sync_search`] already
-/// uses. **Originally shipped using `score_costas_block`** (per-symbol
-/// power-sum, correct for FT8's `sync8d.f90` — verified against
-/// `/home/minoru/src/WSJT-X/lib/ft8/sync8d.f90`, which really does
-/// non-coherent per-symbol power summing) — a ~3 dB-class discrimination
-/// gap at near-threshold SNR (same mechanism as the FST4 fix, issue #146),
-/// caught during the issue #72 AWGN-gap diagnostic
-/// (`docs/notes/FT4_BENCHMARK.md` section 9) by reading `sync4d.f90`'s
-/// inner `z1=sum(...)` line rather than stopping at the outer
-/// `sync=p(z1)+...` formula that (correctly) matched at a glance.
+/// uses. [`ft4_sync_search_window`] twiddles each candidate `(Δf, Δt)`
+/// cell's dot product inline rather than calling `score_flat_coherent`
+/// on a pre-twiddled reference (as an earlier revision did) — same
+/// arithmetic, but avoids re-allocating a twiddled `Vec<Complex<f32>>`
+/// per block on every one of the ~19,900 grid cells the coarse+fine
+/// passes evaluate. **Originally shipped using `score_costas_block`**
+/// (per-symbol power-sum, correct for FT8's `sync8d.f90` — verified
+/// against `/home/minoru/src/WSJT-X/lib/ft8/sync8d.f90`, which really
+/// does non-coherent per-symbol power summing) — a ~3 dB-class
+/// discrimination gap at near-threshold SNR (same mechanism as the
+/// FST4 fix, issue #146), caught during the issue #72 AWGN-gap
+/// diagnostic (`docs/notes/FT4_BENCHMARK.md` section 9) by reading
+/// `sync4d.f90`'s inner `z1=sum(...)` line rather than stopping at the
+/// outer `sync=p(z1)+...` formula that (correctly) matched at a glance.
 ///
 /// **Coarse pass**: ±12 Hz / 3 Hz step (`ft4_decode.f90` isync=1:
 /// `idfmin=-12,idfmax=12,idfstp=3`) × a *fixed absolute* Δt window,
@@ -451,10 +456,47 @@ pub fn ft4_sync_search_window<P: Protocol>(
         })
         .collect();
 
-    let score_at = |twiddled: &[(i32, Vec<Complex<f32>>)], i0: i32| -> f32 {
-        twiddled
+    // Twiddle on the fly inside the score rather than materialising a
+    // fresh `Vec<Complex<f32>>` per block per (Δf, Δt) grid cell — the
+    // coarse+fine passes below evaluate ~19,900 cells, so the old
+    // per-cell `twiddle_flat_ref` allocation added up to ~90 heap
+    // allocations per `ft4_sync_search_window` call (Gemini PR review).
+    // Mathematically identical: `score_flat_coherent` on a pre-twiddled
+    // reference is the same dot product as twiddling each sample of
+    // `cd0` in place here.
+    let score_at = |i0: i32, df: f32| -> f32 {
+        blocks_ref
             .iter()
-            .map(|(off, flat)| score_flat_coherent(cd0, flat, i0 + off))
+            .map(|(off, flat)| {
+                let cd0_start = i0 + off;
+                let np = cd0.len() as i32;
+                let len = flat.len() as i32;
+                if cd0_start < 0 || cd0_start + len > np {
+                    return 0.0;
+                }
+                let s0 = cd0_start as usize;
+                if df.abs() < f32::EPSILON {
+                    let z: Complex<f32> = cd0[s0..s0 + len as usize]
+                        .iter()
+                        .zip(flat.iter())
+                        .map(|(&c, &r)| c * r.conj())
+                        .sum();
+                    z.norm()
+                } else {
+                    let omega = -2.0 * PI * df / ds_rate;
+                    let z: Complex<f32> = cd0[s0..s0 + len as usize]
+                        .iter()
+                        .zip(flat.iter())
+                        .enumerate()
+                        .map(|(n, (&c, &r))| {
+                            let p = omega * n as f32;
+                            let twid = Complex::new(p.cos(), p.sin());
+                            c * r.conj() * twid
+                        })
+                        .sum();
+                    z.norm()
+                }
+            })
             .sum::<f32>()
     };
 
@@ -465,14 +507,9 @@ pub fn ft4_sync_search_window<P: Protocol>(
     let mut idf = -12i32;
     while idf <= 12 {
         let df = idf as f32;
-        let twiddled: Vec<(i32, Vec<Complex<f32>>)> = blocks_ref
-            .iter()
-            .map(|(off, flat)| (*off, twiddle_flat_ref(flat, df, ds_rate)))
-            .collect();
-
         let mut i0 = ib_min;
         while i0 <= ib_max {
-            let s = score_at(&twiddled, i0);
+            let s = score_at(i0, df);
             if s > best_score {
                 best_score = s;
                 best_df = df;
@@ -490,13 +527,9 @@ pub fn ft4_sync_search_window<P: Protocol>(
 
     for si in -4i32..=4 {
         let df = coarse_winner_df + si as f32;
-        let twiddled: Vec<(i32, Vec<Complex<f32>>)> = blocks_ref
-            .iter()
-            .map(|(off, flat)| (*off, twiddle_flat_ref(flat, df, ds_rate)))
-            .collect();
         for di in -5i32..=5 {
             let i0 = coarse_winner_i0 + di;
-            let s = score_at(&twiddled, i0);
+            let s = score_at(i0, df);
             if s > best_score {
                 best_score = s;
                 best_df = df;

--- a/mfsk-core/src/core/sync2d.rs
+++ b/mfsk-core/src/core/sync2d.rs
@@ -464,7 +464,20 @@ pub fn ft4_sync_search_window<P: Protocol>(
     // Mathematically identical: `score_flat_coherent` on a pre-twiddled
     // reference is the same dot product as twiddling each sample of
     // `cd0` in place here.
+    // `df` is constant across all samples in a block, so the per-sample
+    // twiddle phasor is a fixed rotation `step = exp(iω)` applied
+    // incrementally (one complex multiply per sample) rather than
+    // recomputing `cos`/`sin` from scratch at every sample — same
+    // values, ~128x fewer transcendental calls per `score_at` call
+    // (Gemini PR review, second pass after the allocation fix above).
     let score_at = |i0: i32, df: f32| -> f32 {
+        let has_df = df.abs() >= f32::EPSILON;
+        let step = if has_df {
+            let omega = -2.0 * PI * df / ds_rate;
+            Complex::new(omega.cos(), omega.sin())
+        } else {
+            Complex::new(1.0f32, 0.0f32)
+        };
         blocks_ref
             .iter()
             .map(|(off, flat)| {
@@ -475,7 +488,7 @@ pub fn ft4_sync_search_window<P: Protocol>(
                     return 0.0;
                 }
                 let s0 = cd0_start as usize;
-                if df.abs() < f32::EPSILON {
+                if !has_df {
                     let z: Complex<f32> = cd0[s0..s0 + len as usize]
                         .iter()
                         .zip(flat.iter())
@@ -483,15 +496,14 @@ pub fn ft4_sync_search_window<P: Protocol>(
                         .sum();
                     z.norm()
                 } else {
-                    let omega = -2.0 * PI * df / ds_rate;
+                    let mut twid = Complex::new(1.0f32, 0.0f32);
                     let z: Complex<f32> = cd0[s0..s0 + len as usize]
                         .iter()
                         .zip(flat.iter())
-                        .enumerate()
-                        .map(|(n, (&c, &r))| {
-                            let p = omega * n as f32;
-                            let twid = Complex::new(p.cos(), p.sin());
-                            c * r.conj() * twid
+                        .map(|(&c, &r)| {
+                            let val = c * r.conj() * twid;
+                            twid *= step;
+                            val
                         })
                         .sum();
                     z.norm()

--- a/mfsk-core/src/core/sync2d.rs
+++ b/mfsk-core/src/core/sync2d.rs
@@ -470,14 +470,12 @@ pub fn ft4_sync_search_window<P: Protocol>(
     // recomputing `cos`/`sin` from scratch at every sample — same
     // values, ~128x fewer transcendental calls per `score_at` call
     // (Gemini PR review, second pass after the allocation fix above).
-    let score_at = |i0: i32, df: f32| -> f32 {
-        let has_df = df.abs() >= f32::EPSILON;
-        let step = if has_df {
-            let omega = -2.0 * PI * df / ds_rate;
-            Complex::new(omega.cos(), omega.sin())
-        } else {
-            Complex::new(1.0f32, 0.0f32)
-        };
+    // `step`/`has_df` themselves are hoisted one level further out (per
+    // `df`, not per `(i0, df)` cell) by the two loops below — `df` only
+    // changes in the outer loop, so recomputing them inside `score_at`
+    // on every inner-loop `i0` was still >99% redundant `cos`/`sin`
+    // calls (Gemini PR review, third pass).
+    let score_at = |i0: i32, step: Complex<f32>, has_df: bool| -> f32 {
         blocks_ref
             .iter()
             .map(|(off, flat)| {
@@ -516,12 +514,24 @@ pub fn ft4_sync_search_window<P: Protocol>(
     let mut best_i0 = ((candidate.dt_sec + P::TX_START_OFFSET_S) * ds_rate).round() as i32;
     let mut best_score = f32::NEG_INFINITY;
 
+    let phasor_for = |df: f32| -> (Complex<f32>, bool) {
+        let has_df = df.abs() >= f32::EPSILON;
+        let step = if has_df {
+            let omega = -2.0 * PI * df / ds_rate;
+            Complex::new(omega.cos(), omega.sin())
+        } else {
+            Complex::new(1.0f32, 0.0f32)
+        };
+        (step, has_df)
+    };
+
     let mut idf = -12i32;
     while idf <= 12 {
         let df = idf as f32;
+        let (step, has_df) = phasor_for(df);
         let mut i0 = ib_min;
         while i0 <= ib_max {
-            let s = score_at(i0, df);
+            let s = score_at(i0, step, has_df);
             if s > best_score {
                 best_score = s;
                 best_df = df;
@@ -539,9 +549,10 @@ pub fn ft4_sync_search_window<P: Protocol>(
 
     for si in -4i32..=4 {
         let df = coarse_winner_df + si as f32;
+        let (step, has_df) = phasor_for(df);
         for di in -5i32..=5 {
             let i0 = coarse_winner_i0 + di;
-            let s = score_at(i0, df);
+            let s = score_at(i0, step, has_df);
             if s > best_score {
                 best_score = s;
                 best_df = df;

--- a/mfsk-core/src/core/sync2d.rs
+++ b/mfsk-core/src/core/sync2d.rs
@@ -367,6 +367,151 @@ pub fn fst4_sync_search<P: Protocol>(
     }
 }
 
+/// FT4-specific sync: coherent full-slot Δt search, faithful port of
+/// WSJT-X `ft4_decode.f90`'s `isync=1`/`isync=2` loop (`sync4d.f90` scorer)
+/// — added 2026-07-18 after a diagnostic
+/// (`tests/ft4_coherent_wide_search_diag.rs`) confirmed the hypothesis:
+/// `core::sync::coarse_sync`'s non-coherent (power-spectrogram) Δt
+/// estimate can be wrong by more than a second under CCIR fading, and
+/// the previous local `sync2d_refine` (`Sync2dConfig::for_ft4`, ±20
+/// downsampled samples ≈ ±30 ms) could never recover from an error that
+/// large — even though the true peak's *coherent* score was consistently
+/// higher than whatever the non-coherent stage picked instead.
+///
+/// **Scorer**: `score_flat_coherent` per FT4 Costas block (4 blocks:
+/// symbols 0, 33, 66, 99), magnitude-summed across blocks — matches
+/// `sync4d.f90`'s `sync = p(z1)+p(z2)+p(z3)+p(z4)` (`p(z)=|z*fac|`,
+/// magnitude not power) where each `z_k` is itself ONE coherent dot
+/// product spanning all 4 symbols of block k
+/// (`z1=sum(cd0(i1:i1+4*NSS-1:2)*conjg(csync2))`, `sync4d.f90:64`) — i.e.
+/// coherent *within* each block, magnitude-summed (non-coherent) *across*
+/// the 4 blocks, the same combining style [`fst4_sync_search`] already
+/// uses. **Originally shipped using `score_costas_block`** (per-symbol
+/// power-sum, correct for FT8's `sync8d.f90` — verified against
+/// `/home/minoru/src/WSJT-X/lib/ft8/sync8d.f90`, which really does
+/// non-coherent per-symbol power summing) — a ~3 dB-class discrimination
+/// gap at near-threshold SNR (same mechanism as the FST4 fix, issue #146),
+/// caught during the issue #72 AWGN-gap diagnostic
+/// (`docs/notes/FT4_BENCHMARK.md` section 9) by reading `sync4d.f90`'s
+/// inner `z1=sum(...)` line rather than stopping at the outer
+/// `sync=p(z1)+...` formula that (correctly) matched at a glance.
+///
+/// **Coarse pass**: ±12 Hz / 3 Hz step (`ft4_decode.f90` isync=1:
+/// `idfmin=-12,idfmax=12,idfstp=3`) × a *fixed absolute* Δt window,
+/// step 4 downsampled samples (`ibstp=4`). The absolute window
+/// `[-344, 1012]` downsampled samples is WSJT-X's combined 3-segment
+/// coverage (`iseg=1..3`, `ibmin`/`ibmax` per segment) collapsed into
+/// one pass — deliberately centred on the *nominal* frame position
+/// (`i0` for `dt_sec=0`), not on `candidate.dt_sec`, since that
+/// non-coherent estimate is exactly what this function exists to
+/// override.
+///
+/// **Fine pass**: ±4 Hz / 1 Hz × ±5 samples step 1 around the coarse
+/// winner (`ft4_decode.f90` isync=2).
+pub fn ft4_sync_search<P: Protocol>(
+    cd0: &[Complex<f32>],
+    candidate: &SyncCandidate,
+) -> Sync2dResult {
+    // WSJT-X `ft4_decode.f90`: iseg=1 ibmin=108/ibmax=560, iseg=2
+    // ibmin=560/ibmax=1012, iseg=3 ibmin=-344/ibmax=108 — union is
+    // [-344, 1012], an absolute downsampled-sample range independent of
+    // any candidate dt guess. Collapsed into one pass here (see module
+    // doc above `ft4_sync_search`) rather than WSJT-X's literal 3-segment
+    // loop with a per-segment decode attempt — [`ft4_sync_search_window`]
+    // exposes the windowed search directly for diagnosing whether that
+    // collapse loses anything (issue #72, `FT4_BENCHMARK.md` section 11).
+    ft4_sync_search_window::<P>(cd0, candidate, -344, 1012)
+}
+
+/// Same coherent full-slot Δt search as [`ft4_sync_search`], but over an
+/// explicit `[ib_min, ib_max]` downsampled-sample window instead of the
+/// hardcoded full-union range. Lets callers (tests, diagnostics) replicate
+/// WSJT-X's literal per-segment search — `ft4_decode.f90`'s `iseg=1,2,3`
+/// loop, each with its own `ibmin`/`ibmax` — to check whether the
+/// collapsed single-pass search in [`ft4_sync_search`] ever misses a
+/// position that a per-segment search plus a per-segment decode attempt
+/// would have found.
+pub fn ft4_sync_search_window<P: Protocol>(
+    cd0: &[Complex<f32>],
+    candidate: &SyncCandidate,
+    ib_min: i32,
+    ib_max: i32,
+) -> Sync2dResult {
+    let d = SyncDims::of::<P>();
+    let ds_spb = d.ds_spb;
+    let ds_rate = d.ds_rate;
+    const COARSE_DT_STEP: i32 = 4;
+
+    let blocks_ref: Vec<(i32, Vec<Complex<f32>>)> = P::SYNC_MODE
+        .blocks()
+        .iter()
+        .map(|b| {
+            let off = b.start_symbol as i32 * ds_spb as i32;
+            (off, make_costas_ref_continuous(b.pattern, ds_spb))
+        })
+        .collect();
+
+    let score_at = |twiddled: &[(i32, Vec<Complex<f32>>)], i0: i32| -> f32 {
+        twiddled
+            .iter()
+            .map(|(off, flat)| score_flat_coherent(cd0, flat, i0 + off))
+            .sum::<f32>()
+    };
+
+    let mut best_df = 0.0f32;
+    let mut best_i0 = ((candidate.dt_sec + P::TX_START_OFFSET_S) * ds_rate).round() as i32;
+    let mut best_score = f32::NEG_INFINITY;
+
+    let mut idf = -12i32;
+    while idf <= 12 {
+        let df = idf as f32;
+        let twiddled: Vec<(i32, Vec<Complex<f32>>)> = blocks_ref
+            .iter()
+            .map(|(off, flat)| (*off, twiddle_flat_ref(flat, df, ds_rate)))
+            .collect();
+
+        let mut i0 = ib_min;
+        while i0 <= ib_max {
+            let s = score_at(&twiddled, i0);
+            if s > best_score {
+                best_score = s;
+                best_df = df;
+                best_i0 = i0;
+            }
+            i0 += COARSE_DT_STEP;
+        }
+        idf += 3;
+    }
+
+    // Fine pass around the coarse winner.
+    let coarse_winner_df = best_df;
+    let coarse_winner_i0 = best_i0;
+    best_score = f32::NEG_INFINITY;
+
+    for si in -4i32..=4 {
+        let df = coarse_winner_df + si as f32;
+        let twiddled: Vec<(i32, Vec<Complex<f32>>)> = blocks_ref
+            .iter()
+            .map(|(off, flat)| (*off, twiddle_flat_ref(flat, df, ds_rate)))
+            .collect();
+        for di in -5i32..=5 {
+            let i0 = coarse_winner_i0 + di;
+            let s = score_at(&twiddled, i0);
+            if s > best_score {
+                best_score = s;
+                best_df = df;
+                best_i0 = i0;
+            }
+        }
+    }
+
+    Sync2dResult {
+        freq_hz: candidate.freq_hz + best_df,
+        i0: best_i0,
+        score: best_score,
+    }
+}
+
 /// Apply a complex-phasor freq shift to `cd0`. Used by callers that
 /// take the [`Sync2dResult::freq_hz`] from this module and want to
 /// run [`crate::core::llr::symbol_spectra`] on a baseband whose

--- a/mfsk-core/src/ft4/decode.rs
+++ b/mfsk-core/src/ft4/decode.rs
@@ -79,9 +79,10 @@ pub fn decode_frame(
 /// Decode one FT4 slot with an explicit `depth` knob.
 ///
 /// Mirrors [`crate::ft8::decode::decode_frame`]'s `depth` parameter.
-/// FT4's per-candidate strictness is hardcoded to `Normal` — the
-/// FT4-specific re-tune of the FT8-calibrated thresholds never landed
-/// and no caller exercised the `Strict` / `Deep` rungs (issue #72).
+/// FT4's per-candidate strictness is hardcoded to `Normal` — `Normal`'s
+/// numbers were retuned against a `ft4sim` AWGN/CCIR sweep (issue #72,
+/// 2026-07-18); no caller exercises the `Strict` / `Deep` rungs, whose
+/// numbers remain the original unverified FT8 copy.
 ///
 /// `freq_hint` is the same as in `ft8::decode::decode_frame`: when
 /// `Some(f)`, narrows the coarse-sync to candidates near `f` ± a few Hz.

--- a/mfsk-core/tests/ft4_coherent_wide_search_diag.rs
+++ b/mfsk-core/tests/ft4_coherent_wide_search_diag.rs
@@ -1,0 +1,144 @@
+//! Diagnostic (not a regression gate): does `core::sync::coarse_sync`'s
+//! non-coherent wide-Δt search actually land near the true sync peak on
+//! weak FT4 trials, or does a directly-computed coherent wide-Δt scan
+//! (bypassing coarse_sync entirely) find a much stronger peak elsewhere?
+//!
+//! Hypothesis (from a WSJT-X source comparison, 2026-07-18): WSJT-X's
+//! FT4 decoder (`ft4_decode.f90` + `sync4d.f90`) does its wide Δt search
+//! (~350-450 raw samples per segment, step 4 @ 666.7 Hz ≈ 6 ms)
+//! *coherently* — complex Costas correlation, not power spectra. Our
+//! `core::sync::coarse_sync` searches a wider Δt window (±2.5 s) but
+//! *non-coherently* (magnitude-squared spectrogram bins) at a coarser
+//! 24 ms grid, then `sync2d_refine`'s coherent pass only re-examines
+//! ±20 downsampled samples (≈±30 ms) around whatever coarse_sync picked.
+//! If the non-coherent stage's peak-location estimate is noisy at low
+//! SNR and lands more than ~30 ms from the true peak, the coherent
+//! refine never reaches it and the candidate is lost — even though a
+//! coherent search would have found it.
+//!
+//! This test scans a full-slot coherent Costas score directly (mirroring
+//! what a `fst4_sync_search`-style full-slot coherent scan would do for
+//! FT4) at the known-true frequency (1500 Hz, `ft4sim`'s fixed test
+//! frequency) and compares:
+//!   - where the true coherent peak actually sits (should be near
+//!     dt=0.0, the `ft4sim` DT=0.0 nominal)
+//!   - what `coarse_sync` picked as its best candidate near 1500 Hz,
+//!     and how far that is from the true coherent peak
+//!   - whether that distance exceeds `sync2d_refine`'s ±20-sample
+//!     coarse radius (which would mean the coherent refine pass can
+//!     never recover the true peak from there)
+//!
+//! Run:
+//! ```sh
+//! cargo test --release --test ft4_coherent_wide_search_diag \
+//!     --features ft4,fft-rustfft,uvpacket -- --ignored --nocapture
+//! ```
+
+#![cfg(feature = "ft4")]
+
+use std::path::{Path, PathBuf};
+
+use mfsk_core::core::dsp::downsample::downsample;
+use mfsk_core::core::sync::{coarse_sync, fine_sync_power};
+use mfsk_core::ft4::Ft4;
+use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+
+const GOLDEN_FREQ_HZ: f32 = 1500.0;
+/// FT4's `TX_START_OFFSET_S` — nominal frame start in the 90 000-sample
+/// (7.5 s) slot `ft4sim` generates with `DT=0.0`.
+const TX_START_OFFSET_S: f32 = 0.5;
+const DS_RATE: f32 = 12_000.0 / 18.0; // NDOWN=18
+
+fn sweep_dir() -> PathBuf {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    Path::new(&manifest)
+        .join("../embedded-poc/assets/ft4_sweep")
+        .to_path_buf()
+}
+
+#[test]
+#[ignore = "manual diagnostic — FT4 coherent-vs-noncoherent coarse-sync hypothesis"]
+fn coherent_wide_scan_vs_coarse_sync_pick() {
+    let dir = sweep_dir();
+
+    // A few trials from cells where recall is currently weak
+    // (measured 2026-07-18: awgn -16 dB = 4/20, ccir_moderate -16 dB =
+    // 1/20) — pick trials 1..8 so both hits and misses are represented,
+    // to see whether the pattern differs between them.
+    let cells = [("awgn", "m16"), ("ccir_moderate", "m16")];
+
+    for (chan, tag) in cells {
+        println!("\n=== {chan} {tag} ===");
+        for t in 1..=8u32 {
+            let path = dir.join(format!("ft4_{chan}_{tag}_{t:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                println!("  trial {t:02}: (missing, skip)");
+                continue;
+            };
+
+            // 1. Direct coherent wide-Δt scan at the known-true frequency.
+            //    Downsample once at 1500 Hz, then evaluate `fine_sync_power`
+            //    (coherent Costas correlation) at every downsampled-sample
+            //    offset across the full plausible Δt range (±2.5 s, matching
+            //    coarse_sync's own `jz` radius) — this is what a
+            //    `fst4_sync_search`-style full-slot coherent search would do.
+            let (cd0, _) = downsample(&audio, GOLDEN_FREQ_HZ, &FT4_DOWNSAMPLE);
+            let radius_i0 = (2.5 * DS_RATE) as i32;
+            let mut best_i0 = 0i32;
+            let mut best_score = -1.0f32;
+            for i0 in -radius_i0..=radius_i0 {
+                let score = fine_sync_power::<Ft4>(&cd0, i0);
+                if score > best_score {
+                    best_score = score;
+                    best_i0 = i0;
+                }
+            }
+            let true_dt_sec = best_i0 as f32 / DS_RATE - TX_START_OFFSET_S;
+
+            // 2. What coarse_sync actually picked near 1500 Hz.
+            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.0, None, 200);
+            let near = cands
+                .iter()
+                .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= 5.0)
+                .max_by(|a, b| a.score.partial_cmp(&b.score).unwrap());
+
+            match near {
+                Some(c) => {
+                    let dt_gap_ms = (c.dt_sec - true_dt_sec).abs() * 1000.0;
+                    let coherent_score_there = fine_sync_power::<Ft4>(
+                        &cd0,
+                        ((c.dt_sec + TX_START_OFFSET_S) * DS_RATE).round() as i32,
+                    );
+                    let out_of_reach = dt_gap_ms > 30.0; // sync2d_refine coarse radius ≈30ms
+                    println!(
+                        "  trial {t:02}: true_dt={:+.3}s (coherent peak={:.0})  \
+                         coarse_sync_dt={:+.3}s (coherent score there={:.0}, non-coh score={:.3})  \
+                         gap={:.0}ms{}",
+                        true_dt_sec,
+                        best_score,
+                        c.dt_sec,
+                        coherent_score_there,
+                        c.score,
+                        dt_gap_ms,
+                        if out_of_reach {
+                            "  <-- OUT OF sync2d_refine REACH"
+                        } else {
+                            ""
+                        },
+                    );
+                }
+                None => {
+                    println!(
+                        "  trial {t:02}: true_dt={:+.3}s (coherent peak={:.0})  \
+                         coarse_sync found NO candidate near {GOLDEN_FREQ_HZ} Hz",
+                        true_dt_sec, best_score,
+                    );
+                }
+            }
+        }
+    }
+}

--- a/mfsk-core/tests/ft4_sweep.rs
+++ b/mfsk-core/tests/ft4_sweep.rs
@@ -122,7 +122,7 @@ fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
         });
     }
     // Sort: channel → snr desc → trial
-    out.sort_by_key(|m| (m.channel.clone(), -m.snr_db, m.trial));
+    out.sort_by_key(|m| (m.channel.clone(), std::cmp::Reverse(m.snr_db), m.trial));
     out
 }
 

--- a/mfsk-core/tests/ft4_sweep.rs
+++ b/mfsk-core/tests/ft4_sweep.rs
@@ -1,0 +1,705 @@
+//! FT4 SNR sweep + fading benchmark against `ft4sim`-generated signals.
+//!
+//! This test is `#[ignore]` — run it manually when investigating FT4
+//! sensitivity / `DecodeStrictness` calibration (issue #72).
+//!
+//! ```sh
+//! # 1. Generate WAVs (once, or when widening the SNR grid):
+//! scripts/build_ft4sim.sh
+//! scripts/gen_ft4_sweep_wavs.sh
+//!
+//! # 2. Run the sweep:
+//! cargo test --test ft4_sweep --release --features ft4,fft-rustfft,parallel,uvpacket \
+//!   -- --ignored --nocapture
+//! ```
+//!
+//! (`uvpacket` is only required because `tests/common/channel.rs`, pulled in
+//! via `mod common`, unconditionally imports `mfsk_core::uvpacket` — unrelated
+//! to FT4 itself. `MFSK_FT4_SWEEP_DIR` overrides the default corpus location
+//! `../embedded-poc/assets/ft4_sweep`, relative to `CARGO_MANIFEST_DIR`.)
+//!
+//! Output is a recall table — no assertions, statistics only. Set
+//! `MFSK_FT4_SWEEP_CSV=/path/out.csv` to also dump raw per-trial pass/fail
+//! rows for bootstrap-CI analysis of the 50%-crossing estimate. See
+//! `docs/notes/FST4_BENCHMARK.md` for the shared methodology this mirrors —
+//! FT4 has no sub-modes, so there's one grid instead of one per T/R period.
+
+#![cfg(all(feature = "ft4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+use mfsk_core::msg::wsjt77::unpack77;
+
+const GOLDEN_MSG: &str = "CQ JL1NIE PM95";
+const GOLDEN_FREQ_HZ: f32 = 1500.0;
+const FREQ_TOL_HZ: f32 = 5.0;
+const DT_TOL_SEC: f32 = 0.6;
+
+fn sweep_dir() -> PathBuf {
+    if let Ok(d) = std::env::var("MFSK_FT4_SWEEP_DIR") {
+        return PathBuf::from(d);
+    }
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    Path::new(&manifest)
+        .join("../embedded-poc/assets/ft4_sweep")
+        .to_path_buf()
+}
+
+// ── Channel conditions (must match gen_ft4_sweep_wavs.sh CHANNELS) ─────────
+#[allow(dead_code)]
+const CHANNELS: &[&str] = &["awgn", "ccir_good", "ccir_moderate", "ccir_poor"];
+
+fn decode_wav_ft4(audio: &[i16]) -> bool {
+    mfsk_core::ft4::decode::decode_frame(audio, 100.0, 3000.0, 0.8, 50)
+        .iter()
+        .any(|d| {
+            let mut m77 = [0u8; 77];
+            m77.copy_from_slice(d.message77());
+            unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                && (d.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ
+                && d.dt_sec.abs() <= DT_TOL_SEC
+        })
+}
+
+// ── Filename parsing ─────────────────────────────────────────────────────────
+
+/// Parse `ft4_<channel>_<snr_tag>_<trial>.wav`.
+/// snr_tag: `m05` = -5, `p05` = +5.
+fn parse_snr_tag(tag: &str) -> Option<i32> {
+    if let Some(rest) = tag.strip_prefix('m') {
+        rest.parse::<i32>().ok().map(|v| -v)
+    } else if let Some(rest) = tag.strip_prefix('p') {
+        rest.parse::<i32>().ok()
+    } else {
+        None
+    }
+}
+
+struct WavMeta {
+    channel: String,
+    snr_db: i32,
+    trial: u32,
+    path: PathBuf,
+}
+
+fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        // ft4_awgn_m05_01
+        let parts: Vec<&str> = stem.split('_').collect();
+        if parts.len() < 4 || parts[0] != "ft4" {
+            continue;
+        }
+        let trial: u32 = match parts.last().and_then(|s| s.parse().ok()) {
+            Some(v) => v,
+            None => continue,
+        };
+        let snr_tag = parts[parts.len() - 2];
+        let snr_db = match parse_snr_tag(snr_tag) {
+            Some(v) => v,
+            None => continue,
+        };
+        // channel = everything between "ft4" and snr_tag
+        let channel = parts[1..parts.len() - 2].join("_");
+        out.push(WavMeta {
+            channel,
+            snr_db,
+            trial,
+            path,
+        });
+    }
+    // Sort: channel → snr desc → trial
+    out.sort_by_key(|m| (m.channel.clone(), -m.snr_db, m.trial));
+    out
+}
+
+// ── Main sweep test ──────────────────────────────────────────────────────────
+
+#[test]
+#[ignore = "manual pre-merge benchmark — run with --ignored --nocapture"]
+fn ft4_snr_sweep() {
+    let dir = sweep_dir();
+    let all_wavs = collect_wavs(&dir);
+
+    if all_wavs.is_empty() {
+        eprintln!(
+            "No WAVs found in {:?}\n\
+             Run: scripts/build_ft4sim.sh && scripts/gen_ft4_sweep_wavs.sh",
+            dir
+        );
+        return;
+    }
+
+    // Optional env-var filters — narrow the sweep to the region of interest.
+    // MFSK_FT4_SWEEP_CHANNELS=awgn       (comma-separated channel names)
+    // MFSK_FT4_SWEEP_SNR_MIN=-20         (inclusive lower bound, dB)
+    // MFSK_FT4_SWEEP_SNR_MAX=-14         (inclusive upper bound, dB)
+    // MFSK_FT4_SWEEP_CSV=/path/out.csv   (optional: dump raw per-trial
+    //   pass/fail rows — channel,snr_db,trial,pass)
+    let chan_filter: Option<Vec<String>> = std::env::var("MFSK_FT4_SWEEP_CHANNELS")
+        .ok()
+        .map(|s| s.split(',').map(|v| v.trim().to_string()).collect());
+    let snr_min: Option<i32> = std::env::var("MFSK_FT4_SWEEP_SNR_MIN")
+        .ok()
+        .and_then(|s| s.trim().parse().ok());
+    let snr_max: Option<i32> = std::env::var("MFSK_FT4_SWEEP_SNR_MAX")
+        .ok()
+        .and_then(|s| s.trim().parse().ok());
+
+    let wavs: Vec<WavMeta> = all_wavs
+        .into_iter()
+        .filter(|w| {
+            chan_filter
+                .as_ref()
+                .is_none_or(|f| f.iter().any(|c| c == &w.channel))
+        })
+        .filter(|w| snr_min.is_none_or(|m| w.snr_db >= m))
+        .filter(|w| snr_max.is_none_or(|m| w.snr_db <= m))
+        .collect();
+
+    eprintln!("\n{:-<64}", "");
+    eprintln!(
+        "  {:<14} {:>7}   {:>6}  Bar",
+        "Channel", "SNR(dB)", "Recall"
+    );
+    eprintln!("{:-<64}", "");
+
+    let mut csv = std::env::var("MFSK_FT4_SWEEP_CSV").ok().map(|path| {
+        let mut f = std::fs::File::create(&path)
+            .unwrap_or_else(|e| panic!("MFSK_FT4_SWEEP_CSV={path}: {e}"));
+        writeln!(f, "channel,snr_db,trial,pass").unwrap();
+        f
+    });
+
+    #[cfg(feature = "parallel")]
+    use rayon::prelude::*;
+    use std::collections::BTreeMap;
+    use std::io::Write;
+
+    let mut groups: BTreeMap<(String, i32), Vec<&WavMeta>> = BTreeMap::new();
+    for wav in &wavs {
+        groups
+            .entry((wav.channel.clone(), wav.snr_db))
+            .or_default()
+            .push(wav);
+    }
+
+    let mut last_chan: Option<String> = None;
+    for ((chan, snr), wav_group) in &groups {
+        #[cfg(feature = "parallel")]
+        let results: Vec<(u32, bool)> = wav_group
+            .par_iter()
+            .filter_map(|wav| {
+                load_wav_i16_opt(&wav.path).map(|audio| (wav.trial, decode_wav_ft4(&audio)))
+            })
+            .collect();
+
+        #[cfg(not(feature = "parallel"))]
+        let results: Vec<(u32, bool)> = wav_group
+            .iter()
+            .filter_map(|wav| {
+                load_wav_i16_opt(&wav.path).map(|audio| (wav.trial, decode_wav_ft4(&audio)))
+            })
+            .collect();
+
+        let trials = results.len() as u32;
+        if trials == 0 {
+            continue;
+        }
+        let hits = results.iter().filter(|&(_, h)| *h).count() as u32;
+
+        if let Some(f) = csv.as_mut() {
+            for &(trial, pass) in &results {
+                writeln!(f, "{chan},{snr},{trial},{}", pass as u8).unwrap();
+            }
+        }
+
+        if Some(chan) != last_chan.as_ref() {
+            eprintln!("{:-<64}", "");
+            last_chan = Some(chan.clone());
+        }
+        let pct = hits as f32 / trials as f32 * 100.0;
+        let bar_len = (hits as usize * 20).div_ceil(trials as usize);
+        let bar = format!("{}{}", "#".repeat(bar_len), ".".repeat(20 - bar_len));
+        eprintln!(
+            "  {:<14}  {:>4} dB   {:>2}/{:<2}  [{}]  {:4.0}%",
+            chan, snr, hits, trials, bar, pct
+        );
+    }
+    eprintln!("{:-<64}", "");
+    eprintln!(
+        "\nChannels (ITU-R Watterson): awgn=no fading | \
+         ccir_good=fdop 0.1Hz/del 0.5ms | \
+         ccir_moderate=0.5/1.0 | ccir_poor=1.0/2.0"
+    );
+}
+
+/// `DecodeStrictness` calibration probe (issue #72) — does loosening past
+/// `Normal` actually recover any of the near-threshold trials that
+/// `ft4_snr_sweep` shows as misses, or is FT4's SNR floor set entirely by
+/// coarse-sync / BP and the OSD-gate knob copied from FT8 is a no-op for
+/// this protocol? Run once a full sweep (above) has identified the
+/// partial-recall band per channel.
+///
+/// `REFINE_STEPS = 32` / `SYNC_Q_MIN = 8` below mirror the private
+/// constants in `src/ft4/decode.rs` — duplicated here because integration
+/// tests only see `pub` items.
+#[test]
+#[ignore = "manual diagnostic — DecodeStrictness calibration probe (issue #72)"]
+fn ft4_strictness_probe() {
+    use mfsk_core::core::equalize::EqMode;
+    use mfsk_core::core::pipeline::{DecodeDepth, DecodeStrictness, decode_frame};
+    use mfsk_core::ft4::Ft4;
+    use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
+
+    const REFINE_STEPS: i32 = 32;
+    const SYNC_Q_MIN: u32 = 8;
+
+    fn snr_tag(snr: i32) -> String {
+        if snr < 0 {
+            format!("m{:02}", -snr)
+        } else {
+            format!("p{:02}", snr)
+        }
+    }
+
+    let dir = sweep_dir();
+    // Partial-recall band identified by a prior `ft4_snr_sweep` run
+    // (2026-07-18, this corpus/seed): awgn -16..-13, ccir_moderate -16..-13,
+    // ccir_poor -16..-13. Narrow window — this is a diagnostic, not a
+    // full re-sweep (see FST4_BENCHMARK.md section 7).
+    let cells: &[(&str, i32)] = &[
+        ("awgn", -16),
+        ("awgn", -15),
+        ("ccir_moderate", -16),
+        ("ccir_moderate", -15),
+        ("ccir_moderate", -14),
+        ("ccir_poor", -15),
+        ("ccir_poor", -14),
+        ("ccir_poor", -13),
+    ];
+    let strictness_levels = [
+        DecodeStrictness::Strict,
+        DecodeStrictness::Normal,
+        DecodeStrictness::Deep,
+    ];
+
+    eprintln!("\n{:-<72}", "");
+    eprintln!(
+        "  {:<14} {:>7}  {:<8}   {:>10}  {:>10}",
+        "Channel", "SNR(dB)", "Level", "Golden", "Any-msg"
+    );
+    eprintln!("{:-<72}", "");
+    for &(chan, snr) in cells {
+        let tag = snr_tag(snr);
+        for &strictness in &strictness_levels {
+            let mut golden_hits = 0u32;
+            let mut any_hits = 0u32;
+            let mut trials = 0u32;
+            for t in 1..=20u32 {
+                let path = dir.join(format!("ft4_{chan}_{tag}_{t:02}.wav"));
+                let Some(audio) = load_wav_i16_opt(&path) else {
+                    continue;
+                };
+                trials += 1;
+                let (results, _) = decode_frame::<Ft4>(
+                    &audio,
+                    &FT4_DOWNSAMPLE,
+                    100.0,
+                    3000.0,
+                    0.8,
+                    None,
+                    DecodeDepth::BpAllOsd,
+                    50,
+                    strictness,
+                    EqMode::Off,
+                    REFINE_STEPS,
+                    SYNC_Q_MIN,
+                );
+                any_hits += !results.is_empty() as u32;
+                let is_golden = results.iter().any(|d| {
+                    let mut m77 = [0u8; 77];
+                    m77.copy_from_slice(d.message77());
+                    unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                        && (d.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ
+                        && d.dt_sec.abs() <= DT_TOL_SEC
+                });
+                golden_hits += is_golden as u32;
+            }
+            if trials == 0 {
+                continue;
+            }
+            eprintln!(
+                "  {:<14} {:>4} dB  {:<8?}   {:>4}/{:<4}   {:>4}/{:<4}",
+                chan, snr, strictness, golden_hits, trials, any_hits, trials
+            );
+        }
+        eprintln!();
+    }
+    eprintln!("{:-<72}", "");
+    eprintln!(
+        "Golden = matches the known transmitted message (recall).\n\
+         Any-msg = any CRC-passing decode at all (recall + false-accepts).\n\
+         If Golden is flat across Strict/Normal/Deep at a given cell, the\n\
+         OSD-gate knob isn't the bottleneck there — look at coarse-sync/BP\n\
+         instead. If Any-msg grows faster than Golden as strictness loosens,\n\
+         that's false-accept inflation, not real sensitivity gain."
+    );
+}
+
+/// Per-trial diagnostic (issue #72 / `FT4_BENCHMARK.md` AWGN gap
+/// investigation, 2026-07-18) mirroring `fst4_diag_weak_trials` in
+/// `fst4_sweep.rs`. Traces `coarse_sync` + `process_candidate_basic`
+/// directly on individual AWGN trials straddling the current ≈-15.7 dB
+/// 50% crossing, to determine — per trial — whether a losing decode is
+/// because `coarse_sync` never finds a near-golden-freq candidate at all,
+/// or because a found candidate fails somewhere inside
+/// `process_candidate_basic` (fine-refine / sync-quality gate / LLR /
+/// BP / OSD). This is read manually, not asserted — see `FST4_BENCHMARK.md`
+/// section 6 for why this stage-attribution step comes before any fix.
+///
+/// `REFINE_STEPS = 32` / `SYNC_Q_MIN = 8` mirror the private constants in
+/// `src/ft4/decode.rs` (integration tests only see `pub` items).
+#[test]
+#[ignore = "manual diagnostic — AWGN sensitivity gap stage attribution (issue #72)"]
+fn ft4_diag_weak_trials() {
+    use mfsk_core::ModulationParams;
+    use mfsk_core::core::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::core::equalize::EqMode;
+    use mfsk_core::core::llr::{symbol_spectra, sync_quality};
+    use mfsk_core::core::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
+    use mfsk_core::core::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::core::sync2d::ft4_sync_search;
+    use mfsk_core::ft4::Ft4;
+    use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
+
+    const REFINE_STEPS: i32 = 32;
+    const SYNC_Q_MIN: u32 = 8;
+
+    // Mirrors `process_candidate_basic`'s downsample -> RMS-normalize ->
+    // `ft4_sync_search` -> `symbol_spectra` -> `sync_quality` prefix
+    // (`core/pipeline.rs:157-217`), stopping right before the `nsync`
+    // gate so we can print the raw value instead of just pass/fail.
+    fn nsync_for(
+        cand: &SyncCandidate,
+        fft_cache: &[num_complex::Complex<f32>],
+        cfg: &mfsk_core::core::dsp::downsample::DownsampleCfg,
+    ) -> u32 {
+        let mut cd0 = downsample_cached(fft_cache, cand.freq_hz, cfg);
+        let sum2: f32 = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+        if sum2 > f32::EPSILON {
+            let inv = 1.0 / sum2.sqrt();
+            for c in cd0.iter_mut() {
+                *c *= inv;
+            }
+        }
+        let s2 = ft4_sync_search::<Ft4>(&cd0, cand);
+        let df_hz = s2.freq_hz - cand.freq_hz;
+        let ds_rate = 12_000.0 / Ft4::NDOWN as f32;
+        let cd0 = mfsk_core::core::sync2d::freq_shift_cd0(&cd0, df_hz, ds_rate);
+        let cs_raw = symbol_spectra::<Ft4>(&cd0, s2.i0);
+        sync_quality::<Ft4>(&cs_raw)
+    }
+
+    let dir = sweep_dir();
+    // Straddles the post-section-9 AWGN 50% crossing (≈-16.7dB,
+    // FT4_BENCHMARK.md section 9) — deliberately narrow, this is a
+    // stage-attribution probe, not a re-sweep.
+    for snr_tag in ["m18", "m17", "m16", "m15"] {
+        for trial in 1..=20u32 {
+            let path = dir.join(format!("ft4_awgn_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let near: Vec<_> = cands
+                .iter()
+                .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+                .collect();
+            eprintln!(
+                "awgn {snr_tag} trial {trial}: {} candidates total, {} near golden freq",
+                cands.len(),
+                near.len()
+            );
+            if near.is_empty() {
+                continue;
+            }
+            let fft_cache = build_fft_cache(&audio, &FT4_DOWNSAMPLE);
+            for c in &near {
+                // N_SYNC=16 for FT4 (4 blocks x 4-symbol Costas); the
+                // OSD-attempt/depth-3 gates are 9/14 post section-8 fix
+                // (core/pipeline.rs), not the FT8-scale 12/18.
+                let nsync = nsync_for(c, &fft_cache, &FT4_DOWNSAMPLE);
+                eprintln!(
+                    "  cand freq={:.2} dt={:.3} score={:.4} nsync={}/16 (osd@9={} osd3@14={})",
+                    c.freq_hz,
+                    c.dt_sec,
+                    c.score,
+                    nsync,
+                    nsync >= 9,
+                    nsync >= 14
+                );
+            }
+            for c in &near {
+                let r = process_candidate_basic::<Ft4>(
+                    c,
+                    &fft_cache,
+                    &FT4_DOWNSAMPLE,
+                    DecodeDepth::BpAllOsd,
+                    DecodeStrictness::Normal,
+                    &[],
+                    EqMode::Off,
+                    REFINE_STEPS,
+                    SYNC_Q_MIN,
+                );
+                // pass: 0/1/2/3=BP variants a/b/c/d, 6=llre (BP succeeded
+                // without OSD); 4=OSD depth-2, 5=OSD depth-3 (BP needed
+                // rescuing). hard_errors is the LDPC decoder's own residual
+                // error count on the winning codeword.
+                eprintln!(
+                    "  -> decode result: {:?}",
+                    r.map(|d| (d.pass, d.hard_errors, d.sync_score))
+                );
+            }
+        }
+    }
+}
+
+/// Hypothesis 2 from `FT4_BENCHMARK.md` section 8's closing notes: does
+/// `ft4_sync_search`'s collapsed single-pass Δt search (one global best
+/// over the full `[-344,1012]` union) ever lose recall relative to
+/// WSJT-X's literal 3-segment structure (`ft4_decode.f90`'s `iseg=1,2,3`
+/// loop), which can attempt a decode at up to 3 different positions per
+/// candidate (segment 1 `[108,560]`, then segment 2 `[560,1012]` / segment
+/// 3 `[-344,108]` only if that segment's own `smax` clears both the
+/// absolute floor 1.2 and segment 1's `smax`)?
+///
+/// For every currently-failing near-golden candidate in the AWGN
+/// crossing band: run the collapsed search first (skip if it already
+/// succeeds — only interested in today's failures), then replicate the
+/// literal 3-segment search via
+/// [`mfsk_core::core::sync2d::ft4_sync_search_window`] and attempt a
+/// decode at every segment whose gate passes, via a local
+/// `try_decode_at` that mirrors `process_candidate_basic`'s LLR/BP/OSD
+/// tail (symbol_spectra -> sync_quality -> BP variants -> OSD) for an
+/// explicit `(freq_hz, i0)` rather than re-running the full search — the
+/// gate is intentionally permissive (skips the `cand.score >=
+/// osd_score_min` check) to give a segment-2/3 rescue its best possible
+/// chance. A rescue here means WSJT-X's literal per-segment retry
+/// structure is worth porting; a clean floor rules it out for pure AWGN.
+#[test]
+#[ignore = "manual diagnostic — 3-segment Δt-search retry hypothesis (issue #72)"]
+fn ft4_diag_segment_retry() {
+    use mfsk_core::core::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::core::equalize::EqMode;
+    use mfsk_core::core::llr::{compute_llr, symbol_spectra, sync_quality};
+    use mfsk_core::core::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
+    use mfsk_core::core::sync::coarse_sync;
+    use mfsk_core::core::sync2d::{freq_shift_cd0, ft4_sync_search_window};
+    use mfsk_core::core::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::ft4::Ft4;
+    use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
+
+    const REFINE_STEPS: i32 = 32;
+    const SYNC_Q_MIN: u32 = 8;
+    const BP_MAX_ITER: u32 = 40; // FT4's own value, section 10.
+    const OSD_ATTEMPT_MIN: u32 = 9; // section 8's FT4-scaled gate.
+    const OSD_DEPTH3_MIN: u32 = 14;
+    // WSJT-X `ft4_decode.f90:240-251` segment boundaries.
+    const SEGMENTS: [(i32, i32); 3] = [(108, 560), (560, 1012), (-344, 108)];
+    const SYNCMIN: f32 = 1.2;
+
+    // Mirrors `process_candidate_basic`'s LLR/BP/OSD tail for one explicit
+    // `(freq_hz, i0)` position instead of re-deriving it via
+    // `ft4_sync_search` — INCLUDING the `hard_errors >= osd_max_errors`
+    // rejection gate real OSD results go through (first attempt at this
+    // diagnostic omitted it and over-reported rescues — see
+    // `FT4_BENCHMARK.md` section 11 for the retraction). Returns
+    // `Some((hard_errors, message77))` on a decode that would actually
+    // survive production's gates.
+    fn try_decode_at(
+        cd0_norm: &[num_complex::Complex<f32>],
+        freq_hz: f32,
+        cand_freq_hz: f32,
+        i0: i32,
+        ds_rate: f32,
+        allow_osd: bool,
+    ) -> Option<(u32, [u8; 77])> {
+        let df_hz = freq_hz - cand_freq_hz;
+        let shifted = freq_shift_cd0(cd0_norm, df_hz, ds_rate);
+        let cs = symbol_spectra::<Ft4>(&shifted, i0);
+        let nsync = sync_quality::<Ft4>(&cs);
+        if nsync <= SYNC_Q_MIN {
+            return None;
+        }
+        // No `deinterleave_llr_set` call: FT4's `CODEWORD_INTERLEAVE` is
+        // `None`, and `core/pipeline.rs` documents that call as a no-op
+        // for FT4/FT8/FST4 — same result either way.
+        let llr_set = compute_llr::<Ft4, f32>(&cs);
+        let variants = [&llr_set.llra, &llr_set.llrb, &llr_set.llrc, &llr_set.llrd];
+        let fec = <<Ft4 as Protocol>::Fec>::default();
+        let verify_info =
+            Some(<<Ft4 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+        let bp_opts = FecOpts {
+            bp_max_iter: BP_MAX_ITER,
+            osd_depth: 0,
+            ap_mask: None,
+            verify_info,
+            ..FecOpts::default()
+        };
+        let msg77 = |info: &[u8]| -> [u8; 77] {
+            let mut m = [0u8; 77];
+            m.copy_from_slice(&info[..77]);
+            m
+        };
+        for llr in variants {
+            if let Some(r) = fec.decode_soft(llr, &bp_opts) {
+                return Some((r.hard_errors, msg77(&r.info)));
+            }
+        }
+        if !allow_osd || nsync < OSD_ATTEMPT_MIN {
+            return None;
+        }
+        let osd_depth: u32 = if nsync >= OSD_DEPTH3_MIN { 3 } else { 2 };
+        let osd_opts = FecOpts {
+            bp_max_iter: BP_MAX_ITER,
+            osd_depth,
+            ap_mask: None,
+            verify_info,
+            ..FecOpts::default()
+        };
+        let strictness = DecodeStrictness::Normal;
+        for llr in variants {
+            if let Some(r) = fec.decode_soft(llr, &osd_opts) {
+                if r.hard_errors >= strictness.osd_max_errors(osd_depth as u8) {
+                    continue;
+                }
+                return Some((r.hard_errors, msg77(&r.info)));
+            }
+        }
+        if nsync >= OSD_DEPTH3_MIN {
+            let osd4_opts = FecOpts {
+                bp_max_iter: BP_MAX_ITER,
+                osd_depth: 4,
+                ap_mask: None,
+                verify_info,
+                ..FecOpts::default()
+            };
+            for llr in variants {
+                if let Some(r) = fec.decode_soft(llr, &osd4_opts) {
+                    if r.hard_errors >= strictness.osd_max_errors(4) {
+                        continue;
+                    }
+                    return Some((r.hard_errors, msg77(&r.info)));
+                }
+            }
+        }
+        None
+    }
+
+    let dir = sweep_dir();
+    let mut candidates_checked = 0u32;
+    let mut rescued = 0u32;
+
+    for snr_tag in ["m18", "m17", "m16", "m15"] {
+        for trial in 1..=20u32 {
+            let path = dir.join(format!("ft4_awgn_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let near: Vec<_> = cands
+                .iter()
+                .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+                .collect();
+            if near.is_empty() {
+                continue;
+            }
+            let fft_cache = build_fft_cache(&audio, &FT4_DOWNSAMPLE);
+
+            for c in &near {
+                let baseline = process_candidate_basic::<Ft4>(
+                    c,
+                    &fft_cache,
+                    &FT4_DOWNSAMPLE,
+                    DecodeDepth::BpAllOsd,
+                    DecodeStrictness::Normal,
+                    &[],
+                    EqMode::Off,
+                    REFINE_STEPS,
+                    SYNC_Q_MIN,
+                );
+                if baseline.is_some() {
+                    continue;
+                }
+                candidates_checked += 1;
+
+                let ds_rate = 12_000.0 / <Ft4 as mfsk_core::ModulationParams>::NDOWN as f32;
+                let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FT4_DOWNSAMPLE);
+                let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+                if sum2 > f32::EPSILON {
+                    let inv = 1.0 / sum2.sqrt();
+                    for z in cd0.iter_mut() {
+                        *z *= inv;
+                    }
+                }
+
+                let mut smax1 = f32::NEG_INFINITY;
+                let mut seg_rescue = false;
+                for (seg_idx, &(ib_min, ib_max)) in SEGMENTS.iter().enumerate() {
+                    let s2 = ft4_sync_search_window::<Ft4>(&cd0, c, ib_min, ib_max);
+                    if seg_idx == 0 {
+                        smax1 = s2.score;
+                    }
+                    if s2.score < SYNCMIN {
+                        continue;
+                    }
+                    if seg_idx > 0 && s2.score < smax1 {
+                        continue;
+                    }
+                    // Same OSD-attempt score gate production uses
+                    // (`cand.score >= strictness.osd_score_min()`,
+                    // `core/pipeline.rs`) — BP is still attempted
+                    // unconditionally either way, matching production.
+                    let allow_osd = c.score >= DecodeStrictness::Normal.osd_score_min();
+                    if let Some((hard_errors, msg77)) =
+                        try_decode_at(&cd0, s2.freq_hz, c.freq_hz, s2.i0, ds_rate, allow_osd)
+                    {
+                        let is_golden = unpack77(&msg77).as_deref() == Some(GOLDEN_MSG);
+                        eprintln!(
+                            "  {} {snr_tag} trial {trial}: segment {seg_idx} \
+                             (ib={ib_min}..{ib_max}) freq={:.2} i0={} score={:.3} \
+                             hard_errors={hard_errors} golden={is_golden}",
+                            if is_golden { "RESCUE" } else { "FALSE-ACCEPT" },
+                            s2.freq_hz,
+                            s2.i0,
+                            s2.score
+                        );
+                        if is_golden {
+                            seg_rescue = true;
+                        }
+                    }
+                }
+                if seg_rescue {
+                    rescued += 1;
+                }
+            }
+        }
+    }
+    eprintln!(
+        "\nfailing candidates checked={candidates_checked} rescued-by-segment-retry={rescued}"
+    );
+}

--- a/scripts/build_ft4sim.sh
+++ b/scripts/build_ft4sim.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Build ft4sim from WSJT-X Fortran sources.
+#
+# Usage:
+#   scripts/build_ft4sim.sh [WSJT-X-dir] [out-dir]
+#
+# Defaults:
+#   WSJT-X-dir  ../WSJT-X  (sibling of this repo)
+#   out-dir     target/ft4sim/
+#
+# Requires: gfortran, gcc
+#   Ubuntu:  sudo apt-get install gfortran
+#
+# Mirrors scripts/build_fst4sim.sh (see docs/notes/FST4_BENCHMARK.md for the
+# methodology this feeds into) — same shared lib subtree, swapping the
+# fst4-specific compile units for ft4/genft4.f90 + ft4/gen_ft4wave.f90 +
+# ft8/encode174_91.f90 (FT4 reuses FT8's LDPC(174,91) code).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WSJTX_DIR="${1:-$(cd "$REPO_ROOT/../WSJT-X" 2>/dev/null && pwd || echo "")}"
+OUT_DIR="${2:-$REPO_ROOT/target/ft4sim}"
+
+if [[ -z "$WSJTX_DIR" || ! -d "$WSJTX_DIR" ]]; then
+  echo "error: WSJT-X source tree not found. Pass its path as the first argument." >&2
+  echo "  $0 /path/to/WSJT-X" >&2
+  exit 1
+fi
+
+if ! command -v gfortran &>/dev/null; then
+  echo "error: gfortran not found. Install with:" >&2
+  echo "  sudo apt-get install gfortran" >&2
+  exit 1
+fi
+
+LIB="$WSJTX_DIR/lib"
+mkdir -p "$OUT_DIR"
+BUILD="$OUT_DIR/build"
+mkdir -p "$BUILD"
+
+echo "Building ft4sim from $WSJTX_DIR ..."
+echo "Output dir: $OUT_DIR"
+
+# Compilation happens in $BUILD so .mod files land there.
+# The -I flags point to source dirs that contain ft4_params.f90
+# (included via `include 'ft4_params.f90'` in genft4.f90 / ft4sim.f90).
+cd "$BUILD"
+
+FFLAGS=(-O2 -Wall -Wno-unused-variable -Wno-unused-dummy-argument
+        -I"$LIB/ft4" -I"$LIB")
+
+echo "  [1/13] wavhdr.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/wavhdr.f90"
+
+echo "  [2/13] prog_args.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/prog_args.f90"
+
+echo "  [3/13] crc.f90 + crc14.cpp (boost) + sgran.c + init_random_seed.c"
+gfortran "${FFLAGS[@]}" -c "$LIB/crc.f90"
+g++ -O2 -c "$LIB/crc14.cpp" -o crc14.o
+gcc -O2 -I"$LIB" -c "$LIB/sgran.c"
+gcc -O2 -I"$LIB" -c "$LIB/init_random_seed.c"
+
+echo "  [4a/13] packjt.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/packjt.f90"
+
+echo "  [4b/13] 77bit/packjt77.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/77bit/packjt77.f90"
+
+echo "  [5a] deg2grid.f90 + grid2deg.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/deg2grid.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/grid2deg.f90"
+
+echo "  [5b] fmtmsg.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/fmtmsg.f90"
+
+echo "  [5c] chkcall.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/chkcall.f90"
+
+echo "  [5d] ft2/gfsk_pulse.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/ft2/gfsk_pulse.f90"
+
+# ldpc_174_91_c_generator.f90 is a data-only fragment included by
+# encode174_91.f90 via `include`; do NOT compile it as a standalone unit.
+echo "  [6/13] ft8/encode174_91.f90"
+gfortran "${FFLAGS[@]}" -I"$LIB/ft8" -c "$LIB/ft8/encode174_91.f90"
+
+echo "  [7/13] ft4/gen_ft4wave.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/ft4/gen_ft4wave.f90"
+
+echo "  [8/13] ft4/genft4.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/ft4/genft4.f90"
+
+echo "  [9/13] fftw3mod.f90 + four2a.f90 + ft8/watterson.f90"
+gfortran "${FFLAGS[@]}" -I/usr/include -c "$LIB/fftw3mod.f90"
+gfortran "${FFLAGS[@]}" -I/usr/include -c "$LIB/four2a.f90"
+gfortran "${FFLAGS[@]}" -c "$LIB/ft8/watterson.f90"
+
+echo "  [10/13] gran.c"
+gcc -O2 -c "$LIB/gran.c"
+
+echo "  [link] ft4sim"
+gfortran "${FFLAGS[@]}" \
+  wavhdr.o prog_args.o crc.o crc14.o sgran.o init_random_seed.o \
+  deg2grid.o grid2deg.o fmtmsg.o chkcall.o \
+  packjt.o packjt77.o \
+  gfsk_pulse.o fftw3mod.o four2a.o \
+  encode174_91.o gen_ft4wave.o genft4.o watterson.o gran.o \
+  "$LIB/ft4/ft4sim.f90" \
+  -o "$OUT_DIR/ft4sim" -lfftw3f -lm -lstdc++
+
+echo ""
+echo "Built: $OUT_DIR/ft4sim"
+echo "Run 'scripts/gen_ft4_sweep_wavs.sh' to generate the SNR sweep WAV corpus."

--- a/scripts/gen_ft4_sweep_wavs.sh
+++ b/scripts/gen_ft4_sweep_wavs.sh
@@ -22,7 +22,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 FT4SIM="${1:-$REPO_ROOT/target/ft4sim/ft4sim}"
 OUT_DIR="${2:-$REPO_ROOT/embedded-poc/assets/ft4_sweep}"
-JOBS="${JOBS:-$(nproc)}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}"
 
 if [[ ! -x "$FT4SIM" ]]; then
   echo "error: ft4sim not found at $FT4SIM" >&2
@@ -80,7 +80,7 @@ run_cell() {
     "$chan" "$snr" "$TRIALS"
 
   local tmpd; tmpd="$(mktemp -d)"
-  trap 'rm -rf "$tmpd"' RETURN
+  trap 'rm -rf "$tmpd"' EXIT
 
   (
     cd "$tmpd"
@@ -125,7 +125,9 @@ for CELL in "${CELLS[@]}"; do
     (( active-- )) || true
   fi
 done
-wait
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
 
 echo ""
 echo "Done. Assets: $OUT_DIR"

--- a/scripts/gen_ft4_sweep_wavs.sh
+++ b/scripts/gen_ft4_sweep_wavs.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# Generate ft4sim WAV files for SNR sweep + fading benchmark.
+#
+# Usage:
+#   scripts/gen_ft4_sweep_wavs.sh [ft4sim-path] [out-dir]
+#
+# File naming:  ft4_<channel>_<snr>_<trial>.wav
+#   channel:  awgn | ccir_good | ccir_moderate | ccir_poor
+#   snr:      m05 = -5 dB, m24 = -24 dB, etc.
+#   trial:    01..TRIALS
+#
+# Run build_ft4sim.sh first if the binary doesn't exist.
+# Existing files are skipped (safe to re-run after widening the grid).
+# Jobs run in parallel (JOBS env var, default: nproc).
+#
+# Mirrors scripts/gen_fst4_sweep_wavs.sh (see docs/notes/FT4_BENCHMARK.md).
+# FT4 has no sub-modes, so there's one SNR grid instead of one per period.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+FT4SIM="${1:-$REPO_ROOT/target/ft4sim/ft4sim}"
+OUT_DIR="${2:-$REPO_ROOT/embedded-poc/assets/ft4_sweep}"
+JOBS="${JOBS:-$(nproc)}"
+
+if [[ ! -x "$FT4SIM" ]]; then
+  echo "error: ft4sim not found at $FT4SIM" >&2
+  echo "Run scripts/build_ft4sim.sh first." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+MSG="CQ JL1NIE PM95"
+F0=1500
+DT=0.0
+TRIALS=20
+
+# Published WSJT-X AWGN threshold (2500 Hz ref BW) is ~-17.5 dB (vs FT8's
+# -21 dB — FT4 trades sensitivity for the shorter 7.5 s slot / less FEC
+# interleaving). Grid extends a few dB past it on both sides so the 50%
+# crossing is observed rather than censored at the grid edge (see the
+# FST4 #146 lesson in docs/notes/FST4_BENCHMARK.md section 3).
+SNRS="-5 -10 -13 -14 -15 -16 -17 -18 -19 -20 -21 -22 -23"
+
+CHANNELS=(
+  "awgn          0.0  0.0"
+  "ccir_good     0.1  0.5"
+  "ccir_moderate 0.5  1.0"
+  "ccir_poor     1.0  2.0"
+)
+
+snr_tag() {
+  local snr=$1
+  if (( snr < 0 )); then
+    printf "m%02d" "$(( -snr ))"
+  else
+    printf "p%02d" "$snr"
+  fi
+}
+
+# One worker function per (chan, snr) cell — each gets its own tmpdir.
+run_cell() {
+  local chan=$1 fdop=$2 del=$3 snr=$4
+
+  local tag; tag="$(snr_tag "$snr")"
+
+  # Skip if all trials already exist.
+  local missing=0
+  for T in $(seq 1 "$TRIALS"); do
+    local dest="$OUT_DIR/ft4_${chan}_${tag}_$(printf '%02d' "$T").wav"
+    [[ -f "$dest" ]] || (( missing++ )) || true
+  done
+  if (( missing == 0 )); then
+    return 0
+  fi
+
+  printf "  FT4  %-14s  SNR=%4d dB  generating %d files ...\n" \
+    "$chan" "$snr" "$TRIALS"
+
+  local tmpd; tmpd="$(mktemp -d)"
+  trap 'rm -rf "$tmpd"' RETURN
+
+  (
+    cd "$tmpd"
+    "$FT4SIM" "$MSG" "$F0" "$DT" "$fdop" "$del" "$TRIALS" "$snr" \
+      >/dev/null
+    for T in $(seq 1 "$TRIALS"); do
+      local src dest
+      src="$(printf '000000_%06d.wav' "$T")"
+      dest="$OUT_DIR/ft4_${chan}_${tag}_$(printf '%02d' "$T").wav"
+      [[ -f "$src" ]] && mv "$src" "$dest"
+    done
+  )
+}
+
+export -f run_cell snr_tag
+export FT4SIM OUT_DIR TRIALS MSG F0 DT
+
+# Build the full list of (chan fdop del snr) tuples, then fan out.
+CELLS=()
+for CHAN_SPEC in "${CHANNELS[@]}"; do
+  read -r CHAN FDOP DEL <<< "$CHAN_SPEC"
+  for SNR in $SNRS; do
+    CELLS+=("$CHAN $FDOP $DEL $SNR")
+  done
+done
+
+echo "Generating FT4 sweep corpus: ${#CELLS[@]} cells, TRIALS=$TRIALS, JOBS=$JOBS"
+echo "Output: $OUT_DIR"
+echo ""
+
+# Run cells in parallel using a simple job-pool (no GNU parallel needed).
+active=0
+pids=()
+for CELL in "${CELLS[@]}"; do
+  read -r chan fdop del snr <<< "$CELL"
+  run_cell "$chan" "$fdop" "$del" "$snr" &
+  pids+=($!)
+  (( active++ )) || true
+  if (( active >= JOBS )); then
+    wait "${pids[0]}"
+    pids=("${pids[@]:1}")
+    (( active-- )) || true
+  fi
+done
+wait
+
+echo ""
+echo "Done. Assets: $OUT_DIR"
+echo "  $(ls "$OUT_DIR" | wc -l) files total"
+echo ""
+echo "Run the sweep test with:"
+echo "  MFSK_FT4_SWEEP_DIR=$OUT_DIR \\"
+echo "    cargo test --test ft4_sweep --release --features ft4,fft-rustfft,parallel,uvpacket \\"
+echo "    -- --ignored --nocapture"


### PR DESCRIPTION
## Summary

Diagnose-before-fixing investigation (`docs/notes/FT4_BENCHMARK.md` sections 8-12) into FT4's ~2 dB AWGN sensitivity gap vs WSJT-X's published -17.5 dB threshold, using a new per-trial diagnostic harness (`tests/ft4_sweep.rs`: `ft4_diag_weak_trials`, `ft4_diag_segment_retry`) mirroring the FST4 #146 methodology.

Three real, WSJT-X-source-verified fixes landed:

- **Coherent Costas-block scorer**: `ft4_sync_search`'s scorer was non-coherent within each 4-symbol block (per-symbol power-sum) where WSJT-X's `sync4d.f90` does one coherent 4-symbol correlation per block, then sums magnitudes across blocks. Switched to the coherent scorer already built for `fst4_sync_search`. **~+1.0 dB AWGN.**
- **OSD-attempt gate on the wrong score**: `process_candidate_basic`'s OSD-attempt gate checked `cand.score` (coarse_sync's non-coherent score, tuned against pre-coherent-scorer numbers) instead of the coherent score. 13/17 currently-failing near-crossing candidates never even attempted OSD despite clearing WSJT-X's own `syncmin=1.2` easily. WSJT-X's FT4 decoder has no such gate at all. Bypassed `osd_score_min` for FT4 (same precedent as FST4's #146 bypass), kept `osd_max_errors` as the false-accept safety net. **~+0.5 dB AWGN.**
- **OSD depth-3/4 escalation gate scale mismatch**: gate checked `nsync>=18`, calibrated against FT8's `N_SYNC=21`, but FT4's `N_SYNC=16` — mathematically unreachable. Scaled per-protocol. Real bug, measured null effect on AWGN recall (kept anyway, zero cost).

One candidate (WSJT-X's literal 3-segment Δt-search retry structure) was implemented, measured at 10/17 rescued, then correctly retracted: the diagnostic had omitted the real `hard_errors>=osd_max_errors` gate, manufacturing a false positive. Corrected diagnostic: 0/17. Reverted to avoid 3x per-candidate decode cost for zero benefit.

**Net result**: AWGN 50% crossing -15.5 dB (pre-tuning) → **-17.2 dB**, closing the WSJT-X gap to ~0.3 dB. CCIR fading channels improved similarly (+0.25 to +1.1 dB depending on channel).

## Test plan

- [x] `cargo test --release --features full` — 350+ tests, 0 failed
- [x] `ft4_wsjtx_sample_recall_vs_golden` — 6/6, no new false-accepts
- [x] `cargo clippy --release --features full -- -D clippy::perf` — clean
- [x] Narrow AWGN + CCIR re-sweeps (`ft4_snr_sweep`, `--ignored`) — no regressions anywhere
- [x] `cargo fmt --check` — clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvwWmnvPbjZc5qJfUiEquC