### PR TITLE
perf(ft8): wire missing FFT caches in decode_block, ~3.6x qso3_busy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -488,6 +488,38 @@
   test to match, verified identical recall either way. FT4's golden
   test is on a different (non-LPF, constant-amplitude) subtract path
   in `core::pipeline` and was unaffected by this change.
+- **FT8 `decode_block` a further ~3.6× faster on busy-band recordings
+  — two FFT-cache wiring gaps closed.** Follow-up profiling of
+  `decode_block_multipass` (post the 10.5× subtract fix above) found
+  its cost had moved, not disappeared: (1) `refine_candidates` and
+  the per-candidate `process_candidates_tuned_with_ap[_ref]` calls
+  were all passing `fft_cache: None`, so each of up to ~45
+  candidates/slot re-ran the 192 k-point forward FFT from scratch
+  even though the sibling `fine_refine_pass1` stage in the same pass
+  already built and reused exactly this cache — a wiring gap, not a
+  missing algorithm. Threaded the existing
+  `build_fft_cache`/`downsample_cached` helpers through
+  `refine_candidates`, `process_candidates_tuned_with_ap[_ref]`, and
+  `auto_ap_strategy::run`, rebuilding the cache lazily only when the
+  WSJT-X-mandated sequential subtract actually mutates the working
+  buffer (not eagerly every pass) — alone dropped
+  `qso3_apoff_meets_wsjtx_golden_floor` 0.43 s → ~0.12–0.22 s. (2)
+  `subtract_tones_lpf_fft`'s filter-response FFT was already cached
+  (`cached_window_fft`, from the fix above), but its forward/inverse
+  `FftPlanner` *plans* for `nfft = 180 000` were rebuilt on every
+  call — measured at ~2.8 ms/call for plan construction vs ~0.7 ms
+  for the transform itself, i.e. plan-rebuild cost ~4× the FFT it
+  was gating. Cached the plans in an `nfft`-keyed `OnceLock`, the
+  same pattern `fill_symbol_spectra.rs`'s `SYMBOL_FFT_32` already
+  used for the per-symbol 32-pt FFT. Combined: **0.43 s → 0.12 s
+  (~3.6×)**, byte-identical recall (7/8 golden, 7 phantom, 14 total
+  on `qso3_apoff`; 5/6 JTDX AP-on extras unchanged on `qso3_apon`).
+  Both fixes are cache wiring, not new algorithms, so risk is low;
+  `fft-rustfft` is `std`-gated but thread-free, so both caches also
+  apply under `wasm32-unknown-unknown` (build-verified). No embedded
+  impact either way, since `decode_block_multipass`'s
+  `not(fft-rustfft)` variant has no subtract loop (single-pass, no
+  SIC) and never calls these paths.
 
 ## 0.7.4 — MSK144 decode (#25)
 

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -57,7 +57,7 @@ is wall time on a many-core host, not a single-thread figure).
 | Q65-60B | 1296 MHz troposcatter ×1 slot (multi-period averaging) | 60 s | 0.28 s |
 | JT9 | 130418_1742.wav | 60 s | 0.33 s |
 | Q65-300A | 201210_0505.wav (optical scatter, fading metric) | 293.8 s | 0.34 s |
-| FT8 | qso3_busy.wav (16-signal busy band) | 15 s | 0.45 s |
+| FT8 | qso3_busy.wav (16-signal busy band) | 15 s | 0.12 s |
 | Q65-60A | 6 m EME (plain BP + AP) | 60 s | 0.69 s |
 | Q65-30A | 6 m ionoscatter ×4 slots (multi-period averaging) | 4×30 s | 0.72 s |
 | MSK144 | 181211_120800.wav | 30 s | 0.84 s |
@@ -80,6 +80,38 @@ Notes:
   O(N log N) — dropping this row to 0.45 s (~10.5×) with byte-identical
   recall (7/8 golden, 7 phantom, 14 total). FT4's golden test was
   already on a different (non-LPF) subtract path and unaffected.
+- FT8's `qso3_busy.wav` dropped further, **0.45 s → 0.12 s (~3.6×)**,
+  in a follow-up pass (2026-07-25). Two wiring gaps, found by
+  instrumenting `decode_block_multipass` directly rather than
+  re-guessing from the algorithm shape:
+  1. `decode_block`'s own `refine_candidates` / per-candidate
+     `process_candidates_tuned_with_ap` calls were passing
+     `fft_cache: None` at every call site, so each of up to ~45
+     candidates/slot re-ran the 192 k-point forward FFT from scratch
+     even though `fine_refine_pass1` (a sibling stage in the same
+     pass) already built and used exactly this cache. Wired the
+     existing `build_fft_cache`/`downsample_cached` helpers through
+     `refine_candidates`, `process_candidates_tuned_with_ap[_ref]`,
+     and `auto_ap_strategy::run`, lazily rebuilding only when the
+     WSJT-X-mandated sequential subtract actually mutates `work`
+     (not eagerly every pass). Alone: 0.43 s → ~0.12-0.22 s.
+  2. `subtract_tones_lpf_fft`'s filter-response FFT was already
+     cached (`cached_window_fft`, from the original 10.5× fix above),
+     but the forward/inverse `FftPlanner` *plans* for `nfft = 180 000`
+     were rebuilt on every call — measured at ~2.8 ms/call for plan
+     construction vs ~0.7 ms for the transform itself, i.e. plan
+     rebuild cost ~4× the FFT it was gating. Cached the plans in a
+     `nfft`-keyed `OnceLock`, same pattern as
+     `fill_symbol_spectra.rs`'s `SYMBOL_FFT_32`.
+
+  Both fixes are FFT-cache wiring, not new algorithms — byte-identical
+  recall verified at each step (7/8 golden, 7 phantom, 14 total on
+  `qso3_apoff`; 5/6 JTDX AP-on extras unchanged on `qso3_apon`).
+  `fft-rustfft` is `std`-gated but thread-free, so both caches also
+  apply under `wasm32-unknown-unknown` (verified via a feature-matched
+  build) — no embedded-target impact either way, since
+  `decode_block_multipass`'s `not(fft-rustfft)` variant has no
+  subtract loop (single-pass, no SIC) and never calls these paths.
 - FT4 was the outlier at **1.20 s** (7.5 s slot, only 6 signals) until a
   profiling pass (2026-07-20, `dapper-soaring-nest` plan) found its
   coarse-candidate stage was structurally the wrong algorithm — a

--- a/mfsk-core/src/core/dsp/subtract.rs
+++ b/mfsk-core/src/core/dsp/subtract.rs
@@ -338,7 +338,7 @@ mod fft_lpf {
     use core::f32::consts::PI;
     use rustfft::FftPlanner;
     use rustfft::num_complex::Complex32;
-    use std::sync::{Mutex, OnceLock};
+    use std::sync::{Arc, Mutex, OnceLock};
     use std::vec;
     use std::vec::Vec;
 
@@ -422,6 +422,49 @@ mod fft_lpf {
         arc
     }
 
+    /// Cached forward/inverse FFT plans, keyed by `nfft`. Same idea as
+    /// `cached_window_fft` (and `fill_symbol_spectra.rs`'s
+    /// `SYMBOL_FFT_32`): `FftPlanner::plan_fft_{forward,inverse}`
+    /// re-derives the same `nfft`-point twiddle tables on every call —
+    /// measured at ~2.8 ms/call (vs ~0.7 ms for the FFT itself) for
+    /// FT8's `nfft = 180 000`, i.e. plan construction cost ~4x the
+    /// actual transform. `subtract_tones_lpf_fft` runs this twice
+    /// (forward + inverse) per accepted decode subtracted, so this
+    /// dominated the per-call cost even after `cached_window_fft`
+    /// removed the filter-response rebuild.
+    struct CachedPlans {
+        nfft: usize,
+        forward: Arc<dyn rustfft::Fft<f32>>,
+        inverse: Arc<dyn rustfft::Fft<f32>>,
+    }
+
+    static PLAN_CACHE: OnceLock<Mutex<Vec<CachedPlans>>> = OnceLock::new();
+
+    fn cached_plans(nfft: usize) -> (Arc<dyn rustfft::Fft<f32>>, Arc<dyn rustfft::Fft<f32>>) {
+        let cache = PLAN_CACHE.get_or_init(|| Mutex::new(Vec::new()));
+        {
+            let guard = cache.lock().unwrap();
+            if let Some(e) = guard.iter().find(|e| e.nfft == nfft) {
+                return (e.forward.clone(), e.inverse.clone());
+            }
+        }
+
+        let mut planner = FftPlanner::<f32>::new();
+        let forward = planner.plan_fft_forward(nfft);
+        let inverse = planner.plan_fft_inverse(nfft);
+
+        let mut guard = cache.lock().unwrap();
+        if let Some(e) = guard.iter().find(|e| e.nfft == nfft) {
+            return (e.forward.clone(), e.inverse.clone());
+        }
+        guard.push(CachedPlans {
+            nfft,
+            forward: forward.clone(),
+            inverse: inverse.clone(),
+        });
+        (forward, inverse)
+    }
+
     /// Per-edge-distance boost factor, `endcorrection(j)` in
     /// `subtractft8.f90` (`j` there is 1-indexed 1..=lpf_half+1; here
     /// `d = j-1` is the 0-indexed distance from the frame edge,
@@ -473,12 +516,12 @@ mod fft_lpf {
         }
 
         let cw = cached_window_fft(nfft, lpf_half);
-        let mut planner = FftPlanner::<f32>::new();
-        planner.plan_fft_forward(nfft).process(&mut cfilt);
+        let (forward, inverse) = cached_plans(nfft);
+        forward.process(&mut cfilt);
         for (c, w) in cfilt.iter_mut().zip(cw.iter()) {
             *c *= *w;
         }
-        planner.plan_fft_inverse(nfft).process(&mut cfilt);
+        inverse.process(&mut cfilt);
 
         if endcorrection && lpf_half < nframe {
             let ec = end_correction(lpf_half);

--- a/mfsk-core/src/ft8/decode_block/auto_ap_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/auto_ap_strategy.rs
@@ -195,7 +195,14 @@ where
     // wants those weak candidates because they're precisely where AP
     // rescue pays off. Cap at 4× the regular max_cand to bound cost.
     let auto_ap_max_cand = max_cand.saturating_mul(4).max(200);
-    let refined: Vec<RefinedCandidate> = refine_candidates(audio, cands, auto_ap_max_cand);
+    // `audio` is the original (unsubtracted) slot audio and is never
+    // mutated by this function, so one 192k-FFT cache covers both the
+    // `refine_candidates` build below and every per-callsign batch call
+    // further down — same win as the main multipass driver's cache.
+    let audio_i16: Vec<i16> = audio.iter().map(|s| s.to_i16()).collect();
+    let fft_cache = crate::ft8::downsample::build_fft_cache(&audio_i16);
+    let refined: Vec<RefinedCandidate> =
+        refine_candidates(audio, cands, auto_ap_max_cand, Some(&fft_cache));
 
     // Per-callsign batch processing. Gemini PR #118 high-priority
     // optimisation: passing one (cand, callsign) pair at a time
@@ -226,6 +233,7 @@ where
             bp_max_iter,
             Some(&ap),
             strictness,
+            Some(&fft_cache),
         );
         for mut r in batch_results {
             if existing.iter().any(|x| x.message77 == r.message77)

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -101,10 +101,11 @@ pub fn symbol_spectra_direct<S: AudioSample>(
     freq_hz: f32,
     dt_sec: f32,
     sym_mask: SymMask,
+    fft_cache: Option<&[Complex<f32>]>,
 ) -> Box<[[Cmplx<f32>; 8]; 79]> {
     let mut out: Box<[[Cmplx<f32>; 8]; 79]> =
         vec![[Cmplx::<f32>::default(); 8]; 79].try_into().unwrap();
-    fill_symbol_spectra(&mut out, audio, freq_hz, dt_sec, sym_mask, None);
+    fill_symbol_spectra(&mut out, audio, freq_hz, dt_sec, sym_mask, fft_cache);
     out
 }
 

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -41,6 +41,7 @@ use crate::core::sync::SyncCandidate;
 use crate::fec::ldpc::bp::check_crc14;
 #[cfg(feature = "fft-rustfft")]
 use crate::fec::ldpc::osd::osd_decode_deep;
+use num_complex::Complex;
 
 // Phase 1.7.7-Stick: both `refine_candidates_into` (pass-2) and the
 // embedded branch of `process_candidates_into_with_cs_scratch_tuned`
@@ -233,7 +234,14 @@ fn decode_block_multipass<S: AudioSample>(
         let cands = coarse_sync(&spec, freq_min, freq_max, sync_min, pass1_limit());
         drop(spec);
         let cands = fine_refine_pass1(work.as_slice(), cands);
-        let pass2 = refine_candidates(work.as_slice(), cands, max_cand);
+        // Wide-band 192k-FFT cache, shared across every `refine_candidates`
+        // / `process_candidates_tuned_with_ap` call in this pass — valid
+        // as long as `work` hasn't changed. Rebuilt lazily (only when the
+        // next candidate is actually processed) rather than eagerly after
+        // every subtract, since most candidates in a pass don't decode.
+        let mut fft_cache: Option<alloc::vec::Vec<Complex<f32>>> =
+            Some(crate::ft8::downsample::build_fft_cache(work.as_slice()));
+        let pass2 = refine_candidates(work.as_slice(), cands, max_cand, fft_cache.as_deref());
 
         // **WSJT-X ft8b.f90:432-437 sequential subtract**: each
         // accepted decode immediately subtracts from `work` so the
@@ -249,6 +257,9 @@ fn decode_block_multipass<S: AudioSample>(
         #[cfg(not(feature = "std"))]
         let trace = false;
         for cand in pass2 {
+            if fft_cache.is_none() {
+                fft_cache = Some(crate::ft8::downsample::build_fft_cache(work.as_slice()));
+            }
             let single_results = process_candidates_tuned_with_ap(
                 work.as_slice(),
                 alloc::vec![cand],
@@ -257,6 +268,7 @@ fn decode_block_multipass<S: AudioSample>(
                 bp_max_iter,
                 ap_hint,
                 strictness,
+                fft_cache.as_deref(),
             );
             for r in single_results {
                 if all.iter().any(|x| x.message77 == r.message77) {
@@ -272,6 +284,7 @@ fn decode_block_multipass<S: AudioSample>(
                     }
                 }
                 crate::ft8::subtract::subtract_signal_lpf(work.as_mut_slice(), &r);
+                fft_cache = None; // `work` changed — cache is stale.
                 all.push(r);
             }
         }
@@ -654,7 +667,7 @@ fn decode_block_multipass<S: AudioSample>(
     let pass1 = coarse_sync(&spec, freq_min, freq_max, sync_min, pass1_limit());
     drop(spec);
     let pass1 = fine_refine_pass1(audio, pass1);
-    let pass2 = refine_candidates(audio, pass1, max_cand);
+    let pass2 = refine_candidates(audio, pass1, max_cand, None);
     process_candidates_tuned(audio, pass2, depth, DEFAULT_Q_THRESH, bp_max_iter)
 }
 
@@ -808,9 +821,10 @@ pub(super) fn refine_candidates<S: AudioSample>(
     audio: &[S],
     cands: Vec<SyncCandidate>,
     max_cand: usize,
+    fft_cache: Option<&[Complex<f32>]>,
 ) -> Vec<RefinedCandidate> {
     refine_candidates_with(cands, max_cand, |c| {
-        symbol_spectra_direct(audio, c.freq_hz, c.dt_sec, SymMask::SyncBlock0)
+        symbol_spectra_direct(audio, c.freq_hz, c.dt_sec, SymMask::SyncBlock0, fft_cache)
     })
 }
 
@@ -1070,6 +1084,7 @@ pub fn process_candidates_tuned<S: AudioSample>(
         bp_max_iter,
         None,
         DecodeStrictness::Normal,
+        None,
     )
 }
 
@@ -1087,6 +1102,7 @@ pub(super) fn process_candidates_tuned_with_ap<S: AudioSample>(
     bp_max_iter: u32,
     ap_hint: Option<&ApHint>,
     strictness: DecodeStrictness,
+    fft_cache: Option<&[Complex<f32>]>,
 ) -> Vec<DecodeResult> {
     let mut cs_scratch: alloc::boxed::Box<[[Cmplx<f32>; 8]; 79]> =
         alloc::vec![[Cmplx::<f32>::default(); 8]; 79]
@@ -1100,7 +1116,7 @@ pub(super) fn process_candidates_tuned_with_ap<S: AudioSample>(
         bp_max_iter,
         &mut cs_scratch,
         |cs, cand, mask| {
-            fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask, None);
+            fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask, fft_cache);
         },
         ap_hint,
         strictness,
@@ -1124,6 +1140,7 @@ pub(super) fn process_candidates_tuned_with_ap_ref<S: AudioSample>(
     bp_max_iter: u32,
     ap_hint: Option<&ApHint>,
     strictness: DecodeStrictness,
+    fft_cache: Option<&[Complex<f32>]>,
 ) -> Vec<DecodeResult> {
     let mut cs_scratch: alloc::boxed::Box<[[Cmplx<f32>; 8]; 79]> =
         alloc::vec![[Cmplx::<f32>::default(); 8]; 79]
@@ -1137,7 +1154,7 @@ pub(super) fn process_candidates_tuned_with_ap_ref<S: AudioSample>(
         bp_max_iter,
         &mut cs_scratch,
         |cs, cand, mask| {
-            fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask, None);
+            fill_symbol_spectra(cs, audio, cand.freq_hz, cand.dt_sec, mask, fft_cache);
         },
         ap_hint,
         strictness,


### PR DESCRIPTION
## Summary

Follow-up to `28a38e7`'s 10.5x subtract fix — the cost had moved, not disappeared. Two FFT-cache wiring gaps closed in `decode_block_multipass` (host, `fft-rustfft` path):

1. `refine_candidates` and per-candidate `process_candidates_tuned_with_ap[_ref]` were all passing `fft_cache: None`, so each of up to ~45 candidates/slot re-ran the 192k-point forward FFT from scratch, even though the sibling `fine_refine_pass1` stage in the same pass already built and reused exactly this cache. Threaded the existing `build_fft_cache`/`downsample_cached` helpers through `refine_candidates`, `process_candidates_tuned_with_ap[_ref]`, and `auto_ap_strategy::run`, rebuilding lazily only when the WSJT-X-mandated sequential subtract actually mutates the working buffer (not eagerly every pass).
2. `subtract_tones_lpf_fft`'s filter-response FFT was already cached (`cached_window_fft`), but its forward/inverse `FftPlanner` *plans* for `nfft=180000` were rebuilt on every call (~2.8ms/call vs ~0.7ms for the transform itself — plan construction ~4x the FFT it was gating). Cached the plans in an `nfft`-keyed `OnceLock`, same pattern as `fill_symbol_spectra.rs`'s `SYMBOL_FFT_32`.

`qso3_apoff_meets_wsjtx_golden_floor`: **0.43s → 0.12s (~3.6x)**, byte-identical recall (7/8 golden, 7 phantom, 14 total; 5/6 JTDX AP-on extras unchanged on `qso3_apon`).

Both fixes are cache-wiring, not new algorithms — low risk. `fft-rustfft` is `std`-gated but thread-free, so both caches also apply under `wasm32-unknown-unknown` (build-verified). No embedded-target impact: `decode_block_multipass`'s `not(fft-rustfft)` variant has no subtract loop (single-pass, no SIC) and never calls these paths.

Also updates `CHANGELOG.md` (0.8.0 unreleased section) and `docs/notes/BENCHMARKS.md`'s FT8 row (0.45s → 0.12s) + explanatory note, per this repo's established convention of bundling the benchmark/changelog update with the perf commit.

## Test plan

- [x] `cargo build --release --features full` clean
- [x] `cargo build --release --no-default-features --features "std,ft8,fixed-point,fft-rustfft"` clean (host fixed-point)
- [x] `cargo build --release --no-default-features --features "ft8,fixed-point,alloc"` clean (embedded no_std)
- [x] `cargo build --release --target wasm32-unknown-unknown --no-default-features --features "std,ft8,fft-rustfft"` clean
- [x] `cargo test --release --features full` — full suite green, 0 failures
- [x] `qso3_apoff_meets_wsjtx_golden_floor`: byte-identical recall (7/8 golden, 7 phantom, 14 total), 0.43s → 0.12s across repeated A/B runs
- [x] `qso3_apon_recall`: 5/6 JTDX AP-on extras unchanged
- [x] `cargo clippy --release --features full --all-targets -- -D warnings -D clippy::perf` clean
- [x] pre-commit hook (fmt/clippy-workspace/rustdoc) passed at commit time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCqLADUon8oifXG3zSGqfv