### PR TITLE
perf(q65): select_nth instead of full sort for noise-floor estimate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,30 @@
   swap reshaped rather than uniformly improved the SNR curve — 3 of 4
   channels held or improved). See `docs/notes/FT4_BENCHMARK.md` section
   13.
+- **Q65-60B/30A `decode_multi_period_for` sped up further, ~2.3×/~1.3×**
+  (`q65/search.rs::Spectrogram::build_for`) — follow-up to a separate
+  FFT-cache wiring investigation on FT8's `decode_block` (same "does
+  this pattern exist elsewhere" question, applied to Q65). That
+  specific pattern wasn't present here: `decode_at_grid_for`'s
+  `GridDepth::Fast` has exactly one `(Δf,Δt)` grid cell per candidate
+  (confirmed via direct call-count instrumentation — 16 calls for
+  Q65-60A's 16 candidates, not the ~333 an earlier estimate assumed),
+  so no redundant FFT-planner construction existed to cache. Phase-by-
+  phase profiling of `decode_multi_period_for` found a different bug
+  instead: `Spectrogram::build_for`'s noise-floor estimate (run once per
+  candidate-search call) computed a trimmed mean of the bottom 95% of
+  FFT-magnitude bins via a full `sort_unstable_by` (O(n log n)) over the
+  entire magnitude array (hundreds of thousands to millions of cells for
+  a 60-120 s slot) when only the unordered *set* of bottom-95% values
+  was needed. Same class of fix already applied to FT8's
+  `xsnr2_db_simple` noise-floor median — swapped to
+  `select_nth_unstable_by` (O(n) average partition), Q65 just hadn't had
+  it applied. Measured as 64% of wall-clock on Q65-60B (short slot, low
+  candidate count) and 12% on Q65-30A (longer multi-slot audio where the
+  BP/fading-metric stage dominates instead). Golden-WAV decode time:
+  Q65-60B **0.28 s → 0.12 s**, Q65-30A **0.72 s → 0.56 s**, byte-
+  identical recall on both (VK7MO/VK7PD on 60B, K1JT/K9AN AP-list on
+  30A).
 
 ### Removed
 

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -51,15 +51,15 @@ is wall time on a many-core host, not a single-thread figure).
 |---|---|---:|---:|
 | FT4 | 000000_000002.wav | 7.5 s | 0.049 s |
 | Q65-60D | 201212_1838.wav (10 GHz EME, fading metric) | 60 s | 0.08 s |
+| FT8 | qso3_busy.wav (16-signal busy band) | 15 s | 0.12 s |
+| Q65-60B | 1296 MHz troposcatter ×1 slot (multi-period averaging) | 60 s | 0.12 s |
 | Q65-120D | 210117_0920.wav (rainscatter, fading metric) | 120 s | 0.12 s |
 | Q65-120E | 6 m ionoscatter (fading metric) | 120 s | 0.26 s |
 | FST4-60A | 210115_0058.wav | 60 s | 0.27 s |
-| Q65-60B | 1296 MHz troposcatter ×1 slot (multi-period averaging) | 60 s | 0.28 s |
 | JT9 | 130418_1742.wav | 60 s | 0.33 s |
 | Q65-300A | 201210_0505.wav (optical scatter, fading metric) | 293.8 s | 0.34 s |
-| FT8 | qso3_busy.wav (16-signal busy band) | 15 s | 0.12 s |
+| Q65-30A | 6 m ionoscatter ×4 slots (multi-period averaging) | 4×30 s | 0.56 s |
 | Q65-60A | 6 m EME (plain BP + AP) | 60 s | 0.69 s |
-| Q65-30A | 6 m ionoscatter ×4 slots (multi-period averaging) | 4×30 s | 0.72 s |
 | MSK144 | 181211_120800.wav | 30 s | 0.84 s |
 | MSK144 | 181211_120500.wav | 15 s | 0.88 s |
 | WSPR | 150426_0918.wav | 120 s | 0.93 s |
@@ -155,6 +155,30 @@ Notes:
   ~4× more expensive per frequency bin — see next bullet — and this
   4-slot multi-period test's longer combined audio didn't have enough
   downstream savings to offset that).
+- Q65-60B/30A dropped again, **0.28 s → 0.12 s (~2.3×)** and
+  **0.72 s → 0.56 s (~1.3×)**, in a follow-up pass (2026-07-25) prompted
+  by the FT8 FFT-cache investigation above: same "is this pattern
+  elsewhere too" question, applied to Q65. The FFT-cache wiring gap
+  itself wasn't present here — `decode_at_grid_for`'s `GridDepth::Fast`
+  (WSJT-X's own automatic-decode depth) has exactly one `(Δf,Δt)` grid
+  cell per candidate, so a direct call-count instrumentation found only
+  16 `extract_data_energies_wide` calls for Q65-60A's 16 candidates —
+  not the ~333 an earlier estimate assumed — making any FFT-planner
+  cache there negligible (confirmed by measurement, not implemented).
+  Phase-by-phase instrumentation of `Spectrogram::build_for` (used by
+  every candidate-search call) found a different bug instead: its noise-
+  floor estimate (`q65/search.rs`) computed a trimmed mean of the bottom
+  95% of FFT-magnitude bins via a full `sort_unstable_by` (O(n log n))
+  over the *entire* magnitude array (hundreds of thousands to millions
+  of cells for a 60-120 s slot), when only the unordered *set* of
+  bottom-95% values was needed. Same class of fix as FT8's
+  `xsnr2_db_simple` noise-floor median (already on `select_nth_unstable_by`,
+  O(n) average) — Q65 just hadn't had it applied. Measured as 64% of
+  `decode_multi_period_for`'s wall-clock on Q65-60B (short slot, low
+  candidate count — `build_for` dominates), 12% on Q65-30A (longer
+  multi-slot audio where the BP/fading-metric stage dominates instead).
+  Byte-identical recall on both golden tests (VK7MO/VK7PD on 60B,
+  K1JT/K9AN AP-list on 30A) before and after.
 - Q65-60A (`decode_scan_for`/`decode_scan_with_ap_for`, a different code
   path from the two above) was rewritten (2026-07-20) as a faithful
   `q65_loops.f90`/`q65_dec_q012` `(Δf, Δt, b90)` grid search, replacing

--- a/mfsk-core/src/q65/search.rs
+++ b/mfsk-core/src/q65/search.rs
@@ -77,11 +77,21 @@ impl Spectrogram {
         }
 
         // Noise floor estimate: trimmed-mean of the bottom 95 % of
-        // FFT magnitudes (rejects strong narrow-band signals).
+        // FFT magnitudes (rejects strong narrow-band signals). Only
+        // the *set* of bottom-95% values (order within that set is
+        // irrelevant, we just sum them) is needed, not a full
+        // ascending order — `select_nth_unstable_by` partitions in
+        // O(n) average instead of `sort_unstable_by`'s O(n log n),
+        // same fix already applied to FT8's `xsnr2_db_simple` noise
+        // median. Measured as 64% of `decode_multi_period_for`'s
+        // wall-clock on Q65-60B (short-slot, `build_for` called once
+        // per audio slot).
         let mut sorted = mags_sqr.clone();
-        sorted.sort_unstable_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         let keep = (sorted.len() as f32 * 0.95) as usize;
         let noise_per_bin = if keep > 0 {
+            sorted.select_nth_unstable_by(keep - 1, |a, b| {
+                a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
+            });
             sorted[..keep].iter().sum::<f32>() / keep as f32
         } else {
             1.0


### PR DESCRIPTION
**Stacked on #175** — rebased onto `perf/ft8-fft-cache-reuse` and retargeted so `BENCHMARKS.md`/`CHANGELOG.md` merge cleanly with both perf fixes' table/changelog edits in one coherent state (both touch the same ascending-sorted decode-speed table and the same 0.8.0 unreleased CHANGELOG section). Merge #175 first, then this.

## Summary

Follow-up to the FT8 FFT-cache investigation (PR #175): checked whether the same "existing cache/algorithm not applied everywhere" pattern shows up in Q65's `decode_multi_period_for` / `decode_scan_for`.

The FFT-cache gap itself wasn't present in Q65 — `decode_at_grid_for`'s `GridDepth::Fast` (WSJT-X's own automatic-decode depth) has exactly one `(Δf,Δt)` grid cell per candidate, confirmed via direct call-count instrumentation: **16** `extract_data_energies_wide` calls for Q65-60A's 16 candidates, not the ~333 an earlier estimate assumed. No redundant FFT-planner construction existed to cache (verified, not implemented).

Phase-by-phase profiling of `decode_multi_period_for` found a different bug instead: `Spectrogram::build_for`'s noise-floor estimate (`q65/search.rs`) computed a trimmed mean of the bottom 95% of FFT-magnitude bins via a full `sort_unstable_by` (O(n log n)) over the *entire* magnitude array (hundreds of thousands to millions of cells for a 60-120s slot), when only the unordered *set* of bottom-95% values was needed. Same class of fix already applied to FT8's `xsnr2_db_simple` noise-floor median (`select_nth_unstable_by`, O(n) average partition) — Q65 just hadn't had it applied.

Measured as **64%** of `decode_multi_period_for`'s wall-clock on Q65-60B (short slot, low candidate count — `build_for` dominates) and **12%** on Q65-30A (longer multi-slot audio where the BP/fading-metric stage dominates instead).

**Golden-WAV decode time**: Q65-60B **0.28s → 0.12s (~2.3x)**, Q65-30A **0.72s → 0.56s (~1.3x)**, byte-identical recall on both (VK7MO/VK7PD on 60B, K1JT/K9AN AP-list on 30A).

Also updates `CHANGELOG.md` (0.8.0 unreleased section) and `docs/notes/BENCHMARKS.md`'s Q65-60B/30A rows + explanatory note (and re-sorts the decode-speed table, which is ordered ascending by time), per this repo's established convention of bundling the benchmark/changelog update with the perf commit.

## Test plan

- [x] `cargo build --release --features full` clean
- [x] `cargo test --release --features full` — full suite green, 0 failures
- [x] `tropo_1296_60b_decodes_via_averaging` (Q65-60B golden): byte-identical recall (VK7MO/VK7PD, both no-AP and AP-list paths), 0.30-0.31s → 0.12-0.13s across repeated A/B runs
- [x] `ionoscatter_6m_full_stack_decodes_via_averaging` (Q65-30A golden): byte-identical recall, 0.73-0.78s → 0.56s across repeated A/B runs
- [x] All Q65 test files (`q65_wsjtx_samples`, `q65_roundtrip`, `q65_sim_sweep`, `q65_ap_list`, `q65_ap_sweep`, `q65_eme_submodes`, `q65_fast_fading`, `q65_snr_sweep`, `q65_a15_roundtrip`) pass
- [x] `cargo clippy --release --features full --all-targets -- -D warnings -D clippy::perf` clean
- [x] pre-commit hook (fmt/clippy-workspace/rustdoc) passed at commit time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCqLADUon8oifXG3zSGqfv
