### PR TITLE
fix(jt65): swap interleave/deinterleave to match WSJT-X's TX/RX convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,40 @@
 # Changelog
 
+## 0.7.5 — JT65 decode-chain bug fix (#24)
+
+### Fixed
+
+- **JT65 total decode failure, root-caused and fixed** (#24). Every
+  `jt65sim`-generated (or otherwise WSJT-X-compatible) JT65 signal
+  failed to decode regardless of SNR, even when `search::coarse_search`
+  landed candidates within ~1 Hz / a few symbols of ground truth.
+  Root cause: `jt65::interleave::interleave`/`deinterleave` (the 7×9
+  transpose WSJT-X's `interleave63.f90` implements) had their
+  permutations swapped relative to WSJT-X's TX/RX convention
+  (`gen65.f90`/`jt65sim.f90` call `interleave63(sent, idir=1)` at TX;
+  `extract.f90` calls `interleave63(mrsym, idir=-1)` at RX). The swap
+  was internally self-consistent — TX and RX remained exact mutual
+  inverses of each other — so every self-roundtrip test passed while
+  real/independent-reference signals decoded to garbage RS codewords.
+  Structurally identical to the JT9 encoder bug (#19): a decode path
+  only ever cross-checked against this crate's own encoder, never an
+  independent reference.
+- New `tests/jt65_sweep.rs` (`#[ignore]`d, mirrors `ft8_sweep.rs`) +
+  `scripts/gen_jt65_sweep_wavs.sh` build a `jt65sim`-generated AWGN
+  SNR-sweep corpus and characterise the post-fix recall curve: 100%
+  recall down to 0 dB, 50% around -14 dB, near-zero below -19 dB (all
+  in `jt65sim`'s 2500 Hz reference bandwidth convention).
+- Found and documented, but did **not** port in this fix: WSJT-X's
+  own hard-decision-only path (`jt9 -6`, no `kvasd`) holds ~100%
+  recall down to -22 dB on the same corpus — a further ~7-8 dB
+  sensitivity gap. Root cause traced to `lib/ftrsd/ftrsdap.c`, a
+  stochastic Chase decoder (randomized multi-trial soft-symbol
+  erasure-pattern search around Berlekamp-Massey RS) that WSJT-X runs
+  even without `kvasd` — a materially different (and more involved)
+  algorithm than this crate's single-pass confidence-ordered erasure
+  decode (`decode_at_with_erasures`). Tracked as a follow-up issue;
+  see the sweep test's doc comment for the full provenance.
+
 ## 0.7.4 — MSK144 decode (#25)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
   erasure-pattern search around Berlekamp-Massey RS) that WSJT-X runs
   even without `kvasd` — a materially different (and more involved)
   algorithm than this crate's single-pass confidence-ordered erasure
-  decode (`decode_at_with_erasures`). Tracked as a follow-up issue;
+  decode (`decode_at_with_erasures`). Tracked as a follow-up (#169);
   see the sweep test's doc comment for the full provenance.
 
 ## 0.7.4 — MSK144 decode (#25)

--- a/docs/notes/ROADMAP.md
+++ b/docs/notes/ROADMAP.md
@@ -172,22 +172,33 @@ worklist; if you're reading this file to decide what to work on next,
 this section is the one to trust over any recall numbers or hardware
 status stated elsewhere in it):
 
-- **#24** — JT65 golden-WAV recall lock. **Scope changed again,
-  2026-07-19**: built WSJT-X's `jt65sim` and confirmed `kvasd`/
-  erasure metadata is *not* needed for its signals — `jt9 -6` (no
-  kvasd) decodes them cleanly down to -15 dB. But
-  `mfsk_core::jt65::decode_scan_default` found **zero decodes on any
-  of them**, including strong ones — and it's not a search-tolerance
-  problem: a wide-open diagnostic search lands candidates within
-  ~1 Hz / a few symbols of ground truth, but `decode_at()` fails on
-  every one of them. So there's a real decode-chain bug (demod → RS
-  → message-unpack) independent of the kvasd question, likely
-  because this path was only ever self-roundtrip-tested against this
-  crate's own encoder, never against an independent reference — same
-  shape as the JT9 encoder bug (#19). Deferred to a follow-up
-  session; see the issue for the full repro recipe. Once fixed, a
-  `jt65sim`-based sweep (mirroring `msk144_snr_sweep.rs`) becomes a
-  solid regression harness, no `b65a`/`kvasd` port needed after all.
+- **JT65 sensitivity gap vs. WSJT-X's `ftrsdap` stochastic Chase
+  decoder** — follow-up from closing #24, filed 2026-07-19. With the
+  interleave bug fixed (#24), a 15-point AWGN sweep
+  (`tests/jt65_sweep.rs`, `scripts/gen_jt65_sweep_wavs.sh`) shows this
+  crate's hard-decision `decode_at`/`decode_at_with_erasures` at 50%
+  recall around -14 dB and near-zero below -19 dB, while WSJT-X's own
+  no-`kvasd` path (`jt9 -6`) holds ~100% down to -22 dB on the
+  identical corpus. Root cause: `jt9 -6` isn't plain hard-decision RS
+  either — `lib/extract.f90` calls `ftrsdap` (`lib/ftrsd/ftrsdap.c`),
+  a stochastic Chase decoder that runs many randomized soft-symbol
+  erasure-pattern trials around Berlekamp-Massey RS, using both the
+  most- and second-most-reliable symbol per position
+  (`demod64a`'s `mrsym`/`mr2sym`). This crate's
+  `decode_at_with_erasures` only tries a single deterministic
+  increasing-erasure-count ordering — a materially weaker algorithm.
+  Porting `ftrsdap`'s approach is the likely fix; not started.
+- **#24** — JT65 total-decode-failure bug: **fixed 2026-07-19**. Root
+  cause was `jt65::interleave::{interleave,deinterleave}` (the 7×9
+  transpose WSJT-X's `interleave63.f90` implements) having their
+  permutations swapped relative to WSJT-X's TX/RX convention — self-
+  consistent (so self-roundtrip tests passed 100%) but not matching
+  real channel symbol order, so every independently-generated
+  (`jt65sim`) signal failed to decode regardless of SNR. Same shape as
+  the JT9 encoder bug (#19): a decode path only ever self-roundtrip-
+  tested, never cross-checked against an independent reference. See
+  CHANGELOG's 0.7.5 entry and the sensitivity-gap follow-up above for
+  what's still open.
 - **#125** — License question (GPLv3 vs. a more permissive license
   for broader/proprietary adoption). Needs a decision, not code.
 - **#143** — FST4 AP decode + SIC for FST4-15/30, design &

--- a/docs/notes/ROADMAP.md
+++ b/docs/notes/ROADMAP.md
@@ -172,8 +172,8 @@ worklist; if you're reading this file to decide what to work on next,
 this section is the one to trust over any recall numbers or hardware
 status stated elsewhere in it):
 
-- **JT65 sensitivity gap vs. WSJT-X's `ftrsdap` stochastic Chase
-  decoder** — follow-up from closing #24, filed 2026-07-19. With the
+- **#169** — JT65 sensitivity gap vs. WSJT-X's `ftrsdap` stochastic
+  Chase decoder — follow-up from closing #24, filed 2026-07-19. With the
   interleave bug fixed (#24), a 15-point AWGN sweep
   (`tests/jt65_sweep.rs`, `scripts/gen_jt65_sweep_wavs.sh`) shows this
   crate's hard-decision `decode_at`/`decode_at_with_erasures` at 50%

--- a/embedded-poc/assets/jt65_sweep/.gitignore
+++ b/embedded-poc/assets/jt65_sweep/.gitignore
@@ -1,0 +1,2 @@
+# jt65sim-generated sweep WAVs — regenerate with scripts/gen_jt65_sweep_wavs.sh
+*.wav

--- a/mfsk-core/src/jt65/interleave.rs
+++ b/mfsk-core/src/jt65/interleave.rs
@@ -7,23 +7,31 @@
 
 /// Interleave 63 symbols: write as 7 rows × 9 cols, read as 9 rows ×
 /// 7 cols. Invertible by [`deinterleave`].
+///
+/// Matches WSJT-X `interleave63(d1, idir=1)`, called at TX time
+/// (`gen65.f90`, `jt65sim.f90`) to go from RS-codeword order to
+/// channel order. Fortran's column-major `d1(0:6,0:8)` /
+/// `d2(0:8,0:6)` gives `output[9*i+j] = input[7*j+i]`.
 pub fn interleave(sym: &mut [u8; 63]) {
     let mut tmp = [0u8; 63];
     for i in 0..7 {
         for j in 0..9 {
-            // `d2[j, i] = d1[i, j]` — transpose.
-            tmp[j * 7 + i] = sym[i * 9 + j];
+            tmp[i * 9 + j] = sym[j * 7 + i];
         }
     }
     *sym = tmp;
 }
 
 /// Inverse of [`interleave`].
+///
+/// Matches WSJT-X `interleave63(d1, idir=-1)`, called at RX time
+/// (`extract.f90`) to go from channel order back to RS-codeword
+/// order.
 pub fn deinterleave(sym: &mut [u8; 63]) {
     let mut tmp = [0u8; 63];
     for i in 0..7 {
         for j in 0..9 {
-            tmp[i * 9 + j] = sym[j * 7 + i];
+            tmp[j * 7 + i] = sym[i * 9 + j];
         }
     }
     *sym = tmp;

--- a/mfsk-core/src/jt65/rx.rs
+++ b/mfsk-core/src/jt65/rx.rs
@@ -144,12 +144,11 @@ fn demodulate_aligned_with_confidence_inner(
     // Apply the same permutation to confidence so positions line up.
     let mut conf_perm = [0f32; 63];
     {
-        // Re-run the 7×9 transpose on the confidence array with the
-        // same pattern `deinterleave` uses. Since deinterleave is
-        // i_native = j*7 + i_inner, j*9+i_inner mapping, reapply:
+        // Re-run the same 7×9 transpose `deinterleave` uses so
+        // confidence stays aligned with the permuted symbols.
         for i in 0..7 {
             for j in 0..9 {
-                conf_perm[i * 9 + j] = conf[j * 7 + i];
+                conf_perm[j * 7 + i] = conf[i * 9 + j];
             }
         }
     }

--- a/mfsk-core/tests/jt65_sweep.rs
+++ b/mfsk-core/tests/jt65_sweep.rs
@@ -1,0 +1,158 @@
+//! JT65A AWGN SNR sweep against `jt65sim`-generated signals.
+//!
+//! This test is `#[ignore]` — run it manually when investigating JT65
+//! sensitivity. `jt65sim` is WSJT-X's canonical JT65 signal generator
+//! (Fortran, `WSJT-X/lib/jt65sim.f90`); this crate has no from-source
+//! build script for it (unlike `ft8sim`/`ft4sim`/`fst4sim` — `jt65sim`
+//! links the full `wsjt_fort`/`wsjt_cxx` libraries per WSJT-X's
+//! `CMakeLists.txt`, not a small standalone subset), so build it via
+//! the full WSJT-X CMake build:
+//!
+//! ```sh
+//! cmake --build ~/wsjtx-build --target jt65sim -j"$(nproc)"
+//! ```
+//!
+//! Then:
+//!
+//! ```sh
+//! # 1. Generate WAVs (once, or when widening the SNR grid):
+//! scripts/gen_jt65_sweep_wavs.sh ~/wsjtx-build/jt65sim
+//!
+//! # 2. Run the sweep:
+//! cargo test --test jt65_sweep --release --features jt65,fft-rustfft \
+//!   -- --ignored --nocapture
+//! ```
+//!
+//! (`MFSK_JT65_SWEEP_DIR` overrides the default corpus location
+//! `../embedded-poc/assets/jt65_sweep`, relative to `CARGO_MANIFEST_DIR`.)
+//!
+//! ## Provenance (2026-07-19, issue #24)
+//!
+//! This sweep was built as the closing step of the JT65 decode-chain
+//! bug hunt: `mfsk-core`'s JT65 `interleave`/`deinterleave` (the 7×9
+//! transpose `interleave63.f90` implements) were swapped relative to
+//! WSJT-X's TX/RX convention (`gen65.f90`/`jt65sim.f90` call
+//! `interleave63(sent, idir=1)` at TX, `extract.f90` calls
+//! `interleave63(mrsym, idir=-1)` at RX) — self-consistent (so
+//! self-roundtrip tests passed 100%) but not matching the real channel
+//! symbol order, so every `jt65sim`-generated signal failed to decode
+//! regardless of SNR. Structurally identical to the JT9 encoder bug
+//! (#19). Fixed by swapping the two functions' bodies.
+//!
+//! One false alarm during this investigation, worth recording: passing
+//! `-s 0` to `jt65sim` does **not** mean 0 dB — `jt65sim.f90:167-170`
+//! special-cases `snrdb.eq.0.0` and substitutes a built-in ~-19 to
+//! -21 dB weak-signal default, while still echoing "0.0" in its own
+//! console readout. A `0 dB` grid point that looked like a decode gap
+//! was actually a `~-20 dB` signal. `scripts/gen_jt65_sweep_wavs.sh`
+//! uses `0.01` instead of `0` for the near-0 dB grid point.
+//!
+//! Output is a recall table — no assertions, statistics only.
+
+#![cfg(all(feature = "jt65", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_f32_opt;
+use mfsk_core::jt65::decode_scan_default;
+
+const GOLDEN_CALL1: &str = "CQ";
+const GOLDEN_CALL2: &str = "JL1NIE";
+const GOLDEN_GRID: &str = "PM95";
+const GOLDEN_FREQ_HZ: f32 = 1500.0;
+const FREQ_TOL_HZ: f32 = 5.0;
+
+fn sweep_dir() -> PathBuf {
+    if let Ok(d) = std::env::var("MFSK_JT65_SWEEP_DIR") {
+        return PathBuf::from(d);
+    }
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    Path::new(&manifest)
+        .join("../embedded-poc/assets/jt65_sweep")
+        .to_path_buf()
+}
+
+/// Parse `jt65_awgn_<snr_tag>_<trial>.wav`. snr_tag: `m20` = -20, `p10` = +10.
+fn parse_snr_tag(tag: &str) -> Option<i32> {
+    if let Some(rest) = tag.strip_prefix('m') {
+        rest.parse::<i32>().ok().map(|v| -v)
+    } else if let Some(rest) = tag.strip_prefix('p') {
+        rest.parse::<i32>().ok()
+    } else {
+        None
+    }
+}
+
+fn decode_wav_jt65(audio: &[f32]) -> bool {
+    decode_scan_default(audio, 12_000).iter().any(|d| {
+        matches!(
+            &d.message,
+            mfsk_core::msg::Jt72Message::Standard { call1, call2, grid_or_report }
+                if call1 == GOLDEN_CALL1 && call2 == GOLDEN_CALL2 && grid_or_report == GOLDEN_GRID
+        ) && (d.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ
+    })
+}
+
+#[test]
+#[ignore]
+fn jt65_awgn_snr_sweep() {
+    let dir = sweep_dir();
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        eprintln!(
+            "skipping jt65_awgn_snr_sweep: corpus dir not found at {:?}\n\
+             Run scripts/gen_jt65_sweep_wavs.sh ~/wsjtx-build/jt65sim",
+            dir
+        );
+        return;
+    };
+
+    // snr -> (hits, trials)
+    let mut cells: std::collections::BTreeMap<i32, (u32, u32)> = std::collections::BTreeMap::new();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Some(stem) = path.file_stem().and_then(|s| s.to_str()) else {
+            continue;
+        };
+        let Some(rest) = stem.strip_prefix("jt65_awgn_") else {
+            continue;
+        };
+        let Some((tag, _trial)) = rest.split_once('_') else {
+            continue;
+        };
+        let Some(snr) = parse_snr_tag(tag) else {
+            continue;
+        };
+        let Some(audio) = load_wav_f32_opt(&path) else {
+            continue;
+        };
+        let hit = decode_wav_jt65(&audio);
+        let cell = cells.entry(snr).or_insert((0, 0));
+        cell.1 += 1;
+        if hit {
+            cell.0 += 1;
+        }
+    }
+
+    if cells.is_empty() {
+        eprintln!(
+            "skipping jt65_awgn_snr_sweep: no jt65_awgn_*.wav files found in {:?}",
+            dir
+        );
+        return;
+    }
+
+    println!("JT65A AWGN SNR sweep — {:?}", dir);
+    println!("{:>6}  {:>10}  {:>6}", "SNR", "hits/trials", "pct");
+    for (snr, (hits, trials)) in &cells {
+        let pct = *hits as f32 / *trials as f32 * 100.0;
+        println!(
+            "{:>+5}dB  {:>10}  {:5.1}%",
+            snr,
+            format!("{hits}/{trials}"),
+            pct
+        );
+    }
+}

--- a/scripts/gen_jt65_sweep_wavs.sh
+++ b/scripts/gen_jt65_sweep_wavs.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# Generate jt65sim WAV files for a JT65A AWGN SNR sweep.
+#
+# Usage:
+#   scripts/gen_jt65_sweep_wavs.sh [jt65sim-path] [out-dir]
+#
+# File naming:  jt65_awgn_<snr>_<trial>.wav
+#   snr:      m05 = -5 dB, p05 = +5 dB (real, applied SNR — see the
+#             sentinel note below)
+#   trial:    01..TRIALS
+#
+# jt65sim has no standalone from-source build script in this repo (unlike
+# ft8sim/ft4sim/fst4sim — jt65sim links the full wsjt_fort/wsjt_cxx
+# libraries per WSJT-X's CMakeLists.txt, not a small standalone subset).
+# Build it via the full WSJT-X CMake build instead:
+#   cmake --build ~/wsjtx-build --target jt65sim -j"$(nproc)"
+# then point this script at the resulting binary (default guess below).
+#
+# ## jt65sim SNR=0 sentinel — do not pass "0" as a grid value
+#
+# `jt65sim.f90` special-cases `snrdb == 0.0`: it does NOT mean "0 dB",
+# it silently substitutes a built-in weak-signal default (~-19 to -21 dB
+# depending on sub-mode). Passing a literal 0 to `-s` produces a signal
+# nowhere near 0 dB even though jt65sim's own console readout still
+# prints "0.0" in that case (it's echoing the requested value, not the
+# applied one) — this cost a full debugging detour before being traced
+# to `jt65sim.f90:167-170`. This script's grid must never include the
+# literal integer/float 0; use a small non-zero value (e.g. 0.01) if a
+# near-0 dB point is wanted.
+#
+# Run existing files are skipped (safe to re-run after widening the grid).
+# Jobs run in parallel (JOBS env var, default: nproc).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+JT65SIM="${1:-$HOME/wsjtx-build/jt65sim}"
+OUT_DIR="${2:-$REPO_ROOT/embedded-poc/assets/jt65_sweep}"
+JOBS="${JOBS:-$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 1)}"
+
+if [[ ! -x "$JT65SIM" ]]; then
+  echo "error: jt65sim not found at $JT65SIM" >&2
+  echo "Build it with: cmake --build ~/wsjtx-build --target jt65sim -j\$(nproc)" >&2
+  echo "(requires a configured WSJT-X CMake build tree; see CLAUDE.md)" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+MSG="CQ JL1NIE PM95"
+F0=1500
+TRIALS=20
+
+# JT65A hard-decision (no kvasd) sensitivity floor is roughly -15 to -20 dB
+# in this reference bandwidth (see docs/notes/ — grid centres on the steep
+# part of that curve so the 50% crossing is observed, not censored at the
+# grid edge, mirroring the FST4 #146 lesson).
+SNRS="10 5 0.01 -5 -10 -12 -14 -15 -16 -17 -18 -19 -20 -22 -25"
+
+snr_tag() {
+  local snr=$1
+  # snr may be fractional (e.g. 0.01); format as an integer-rounded tag.
+  local rounded
+  rounded="$(printf '%.0f' "$snr")"
+  if (( rounded < 0 )); then
+    printf "m%02d" "$(( -rounded ))"
+  else
+    printf "p%02d" "$rounded"
+  fi
+}
+
+run_cell() {
+  local snr=$1
+  local tag; tag="$(snr_tag "$snr")"
+
+  local missing=0
+  for T in $(seq 1 "$TRIALS"); do
+    local dest="$OUT_DIR/jt65_awgn_${tag}_$(printf '%02d' "$T").wav"
+    [[ -f "$dest" ]] || (( missing++ )) || true
+  done
+  if (( missing == 0 )); then
+    return 0
+  fi
+
+  printf "  JT65  SNR=%6s dB  generating %d files ...\n" "$snr" "$TRIALS"
+
+  # jt65sim's own arg parser requires negative values escaped with a
+  # literal leading backslash (its help text: "Use \ (\\ on *nix shells)
+  # to escape -ve arguments") — a bare "-20" is rejected as "option -s
+  # requires an argument".
+  local snr_arg="$snr"
+  if [[ "$snr" == -* ]]; then
+    snr_arg="\\$snr"
+  fi
+
+  local tmpd; tmpd="$(mktemp -d)"
+  trap 'rm -rf "$tmpd"' EXIT
+
+  (
+    cd "$tmpd"
+    "$JT65SIM" -M "$MSG" -n 1 -s "$snr_arg" -f "$TRIALS" -F "$F0" >/dev/null
+    for T in $(seq 1 "$TRIALS"); do
+      local src dest
+      src="$(printf '000000_%04d.wav' "$T")"
+      dest="$OUT_DIR/jt65_awgn_${tag}_$(printf '%02d' "$T").wav"
+      [[ -f "$src" ]] && mv "$src" "$dest"
+    done
+  )
+}
+
+export -f run_cell snr_tag
+export JT65SIM OUT_DIR TRIALS MSG F0
+
+echo "Generating JT65 AWGN sweep corpus: $(echo $SNRS | wc -w) SNR points, TRIALS=$TRIALS, JOBS=$JOBS"
+echo "Output: $OUT_DIR"
+echo ""
+
+active=0
+pids=()
+for SNR in $SNRS; do
+  run_cell "$SNR" &
+  pids+=($!)
+  (( active++ )) || true
+  if (( active >= JOBS )); then
+    wait "${pids[0]}"
+    pids=("${pids[@]:1}")
+    (( active-- )) || true
+  fi
+done
+for pid in "${pids[@]}"; do
+  wait "$pid"
+done
+
+echo ""
+echo "Done. Assets: $OUT_DIR"
+echo "  $(ls "$OUT_DIR" | wc -l) files total"
+echo ""
+echo "Run the sweep test with:"
+echo "  cargo test --test jt65_sweep --release --features jt65,fft-rustfft \\"
+echo "    -- --ignored --nocapture"


### PR DESCRIPTION
## Summary

- JT65 decode was totally broken against any real/independent signal: `decode_scan_default` found **zero decodes** on any WSJT-X `jt65sim`-generated WAV, at any SNR, even when `coarse_search` landed candidates within ~1 Hz / a few symbols of ground truth (the finding originally posted to #24).
- Root cause: `jt65::interleave`'s two functions (the 7×9 transpose `interleave63.f90` implements) had their permutations **swapped** relative to WSJT-X's TX/RX convention — `gen65.f90`/`jt65sim.f90` call `interleave63(sent, idir=1)` at TX, `extract.f90` calls `interleave63(mrsym, idir=-1)` at RX. The swap was internally self-consistent (TX and RX remained exact mutual inverses of each other), so every self-roundtrip test passed 100% while real signals decoded to garbage RS codewords — structurally identical to the JT9 encoder bug (#19): a path only ever validated against its own encoder, never an independent reference.
- Fix: swap the two functions' bodies (and the matching manual confidence-array transpose in `rx.rs`). Verified against a freshly-built `jt65sim` signal (`K1ABC W9XYZ EN37` decodes cleanly, matching WSJT-X's own `jt9 -6` output exactly).
- New `scripts/gen_jt65_sweep_wavs.sh` + `tests/jt65_sweep.rs` (ignored by default, mirrors `ft8_sweep.rs`): a 15-point AWGN SNR sweep against `jt65sim` that validates the fix across the grid (100% recall down to 0 dB, 50% around -14 dB) and documents a `jt65sim` CLI gotcha found along the way — `-s 0` is a sentinel for a built-in ~-19 to -21 dB default, not literal 0 dB (`jt65sim.f90:167-170`); it took a debugging detour before that was traced.
- CHANGELOG (`## 0.7.5`, not yet tagged) + ROADMAP `#24` entry updated. **Not included**: a separate ~7-8 dB residual sensitivity gap vs. WSJT-X's `ftrsdap` stochastic Chase decoder, found during the same investigation — filed as its own follow-up issue rather than bundled into this fix.

Fixes #24.

## Test plan

- [x] `cargo test --release --features full --lib` — 377 passed, 0 failed
- [x] `cargo clippy --release --features full --lib -p mfsk-core -- -D warnings -D clippy::perf` — clean
- [x] `cargo test --test jt65_sweep --release --features jt65,fft-rustfft,uvpacket -- --ignored --nocapture` — 15-point AWGN sweep, matches expected recall curve
- [x] Manual cross-check against a fresh `jt65sim`-generated WAV: decodes `K1ABC W9XYZ EN37` at 1500 Hz, matching `jt9 -6`'s own decode of the same file exactly
- [x] pre-commit hooks (fmt, clippy --workspace, rustdoc) all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01M4W6LwFkVZDmrrphMDaowV