### PR TITLE
fix(msk144): port WSJT-X's fixed bandpass filter, closing -1dB SNR bias

### DIFF
--- a/mfsk-core/src/core/dsp/analytic.rs
+++ b/mfsk-core/src/core/dsp/analytic.rs
@@ -17,6 +17,8 @@
 
 use alloc::vec::Vec;
 use num_complex::Complex32;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
 
 use super::super::fft::default_planner;
 use super::msk::FS_HZ;

--- a/mfsk-core/src/core/dsp/analytic.rs
+++ b/mfsk-core/src/core/dsp/analytic.rs
@@ -1,25 +1,57 @@
 //! FFT-based analytic-signal (Hilbert transform) construction.
 //!
 //! Converts a real-valued signal (e.g. receiver audio) to its complex
-//! analytic form by zeroing the negative-frequency half of its
-//! spectrum and doubling the positive half. This is how a real audio
-//! buffer becomes the complex passband/baseband signal the MSK144
-//! sync/matched-filter code (`crate::msk144::sync`,
-//! `crate::core::dsp::msk`) operates on — mirrors WSJT-X `analytic()`
-//! (called from `mskrtd.f90`), though this port lets the FFT size
-//! equal the input length rather than fixing an oversized/zero-padded
-//! `NFFT1` — callers needing that specific padding behaviour can
-//! zero-pad their input before calling.
+//! analytic form by applying a fixed bandpass filter, then zeroing
+//! the negative-frequency half of its spectrum and doubling the
+//! positive half. This is how a real audio buffer becomes the
+//! complex passband/baseband signal the MSK144 sync/matched-filter
+//! code (`crate::msk144::sync`, `crate::core::dsp::msk`) operates on
+//! — mirrors WSJT-X `analytic()` (called from `mskrtd.f90`), though
+//! this port lets the FFT size equal the input length rather than
+//! fixing an oversized/zero-padded `NFFT1` — callers needing that
+//! specific padding behaviour can zero-pad their input before
+//! calling. The adaptive RX-equalizer correction WSJT-X layers on top
+//! of the fixed filter (`beq`/`corr(i)`, trained by
+//! `msk144signalquality.f90`) is not ported — this only applies the
+//! always-on fixed filter, not the session-adaptive one.
 
 use alloc::vec::Vec;
 use num_complex::Complex32;
 
 use super::super::fft::default_planner;
+use super::msk::FS_HZ;
+
+/// Center frequency of the fixed bandpass filter (`analytic.f90`'s
+/// `f=ff-1500.0`).
+const FILTER_CENTER_HZ: f32 = 1500.0;
+/// Full-pass half-width: `(1-beta)/(2*T)` with `T=1/2000`, `beta=0.1`.
+const FILTER_PASSBAND_HALF_HZ: f32 = 900.0;
+/// Raised-cosine taper half-width: `(1+beta)/(2*T)`.
+const FILTER_STOPBAND_HALF_HZ: f32 = 1_100.0;
+/// Raised-cosine roll-off rate: `pi*T/beta`.
+const FILTER_ROLLOFF_RATE: f32 = core::f32::consts::PI / 200.0;
+
+/// WSJT-X's fixed raised-cosine bandpass gain at `freq_hz`
+/// (`analytic.f90:26-43`'s `h(i)`): unity within ±900 Hz of 1500 Hz,
+/// raised-cosine taper to zero by ±1100 Hz, zero beyond.
+fn bandpass_gain(freq_hz: f32) -> f32 {
+    let f = (freq_hz - FILTER_CENTER_HZ).abs();
+    if f <= FILTER_PASSBAND_HALF_HZ {
+        1.0
+    } else if f <= FILTER_STOPBAND_HALF_HZ {
+        0.5 * (1.0 + (FILTER_ROLLOFF_RATE * (f - FILTER_PASSBAND_HALF_HZ)).cos())
+    } else {
+        0.0
+    }
+}
 
 /// Construct the analytic signal of a real-valued buffer via FFT:
-/// zero the negative-frequency bins, double the positive-frequency
-/// bins (DC, and Nyquist if `input.len()` is even, are left
-/// unscaled), then inverse FFT and normalize.
+/// apply the fixed 1500 Hz-centered bandpass filter, zero the
+/// negative-frequency bins, double the positive-frequency bins (DC,
+/// and Nyquist if `input.len()` is even, are left unscaled), then
+/// inverse FFT and normalize. Assumes `input` was sampled at
+/// [`FS_HZ`] — the only sample rate this crate's MSK144 pipeline
+/// uses.
 pub fn analytic_signal(input: &[f32]) -> Vec<Complex32> {
     let n = input.len();
     let mut planner = default_planner();
@@ -29,6 +61,7 @@ pub fn analytic_signal(input: &[f32]) -> Vec<Complex32> {
     let mut x: Vec<Complex32> = input.iter().map(|&v| Complex32::new(v, 0.0)).collect();
     fwd.process(&mut x);
 
+    let df = FS_HZ / n as f32;
     let nyquist = if n.is_multiple_of(2) {
         Some(n / 2)
     } else {
@@ -36,9 +69,10 @@ pub fn analytic_signal(input: &[f32]) -> Vec<Complex32> {
     };
     for (k, xv) in x.iter_mut().enumerate() {
         if k == 0 || Some(k) == nyquist {
-            // DC / Nyquist: leave unscaled.
+            // DC / Nyquist: leave unscaled (but still filtered).
+            *xv *= bandpass_gain(k as f32 * df);
         } else if k < n.div_ceil(2) {
-            *xv *= 2.0;
+            *xv *= 2.0 * bandpass_gain(k as f32 * df);
         } else {
             *xv = Complex32::new(0.0, 0.0);
         }
@@ -60,11 +94,13 @@ mod tests {
     /// whose real part matches the input and whose imaginary part is
     /// its Hilbert transform (a sine at the same frequency, 90 deg
     /// lagging) -- i.e. `analytic[n] ~= exp(i*2*pi*k0*n/N)` (positive
-    /// frequency only, unit amplitude).
+    /// frequency only, unit amplitude). `k0` is chosen to land at
+    /// 1500 Hz (assuming [`FS_HZ`]), the center of the fixed bandpass
+    /// filter's full-pass band, so the filter doesn't attenuate it.
     #[test]
     fn analytic_signal_of_pure_cosine_is_a_complex_exponential() {
         let n = 256;
-        let k0 = 10;
+        let k0 = 32;
         let input: Vec<f32> = (0..n)
             .map(|i| (2.0 * core::f32::consts::PI * k0 as f32 * i as f32 / n as f32).cos())
             .collect();
@@ -78,5 +114,33 @@ mod tests {
                 "sample {i}: got {a:?}, expected {expected:?}"
             );
         }
+    }
+
+    /// A tone well outside the fixed bandpass filter's stopband edge
+    /// (±1100 Hz of 1500 Hz) should be almost entirely suppressed --
+    /// this is the WSJT-X-equivalent `h(i)` filter (`analytic.f90:26-43`)
+    /// this port now applies.
+    #[test]
+    fn analytic_signal_attenuates_out_of_band_tone() {
+        let n = 256;
+        let k0 = 64; // freq = 64 * (12000/256) = 3000 Hz, |3000-1500| = 1500 Hz > 1100 Hz stopband edge.
+        let input: Vec<f32> = (0..n)
+            .map(|i| (2.0 * core::f32::consts::PI * k0 as f32 * i as f32 / n as f32).cos())
+            .collect();
+
+        let analytic = analytic_signal(&input);
+        let energy: f32 = analytic.iter().map(|a| a.norm_sqr()).sum();
+        assert!(energy < 1e-4, "expected near-zero energy, got {energy}");
+    }
+
+    /// A tone right at the filter's center frequency should pass
+    /// through with unit gain (sanity check on [`bandpass_gain`]
+    /// directly, independent of FFT bin alignment).
+    #[test]
+    fn bandpass_gain_is_unity_at_center_and_zero_far_outside() {
+        assert!((bandpass_gain(FILTER_CENTER_HZ) - 1.0).abs() < 1e-6);
+        assert!((bandpass_gain(FILTER_CENTER_HZ - 500.0) - 1.0).abs() < 1e-6);
+        assert_eq!(bandpass_gain(FILTER_CENTER_HZ + 2000.0), 0.0);
+        assert_eq!(bandpass_gain(0.0), 0.0);
     }
 }

--- a/mfsk-core/src/msk144/decode.rs
+++ b/mfsk-core/src/msk144/decode.rs
@@ -8,12 +8,13 @@
 //! deliberate simplifications from the WSJT-X reference, both
 //! documented at the point they matter below:
 //!
-//! - No RX-equalizer training (`bvar`/`pcoeffs` in `mskrtd.f90`,
-//!   trained by `msk144signalquality.f90`): this port always builds
-//!   the analytic signal via a plain FFT-based Hilbert transform
-//!   ([`crate::core::dsp::analytic_signal`]), with no adaptive
-//!   phase/amplitude correction across decodes. Signal-quality
-//!   estimation/training is not ported.
+//! - No adaptive RX-equalizer training (`beq`/`pcoeffs`/`corr(i)` in
+//!   `mskrtd.f90`, trained by `msk144signalquality.f90`):
+//!   [`crate::core::dsp::analytic_signal`] applies WSJT-X's *fixed*
+//!   1500 Hz-centered bandpass filter (`analytic.f90`'s `h(i)`,
+//!   unconditional in the reference), but not the *adaptive*
+//!   session-trained phase/amplitude correction layered on top of it.
+//!   Signal-quality estimation/training is not ported.
 //! - MSK40 (the legacy shorthand mode, `msk40spd.f90`) and SWL/hash
 //!   dedup bookkeeping are out of scope (matches the original scoping
 //!   in this crate's issue #25).

--- a/mfsk-core/tests/msk144_wsjtx_samples.rs
+++ b/mfsk-core/tests/msk144_wsjtx_samples.rs
@@ -14,9 +14,17 @@
 //! principled derivation, validated against synthetic/independent-
 //! oracle signals only up to this point) — but this first real-WAV
 //! run recovers all 3 golden messages across both files with no
-//! tuning needed (freq within a few Hz, `tsec` exact, SNR within 1 dB
-//! of WSJT-X), so this is a strict gate like the other protocols'
-//! golden-WAV tests.
+//! tuning needed (freq within a few Hz, `tsec` exact), so this is a
+//! strict gate like the other protocols' golden-WAV tests.
+//!
+//! SNR is gated too, exact-match after the `analytic_signal` fixed
+//! bandpass filter fix (`core/dsp/analytic.rs` — WSJT-X's `analytic()`
+//! always applies a 1500 Hz-centered raised-cosine bandpass before
+//! computing `pmax`/`pnoise`; the initial port omitted it, producing
+//! a systematic -1dB bias on all 3 golden decodes). `SNR_TOL_DB`
+//! leaves headroom for future incidental changes upstream of the SNR
+//! computation (e.g. FFT backend swaps) without making this an
+//! exact-bit-match gate.
 //!
 //! Skipped when the WSJT-X tree is not present at the expected
 //! sibling path so developers cloning only `mfsk-core` won't see a
@@ -51,10 +59,12 @@ struct Golden {
     msg: &'static str,
     freq_hz: f32,
     tsec: f32,
+    snr_db: i32,
 }
 
 const FREQ_TOL_HZ: f32 = 15.0;
 const TSEC_TOL: f32 = 1.0;
+const SNR_TOL_DB: i32 = 1;
 
 fn check(name: &str, golden: &[Golden]) {
     let Some(path) = sample_path(name) else {
@@ -85,6 +95,7 @@ fn check(name: &str, golden: &[Golden]) {
             d.message == g.msg
                 && (d.freq_hz - g.freq_hz).abs() <= FREQ_TOL_HZ
                 && (d.tsec - g.tsec).abs() <= TSEC_TOL
+                && (d.snr_db - g.snr_db).abs() <= SNR_TOL_DB
         });
         if hit {
             hits += 1;
@@ -98,8 +109,8 @@ fn check(name: &str, golden: &[Golden]) {
     );
     for g in &misses {
         eprintln!(
-            "  MISSING: '{}' @ {:.1} Hz tsec={:.1}",
-            g.msg, g.freq_hz, g.tsec
+            "  MISSING: '{}' @ {:.1} Hz tsec={:.1} snr={:+}",
+            g.msg, g.freq_hz, g.tsec, g.snr_db
         );
     }
 
@@ -123,6 +134,7 @@ fn msk144_181211_120500_wsjtx_sample() {
             msg: "K1JT WA4CQG EM72",
             freq_hz: 1488.0,
             tsec: 8.7,
+            snr_db: 8,
         }],
     );
 }
@@ -136,11 +148,13 @@ fn msk144_181211_120800_wsjtx_sample() {
                 msg: "CQ W4IMD EM84",
                 freq_hz: 1458.0,
                 tsec: 4.6,
+                snr_db: 5,
             },
             Golden {
                 msg: "CQ KD9VV EN71",
                 freq_hz: 1496.0,
                 tsec: 12.2,
+                snr_db: 7,
             },
         ],
     );


### PR DESCRIPTION
## Summary
- MSK144's golden-WAV test (shipped 0.7.4, `ee55a1e`) recovered all 3 reference messages from day one but never asserted SNR, only printed it -- a manual check found every decode running exactly -1dB vs WSJT-X, consistent enough to be systematic.
- Root-caused by tracing the SNR chain in `mskrtd.f90`/`msk144spd.f90` against the Rust port in parallel: the reported-SNR formula, noise-floor EMA, and a `detmet`-based formula in `spd.rs` (confirmed dead code in WSJT-X itself) all matched exactly. The actual gap: WSJT-X's `analytic()` always applies a fixed 1500 Hz-centered raised-cosine bandpass filter before computing the `pmax`/`pnoise` SNR ratio; this port's `analytic_signal()` was a bare Hilbert transform with no filtering, inflating the noise floor and depressing `snr0`.
- Also confirmed (structural diff against `msk144spd.f90`/`msk144sync.f90`/`msk144decodeframe.f90`) that candidate detection, diversity combining, the 3-tier `Depth` ladder, and sync search are all faithful line-for-line ports -- no "less search" recall gap from decode-method differences.
- Porting the filter closes the gap exactly: golden SNR now matches WSJT-X bit-for-bit (+8/+5/+7, was +7/+4/+6), recall still 3/3.
- `msk144_wsjtx_samples.rs` now asserts SNR (±1 dB) instead of only printing it, so a future regression here is caught the same way message-recall regressions already are.

## Test plan
- [x] `cargo test -p mfsk-core --features "msk144,fft-rustfft,uvpacket" --lib core::dsp::analytic` -- new filter unit tests pass
- [x] `cargo test --release -p mfsk-core --features "msk144,fft-rustfft,uvpacket" --test msk144_wsjtx_samples -- --nocapture` -- 3/3 recall, SNR exact match to WSJT-X
- [x] `cargo test -p mfsk-core --features "msk144,fft-rustfft,uvpacket" --lib msk144::` -- all 16 msk144 unit tests pass (incl. independent-oracle end-to-end)
- [x] `cargo clippy --workspace --all-targets --features full -- -D warnings` clean (pre-commit hook)
- [x] `cargo fmt --check` clean (pre-commit hook)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01M4W6LwFkVZDmrrphMDaowV