### PR TITLE
chore(release): 0.7.4 — MSK144 decode + SNR fix + jt9 sensitivity verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,18 @@
   characterization" tier) reproduces the same synthetic-signal recipe
   as an ongoing regression signal.
 
+### Docs
+
+- **`docs/notes/MSK144_BENCHMARK.md` + `.ja.md`**, matching
+  `FT4_BENCHMARK.md`/`FST4_BENCHMARK.md`'s convention: how to
+  reproduce the `jt9`-based verification above (prerequisites,
+  building `jt9`/`msk144sim`/Hamlib from source — Hamlib's
+  `integration` branch referenced by `WSJT-X/INSTALL` no longer
+  exists, use `master` — `msk144sim`'s verified SNR convention, and
+  the measured baseline). Explicitly notes this is a one-time
+  verification: `tests/msk144_snr_sweep.rs` itself needs no WSJT-X
+  checkout.
+
 ## 0.7.3 — FT4 AWGN + FT8 CCIR fading sensitivity close-out (#151, #152, #153)
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,45 @@ Sequence:
 3. `git tag vX.Y.Z <merge-sha>` then `git push origin vX.Y.Z`.
 4. Watch the Actions tab for the `Release` workflow.
 
+### Release cadence — biweekly, decoupled from merging
+
+PRs land on `main` immediately as they're ready — CHANGELOG.md's
+top (unreleased/latest-numbered) section accumulates entries between
+tags, so `main`'s history and the CHANGELOG are always current for
+anyone reading the repo directly. **Tagging is separate and
+throttled**: established 2026-07-19 after v0.7.0-v0.7.3 shipped in a
+4-day burst (see `~/.claude/projects/.../memory/` for the session
+that measured this) — that burst wasn't itself a problem (each tag
+was a genuinely complete, coherently-scoped unit of work, not an
+arbitrary slice; per-tag diff size was comparable to or larger than
+historically slower-cadence releases), but four crates.io publishes /
+GitHub Releases in four days is more update-notification noise than
+downstream consumers want, even when every individual change was
+sound.
+
+**Default cadence: every 2 weeks** (max wait 13 days, average 7) from
+the last tag, bundling everything merged to `main` since then into
+one release PR + tag. Don't tag opportunistically just because a
+feature or fix finished — let it sit in the unreleased CHANGELOG
+section until the next scheduled cut, *unless* the escape hatch below
+applies.
+
+**Escape hatch**: an out-of-cadence tag is fine for a security fix, a
+data-loss/correctness bug serious enough to want off the broken
+version quickly, or whenever the user explicitly asks for an
+immediate release regardless of reason. Cutting early is the user's
+call, not something to infer on your own from "this seems important."
+
+**Versioning within this cadence**: a new protocol/mode addition is
+patch-level by this crate's own established convention (MSK144
+shipped as `0.7.4`, not `0.8.0` — grep `CHANGELOG.md` for prior
+protocol additions before assuming otherwise). Minor bumps
+(`0.6→0.7`) have historically marked a more structural change (e.g.
+`0.7.0`'s generic `decode_frame_for::<P>` API landing alongside FST4's
+remaining sub-modes), not simply "a release with new capability in
+it" — when genuinely unsure which a given accumulated batch warrants,
+ask rather than default to whichever bump feels more exciting.
+
 ## Memory
 
 - `~/.claude/projects/-home-minoru-src-mfsk-core/memory/` holds the

--- a/README.md
+++ b/README.md
@@ -66,6 +66,15 @@ for why there's no runtime `register_protocol()`.
 mfsk-core = { version = "0.7", features = ["ft8", "ft4"] }
 ```
 
+New features and fixes land on `main` immediately as PRs merge, but
+crates.io releases are cut on a throttled cadence (see
+[Status](#status)) — if you want a specific fix or new mode before it
+ships to crates.io, point at the git repo instead:
+
+```toml
+mfsk-core = { git = "https://github.com/jl1nie/mfsk-core", branch = "main", features = ["ft8", "ft4"] }
+```
+
 Synthesise an FT8 frame and decode it back:
 
 ```rust
@@ -525,10 +534,24 @@ reference:
 
 ## Status
 
-**Current line: `0.7.x`** (latest tag `v0.7.2`, 2026-07-18) — API
+**Current line: `0.7.x`** (latest tag `v0.7.4`, 2026-07-19) — API
 is deliberately not frozen. Breaking changes follow cargo-style minor
-bumps (`0.6 → 0.7`). See `CHANGELOG.md` for the per-release breakdown;
-the line history below explains what each series brought in. **0.7.0**
+bumps (`0.6 → 0.7`); a new protocol/mode addition on its own is
+patch-level (e.g. MSK144 shipped as `0.7.4`, not `0.8.0`) — minor
+bumps mark more structural changes (`0.7.0`'s generic
+`decode_frame_for::<P>` API, alongside FST4's remaining sub-modes).
+See `CHANGELOG.md` for the per-release breakdown; the line history
+below explains what each series brought in.
+
+**Release cadence**: PRs merge to `main` continuously — CHANGELOG.md's
+top section always reflects the latest unreleased state, so tracking
+`main` directly (see [Quick Start](#quick-start)) gets you every
+change immediately. Actual crates.io tags/GitHub Releases are cut on
+a **biweekly** cadence (bundling everything merged since the last
+tag) rather than after every individual change, to keep update
+notifications for crates.io consumers from firing too often — an
+out-of-cadence release is still fine for a security fix, a serious
+correctness bug, or on explicit request. **0.7.0**
 added the remaining FST4 sub-modes (FST4-15/30/120/300, alongside the
 existing FST4-60) and parallelised `coarse_sync` under `--features
 parallel`. **0.7.1** closed FST4's AWGN sensitivity gap vs. WSJT-X's

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-core"
-version     = "0.7.3"
+version     = "0.7.4"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 description = "Pure-Rust WSJT-family decoders + synthesisers (FT8 FT4 FST4 WSPR JT9 JT65 Q65) behind a zero-cost Protocol trait. Host (rustfft) or no_std embedded (ESP32-S3, RP2350, Cortex-M) via a pluggable FFT backend; fixed-point hot path for FPU-less MCUs. Ships with embedded-poc/m5stack-s3-app, a working M5StickS3 FT8 controller (LCD UI, BLE CI-V to IC-705, acoustic mic, QSO FSM) decoding real on-air signals in ~1.2 s post-SlotEnd on Xtensa LX7."

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "mfsk-ffi-ft8"
-version     = "0.7.3"
+version     = "0.7.4"
 edition     = "2024"
 license     = "GPL-3.0-or-later"
 publish     = false
@@ -53,7 +53,7 @@ embedded-fixed-point = [
 embedded-runtime = []
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.7.3", default-features = false }
+mfsk-core = { path = "../mfsk-core", version = "0.7.4", default-features = false }
 
 [build-dependencies]
 cbindgen = "0.29"


### PR DESCRIPTION
## Summary
Metadata/docs-only release PR bundling issue #25 (MSK144 decode), #156 (SNR sensitivity verification against real WSJT-X), and PR #157/#158/#159's SNR-bias fix + regression sweep + benchmark docs. See CHANGELOG.md's 0.7.4 section for the full per-change breakdown (already accumulated across those merges).

Also establishes a release cadence policy:
- PRs keep landing on `main` immediately as before -- nothing changes about merge velocity.
- crates.io tags / GitHub Releases move to a **biweekly** cadence (bundling everything since the last tag) instead of one per closed issue, after v0.7.0-v0.7.3 shipped in a 4-day burst.
- Escape hatch: security fixes, correctness-critical bugs, or explicit request can still trigger an out-of-cadence tag.
- Documented in both `CLAUDE.md` (agent-facing process notes) and `README.md`'s Status section (consumer-facing), plus a `git = "..."` dependency example in Quick Start for anyone who wants `main` directly between tags.

Bumps `mfsk-core` + `mfsk-ffi-ft8` to 0.7.4.

## Test plan
- [x] `cargo fmt --all -- --check` / `cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings -D clippy::perf` clean (pre-commit hook)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc -p mfsk-core --features full --no-deps` clean
- [x] `cargo publish -p mfsk-core --features full --dry-run` succeeds (packages + verifies + would-upload v0.7.4)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01M4W6LwFkVZDmrrphMDaowV