### PR TITLE
test(ft8): classify K1BZM DK8NE / WA2FZW DL5AXX (issue #150 follow-up)

### DIFF
--- a/mfsk-core/tests/ft8_qso3_dk8ne_probe.rs
+++ b/mfsk-core/tests/ft8_qso3_dk8ne_probe.rs
@@ -149,3 +149,43 @@ fn probe_wa2fzw_with_exact_context() {
         "    even with exact operator AP context — confirms JTDX false positive #4 (sync-artifact)."
     );
 }
+
+/// Before trusting the "no recoverable content" conclusion above: does
+/// `coarse_sync` even find a candidate near 2546 Hz at all? If not, the
+/// AP contexts in `probe_wa2fzw_with_exact_context` never had a chance
+/// to try in the first place (a structural gap, not evidence the claim
+/// is false) — if a candidate *is* found there and every AP context
+/// still misses, that's real evidence against the codeword content,
+/// not just "we never looked."
+#[test]
+#[ignore]
+fn probe_wa2fzw_coarse_sync_candidates() {
+    let audio = load_wav_i16(Path::new(QSO3_PATH));
+    let spec = mfsk_core::ft8::decode_block::compute_spectrogram(&audio, 3000.0);
+    let candidates = mfsk_core::ft8::decode_block::coarse_sync(&spec, 100.0, 3000.0, 0.8, 200);
+    let near: Vec<_> = candidates
+        .iter()
+        .filter(|c| (c.freq_hz - 2546.0).abs() <= 10.0)
+        .collect();
+    println!("\n=== coarse_sync near 2546 Hz (WA2FZW DL5AXX RR73 claimed site) ===");
+    println!(
+        "{} candidates total, {} within ±10 Hz of 2546 Hz",
+        candidates.len(),
+        near.len()
+    );
+    for c in &near {
+        println!(
+            "  cand freq={:.2} dt={:.3} score={:.4}",
+            c.freq_hz, c.dt_sec, c.score
+        );
+    }
+    if near.is_empty() {
+        println!(
+            "  → no candidate at all near 2546 Hz: the AP probes above never had a\n    real shot — this is a coarse-sync gap, not evidence against the codeword."
+        );
+    } else {
+        println!(
+            "  → candidate(s) exist near 2546 Hz; every AP context in\n    probe_wa2fzw_with_exact_context still missed, which is real evidence\n    the codeword content doesn't match DL5AXX RR73."
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Follow-up to issue #150 (JTDX-18 ground-truth question), re-running the existing `tests/ft8_qso3_dk8ne_probe.rs` AP-context probes (issue #116) against current `main` (post issue #72's `OSD_HARDERRORS_MAX` fix, #152).

**K1BZM DK8NE -10** — HIT with `mycall=K1BZM` AP context (both the exact operator pair and mycall-only). AP-off still misses it, but this is a real signal that needs AP assistance to recover, not a JTDX false positive. This also explains why WSJT-X's own golden-8 includes it while our blind AP-off scan doesn't — WSJT-X always operates with a configured `mycall` feeding its own AP path in normal use.

**WA2FZW DL5AXX RR73** — miss in all 4 AP contexts tried, including the exact operator pair. Added `probe_wa2fzw_coarse_sync_candidates` to rule out "never had a candidate to try": `coarse_sync` does find 5 candidates within ±10 Hz of the claimed 2546 Hz site (scores 1.73–3.52, scattered `dt` values), so the AP misses are real evidence against the codeword content, not a structural gap. Supports the probe file's own pre-existing "JTDX false positive" hypothesis for this one entry.

Net effect on issue #150: of the originally-unverified JTDX-only entries, DK8NE and 3 others (`N1API F2VX`, `N1API HA6FQ`, `CQ EA2BFM`, resolved in #152) are now confirmed real via independent corroboration. `WA2FZW DL5AXX RR73` remains the one entry with evidence pointing toward false-positive.

No production code changes — diagnostic-only, `#[ignore]`'d tests, zero runtime cost when not run.

## Test plan

- [x] `probe_dk8ne_with_exact_context` — manual run, documented in commit message
- [x] `probe_wa2fzw_with_exact_context` — manual run, documented in commit message
- [x] `probe_wa2fzw_coarse_sync_candidates` (new) — manual run, documented in commit message
- [x] `cargo test --release --features full` — full suite green
- [x] `cargo clippy --release --features full -- -D clippy::perf` — clean
- [x] `cargo fmt --check` — clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LvwWmnvPbjZc5qJfUiEquC