### PR TITLE
docs(msk144): add MSK144_BENCHMARK.md/.ja.md, matching FT4/FST4 convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -509,6 +509,14 @@ reference:
   prerequisites, building `fst4sim` from WSJT-X source, generating
   the WAV corpus, and how to avoid grid-censoring artifacts when
   reading off the recall crossing.
+- **MSK144 sensitivity benchmark setup:**
+  [English `docs/notes/MSK144_BENCHMARK.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/MSK144_BENCHMARK.md)
+  / [日本語 `docs/notes/MSK144_BENCHMARK.ja.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/MSK144_BENCHMARK.ja.md)
+  — the self-contained `tests/msk144_snr_sweep.rs` regression sweep
+  (no WSJT-X checkout needed), plus how to reproduce the one-time
+  apples-to-apples verification against a real WSJT-X `jt9` build
+  (building `jt9`/`msk144sim`/Hamlib from source, `msk144sim`'s SNR
+  convention, and the measured baseline results).
 - **M5StickS3 FT8 controller manual:**
   [English `docs/reference/MANUAL_M5STICKS3.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/reference/MANUAL_M5STICKS3.md)
   / [日本語 `docs/reference/MANUAL_M5STICKS3.ja.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/reference/MANUAL_M5STICKS3.ja.md)
@@ -728,9 +736,12 @@ tree is present at the expected sibling path):
   differed by exactly 1 file out of 20 — no measurable recall gap at
   any tested SNR, 50% crossing ≈ -5.5 to -6 dB (WSJT-X's 2500 Hz
   reference-bandwidth convention) for both short (~0.4 s) and long
-  (~2.5 s) ping profiles. MSK40 (the legacy shorthand mode) and the
-  *adaptive* RX-equalizer training loop (as opposed to the fixed
-  bandpass filter above, which is ported) remain out of scope. Behind
-  the `msk144` feature (part of `full`).
+  (~2.5 s) ping profiles — see
+  [`docs/notes/MSK144_BENCHMARK.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/MSK144_BENCHMARK.md)
+  for how to reproduce this and the self-contained
+  `tests/msk144_snr_sweep.rs` regression sweep. MSK40 (the legacy
+  shorthand mode) and the *adaptive* RX-equalizer training loop (as
+  opposed to the fixed bandpass filter above, which is ported) remain
+  out of scope. Behind the `msk144` feature (part of `full`).
 - **SNR (FT8)** — `xsnr2_db_simple` calibration (0.5.7 + 0.5.8) lands
   reported SNR within ±3 dB of JTDX absolute on real silicon.

--- a/docs/notes/MSK144_BENCHMARK.ja.md
+++ b/docs/notes/MSK144_BENCHMARK.ja.md
@@ -1,0 +1,222 @@
+# MSK144 感度ベンチマーク — 環境セットアップ
+
+MSK144 の SNR sensitivity sweep (`tests/msk144_snr_sweep.rs`) を
+実際の WSJT-X と突き合わせて検証した方法と、その検証をクリーンな
+チェックアウトから再現する手順。この調査の経緯は
+[#156](https://github.com/jl1nie/mfsk-core/issues/156)
+（[#157](https://github.com/jl1nie/mfsk-core/pull/157) の SNR バイアス
+修正の follow-up）を参照。
+
+FT4/FST4 のベンチマークハーネス
+([`FT4_BENCHMARK.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/FT4_BENCHMARK.md)、
+[`FST4_BENCHMARK.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/FST4_BENCHMARK.md))
+は `lib/` だけからビルドできる小さな単体 Fortran `*sim` バイナリを
+必要とするのに対し、**MSK144 の日常的な回帰テストは WSJT-X の
+チェックアウトを一切必要としない** — `tests/msk144_snr_sweep.rs` は
+完全に自己完結している（独自の合成信号ジェネレータ、独自のノイズ
+モデル、外部プロセス無し）。ここで説明する WSJT-X 比較ステップ
+（フル版の `jt9` CLI のビルド）は**一回きりの検証**であり、CI や
+日常の開発で繰り返す必要はない。新しい WSJT-X リリースと再照合したい
+場合や SNR グリッドを拡張したい場合にのみ再現すればよい。
+
+## 1. 回帰テスト（WSJT-X 不要）
+
+```sh
+cargo test --release -p mfsk-core --features "msk144,fft-rustfft,uvpacket,parallel" \
+  --test msk144_snr_sweep -- --ignored --nocapture
+```
+
+- `--release` と `--features parallel` の両方が重要: このスイープは
+  2 ping-length 設定 × 7 SNR ポイント × 20 seed で、各 seed が
+  15〜30 秒スロット全体に対するフルの `Depth::Deep`
+  `decode_slot()` 呼び出し。`parallel` 無しだと release でも
+  約 266 秒（各 seed のトライアルは独立だが逐次実行）、
+  `parallel` 有りだと約 22 秒（rayon の `into_par_iter()` で
+  SNR ポイントごとの 20 seed を並列化）。
+- 出力は単なる recall 表（SNR ポイントごとの hits/20）— pass/fail
+  のアサーションは無い。FT4/FST4/FT8 のスイープテストと同様、
+  ハードコードされた閾値 dB ゲートはここでは安定した回帰シグナルに
+  ならない（FFT バックエンドや浮動小数点の細部に敏感で、実際の
+  recall 回帰を反映しないため）。以下のベースラインと目視で照合する。
+- CI は main への merge 後、"catchall characterization" スイート
+  (`.github/workflows/ci.yml`) 経由で自動実行される — PR で強制的に
+  走らせたい場合は `run-full-sweep` ラベルを付与する。
+
+テスト内部の合成器は WSJT-X 本家の `msk144sim.f90` の信号モデルを
+Rust で直接再現している（本クレート自身の OQPSK TX パスではない
+ので、recall の数字が自クレートの modulator に対して自己成就的に
+ならない）:
+
+- スロット中 1 秒ごとに 1 回のメテオピング
+  (`t = 1, 2, ..., ntr_period - 1`)、`2.718 * t * exp(-t)` の減衰
+  エンベロープ (`makepings.f90`)。
+- 連続位相バイナリ FSK キャリア。本クレート自身の LDPC(128,90) +
+  CRC-13 エンコーダ出力から、`msk144::decode` 自身の独立オラクル
+  ユニットテストが既に使っている差分関係を通じて復元 — つまり
+  *メッセージエンコーディング*は本クレート自身のものだが、
+  *波形合成*は意図的にそうではない。
+- WSJT-X の **2500 Hz 基準帯域幅** SNR convention に較正した
+  AWGN（下記参照）— つまりスイープが出力する `snr_db` は本クレート
+  自身の生の full-Nyquist-band convention ではなく、WSJT-X 本家が
+  報告する SNR と直接比較可能。
+
+## 2. 一回きりの WSJT-X 突き合わせを再現する
+
+### 2.1 前提パッケージ
+
+MSK144 の `jt9` ターゲットは CMake の configure 時点で WSJT-X の
+依存関係を**まるごと**引き込む（`find_package(... REQUIRED)` は
+どのターゲットをビルドするかに関わらず無条件に実行される）—
+FT4/FST4 の単体 `*sim` バイナリよりもはるかに重い前提条件になる:
+
+| 要件 | Ubuntu/Debian パッケージ | 用途 |
+|---|---|---|
+| Qt5 (Widgets, SerialPort, Multimedia, PrintSupport, Sql, LinguistTools) | `qtbase5-dev qtmultimedia5-dev libqt5serialport5-dev qttools5-dev qttools5-dev-tools` | `fort_qt` からリンクされる |
+| Boost (log, log_setup) | `libboost-log-dev libboost-dev` | `find_package(Boost ... log_setup log)` |
+| libusb-1.0 | `libusb-1.0-0-dev` | Hamlib のオプション USB リグバックエンド |
+| readline | `libreadline-dev` | Hamlib CLI の history |
+| autoconf/automake/libtool/pkg-config | 同名 | Hamlib の `./bootstrap` |
+| `cmake`, `gfortran`, `libfftw3-dev` | 同名 | 通常は既にインストール済み |
+
+```sh
+sudo apt-get install -y \
+  qtbase5-dev qtmultimedia5-dev libqt5serialport5-dev \
+  qttools5-dev qttools5-dev-tools \
+  libboost-log-dev libboost-dev \
+  libusb-1.0-0-dev libreadline-dev \
+  autoconf automake libtool pkg-config git
+```
+
+### 2.2 Hamlib をソースからビルド
+
+`WSJT-X/INSTALL` 本家のレシピは Hamlib の `integration` ブランチを
+指定しているが、**このブランチはもう存在しない**（しばらく前に
+`master` へマージ済み）。代わりに `master` を使う、それ以外の手順は
+そのまま適用できる:
+
+```sh
+mkdir -p ~/hamlib-prefix && cd ~/hamlib-prefix
+git clone https://github.com/Hamlib/Hamlib src
+cd src && ./bootstrap
+mkdir ../build && cd ../build
+../src/configure --prefix=$HOME/hamlib-prefix \
+   --disable-shared --enable-static \
+   --without-cxx-binding --disable-winradio \
+   CFLAGS="-g -O2 -fdata-sections -ffunction-sections" \
+   LDFLAGS="-Wl,--gc-sections"
+make -j"$(nproc)" && make install-strip
+```
+
+### 2.3 `jt9` と `msk144sim` をビルド
+
+```sh
+mkdir -p ~/wsjtx-build && cd ~/wsjtx-build
+cmake -D CMAKE_PREFIX_PATH=$HOME/hamlib-prefix \
+  -DWSJT_SKIP_MANPAGES=ON -DWSJT_GENERATE_DOCS=OFF \
+  /path/to/WSJT-X
+cmake --build . --target jt9 -j"$(nproc)"
+cmake --build . --target msk144sim -j"$(nproc)"
+```
+
+`--target jt9`/`--target msk144sim` はフルの Qt GUI アプリケーション
+(`wsjtx` 本体) のコンパイルをスキップする — CMake の configure 自体は
+（上記の全依存を要するため）フルで走るが、実際のビルドはこの 2
+バイナリだけに絞られる。
+
+**サニティチェック**として、他の用途に使う前にまず vendored golden
+WAV で確認する:
+
+```sh
+cd /path/to/WSJT-X/samples/MSK144
+~/wsjtx-build/jt9 -k -d 3 -f 1477 -F 60 181211_120500.wav 181211_120800.wav
+```
+
+`mfsk-core/tests/msk144_wsjtx_samples.rs` の `Golden` テーブルにある
+3 件の golden decode を全て再現するはず — message / freq / timing /
+SNR 全て一致。デフォルトの `-F 20` (周波数探索許容幅) は 2 番目の
+ファイルの 1458 Hz 信号には狭すぎるため、上記のように広げる必要が
+ある。
+
+**落とし穴**: `jt9` は実行時のカレントディレクトリに
+`decoded.txt` / `jt9_wisdom.dat` / `timer.out` を書き出す —
+repo root ではなくスクラッチディレクトリから実行すること。
+
+### 2.4 `msk144sim` の SNR convention
+
+`msk144sim.f90` は注入するノイズを加算する前に
+`fac = sqrt(6000.0/2500.0)` でスケーリングしている — シミュレーション
+自体は 12kHz サンプルレート／6kHz Nyquist で動くにも関わらず、
+`snrdb` 引数は WSJT-X の**2500 Hz 基準帯域幅**に較正されている。
+これは本クレートの生の full-Nyquist-band SNR convention
+（他の箇所、例えば `msk144::decode::SlotDecode::snr_db` 自身の
+`pmax`/`pnoise` 計算で使われているもの）と WSJT-X の報告値との間の
+「+10·log10(6000/2500) ≈ +3.8 dB」という換算係数の一次資料的な
+裏付けになる — シミュレータのソースから直接確認済みで、推測では
+ない。
+
+**落とし穴**: `msk144sim` の RNG はプロセス起動をまたいで
+再シード**されない** — 同じ引数で 2 回実行するとバイト単位で
+同一の WAV が生成される。独立したノイズ実現値が欲しい場合は
+`nfiles > 1` を指定した**単一の**実行呼び出しでのみ得られる
+（内部の `do ifile=1,nfiles` ループの中で RNG ストリームが進む）。
+
+```
+Usage:   msk144sim       message      TRp freq width snr nfiles
+Example: msk144sim "K1ABC W9XYZ EN37"  15 1500  0.12   2    1   # short ping
+         msk144sim "K1ABC W9XYZ EN37"  30 1500  2.5   15    1   # long ping
+```
+
+`TRp`/`width` がメテオピングのプロファイルを決める:
+`TRp=15, width=0.12` は 15 秒スロット中 1 秒ごとに約 0.4 秒のピング、
+`TRp=30, width=2.5` は 30 秒スロット中 1 秒ごとに約 2.5 秒のピング。
+これらは WSJT-X 本家自身のサンプル例であり、
+`tests/msk144_snr_sweep.rs` の "short"/"long" 設定が再現しているのも
+これ。
+
+### 2.5 突き合わせの実行
+
+これ用のチェックイン済みスクリプトは無い（一回きりの検証であり、
+繰り返す CI ステップではないため）— おおよその形:
+
+```sh
+for snr in -9 -8 -7 -6 -5 -4 -3; do
+  msk144sim "K1ABC W9XYZ EN37" 15 1500 0.12 "$snr" 20   # 1回の呼び出しで20ファイル
+  for f in 000000_*.wav; do
+    jt9 -k -d 3 "$f" | grep -qF "K1ABC W9XYZ EN37" && echo hit
+  done
+done
+```
+
+...同じ WAV を `jt9 -k -d 3` と、`msk144::decode::decode_slot()` を
+直接呼ぶ使い捨ての Rust バイナリの両方でデコードする（ローカルの
+`mfsk-core` チェックアウトへの `path` 依存を持つ小さな Cargo
+プロジェクトで十分 — クレート本体に恒久的な bin ターゲットを
+追加する必要は無い）。
+
+## 3. 結果 (2026-07-19、WSJT-X `jt9` との比較)
+
+SNR ポイントごとに 20 seed、両設定:
+
+| config | SNR (dB) | jt9 | mfsk-core |
+|---|---|---|---|
+| short (~0.4 秒 ping) | -7 | 0/20 | 0/20 |
+| | -6 | 3/20 | 3/20 |
+| | -5 | 17/20 | 16/20 |
+| | -4 | 20/20 | 20/20 |
+| long (~2.5 秒 ping) | -7 | 1/20 | 0/20 |
+| | -6 | 1/20 | 1/20 |
+| | -5 | 14/20 | 13/20 |
+| | -4 | 20/20 | 20/20 |
+
+**28 セル中 25 セルが完全一致、残り 3 件も 20 ファイル中ちょうど
+1 ファイルの差** — 閾値カーブが最も急峻な部分での境界的なノイズ
+実現値のブレであり、系統的なギャップではない。50% recall crossing
+は両 ping プロファイルとも WSJT-X convention（2500 Hz 基準帯域幅）で
+概ね -5.5〜-6 dB。
+
+これは今後 `tests/msk144_snr_sweep.rs` を実行した結果と比較する際の
+ベースラインとなる — テスト内蔵の合成器は `msk144sim` とバイト単位
+で同一ではない（同じモデルの独立した Rust 再実装で、RNG も独自）
+ため、この表と完全一致ではなく*近い*値になるはず。このベースライン
+からの数 dB のシフトこそが調査に値するシグナルであり、セルごとの
+小さなブレではない。

--- a/docs/notes/MSK144_BENCHMARK.md
+++ b/docs/notes/MSK144_BENCHMARK.md
@@ -1,0 +1,221 @@
+# MSK144 sensitivity benchmark — environment setup
+
+How the MSK144 SNR sensitivity sweep (`tests/msk144_snr_sweep.rs`) was
+verified against real WSJT-X, and how to reproduce that verification
+from a clean checkout. See
+[#156](https://github.com/jl1nie/mfsk-core/issues/156) for the
+investigation this grew out of (a follow-up to the SNR-bias fix in
+[#157](https://github.com/jl1nie/mfsk-core/pull/157)).
+
+Unlike the FT4/FST4 benchmark harnesses
+([`FT4_BENCHMARK.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/FT4_BENCHMARK.md),
+[`FST4_BENCHMARK.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/FST4_BENCHMARK.md)),
+which need a small standalone Fortran `*sim` binary built from just
+`lib/`, **MSK144's day-to-day regression test needs no WSJT-X checkout
+at all** — `tests/msk144_snr_sweep.rs` is fully self-contained (its
+own synthetic-signal generator, its own noise model, no external
+process). The WSJT-X-comparison step described here (building the
+full `jt9` CLI) was a **one-time verification**, not something CI or
+routine development needs to repeat. Reproduce it only if you want to
+re-check against a newer WSJT-X release or extend the SNR grid.
+
+## 1. The regression test (no WSJT-X needed)
+
+```sh
+cargo test --release -p mfsk-core --features "msk144,fft-rustfft,uvpacket,parallel" \
+  --test msk144_snr_sweep -- --ignored --nocapture
+```
+
+- `--release` and `--features parallel` both matter a lot here: the
+  sweep is 2 ping-length configs × 7 SNR points × 20 seeds, each seed
+  a full `Depth::Deep` `decode_slot()` call over a 15-30 s slot.
+  ~266 s in release without `parallel` (the per-seed trials are
+  independent, sequential otherwise), ~22 s with it (rayon
+  `into_par_iter()` over the 20 seeds per SNR point).
+- Output is a plain recall table (hits/20 per SNR point) — no
+  pass/fail assertion. Like the FT4/FST4/FT8 sweep tests, a hardcoded
+  threshold-dB gate isn't a stable regression signal here (sensitive
+  to FFT backend / floating-point details that don't reflect a real
+  recall regression); watch the printed table by eye against the
+  baseline below.
+- CI runs this automatically post-merge to `main` via the "catchall
+  characterization" suite (`.github/workflows/ci.yml`) — add the
+  `run-full-sweep` label to a PR to force it there too.
+
+The synthesizer inside the test reproduces WSJT-X's own `msk144sim.f90`
+signal model directly in Rust (not this crate's own OQPSK TX path, so
+recall numbers aren't self-fulfilling against this crate's own
+modulator):
+
+- A meteor ping once per second across the slot
+  (`t = 1, 2, ..., ntr_period - 1`), `2.718 * t * exp(-t)` decay
+  envelope (`makepings.f90`).
+- Continuous-phase binary FSK carrier, recovered from this crate's own
+  LDPC(128,90) + CRC-13 encoder output via the differential relation
+  `msk144::decode`'s own independent-oracle unit test already uses —
+  i.e. the *message encoding* is this crate's own, but the *waveform
+  synthesis* deliberately is not.
+- AWGN calibrated to WSJT-X's **2500 Hz reference bandwidth** SNR
+  convention (see below) — so the `snr_db` values printed by the sweep
+  are directly comparable to WSJT-X's own reported SNR, not this
+  crate's raw full-Nyquist-band convention.
+
+## 2. Reproducing the one-time WSJT-X cross-check
+
+### 2.1 Prerequisites
+
+MSK144's `jt9` target pulls in WSJT-X's *entire* dependency chain at
+CMake configure time (`find_package(... REQUIRED)` for all of these
+runs unconditionally, regardless of which target you actually build)
+— this is a much heavier prerequisite set than FT4/FST4's standalone
+`*sim` binaries:
+
+| Requirement | Ubuntu/Debian package | Purpose |
+|---|---|---|
+| Qt5 (Widgets, SerialPort, Multimedia, PrintSupport, Sql, LinguistTools) | `qtbase5-dev qtmultimedia5-dev libqt5serialport5-dev qttools5-dev qttools5-dev-tools` | linked by `fort_qt` |
+| Boost (log, log_setup) | `libboost-log-dev libboost-dev` | `find_package(Boost ... log_setup log)` |
+| libusb-1.0 | `libusb-1.0-0-dev` | Hamlib's optional USB rig backends |
+| readline | `libreadline-dev` | Hamlib CLI history |
+| autoconf/automake/libtool/pkg-config | same names | Hamlib's `./bootstrap` |
+| `cmake`, `gfortran`, `libfftw3-dev` | same names | usually already present |
+
+```sh
+sudo apt-get install -y \
+  qtbase5-dev qtmultimedia5-dev libqt5serialport5-dev \
+  qttools5-dev qttools5-dev-tools \
+  libboost-log-dev libboost-dev \
+  libusb-1.0-0-dev libreadline-dev \
+  autoconf automake libtool pkg-config git
+```
+
+### 2.2 Build Hamlib from source
+
+`WSJT-X/INSTALL`'s own recipe calls for Hamlib's `integration`
+branch — **that branch no longer exists** (merged into `master` some
+time ago); use `master` instead, everything else in the recipe still
+applies:
+
+```sh
+mkdir -p ~/hamlib-prefix && cd ~/hamlib-prefix
+git clone https://github.com/Hamlib/Hamlib src
+cd src && ./bootstrap
+mkdir ../build && cd ../build
+../src/configure --prefix=$HOME/hamlib-prefix \
+   --disable-shared --enable-static \
+   --without-cxx-binding --disable-winradio \
+   CFLAGS="-g -O2 -fdata-sections -ffunction-sections" \
+   LDFLAGS="-Wl,--gc-sections"
+make -j"$(nproc)" && make install-strip
+```
+
+### 2.3 Build `jt9` and `msk144sim`
+
+```sh
+mkdir -p ~/wsjtx-build && cd ~/wsjtx-build
+cmake -D CMAKE_PREFIX_PATH=$HOME/hamlib-prefix \
+  -DWSJT_SKIP_MANPAGES=ON -DWSJT_GENERATE_DOCS=OFF \
+  /path/to/WSJT-X
+cmake --build . --target jt9 -j"$(nproc)"
+cmake --build . --target msk144sim -j"$(nproc)"
+```
+
+`--target jt9`/`--target msk144sim` skip compiling the full Qt GUI
+application (`wsjtx` itself) — CMake still configures everything
+(hence the full dependency list above), but the actual build stays
+scoped to the two binaries needed here.
+
+**Sanity check** against the vendored golden WAVs before trusting the
+build for anything else:
+
+```sh
+cd /path/to/WSJT-X/samples/MSK144
+~/wsjtx-build/jt9 -k -d 3 -f 1477 -F 60 181211_120500.wav 181211_120800.wav
+```
+
+Should reproduce all 3 golden decodes from
+[`reference_msk144_jt65_wsjtx_sample_decode.md`](https://github.com/jl1nie/mfsk-core)-equivalent
+(`mfsk-core/tests/msk144_wsjtx_samples.rs`'s `Golden` table) —
+message, frequency, timing, and SNR all matching. The default `-F 20`
+frequency-search tolerance is too narrow for the 1458 Hz signal in the
+second file; widen it as shown.
+
+**Foot-gun**: `jt9` drops `decoded.txt` / `jt9_wisdom.dat` /
+`timer.out` into whatever the current directory was when it ran — run
+it from a scratch directory, not the repo root.
+
+### 2.4 `msk144sim`'s SNR convention
+
+`msk144sim.f90` scales its injected noise by
+`fac = sqrt(6000.0/2500.0)` before adding it — its `snrdb` argument is
+calibrated to WSJT-X's **2500 Hz reference bandwidth**, even though
+the simulation itself runs at 12 kHz sample rate / 6 kHz Nyquist. This
+is the authoritative source for the "+10·log10(6000/2500) ≈ +3.8 dB"
+conversion between this crate's raw full-Nyquist-band SNR convention
+(used elsewhere, e.g. `msk144::decode::SlotDecode::snr_db`'s own
+internal `pmax`/`pnoise` computation) and WSJT-X's reported figures —
+confirmed directly from the simulator source, not inferred.
+
+**Gotcha**: `msk144sim`'s RNG is *not* re-seeded across separate
+process invocations — running it twice with identical arguments
+produces byte-identical WAVs. Independent noise realizations only come
+from a *single* invocation with `nfiles > 1` (the RNG stream advances
+across the internal `do ifile=1,nfiles` loop).
+
+```
+Usage:   msk144sim       message      TRp freq width snr nfiles
+Example: msk144sim "K1ABC W9XYZ EN37"  15 1500  0.12   2    1   # short ping
+         msk144sim "K1ABC W9XYZ EN37"  30 1500  2.5   15    1   # long ping
+```
+
+`TRp`/`width` set the meteor-ping profile: `TRp=15, width=0.12` gives
+a ~0.4 s ping once/second across a 15 s slot; `TRp=30, width=2.5`
+gives a ~2.5 s ping once/second across a 30 s slot. These are
+WSJT-X's own worked examples and are what `tests/msk144_snr_sweep.rs`
+reproduces as its "short"/"long" configs.
+
+### 2.5 Running the cross-check
+
+There's no checked-in script for this (it was a one-time
+verification, not a repeatable CI step) — the shape of it:
+
+```sh
+for snr in -9 -8 -7 -6 -5 -4 -3; do
+  msk144sim "K1ABC W9XYZ EN37" 15 1500 0.12 "$snr" 20   # one call, 20 files
+  for f in 000000_*.wav; do
+    jt9 -k -d 3 "$f" | grep -qF "K1ABC W9XYZ EN37" && echo hit
+  done
+done
+```
+
+...decoding the same WAVs with both `jt9 -k -d 3` and a throwaway Rust
+binary calling `msk144::decode::decode_slot()` directly (a small
+`path`-dependency Cargo project against the local `mfsk-core` checkout
+is enough — no need to add a permanent binary target to the crate).
+
+## 3. Results (2026-07-19, vs WSJT-X `jt9`)
+
+20 seeds/SNR point, both configs:
+
+| config | SNR (dB) | jt9 | mfsk-core |
+|---|---|---|---|
+| short (~0.4 s ping) | -7 | 0/20 | 0/20 |
+| | -6 | 3/20 | 3/20 |
+| | -5 | 17/20 | 16/20 |
+| | -4 | 20/20 | 20/20 |
+| long (~2.5 s ping) | -7 | 1/20 | 0/20 |
+| | -6 | 1/20 | 1/20 |
+| | -5 | 14/20 | 13/20 |
+| | -4 | 20/20 | 20/20 |
+
+**25 of 28 cells matched exactly; the other 3 differed by exactly 1
+file out of 20** — a single borderline noise realization at the
+steepest part of the threshold curve, not a systematic gap. 50%
+recall crossing ≈ -5.5 to -6 dB (WSJT-X's 2500 Hz reference-bandwidth
+convention) for both ping profiles.
+
+This is the baseline to compare future `tests/msk144_snr_sweep.rs`
+runs against — its own synthesizer isn't byte-identical to
+`msk144sim`'s (independent Rust reimplementation of the same model,
+own RNG), so expect the printed numbers to be *close* to this table
+rather than identical to it; a multi-dB shift from this baseline is
+the signal worth investigating, not small per-cell noise.


### PR DESCRIPTION
## Summary
- Adds `docs/notes/MSK144_BENCHMARK.md` + `.ja.md`, documenting the jt9-CLI-based apples-to-apples SNR sensitivity verification from #156/#158 as a reproducible methodology guide -- mirroring `FT4_BENCHMARK.md`/`FST4_BENCHMARK.md`'s structure (prerequisites, build recipe, results table).
- Explicitly calls out the one structural difference from FT4/FST4's benchmark docs: MSK144's `jt9` target pulls in WSJT-X's *entire* dependency chain (Qt5 + Hamlib + Boost + libusb) at CMake configure time, much heavier than FT4/FST4's standalone `*sim` binaries -- and that this is a one-time verification, since `tests/msk144_snr_sweep.rs` itself is fully self-contained and needs no WSJT-X checkout for day-to-day use.
- Documents two things not written down anywhere else in the repo: Hamlib's `integration` branch (referenced by `WSJT-X/INSTALL`) no longer exists, use `master`; and `msk144sim.f90`'s `fac=sqrt(6000/2500)` noise scaling is the verified (not inferred) source of the 2500 Hz reference-bandwidth SNR conversion.
- README: new bilingual doc-index entry (matching the `FST4_BENCHMARK.md` link pattern) + a link from the MSK144 "What's solid" bullet.

Docs-only change, no code/test modifications.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01M4W6LwFkVZDmrrphMDaowV