### PR TITLE
fix(ft8): seed OSD with BP-refined LLR + bit-pack setup, closing issue #182

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -384,6 +384,63 @@
   says plainly not to reach for it by default until a concrete
   zsum-unreachable case justifies its cost again.
 
+- **Reverted the now-pointless auto-AP `rayon` parallelism and
+  `AudioSample: Sync` bound** (issue #182 follow-up) —
+  `decode_block::auto_ap_strategy`'s per-callsign `par_iter` loop was
+  parallelising a search that, per the entry above, now finds zero
+  additional decodes on `qso3_busy.wav`: real multi-core speedup with
+  no offsetting value, plus a second (parallel/sequential) code path
+  to maintain for a function not wired into any default path. Reverted
+  to one sequential path. With that gone, `AudioSample`'s `+ Sync`
+  supertrait (added specifically to let `&[S]` cross that `rayon` task
+  boundary) has no remaining caller that needs it — every other
+  `rayon` usage in the codebase (`core/sync.rs`, `ft8/decode.rs`,
+  `core/pipeline.rs`) operates on concrete `i16` or non-`AudioSample`-
+  generic types where `Sync` was already automatic. Reverted to `Copy`
+  only. Full workspace regression: 100% pass.
+
+- **Bit-packed `osd_setup_ldpc174_91`'s Gaussian elimination — 6.8×
+  faster setup, ~4× faster overall OSD dispatch** (issue #182
+  perf follow-up). Profiling `try_fallback` found it was ~22-25% of
+  total decode wall-clock (~281ms of ~1.27s on `qso3_busy.wav`, ~200
+  candidates × up to 8 zsave-seeded dispatches each, ~1% success rate).
+  Splitting a single `osd_decode_npre1` call's cost further (2000-rep
+  synthetic-LLR microbenchmark) found **86% of it was
+  `osd_setup_ldpc174_91`** (sort + Gaussian elimination to build the
+  MRB systematic generator) — 113.5µs/call — versus only ~18µs/call
+  for the actual `npre1` combinatorial search (the OSD algorithm
+  itself). Root cause: `OsdSetup.g` stored the GF(2) generator matrix
+  as **one byte per bit** (`Vec<u8>`, 91×174 bytes), so the
+  elimination's row-XOR step did up to 174 individual byte XORs per
+  row instead of ~3 packed 64-bit-word XORs — paid fresh on every one
+  of the 8 zsave-seeded dispatches per candidate, since each has a
+  different LLR reliability ordering and can't share a cached basis.
+  Note this isn't a WSJT-X-fidelity gap: `osd174_91.f90`'s own
+  `genmrb` is `integer*1` (byte-per-bit) too — bit-packing is a
+  legitimate algorithmic improvement *beyond* what WSJT-X itself does,
+  not a port of anything.
+
+  Rewrote only `osd_setup_ldpc174_91`'s internals to build and
+  eliminate on a packed `[u64; 3]`-per-row representation, unpacking
+  to the existing `Vec<u8>` `g` format at the end — `OsdSetup`'s shape
+  and every downstream consumer (`osd_npre1_pass`, `osd_npre2_pass`,
+  `build_npre2_table`, `try_candidate_ldpc174_91`) are byte-for-byte
+  unchanged, confining all risk to one function. Verified with a new
+  differential test (`packed_elimination_matches_byte_reference`)
+  asserting the packed rewrite produces identical `perm`/`g`/
+  `hdec_perm`/`absrx_perm`/`c_perm` to a frozen byte-per-bit reference
+  copy of the pre-rewrite code, across 5 seeded synthetic LLR vectors
+  plus all-zero and exact-tie edge cases — not just "does the
+  regression suite still pass."
+
+  **Result**: `osd_setup_ldpc174_91` 113.5µs → 16.7µs/call (6.8×);
+  total OSD dispatch (setup + `npre1_pass`) 131.6µs → 34.1µs/call
+  (3.9×). End-to-end single-threaded blind decode of `qso3_busy.wav`:
+  **1.27-1.30s → 1.09-1.12s** — landing right at real `jt9 -8 -d3`'s
+  own measured ~1.1s total file decode time. Still 22/22 decodes, zero
+  regressions (full workspace `cargo test --release --features full`,
+  `qso3_apon_subtract_jtdx_extras_diag` still 6/6 JTDX extras).
+
 ### Changed
 
 - **Q65-60B/30A `decode_multi_period_for` sped up ~4×**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,6 +305,48 @@
   disagreements within the shared basis). Filed as a genuine OSD
   algorithm fidelity gap — issue #182, open.
 
+- **FT8 OSD now seeds with BP-refined LLR, closing issue #182.**
+  Root-caused the `osd_decode_npre1` fidelity gap above: WSJT-X's real
+  `decode174_91.f90` driver never feeds `osd174_91` the raw channel LLR
+  when `maxosd>0` — and FT8's blind `ndepth=3` dispatch always sets
+  `maxosd=2` (`ft8b.f90:434-441`). It feeds `zsave(:,i)`, the running
+  sum of the BP variable-node soft estimate `zn` across the first `i`
+  BP iterations, trying `i=1` then `i=2` (`decode174_91.f90:52-64,
+  137-148`). mfsk-core's OSD had only ever used the raw channel LLR
+  (the 4 `a/b/c/d` variants) — confirmed exhaustively: `K1BZM DK8NE
+  -10` never decodes via any channel-LLR variant at any OSD depth up
+  to and including brute-force order-2 exhaustive search (no
+  `ntheta` gate at all), so the true codeword simply isn't reachable
+  from a channel-LLR-selected basis. The mechanism needed
+  (`bp_llr_zsum`) already existed and is wired for FST4-120
+  (`Ldpc240_101`, issue #146) but was never ported to FT8's
+  `osd_strategy.rs` dispatch. Wired it in as a second-stage fallback
+  (after the existing 4 channel-LLR attempts fail): feeding
+  `bp_llr_zsum(llrd, 2)` into the *same*, unmodified `osd_decode_npre1`
+  decodes DK8NE outright at `hard_errors=17` — better than jt9's own
+  real result (`hard_errors=18`) on this exact candidate. (A parallel
+  hypothesis — that WSJT-X's `osd174_91.f90:86-107` bounded-window
+  `k+20` pivot search selects a different MRB basis than mfsk-core's
+  unbounded one — was tested directly and disproven: the bases do
+  differ, but `osd_decode_npre1` fails on *either* basis. Kept as a
+  documented, `#[cfg(test)]`-only diagnostic so it isn't
+  re-investigated from scratch.)
+  **Effect**: `K1BZM DK8NE -10` now decodes through the real
+  production dispatch (`decode_frame_subtract_with_ap`'s AP-on
+  multipass path, `qso3_apon_subtract_jtdx_extras_diag`: 5/6 → 6/6
+  JTDX extras). **Cost**: ~30-40% wall-clock increase on candidates
+  that reach the OSD fallback at all (most candidates decode earlier
+  in the BP/OSD staircase and never reach this code path) —
+  `ft8_qso3_staged_sic_check.rs` ~1.0s → ~1.4s. **One new
+  near-ceiling phantom observed** (`qso3_busy.wav`, freq 2570.25 Hz,
+  `hard_errors=30`, malformed callsign token — ~1 Hz from the real,
+  strong `W1FC F5BZB` at 2571.38 Hz, almost certainly spectral
+  leakage): same class of tradeoff already accepted in this file's
+  `OSD_HARDERRORS_MAX` 22→36 history, where tightening the ceiling to
+  suppress phantoms was found to silently discard genuine weak
+  decodes living in the same hard-error range. Full workspace `cargo
+  test --release --features full`: 100% pass, no regressions.
+
 ### Changed
 
 - **Q65-60B/30A `decode_multi_period_for` sped up ~4×**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -347,6 +347,43 @@
   decodes living in the same hard-error range. Full workspace `cargo
   test --release --features full`: 100% pass, no regressions.
 
+- **FT8 OSD dispatch: dropped the direct-channel-LLR loop, since it
+  was never what real WSJT-X does either** (issue #182 follow-up).
+  Checking `ft8b.f90`'s actual `do ipass=1,4` / `decode174_91.f90`'s
+  `maxosd` branches confirmed the raw-channel-LLR OSD path
+  (`maxosd=0`) is a *different* WSJT-X depth setting FT8's blind
+  `ndepth=3` dispatch never takes (that always sets `maxosd=2`, which
+  only ever calls `osd174_91` on `zsave(:,i)`). So the pre-#182
+  `osd_strategy.rs::try_fallback` loop that tried the 4 llr variants
+  directly against `osd_decode_npre1`/`_npre2` — predating this
+  session, from issue #63 — was itself not WSJT-X-faithful for this
+  depth; the `bp_llr_zsum` fallback added above was layered *on top*
+  of it rather than replacing it. Removed the direct-channel loop
+  entirely and restructured the `zsave(:,1)`/`zsave(:,2)` loop to nest
+  in WSJT-X's actual order (outer = llr variant / `ipass`, inner =
+  `zsave` index — `ft8b.f90:294-298`, `decode174_91.f90:137-148`),
+  rather than the previous variant-innermost ordering. Full workspace
+  regression: 100% pass, zero decodes lost — every candidate that used
+  to succeed via the direct-channel path also succeeds via
+  `zsave`-seeded OSD. **Net effect vs the immediately-preceding
+  zsum-as-addition state**: 12 OSD dispatches worst-case → 8 (33%
+  fewer), single-threaded `qso3_busy.wav` blind decode
+  1.37s → 1.27-1.30s, still 22/22 decodes.
+
+- **`decode_frame_subtract_with_auto_ap` marked explicitly opt-in-only**
+  (issue #182 follow-up) — with the `bp_llr_zsum` OSD fix above, this
+  function's own motivating case (`K1BZM DK8NE -10`) now decodes via
+  blind `decode_frame_subtract_with_ap` alone: measured on
+  `qso3_busy.wav`, blind-only and blind-plus-auto-AP both return the
+  same 22 decodes, so the auto-AP pass currently finds *zero*
+  additional signals there while still paying its own full search cost
+  (~0.3-0.5s single-threaded on top of blind). It was never wired into
+  any default decode path (always a separate, explicitly-called
+  function), so this is a documentation-only change making that
+  explicit rather than a behavioural one — but the doc comment now
+  says plainly not to reach for it by default until a concrete
+  zsum-unreachable case justifies its cost again.
+
 ### Changed
 
 - **Q65-60B/30A `decode_multi_period_for` sped up ~4×**

--- a/mfsk-core/src/fec/ldpc/osd.rs
+++ b/mfsk-core/src/fec/ldpc/osd.rs
@@ -714,15 +714,32 @@ fn osd_setup_ldpc174_91(llr: &[f32; LDPC_N]) -> Option<OsdSetup> {
             .unwrap_or(core::cmp::Ordering::Equal)
     });
 
-    let mut g: Vec<u8> = vec![0u8; k * n];
+    // Bit-packed Gaussian elimination (issue #182 perf follow-up).
+    // Profiling found this setup (sort + elimination) is ~86% of a
+    // single `osd_decode_npre1`/`_npre2` call's cost (~113µs of
+    // ~132µs, synthetic-LLR microbenchmark), paid fresh on every one
+    // of the 8 zsave-seeded dispatches per candidate in
+    // `osd_strategy.rs::try_fallback` (each has a different LLR
+    // reliability ordering, so results can't be cached across them).
+    // `osd174_91.f90`'s own `genmrb` is `integer*1` (byte-per-bit)
+    // too — this isn't a WSJT-X-fidelity fix, it's a legitimate
+    // algorithmic improvement beyond what WSJT-X itself does. `g`'s
+    // *final* representation (`Vec<u8>`, unpacked below) and every
+    // downstream consumer (`osd_npre1_pass`, `osd_npre2_pass`,
+    // `build_npre2_table`, `try_candidate_ldpc174_91`) are unchanged —
+    // only the elimination's internal representation differs.
+    const WORDS: usize = LDPC_N.div_ceil(64); // 3 for LDPC_N=174
+    type PackedRow = [u64; WORDS];
+    let mut g_packed: Vec<PackedRow> = vec![[0u64; WORDS]; k];
     for row in 0..k {
         for col in 0..n {
             let j = perm[col];
-            g[row * n + col] = if j < k {
-                (row == j) as u8
+            let bit = if j < k {
+                (row == j) as u64
             } else {
-                <Ldpc174_91Params as LdpcParams>::gen_parity(j - k, row)
+                <Ldpc174_91Params as LdpcParams>::gen_parity(j - k, row) as u64
             };
+            g_packed[row][col / 64] |= bit << (col % 64);
         }
     }
 
@@ -732,23 +749,24 @@ fn osd_setup_ldpc174_91(llr: &[f32; LDPC_N]) -> Option<OsdSetup> {
         if pivot_row >= k {
             break;
         }
+        let word = col / 64;
+        let bit = col % 64;
         let mut found: Option<usize> = None;
         for r in pivot_row..k {
-            if g[r * n + col] != 0 {
+            if (g_packed[r][word] >> bit) & 1 != 0 {
                 found = Some(r);
                 break;
             }
         }
         if let Some(r) = found {
             if r != pivot_row {
-                for c in 0..n {
-                    g.swap(r * n + c, pivot_row * n + c);
-                }
+                g_packed.swap(r, pivot_row);
             }
+            let pivot = g_packed[pivot_row];
             for r2 in 0..k {
-                if r2 != pivot_row && g[r2 * n + col] != 0 {
-                    for c in 0..n {
-                        g[r2 * n + c] ^= g[pivot_row * n + c];
+                if r2 != pivot_row && (g_packed[r2][word] >> bit) & 1 != 0 {
+                    for c in 0..WORDS {
+                        g_packed[r2][c] ^= pivot[c];
                     }
                 }
             }
@@ -758,6 +776,16 @@ fn osd_setup_ldpc174_91(llr: &[f32; LDPC_N]) -> Option<OsdSetup> {
     }
     if pivot_row < k {
         return None;
+    }
+
+    // Unpack to the byte-per-bit format every downstream consumer
+    // expects — one linear O(k*n) pass, negligible next to the O(k²*n)
+    // elimination it replaces.
+    let mut g: Vec<u8> = vec![0u8; k * n];
+    for row in 0..k {
+        for col in 0..n {
+            g[row * n + col] = ((g_packed[row][col / 64] >> (col % 64)) & 1) as u8;
+        }
     }
 
     let mut m0: Vec<u8> = vec![0u8; k];
@@ -1577,6 +1605,218 @@ pub fn osd_decode_generic<P: LdpcParams>(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Byte-per-bit reference copy of `osd_setup_ldpc174_91` as it
+    /// existed before the bit-packed Gaussian elimination rewrite
+    /// (issue #182 perf follow-up). Exists solely so
+    /// `packed_elimination_matches_byte_reference` can differentially
+    /// verify the packed rewrite is a pure implementation-detail
+    /// change, not a behavior change — do not "fix" this to match any
+    /// future change to the real function; it's intentionally frozen.
+    fn osd_setup_ldpc174_91_byte_reference(llr: &[f32; LDPC_N]) -> Option<OsdSetup> {
+        let n = LDPC_N;
+        let k = LDPC_K;
+
+        let mut perm: Vec<usize> = (0..n).collect();
+        perm.sort_unstable_by(|&a, &b| {
+            llr[b]
+                .abs()
+                .partial_cmp(&llr[a].abs())
+                .unwrap_or(core::cmp::Ordering::Equal)
+        });
+
+        let mut g: Vec<u8> = vec![0u8; k * n];
+        for row in 0..k {
+            for col in 0..n {
+                let j = perm[col];
+                g[row * n + col] = if j < k {
+                    (row == j) as u8
+                } else {
+                    <Ldpc174_91Params as LdpcParams>::gen_parity(j - k, row)
+                };
+            }
+        }
+
+        let mut pivot_col: Vec<usize> = vec![0; k];
+        let mut pivot_row = 0usize;
+        for col in 0..n {
+            if pivot_row >= k {
+                break;
+            }
+            let mut found: Option<usize> = None;
+            for r in pivot_row..k {
+                if g[r * n + col] != 0 {
+                    found = Some(r);
+                    break;
+                }
+            }
+            if let Some(r) = found {
+                if r != pivot_row {
+                    for c in 0..n {
+                        g.swap(r * n + c, pivot_row * n + c);
+                    }
+                }
+                for r2 in 0..k {
+                    if r2 != pivot_row && g[r2 * n + col] != 0 {
+                        for c in 0..n {
+                            g[r2 * n + c] ^= g[pivot_row * n + c];
+                        }
+                    }
+                }
+                pivot_col[pivot_row] = col;
+                pivot_row += 1;
+            }
+        }
+        if pivot_row < k {
+            return None;
+        }
+
+        let mut m0: Vec<u8> = vec![0u8; k];
+        for r in 0..k {
+            let orig = perm[pivot_col[r]];
+            m0[r] = if llr[orig] > 0.0 { 1 } else { 0 };
+        }
+
+        let mut hdec_perm: Vec<u8> = vec![0u8; n];
+        let mut absrx_perm: Vec<f32> = vec![0.0f32; n];
+        for col in 0..n {
+            hdec_perm[col] = if llr[perm[col]] > 0.0 { 1u8 } else { 0u8 };
+            absrx_perm[col] = llr[perm[col]].abs();
+        }
+
+        let mut c_perm: Vec<u8> = vec![0u8; n];
+        for r in 0..k {
+            if m0[r] == 1 {
+                for col in 0..n {
+                    c_perm[col] ^= g[r * n + col];
+                }
+            }
+        }
+
+        Some(OsdSetup {
+            perm,
+            g,
+            hdec_perm,
+            absrx_perm,
+            c_perm,
+        })
+    }
+
+    /// Differential test (issue #182 perf follow-up): the bit-packed
+    /// `osd_setup_ldpc174_91` must produce byte-for-byte identical
+    /// output to the frozen byte-per-bit reference above, across many
+    /// LLR inputs — not just "does the regression suite still pass"
+    /// (which only exercises a handful of real-world candidates), but
+    /// exhaustive equivalence including edge cases the reference WAVs
+    /// may not hit (e.g. exact-tie |LLR| magnitudes).
+    #[test]
+    fn packed_elimination_matches_byte_reference() {
+        fn synth_llr(seed: u32) -> [f32; LDPC_N] {
+            let mut llr = [0f32; LDPC_N];
+            let mut s = seed;
+            for x in llr.iter_mut() {
+                s = s.wrapping_mul(1_103_515_245).wrapping_add(12345);
+                let u = (s >> 8) as f32 / (1u32 << 24) as f32; // [0,1)
+                *x = (u - 0.5) * 6.0;
+            }
+            llr
+        }
+
+        for seed in [0x1234_5678u32, 1, 42, 0xdead_beef, 0xc0ffee] {
+            let llr = synth_llr(seed);
+            let expected = osd_setup_ldpc174_91_byte_reference(&llr);
+            let actual = osd_setup_ldpc174_91(&llr);
+            match (expected, actual) {
+                (Some(e), Some(a)) => {
+                    assert_eq!(e.perm, a.perm, "seed={seed}: perm mismatch");
+                    assert_eq!(e.g, a.g, "seed={seed}: g mismatch");
+                    assert_eq!(e.hdec_perm, a.hdec_perm, "seed={seed}: hdec_perm mismatch");
+                    assert_eq!(
+                        e.absrx_perm, a.absrx_perm,
+                        "seed={seed}: absrx_perm mismatch"
+                    );
+                    assert_eq!(e.c_perm, a.c_perm, "seed={seed}: c_perm mismatch");
+                }
+                (None, None) => {}
+                _ => panic!("seed={seed}: Some/None mismatch between reference and packed"),
+            }
+        }
+
+        // Degenerate/edge cases: all-zero (many exact ties), all-same-
+        // sign, and an exact-tie-heavy pattern.
+        let all_zero = [0f32; LDPC_N];
+        let mut alternating = [0f32; LDPC_N];
+        for (i, x) in alternating.iter_mut().enumerate() {
+            *x = if i % 2 == 0 { 1.0 } else { -1.0 };
+        }
+        for (label, llr) in [("all_zero", all_zero), ("alternating", alternating)] {
+            let expected = osd_setup_ldpc174_91_byte_reference(&llr);
+            let actual = osd_setup_ldpc174_91(&llr);
+            match (expected, actual) {
+                (Some(e), Some(a)) => {
+                    assert_eq!(e.perm, a.perm, "{label}: perm mismatch");
+                    assert_eq!(e.g, a.g, "{label}: g mismatch");
+                    assert_eq!(e.hdec_perm, a.hdec_perm, "{label}: hdec_perm mismatch");
+                    assert_eq!(e.absrx_perm, a.absrx_perm, "{label}: absrx_perm mismatch");
+                    assert_eq!(e.c_perm, a.c_perm, "{label}: c_perm mismatch");
+                }
+                (None, None) => {}
+                _ => panic!("{label}: Some/None mismatch between reference and packed"),
+            }
+        }
+    }
+
+    /// Throwaway probe (issue #182 cost investigation) — NOT for
+    /// commit. `osd_setup_ldpc174_91` (basis construction: sort +
+    /// Gaussian elimination) reruns from scratch on every one of the 8
+    /// zsave-seeded dispatches per candidate in `try_fallback` — splits
+    /// out how much of a single `osd_decode_npre1` call's cost is setup
+    /// vs the actual `npre1` pattern search.
+    #[test]
+    #[ignore = "manual diagnostic — issue #182 setup-vs-search cost split"]
+    fn issue_182_setup_vs_search_cost() {
+        // Synthetic but realistic-shaped LLR: random-ish magnitudes so
+        // the Gaussian elimination and npre1 gate behave like a real
+        // noisy candidate, not a degenerate all-same-value case.
+        let mut llr = [0f32; LDPC_N];
+        let mut seed = 0x1234_5678u32;
+        for x in llr.iter_mut() {
+            seed = seed.wrapping_mul(1_103_515_245).wrapping_add(12345);
+            let u = (seed >> 8) as f32 / (1u32 << 24) as f32; // [0,1)
+            *x = (u - 0.5) * 6.0; // roughly [-3,3), plausible LLR range
+        }
+
+        const REPS: usize = 2000;
+        let t0 = std::time::Instant::now();
+        for _ in 0..REPS {
+            let _ = osd_setup_ldpc174_91(&llr);
+        }
+        let setup_only = t0.elapsed();
+
+        let t1 = std::time::Instant::now();
+        for _ in 0..REPS {
+            if let Some(setup) = osd_setup_ldpc174_91(&llr) {
+                let mut best = OsdBest::new();
+                osd_npre1_pass(&setup, &mut best, NPRE1_GATE_NDEEP2);
+            }
+        }
+        let setup_plus_search = t1.elapsed();
+
+        println!(
+            "setup_only: {:?}/call ({:?} total for {REPS} reps)",
+            setup_only / REPS as u32,
+            setup_only
+        );
+        println!(
+            "setup+npre1_pass: {:?}/call ({:?} total for {REPS} reps)",
+            setup_plus_search / REPS as u32,
+            setup_plus_search
+        );
+        println!(
+            "npre1_pass alone (by subtraction): {:?}/call",
+            (setup_plus_search.saturating_sub(setup_only)) / REPS as u32
+        );
+    }
 
     /// All-zero LLR should not produce a spurious decode (CRC check guards it).
     #[test]

--- a/mfsk-core/src/fec/ldpc/osd.rs
+++ b/mfsk-core/src/fec/ldpc/osd.rs
@@ -791,6 +791,163 @@ fn osd_setup_ldpc174_91(llr: &[f32; LDPC_N]) -> Option<OsdSetup> {
     })
 }
 
+/// Diagnostic variant of [`osd_setup_ldpc174_91`] (issue #182) — builds
+/// the systematic generator with `osd174_91.f90:86-107`'s *exact*
+/// bounded-window column-swap pivot search instead of
+/// [`osd_setup_ldpc174_91`]'s unbounded full-column-range row
+/// reduction.
+///
+/// The two are **not** the same algorithm. WSJT-X's real Gaussian
+/// elimination processes diagonal indices `id=1..k` and, for each,
+/// searches only columns `id..k+20` (`do icol=id,k+20` — "The 20 is ad
+/// hoc - beware", per the source comment itself) for a usable pivot,
+/// swapping that column into position `id` when found. Any column
+/// beyond `k+20` in reliability order is never eligible to become an
+/// MRB (most-reliable-basis) position, no matter how the elimination
+/// unfolds. [`osd_setup_ldpc174_91`] instead scans the *entire* N=174
+/// column range for each pivot row — a more complete elimination that
+/// never leaves a row un-pivoted, but which can select a genuinely
+/// *different* set of k physical bit positions as the systematic basis
+/// whenever the top `k+20` reliable columns don't happen to be the
+/// ones WSJT-X's row-major search would have chosen.
+///
+/// Since `osd_npre1_pass` only explores single- and paired-bit flips
+/// *within* whichever k positions got selected as the MRB, a different
+/// basis changes which candidate codewords are reachable at all —
+/// independent of `ntheta`/`nt` gate values, which already matched
+/// exactly.
+///
+/// **Disproven.** This was the leading hypothesis for
+/// `osd_decode_npre1`'s `K1BZM DK8NE -10` gap, tested directly
+/// (`issue_182_dk8ne_osd_fortran_pivot_probe`): the bounded-window
+/// basis genuinely differs from [`osd_setup_ldpc174_91`]'s (87-90/91
+/// position overlap across the 4 LLR variants), but `osd_decode_npre1`
+/// built on *either* basis still fails on this candidate — even a full
+/// unrestricted order-2 exhaustive search (no `ntheta` gate at all)
+/// never reaches it. The real gap was upstream of basis construction
+/// entirely: see [`super::bp::bp_llr_zsum`]'s doc comment and
+/// `osd_strategy.rs`'s `try_fallback` for the actual fix (WSJT-X's
+/// `decode174_91.f90` never feeds `osd174_91` the raw channel LLR when
+/// `maxosd>0`, which FT8's blind dispatch always is). Kept as a
+/// diagnostic — `#[cfg(test)]` only, not part of the production
+/// dispatch — documenting a plausible-but-wrong hypothesis so it isn't
+/// re-investigated from scratch later.
+#[cfg(test)]
+fn osd_setup_ldpc174_91_fortran_pivot(llr: &[f32; LDPC_N]) -> Option<OsdSetup> {
+    let n = LDPC_N;
+    let k = LDPC_K;
+
+    let mut perm: Vec<usize> = (0..n).collect();
+    perm.sort_unstable_by(|&a, &b| {
+        llr[b]
+            .abs()
+            .partial_cmp(&llr[a].abs())
+            .unwrap_or(core::cmp::Ordering::Equal)
+    });
+
+    let mut g: Vec<u8> = vec![0u8; k * n];
+    for row in 0..k {
+        for col in 0..n {
+            let j = perm[col];
+            g[row * n + col] = if j < k {
+                (row == j) as u8
+            } else {
+                <Ldpc174_91Params as LdpcParams>::gen_parity(j - k, row)
+            };
+        }
+    }
+
+    // `osd174_91.f90:86-107`: for each diagonal row `id`, search only
+    // columns `id..k+20` (ad hoc 20-column slack) for a usable pivot,
+    // swapping it into position `id` and eliminating it from every
+    // other row. Unlike `osd_setup_ldpc174_91`, a row that finds no
+    // pivot within this bounded window is silently left un-eliminated
+    // (matching WSJT-X's own behaviour, "beware" and all — not treated
+    // as an error here either).
+    const PIVOT_WINDOW_SLACK: usize = 20;
+    for id in 0..k {
+        let upper = (k + PIVOT_WINDOW_SLACK).min(n);
+        let mut found: Option<usize> = None;
+        for icol in id..upper {
+            if g[id * n + icol] == 1 {
+                found = Some(icol);
+                break;
+            }
+        }
+        let Some(icol) = found else { continue };
+        if icol != id {
+            for r in 0..k {
+                g.swap(r * n + id, r * n + icol);
+            }
+            perm.swap(id, icol);
+        }
+        for ii in 0..k {
+            if ii != id && g[ii * n + id] == 1 {
+                for c in 0..n {
+                    g[ii * n + c] ^= g[id * n + c];
+                }
+            }
+        }
+    }
+
+    let mut m0: Vec<u8> = vec![0u8; k];
+    for r in 0..k {
+        m0[r] = if llr[perm[r]] > 0.0 { 1 } else { 0 };
+    }
+
+    let mut hdec_perm: Vec<u8> = vec![0u8; n];
+    let mut absrx_perm: Vec<f32> = vec![0.0f32; n];
+    for col in 0..n {
+        hdec_perm[col] = if llr[perm[col]] > 0.0 { 1u8 } else { 0u8 };
+        absrx_perm[col] = llr[perm[col]].abs();
+    }
+
+    let mut c_perm: Vec<u8> = vec![0u8; n];
+    for r in 0..k {
+        if m0[r] == 1 {
+            for col in 0..n {
+                c_perm[col] ^= g[r * n + col];
+            }
+        }
+    }
+
+    Some(OsdSetup {
+        perm,
+        g,
+        hdec_perm,
+        absrx_perm,
+        c_perm,
+    })
+}
+
+/// Diagnostic (issue #182, disproven hypothesis — see
+/// [`osd_setup_ldpc174_91_fortran_pivot`]'s doc comment):
+/// [`osd_decode_npre1`] built on
+/// [`osd_setup_ldpc174_91_fortran_pivot`] instead of
+/// [`osd_setup_ldpc174_91`] — same `npre1` search, different MRB basis
+/// construction.
+#[cfg(test)]
+pub(crate) fn osd_decode_npre1_fortran_pivot(llr: &[f32; LDPC_N]) -> Option<OsdResult> {
+    let setup = osd_setup_ldpc174_91_fortran_pivot(llr)?;
+    let mut best = OsdBest::new();
+    osd_npre1_pass(&setup, &mut best, NPRE1_GATE_NDEEP2);
+    osd_result_from_best(llr, best)
+}
+
+/// Diagnostic (issue #182, disproven hypothesis): the MRB basis
+/// (`perm[0..LDPC_K]`, as a set of physical bit indices) each setup
+/// variant selects, for direct comparison. `(current, fortran_pivot)`.
+#[cfg(test)]
+pub(crate) fn osd_debug_basis_sets(llr: &[f32; LDPC_N]) -> (Vec<usize>, Vec<usize>) {
+    let current = osd_setup_ldpc174_91(llr)
+        .map(|s| s.perm[..LDPC_K].to_vec())
+        .unwrap_or_default();
+    let fortran_pivot = osd_setup_ldpc174_91_fortran_pivot(llr)
+        .map(|s| s.perm[..LDPC_K].to_vec())
+        .unwrap_or_default();
+    (current, fortran_pivot)
+}
+
 /// Un-permute a candidate codeword into the caller-provided
 /// `c_unperm` scratch buffer and CRC-verify it. Returns the
 /// unpermuted full codeword + its first-`K` info slice as fresh

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -3162,4 +3162,222 @@ mod tests {
             );
         }
     }
+
+    /// Throwaway probe (issue #182) — NOT for commit. Tests the leading
+    /// hypothesis for `osd_decode_npre1`'s DK8NE fidelity gap: WSJT-X's
+    /// real Gaussian elimination (`osd174_91.f90:86-107`) bounds its
+    /// pivot search to `id..k+20` with column swaps ("ad hoc... beware"
+    /// per its own comment), while `osd_setup_ldpc174_91` scans the
+    /// full N=174 column range — a more complete elimination that can
+    /// select a genuinely different set of MRB (most-reliable-basis)
+    /// physical bit positions. Since `osd_npre1_pass` only explores
+    /// flips *within* whichever basis got selected, a different basis
+    /// changes which codewords are reachable at all. Runs
+    /// `osd_decode_npre1_fortran_pivot` (same npre1 search, WSJT-X's
+    /// bounded-window pivot construction) against
+    /// `osd_decode_npre1`'s own construction, on the identical LLR, to
+    /// see whether the bounded pivot window is what recovers DK8NE.
+    #[test]
+    #[ignore = "manual diagnostic — issue #182 Fortran-pivot-window OSD basis probe"]
+    fn issue_182_dk8ne_osd_fortran_pivot_probe() {
+        use crate::core::sync::refine_candidate;
+        use crate::fec::ldpc::bp::bp_llr_zsum;
+        use crate::fec::ldpc::osd::{
+            osd_debug_basis_sets, osd_decode, osd_decode_npre1, osd_decode_npre1_fortran_pivot,
+        };
+        use crate::fec::ldpc::params::Ldpc174_91Params;
+        use crate::ft8::decode_block::{SymMask, fill_symbol_spectra, symbol_spectra_direct};
+        use crate::ft8::downsample::downsample;
+        use crate::ft8::llr::compute_llr;
+        use crate::msg::wsjt77::unpack77;
+
+        fn load_wav_i16(path: &std::path::Path) -> Option<alloc::vec::Vec<i16>> {
+            let bytes = std::fs::read(path).ok()?;
+            if bytes.len() < 44 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+                return None;
+            }
+            let mut i = 12usize;
+            let mut data_off = None;
+            let mut data_len = 0usize;
+            while i + 8 <= bytes.len() {
+                let id = &bytes[i..i + 4];
+                let sz = u32::from_le_bytes(bytes[i + 4..i + 8].try_into().unwrap()) as usize;
+                let body = i + 8;
+                if id == b"data" {
+                    data_off = Some(body);
+                    data_len = sz;
+                    break;
+                }
+                match body.checked_add(sz).and_then(|s| s.checked_add(sz & 1)) {
+                    Some(next) => i = next,
+                    None => break,
+                }
+            }
+            let off = data_off?;
+            let end = off.saturating_add(data_len).min(bytes.len());
+            Some(
+                bytes[off..end]
+                    .chunks_exact(2)
+                    .map(|c| i16::from_le_bytes([c[0], c[1]]))
+                    .collect(),
+            )
+        }
+
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let path = std::path::Path::new(manifest).join("../embedded-poc/assets/qso3_busy.wav");
+        let audio = load_wav_i16(&path).expect("load qso3_busy.wav");
+
+        let (_results, mfsk_residual) = decode_frame_subtract_staged_with_ap_debug_residual(
+            &audio,
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            DecodeDepth::BpAllOsd,
+            200,
+            DecodeStrictness::Normal,
+            None,
+        );
+
+        let freq = 244.2f32;
+        let dt = 0.505f32;
+        let cand = crate::core::sync::SyncCandidate {
+            freq_hz: freq,
+            dt_sec: dt,
+            score: 0.0,
+        };
+        let (cd0, _cache) = downsample(&mfsk_residual, cand.freq_hz, None);
+        let refined = refine_candidate::<crate::ft8::Ft8>(&cd0, &cand, 10);
+        let mut cs = symbol_spectra_direct::<i16>(
+            &mfsk_residual,
+            cand.freq_hz,
+            refined.dt_sec,
+            SymMask::SyncOnly,
+            None,
+        );
+        fill_symbol_spectra(
+            &mut cs,
+            &mfsk_residual,
+            cand.freq_hz,
+            refined.dt_sec,
+            SymMask::DataOnly,
+            None,
+        );
+        let llr_set = compute_llr::<f32>(&cs);
+
+        let target = "K1BZM DK8NE -10";
+        for (name, llr) in [
+            ("a", &llr_set.llra),
+            ("b", &llr_set.llrb),
+            ("c", &llr_set.llrc),
+            ("d", &llr_set.llrd),
+        ] {
+            let current = osd_decode_npre1(llr)
+                .map(|o| (unpack77(&o.message77).unwrap_or_default(), o.hard_errors));
+            let fortran_pivot = osd_decode_npre1_fortran_pivot(llr)
+                .map(|o| (unpack77(&o.message77).unwrap_or_default(), o.hard_errors));
+            let (basis_current, basis_fortran) = osd_debug_basis_sets(llr);
+            let set_current: std::collections::HashSet<usize> =
+                basis_current.iter().copied().collect();
+            let set_fortran: std::collections::HashSet<usize> =
+                basis_fortran.iter().copied().collect();
+            let basis_overlap = set_current.intersection(&set_fortran).count();
+            let exhaustive = osd_decode(llr)
+                .map(|o| (unpack77(&o.message77).unwrap_or_default(), o.hard_errors));
+            println!(
+                "llr({name}): current_basis={current:?}  fortran_pivot_basis={fortran_pivot:?}  basis_position_overlap={basis_overlap}/{}  exhaustive_order2={exhaustive:?}",
+                set_current.len()
+            );
+
+            // WSJT-X's real decode174_91.f90 driver never feeds osd174_91
+            // the raw channel LLR when maxosd>0 (FT8 ndepth=3 always sets
+            // maxosd=2) -- it feeds `zsave(:,i)`, the running sum of the
+            // BP variable-node soft estimate `zn` across the first `i`
+            // BP iterations (i=1,2 for maxosd=2), trying i=1 then i=2.
+            // `bp_llr_zsum` already exists and is wired for FST4-120
+            // (Ldpc240_101) but was never wired into FT8's osd_strategy.rs
+            // dispatch at all -- FT8's OSD has only ever seen the raw
+            // channel LLR variants (a/b/c/d), never a BP-refined one.
+            for n_iter in [1u32, 2u32] {
+                let zsum_vec = bp_llr_zsum::<Ldpc174_91Params>(llr, n_iter);
+                let mut zsum = [0f32; LDPC_N];
+                zsum.copy_from_slice(&zsum_vec);
+                let via_zsum = osd_decode_npre1(&zsum)
+                    .map(|o| (unpack77(&o.message77).unwrap_or_default(), o.hard_errors));
+                println!("  bp_llr_zsum(llr, {n_iter}) -> osd_decode_npre1: {via_zsum:?}");
+            }
+            if let Some((msg, _)) = &fortran_pivot
+                && msg == target
+            {
+                println!("  -> fortran_pivot_basis RECOVERS {target} on llr variant {name}!");
+            }
+        }
+    }
+
+    /// Throwaway probe (issue #182) — NOT for commit. The `bp_llr_zsum`
+    /// OSD-seed fix surfaced a new decode (`<?> 5T5ZGS/R FE02`) on
+    /// `qso3_busy.wav`'s AP-on multipass run that wasn't there before.
+    /// Print pass/hard_errors/freq for every decode to check whether
+    /// it's a plausible weak-but-real signal or a CRC-luck phantom.
+    #[test]
+    #[ignore = "manual diagnostic — issue #182 zsum-fix phantom check"]
+    fn issue_182_zsum_fix_phantom_check() {
+        use crate::msg::wsjt77::unpack77;
+
+        fn load_wav_i16(path: &std::path::Path) -> Option<alloc::vec::Vec<i16>> {
+            let bytes = std::fs::read(path).ok()?;
+            if bytes.len() < 44 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+                return None;
+            }
+            let mut i = 12usize;
+            let mut data_off = None;
+            let mut data_len = 0usize;
+            while i + 8 <= bytes.len() {
+                let id = &bytes[i..i + 4];
+                let sz = u32::from_le_bytes(bytes[i + 4..i + 8].try_into().unwrap()) as usize;
+                let body = i + 8;
+                if id == b"data" {
+                    data_off = Some(body);
+                    data_len = sz;
+                    break;
+                }
+                match body.checked_add(sz).and_then(|s| s.checked_add(sz & 1)) {
+                    Some(next) => i = next,
+                    None => break,
+                }
+            }
+            let off = data_off?;
+            let end = off.saturating_add(data_len).min(bytes.len());
+            Some(
+                bytes[off..end]
+                    .chunks_exact(2)
+                    .map(|c| i16::from_le_bytes([c[0], c[1]]))
+                    .collect(),
+            )
+        }
+
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let path = std::path::Path::new(manifest).join("../embedded-poc/assets/qso3_busy.wav");
+        let audio = load_wav_i16(&path).expect("load qso3_busy.wav");
+
+        let ap = ApHint::new().with_call1("K1JT").with_call2("HA0DU");
+        let results = decode_frame_subtract_with_ap(
+            &audio,
+            100.0,
+            3000.0,
+            1.3,
+            None,
+            DecodeDepth::BpAllOsd,
+            50,
+            DecodeStrictness::Normal,
+            Some(&ap),
+        );
+        for r in &results {
+            let msg = unpack77(&r.message77).unwrap_or_default();
+            println!(
+                "pass={:3} hard_errors={:3} freq={:8.2} dt={:+.3} msg={msg:?}",
+                r.pass, r.hard_errors, r.freq_hz, r.dt_sec
+            );
+        }
+    }
 }

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -816,10 +816,24 @@ pub fn decode_frame_subtract_flat_with_ap(
 /// caller callsigns from the blind decodes and retry coarse_sync
 /// candidates that didn't decode blind, using each harvested callsign
 /// as an AP `mycall` hint. Recovers signals too weak for blind BP/OSD
-/// but not too weak to sync — e.g. `K1BZM DK8NE -10` (-19 dB) on
-/// `qso3_busy.wav`, real but unrecoverable via this crate's own blind
-/// decode without knowing `K1BZM` is a plausible caller (issue #180
-/// follow-up).
+/// but not too weak to sync — originally motivated by `K1BZM DK8NE
+/// -10` (-19 dB) on `qso3_busy.wav` (issue #180 follow-up), which at
+/// the time was unrecoverable via this crate's own blind decode
+/// without knowing `K1BZM` is a plausible caller.
+///
+/// **Deliberately not wired into any default decode path — call this
+/// explicitly, opt-in only.** As of issue #182's `bp_llr_zsum` OSD fix
+/// (`decode_block/osd_strategy.rs`), this function's own motivating
+/// case decodes via blind [`decode_frame_subtract_with_ap`] alone —
+/// measured on `qso3_busy.wav`: blind-only and blind-plus-this-
+/// function now both return the same 22 decodes, so the auto-AP pass
+/// finds *zero* additional signals there while still paying its own
+/// full search cost (~0.3-0.5s single-threaded on top of blind). This
+/// doesn't mean the mechanism is dead in general — an AP-rescuable-
+/// but-zsum-OSD-unreachable signal is still conceivable — but there is
+/// no evidence for one currently, so treat this as a research/
+/// diagnostic tool rather than a default production step until a
+/// concrete case justifies its cost again.
 ///
 /// **Not a port of any real jt9/WSJT-X mechanism** — this is a genuine
 /// mfsk-core-original extension, and an earlier version of this doc
@@ -3377,6 +3391,95 @@ mod tests {
             println!(
                 "pass={:3} hard_errors={:3} freq={:8.2} dt={:+.3} msg={msg:?}",
                 r.pass, r.hard_errors, r.freq_hz, r.dt_sec
+            );
+        }
+    }
+
+    /// Throwaway probe (issue #182 follow-up) — NOT for commit. Real
+    /// blind-decode wall-clock on `qso3_busy.wav` after the
+    /// `bp_llr_zsum` OSD fix, for direct comparison against jt9's own
+    /// real `-8 -d3` file decode time (~1.1s, measured in an earlier
+    /// session via jt9's built-in `timer.out` profiler).
+    #[test]
+    #[ignore = "manual diagnostic — issue #182 post-fix wall-clock check"]
+    fn issue_182_postfix_wallclock_check() {
+        fn load_wav_i16(path: &std::path::Path) -> Option<alloc::vec::Vec<i16>> {
+            let bytes = std::fs::read(path).ok()?;
+            if bytes.len() < 44 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+                return None;
+            }
+            let mut i = 12usize;
+            let mut data_off = None;
+            let mut data_len = 0usize;
+            while i + 8 <= bytes.len() {
+                let id = &bytes[i..i + 4];
+                let sz = u32::from_le_bytes(bytes[i + 4..i + 8].try_into().unwrap()) as usize;
+                let body = i + 8;
+                if id == b"data" {
+                    data_off = Some(body);
+                    data_len = sz;
+                    break;
+                }
+                match body.checked_add(sz).and_then(|s| s.checked_add(sz & 1)) {
+                    Some(next) => i = next,
+                    None => break,
+                }
+            }
+            let off = data_off?;
+            let end = off.saturating_add(data_len).min(bytes.len());
+            Some(
+                bytes[off..end]
+                    .chunks_exact(2)
+                    .map(|c| i16::from_le_bytes([c[0], c[1]]))
+                    .collect(),
+            )
+        }
+
+        let manifest = env!("CARGO_MANIFEST_DIR");
+        let path = std::path::Path::new(manifest).join("../embedded-poc/assets/qso3_busy.wav");
+        let audio = load_wav_i16(&path).expect("load qso3_busy.wav");
+
+        // Blind decode only (no AP hint) -- staged SIC is the default
+        // decode_frame_subtract_with_ap path since #180/#183.
+        for rep in 0..3 {
+            let t0 = std::time::Instant::now();
+            let results = decode_frame_subtract_with_ap(
+                &audio,
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                DecodeDepth::BpAllOsd,
+                200,
+                DecodeStrictness::Normal,
+                None,
+            );
+            let elapsed = t0.elapsed();
+            println!(
+                "rep={rep} blind decode_frame_subtract_with_ap: {:?}, {} decodes",
+                elapsed,
+                results.len()
+            );
+        }
+
+        // Blind + auto-AP rescue (the full production-equivalent path).
+        #[cfg(feature = "fft-rustfft")]
+        for rep in 0..3 {
+            let t0 = std::time::Instant::now();
+            let results = decode_frame_subtract_with_auto_ap(
+                &audio,
+                100.0,
+                3000.0,
+                0.8,
+                DecodeDepth::BpAllOsd,
+                200,
+                DecodeStrictness::Normal,
+            );
+            let elapsed = t0.elapsed();
+            println!(
+                "rep={rep} blind + auto-AP: {:?}, {} decodes",
+                elapsed,
+                results.len()
             );
         }
     }

--- a/mfsk-core/src/ft8/decode_block/auto_ap_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/auto_ap_strategy.rs
@@ -38,9 +38,6 @@ use alloc::collections::BTreeSet;
 use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
-#[cfg(feature = "parallel")]
-use rayon::prelude::*;
-
 use super::super::decode::{ApHint, DecodeDepth, DecodeResult, DecodeStrictness};
 use super::super::llr::sync_quality;
 use super::coarse_sync::coarse_sync;
@@ -358,53 +355,34 @@ where
         }
     }
 
-    // Per-callsign batch processing, one Rayon task per harvested
-    // callsign — this is why the presync/blind-decode filters above
-    // matter for more than raw op count: by the time this loop runs,
-    // `refined` is down to a handful of genuinely-synced candidates
-    // (typically 1-7 on a real WAV), so each callsign's own batch call
-    // is cheap and the 15-ish callsigns are fully independent (a
-    // different `ApHint::call1` each, same read-only `refined`/`audio`
-    // /`fft_cache`) — an easy fit for the 15-way (or however many
-    // callsigns) parallelism this crate already uses for the analogous
-    // per-candidate loop in `ft8::decode`'s host driver. Each task
-    // computes against the *full* `refined` list rather than a
-    // shrinking one (the pre-parallelisation version removed a
-    // candidate from `remaining` once some callsign decoded it, so
-    // later callsigns wouldn't redundantly re-attempt it) — safe to
-    // drop now that there are only a handful of candidates left to
-    // begin with, and required for parallel workers to stay
-    // independent (no shared mutable state to race on).
+    // Per-callsign batch processing (sequential — see below for why
+    // this used to be a Rayon `par_iter` and no longer is).
     //
-    // Gemini PR #118 high-priority optimisation (still applies within
-    // each task): passing one (cand, callsign) pair at a time
-    // re-allocates `BpScratch` (~12 KB) on every invocation; batching
-    // all `refined` candidates per callsign reuses the BpScratch inside
+    // Gemini PR #118 high-priority optimisation (still applies): passing
+    // one (cand, callsign) pair at a time re-allocates `BpScratch`
+    // (~12 KB) on every invocation; batching all `refined` candidates
+    // per callsign reuses the BpScratch inside
     // `process_candidates_tuned_with_ap_ref`'s inner loop.
-    #[cfg(feature = "parallel")]
-    let all_batches: Vec<Vec<DecodeResult>> = callsigns
-        .par_iter()
-        .map(|callsign| {
-            let ap = ApHint::new().with_call1(callsign);
-            // `DecodeDepth::BpAll` — see the blind-precheck step above
-            // for why this loop skips OSD too.
-            process_candidates_tuned_with_ap_ref(
-                audio,
-                &refined,
-                DecodeDepth::BpAll,
-                DEFAULT_Q_THRESH,
-                bp_max_iter,
-                Some(&ap),
-                strictness,
-                Some(&fft_cache),
-            )
-        })
-        .collect();
-    #[cfg(not(feature = "parallel"))]
+    //
+    // **Reverted the Rayon parallelisation (issue #182 follow-up).**
+    // This function's own motivating case (`K1BZM DK8NE -10`) now
+    // decodes via blind `decode_frame_subtract_with_ap` alone once the
+    // OSD `bp_llr_zsum` fix landed (see
+    // `decode_frame_subtract_with_auto_ap`'s doc comment) — measured
+    // zero additional decodes from this whole function on
+    // `qso3_busy.wav`. Parallelising a search that finds nothing is
+    // pure wasted complexity: real, independent multi-core speedup
+    // with no offsetting value, carrying a second (parallel/sequential)
+    // code path to test and maintain for a research/diagnostic
+    // function that isn't part of any default decode path. Simplified
+    // back to one sequential path; re-introduce parallelism here only
+    // if a concrete case re-justifies this function's cost.
     let all_batches: Vec<Vec<DecodeResult>> = callsigns
         .iter()
         .map(|callsign| {
             let ap = ApHint::new().with_call1(callsign);
+            // `DecodeDepth::BpAll` — see the blind-precheck step above
+            // for why this loop skips OSD too.
             process_candidates_tuned_with_ap_ref(
                 audio,
                 &refined,

--- a/mfsk-core/src/ft8/decode_block/osd_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/osd_strategy.rs
@@ -19,8 +19,10 @@
 
 use super::super::decode::DecodeDepth;
 use crate::core::scalar::Cmplx;
-use crate::fec::ldpc::bp::BpResult;
-use crate::fec::ldpc::osd::{osd_decode_npre1, osd_decode_npre1_npre2};
+use crate::fec::ldpc::LDPC_N;
+use crate::fec::ldpc::bp::{BpResult, bp_llr_zsum};
+use crate::fec::ldpc::osd::{OsdResult, osd_decode_npre1, osd_decode_npre1_npre2};
+use crate::fec::ldpc::params::Ldpc174_91Params;
 
 /// `sync_quality` threshold for dispatching to the heavier WSJT-X
 /// ndeep=3 entry ([`osd_decode_npre1_npre2`]) instead of ndeep=2
@@ -63,6 +65,15 @@ const OSD_HARDERRORS_MAX: u32 = 36;
 /// can size its pass-tracking buffers without re-declaring magic
 /// numbers.
 pub(super) const PASS_ID_OSD_A: u8 = 14;
+
+/// Pass-ID range for the BP-refined-LLR (`zsave(:,1)`-equivalent)
+/// OSD attempts — issue #182. `19..=22` for llr-variants a/b/c/d.
+/// (18 is already `auto_ap_strategy::PASS_ID_AUTO_AP`.)
+pub(super) const PASS_ID_OSD_ZSUM1_A: u8 = 19;
+
+/// Pass-ID range for the BP-refined-LLR (`zsave(:,2)`-equivalent)
+/// OSD attempts — issue #182. `23..=26` for llr-variants a/b/c/d.
+pub(super) const PASS_ID_OSD_ZSUM2_A: u8 = 23;
 
 /// Try the OSD staircase for a candidate whose BP staircase didn't
 /// converge. Returns `Some((bp_result, pass_id))` on the first
@@ -119,6 +130,37 @@ pub(super) fn try_fallback(
         }
     };
 
+    // WSJT-X-faithful OSD dispatch (issue #63). Mirrors WSJT-X's
+    // ndeep=2/3 split: ndeep=2 (= nord=1 + npre1=1, ~165 patterns
+    // post-gate) for the default `q < 18` candidates; ndeep=3
+    // (= ndeep=2 + npre2 weight-3 anchored pairs via a ntau=14
+    // hash table) for cleaner candidates that justify the extra
+    // 64 KB hash-table build.
+    //
+    // Both entries carry implicit `check_crc14` verifiers (mirror
+    // WSJT-X's `nbadcrc` gate inside `osd174_91`), so no
+    // `Some(check_crc14)` argument.
+    let dispatch = |llr: &[f32; LDPC_N]| -> Option<OsdResult> {
+        let osd = if q >= Q_NDEEP3_THRESHOLD {
+            osd_decode_npre1_npre2(llr)
+        } else {
+            osd_decode_npre1(llr)
+        };
+        // WSJT-X-faithful ceiling — see [`OSD_HARDERRORS_MAX`]'s docstring.
+        osd.filter(|o| o.hard_errors <= OSD_HARDERRORS_MAX)
+    };
+    // Reuse `osd.codeword` instead of allocating a fresh zero vec —
+    // `OsdResult` already carries the actual decoded codeword bits,
+    // which the previous `vec![0; N]` dropped on the floor (Gemini PR
+    // #86 review).
+    let to_bp = |osd: OsdResult| BpResult {
+        message77: osd.message77,
+        info: osd.info,
+        codeword: osd.codeword,
+        hard_errors: osd.hard_errors,
+        iterations: 0,
+    };
+
     // Pass-ID space (post-0.6.1): BP variants 0..3, AP iaptypes
     // 5..12 (mirroring WSJT-X ipass 5..12), host OSD-Deep 13,
     // embedded OSD a/b/c/d 14/15/16/17. The +10 shift on OSD
@@ -130,40 +172,53 @@ pub(super) fn try_fallback(
         (&llr_full_f32.llrc, PASS_ID_OSD_A + 2),
         (&llr_full_f32.llrd, PASS_ID_OSD_A + 3),
     ] {
-        // WSJT-X-faithful OSD dispatch (issue #63). Mirrors WSJT-X's
-        // ndeep=2/3 split: ndeep=2 (= nord=1 + npre1=1, ~165 patterns
-        // post-gate) for the default `q < 18` candidates; ndeep=3
-        // (= ndeep=2 + npre2 weight-3 anchored pairs via a ntau=14
-        // hash table) for cleaner candidates that justify the extra
-        // 64 KB hash-table build.
-        //
-        // Both entries carry implicit `check_crc14` verifiers (mirror
-        // WSJT-X's `nbadcrc` gate inside `osd174_91`), so no
-        // `Some(check_crc14)` argument.
-        let osd = if q >= Q_NDEEP3_THRESHOLD {
-            osd_decode_npre1_npre2(llr)
-        } else {
-            osd_decode_npre1(llr)
-        };
-        if let Some(osd) = osd {
-            // WSJT-X-faithful ceiling — see [`OSD_HARDERRORS_MAX`]'s
-            // docstring.
-            if osd.hard_errors > OSD_HARDERRORS_MAX {
-                continue;
-            }
-            // Reuse `osd.codeword` instead of allocating a fresh
-            // zero vec — `OsdResult` already carries the actual
-            // decoded codeword bits, which the previous `vec![0; N]`
-            // dropped on the floor (Gemini PR #86 review).
-            let bp = BpResult {
-                message77: osd.message77,
-                info: osd.info,
-                codeword: osd.codeword,
-                hard_errors: osd.hard_errors,
-                iterations: 0,
-            };
-            return Some((bp, pid));
+        if let Some(osd) = dispatch(llr) {
+            return Some((to_bp(osd), pid));
         }
     }
+
+    // WSJT-X-faithful BP-refined-LLR seed (issue #182). WSJT-X's real
+    // `decode174_91.f90` driver never feeds `osd174_91` the raw channel
+    // LLR when `maxosd>0` — and FT8's blind `ndepth=3` dispatch always
+    // sets `maxosd=2` (`ft8b.f90:434-441`). It feeds `zsave(:,i)`, the
+    // running sum of the BP variable-node soft estimate `zn` across the
+    // first `i` BP iterations, trying `i=1` then `i=2`
+    // (`decode174_91.f90:52-64,137-148`). The direct-channel-LLR loop
+    // above is what mfsk-core's OSD has *always* used — it never
+    // implements this BP-refined seed for FT8 at all, even though the
+    // exact same mechanism (`bp_llr_zsum`) is already ported and wired
+    // for FST4-120 (`Ldpc240_101`, see that function's own doc comment).
+    // Root-caused directly: `K1BZM DK8NE -10` (-19 dB, `qso3_busy.wav`)
+    // never decodes via any direct-channel-LLR variant (a/b/c/d) at any
+    // OSD depth up to and including brute-force order-2 exhaustive
+    // search (no gate) — the true codeword is not reachable via a
+    // weight <=2 flip of the channel-LLR-selected MRB basis at all.
+    // Feeding `bp_llr_zsum(llrd, 2)` into the *same* `osd_decode_npre1`
+    // decodes it outright at `hard_errors=17` (better than jt9's own
+    // real `hard_errors=18` on this exact candidate).
+    for n_iter in [1u32, 2u32] {
+        let base = if n_iter == 1 {
+            PASS_ID_OSD_ZSUM1_A
+        } else {
+            PASS_ID_OSD_ZSUM2_A
+        };
+        for (idx, llr) in [
+            &llr_full_f32.llra,
+            &llr_full_f32.llrb,
+            &llr_full_f32.llrc,
+            &llr_full_f32.llrd,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let zsum_vec = bp_llr_zsum::<Ldpc174_91Params>(llr, n_iter);
+            let mut zsum = [0f32; LDPC_N];
+            zsum.copy_from_slice(&zsum_vec);
+            if let Some(osd) = dispatch(&zsum) {
+                return Some((to_bp(osd), base + idx as u8));
+            }
+        }
+    }
+
     None
 }

--- a/mfsk-core/src/ft8/decode_block/osd_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/osd_strategy.rs
@@ -4,18 +4,30 @@
 //! Runs only when Steps 1–2 (BP staircase) fail and the caller asks
 //! for `BpAllOsd` depth at sufficient `sync_quality`. Computes a
 //! fresh f32 LLR bundle for the candidate (OSD operates on f32
-//! regardless of the embedded fixed-point `LlrT`), walks the four
-//! LLR variants (a/b/c/d) through the WSJT-X-faithful OSD entry
+//! regardless of the embedded fixed-point `LlrT`), and for each of
+//! the four LLR variants (a/b/c/d, matching `ft8b.f90`'s `ipass=1..4`
+//! `llra/b/c/d`), tries the WSJT-X-faithful OSD entry
 //! ([`osd_decode_npre1`] for low-`q` candidates, [`osd_decode_npre1_npre2`]
-//! for `q >= Q_NDEEP3_THRESHOLD`), and applies the
-//! `nharderrors > 36` cycle gate to weed out high-error CRC-luck
+//! for `q >= Q_NDEEP3_THRESHOLD`) seeded with `bp_llr_zsum(llr, 1)`
+//! then `bp_llr_zsum(llr, 2)` — mirroring `decode174_91.f90`'s own
+//! `do i=1,nosd` loop over its `zsave(:,i)` snapshots — and applies
+//! the `nharderrors > 36` cycle gate to weed out high-error CRC-luck
 //! codewords.
 //!
 //! ε.6 of the `docs/CLEANUP_2026_05.md` `decode_block` split. As of
 //! issue **#63** this module hosts the WSJT-X-faithful OSD dispatch
 //! — the q-conditional split mirrors `osd174_91.f90`'s ndeep=2/3
 //! dispatch table, replacing the previous mfsk-core-specific
-//! brute-force ndeep=2/3 split (`osd_decode` / `osd_decode_deep`).
+//! brute-force ndeep=2/3 split (`osd_decode` / `osd_decode_deep`). As
+//! of issue **#182** the OSD *input* is also WSJT-X-faithful: earlier
+//! versions fed `osd_decode_npre1`/`_npre2` the raw channel LLR
+//! directly, which is not what real WSJT-X does for FT8's blind
+//! `ndepth=3` dispatch — that always sets `maxosd=2`
+//! (`ft8b.f90:434-441`), and `decode174_91.f90` never calls
+//! `osd174_91` on the raw channel LLR when `maxosd>0` (that's a
+//! separate `maxosd=0` branch FT8's blind dispatch never takes). It
+//! always calls with `zsave(:,i)`, the running BP variable-node soft-
+//! estimate sum through the first `i` BP iterations.
 
 use super::super::decode::DecodeDepth;
 use crate::core::scalar::Cmplx;
@@ -59,21 +71,20 @@ const Q_NDEEP3_THRESHOLD: u32 = 18;
 /// tightened gate to stay green.
 const OSD_HARDERRORS_MAX: u32 = 36;
 
-/// Pass-ID range emitted by the OSD fallback (`14..=17` mirrors the
-/// llr-variant order `a/b/c/d` — see the post-0.6.1 pass-ID layout
-/// documented inline below). Exposed so `process_one_candidate_inner`
-/// can size its pass-tracking buffers without re-declaring magic
-/// numbers.
-pub(super) const PASS_ID_OSD_A: u8 = 14;
+/// Pass-ID range for the `zsave(:,1)`-equivalent (BP-refined, 1
+/// iteration) OSD attempts, `14..=17` for llr-variants a/b/c/d.
+/// Exposed so `process_one_candidate_inner` can size its
+/// pass-tracking buffers without re-declaring magic numbers.
+///
+/// Was the direct-channel-LLR OSD pass-ID range pre-issue-#182; that
+/// loop is gone now (see [`try_fallback`]'s doc comment for why), so
+/// this range was free to reclaim.
+pub(super) const PASS_ID_OSD_ZSAVE1_A: u8 = 14;
 
-/// Pass-ID range for the BP-refined-LLR (`zsave(:,1)`-equivalent)
-/// OSD attempts — issue #182. `19..=22` for llr-variants a/b/c/d.
-/// (18 is already `auto_ap_strategy::PASS_ID_AUTO_AP`.)
-pub(super) const PASS_ID_OSD_ZSUM1_A: u8 = 19;
-
-/// Pass-ID range for the BP-refined-LLR (`zsave(:,2)`-equivalent)
-/// OSD attempts — issue #182. `23..=26` for llr-variants a/b/c/d.
-pub(super) const PASS_ID_OSD_ZSUM2_A: u8 = 23;
+/// Pass-ID range for the `zsave(:,2)`-equivalent (BP-refined, 2
+/// iterations) OSD attempts — issue #182. `19..=22` for llr-variants
+/// a/b/c/d. (18 is `auto_ap_strategy::PASS_ID_AUTO_AP`.)
+pub(super) const PASS_ID_OSD_ZSAVE2_A: u8 = 19;
 
 /// Try the OSD staircase for a candidate whose BP staircase didn't
 /// converge. Returns `Some((bp_result, pass_id))` on the first
@@ -161,56 +172,48 @@ pub(super) fn try_fallback(
         iterations: 0,
     };
 
-    // Pass-ID space (post-0.6.1): BP variants 0..3, AP iaptypes
-    // 5..12 (mirroring WSJT-X ipass 5..12), host OSD-Deep 13,
-    // embedded OSD a/b/c/d 14/15/16/17. The +10 shift on OSD
-    // frees 5..12 for the AP loop being plumbed into the same
-    // per-candidate function in 0.6.1.
-    for (llr, pid) in [
-        (&llr_full_f32.llra, PASS_ID_OSD_A),
-        (&llr_full_f32.llrb, PASS_ID_OSD_A + 1),
-        (&llr_full_f32.llrc, PASS_ID_OSD_A + 2),
-        (&llr_full_f32.llrd, PASS_ID_OSD_A + 3),
-    ] {
-        if let Some(osd) = dispatch(llr) {
-            return Some((to_bp(osd), pid));
-        }
-    }
-
-    // WSJT-X-faithful BP-refined-LLR seed (issue #182). WSJT-X's real
-    // `decode174_91.f90` driver never feeds `osd174_91` the raw channel
-    // LLR when `maxosd>0` — and FT8's blind `ndepth=3` dispatch always
-    // sets `maxosd=2` (`ft8b.f90:434-441`). It feeds `zsave(:,i)`, the
-    // running sum of the BP variable-node soft estimate `zn` across the
-    // first `i` BP iterations, trying `i=1` then `i=2`
-    // (`decode174_91.f90:52-64,137-148`). The direct-channel-LLR loop
-    // above is what mfsk-core's OSD has *always* used — it never
-    // implements this BP-refined seed for FT8 at all, even though the
-    // exact same mechanism (`bp_llr_zsum`) is already ported and wired
-    // for FST4-120 (`Ldpc240_101`, see that function's own doc comment).
+    // WSJT-X-faithful BP-refined-LLR seed (issue #182), replacing what
+    // used to be a direct-channel-LLR OSD loop here. `decode174_91.f90`
+    // never calls `osd174_91` on the raw channel LLR when `maxosd>0` —
+    // and FT8's blind `ndepth=3` dispatch always sets `maxosd=2`
+    // (`ft8b.f90:434-441`), so the raw-channel-LLR OSD path
+    // (`maxosd=0`, a *different* WSJT-X depth setting FT8's blind
+    // dispatch never takes) was never actually what real `jt9 -d3`
+    // does here. It always calls `osd174_91` with `zsave(:,i)`, the
+    // running sum of the BP variable-node soft estimate `zn` across
+    // the first `i` BP iterations — trying `i=1` then `i=2`
+    // (`decode174_91.f90:52-64,137-148`) *before* moving to the next
+    // `ipass`/llr variant (`ft8b.f90:294-298`, `do ipass=1,4`). Nesting
+    // mirrored exactly here: outer loop over the 4 llr variants, inner
+    // loop over the 2 `zsave` snapshots — not the other way around, so
+    // the search order (and which candidate gets returned first when
+    // more than one would eventually succeed) matches WSJT-X's own.
+    //
     // Root-caused directly: `K1BZM DK8NE -10` (-19 dB, `qso3_busy.wav`)
-    // never decodes via any direct-channel-LLR variant (a/b/c/d) at any
-    // OSD depth up to and including brute-force order-2 exhaustive
-    // search (no gate) — the true codeword is not reachable via a
-    // weight <=2 flip of the channel-LLR-selected MRB basis at all.
-    // Feeding `bp_llr_zsum(llrd, 2)` into the *same* `osd_decode_npre1`
-    // decodes it outright at `hard_errors=17` (better than jt9's own
-    // real `hard_errors=18` on this exact candidate).
-    for n_iter in [1u32, 2u32] {
-        let base = if n_iter == 1 {
-            PASS_ID_OSD_ZSUM1_A
-        } else {
-            PASS_ID_OSD_ZSUM2_A
-        };
-        for (idx, llr) in [
-            &llr_full_f32.llra,
-            &llr_full_f32.llrb,
-            &llr_full_f32.llrc,
-            &llr_full_f32.llrd,
-        ]
-        .into_iter()
-        .enumerate()
-        {
+    // never decoded via the old direct-channel-LLR loop at any OSD
+    // depth up to and including a brute-force order-2 exhaustive
+    // search (no gate) — the true codeword was not reachable from a
+    // channel-LLR-selected MRB basis at all. Feeding
+    // `bp_llr_zsum(llrd, 2)` into the *same*, unmodified
+    // `osd_decode_npre1` decodes it outright at `hard_errors=17`
+    // (better than jt9's own real `hard_errors=18` on this exact
+    // candidate). The mechanism (`bp_llr_zsum`) already existed and is
+    // wired for FST4-120 (`Ldpc240_101`, issue #146) but was never
+    // ported to FT8 before now.
+    //
+    // Pass-ID space (post-0.6.1): BP variants 0..3, AP iaptypes 5..12
+    // (mirroring WSJT-X ipass 5..12), host OSD-Deep 13, embedded OSD
+    // zsave(1) a/b/c/d 14..17, auto-AP 18, zsave(2) a/b/c/d 19..22.
+    for (idx, llr) in [
+        &llr_full_f32.llra,
+        &llr_full_f32.llrb,
+        &llr_full_f32.llrc,
+        &llr_full_f32.llrd,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        for (n_iter, base) in [(1u32, PASS_ID_OSD_ZSAVE1_A), (2u32, PASS_ID_OSD_ZSAVE2_A)] {
             let zsum_vec = bp_llr_zsum::<Ldpc174_91Params>(llr, n_iter);
             let mut zsum = [0f32; LDPC_N];
             zsum.copy_from_slice(&zsum_vec);

--- a/mfsk-core/src/ft8/decode_block/types.rs
+++ b/mfsk-core/src/ft8/decode_block/types.rs
@@ -25,14 +25,17 @@ use super::super::params::NSPS;
 /// The `to_f32` implementation must produce values on the same
 /// amplitude scale as `i16` so the LLR computation downstream keeps
 /// its calibration; for `i8` we therefore multiply by 256.
-/// `Sync` (both current impls, `i16`/`i8`, are plain `Copy` primitives
-/// with no interior mutability, so this costs real implementors
-/// nothing): lets `&[S]` cross the `rayon` task boundary in the
-/// `parallel`-feature host paths (e.g.
+///
+/// `Copy` only — no `Sync` supertrait. An earlier version added `+
+/// Sync` here so `&[S]` could cross a `rayon` task boundary in
 /// `decode_block::auto_ap_strategy::run_bounded`'s per-callsign
-/// parallel loop) without every generic caller needing to spell out
-/// the bound itself.
-pub trait AudioSample: Copy + Sync {
+/// parallel loop; that parallelism was reverted (issue #182 follow-up
+/// — the loop it sped up now finds zero additional decodes once the
+/// OSD `bp_llr_zsum` fix landed, so parallelising it further was pure
+/// unused complexity), and no other `AudioSample`-generic function
+/// crosses a thread boundary. Re-add `+ Sync` only alongside a real
+/// generic-over-`S` parallel caller, not preemptively.
+pub trait AudioSample: Copy {
     fn to_f32(self) -> f32;
     /// Promote to i16 range. i8 → i16 via `<<8`; i16 → i16
     /// identity. Used by the fixed-point FFT input path.


### PR DESCRIPTION
## Summary

Closes #182. Root-causes and fixes the `K1BZM DK8NE -10` (-19 dB)
`osd_decode_npre1` fidelity gap, reconsiders OSD's cost against WSJT-X's
real implementation (not ad hoc), reverts parallelism that's no longer
justified, and bit-packs OSD's dominant cost center. End-to-end result:
single-threaded blind decode of `qso3_busy.wav` went from the pre-#182
baseline (~1.0s, but missing DK8NE) through several intermediate states
to **1.09-1.12s with DK8NE decoding** — landing right at real `jt9 -8 -d3`'s
own measured ~1.1s total file decode time.

## Commits

**1. Seed OSD with BP-refined LLR.** WSJT-X's real `decode174_91.f90`
driver never feeds `osd174_91` the raw channel LLR when `maxosd>0` — and
FT8's blind `ndepth=3` dispatch always sets `maxosd=2`. It feeds
`zsave(:,i)`, the running BP variable-node soft-estimate sum through the
first `i` BP iterations. mfsk-core's OSD had only ever used raw channel
LLR — confirmed exhaustively (including brute-force order-2, no gate)
that DK8NE's true codeword isn't reachable from a channel-LLR-selected
basis at all. `bp_llr_zsum` already existed for FST4-120 but was never
ported to FT8. Wiring it in decodes DK8NE at `hard_errors=17` (vs jt9's
own 18). Also tests and disproves a parallel hypothesis (WSJT-X's
bounded-window pivot search selecting a different basis) — kept as a
`#[cfg(test)]`-only diagnostic.

**2. Drop the non-faithful direct-channel OSD loop.** Checking
`ft8b.f90`'s actual `do ipass=1,4` / `decode174_91.f90`'s `maxosd`
branches showed the pre-existing direct-channel-LLR OSD loop (issue #63,
predating this session) was itself never what real WSJT-X does for this
depth. Removed it, restructured to WSJT-X's actual nesting (outer =
variant/`ipass`, inner = `zsave` index). Zero decodes lost; 12 OSD
dispatches worst-case → 8.

**3. Revert now-pointless auto-AP `rayon` + `AudioSample: Sync`.** With
commit 1 landed, auto-AP's motivating case now decodes blind, so its
per-callsign `rayon` parallel loop finds zero additional decodes on
`qso3_busy.wav` while still paying its full search cost. Reverted to
sequential; reverted `AudioSample`'s now-unneeded `+ Sync` bound (every
other `rayon` usage in the codebase operates on concrete `i16`, `Sync`
was already automatic there).

**4. Bit-pack `osd_setup_ldpc174_91`'s Gaussian elimination.** Profiling
found OSD fallback was ~22-25% of total decode wall-clock, and within a
single `osd_decode_npre1` call, 86% of *that* was basis construction
(sort + elimination) — 113.5µs/call — vs ~18µs for the actual `npre1`
search. Root cause: the GF(2) matrix was stored one byte per bit,
so the elimination's row-XOR did up to 174 byte-XORs instead of ~3
packed 64-bit-word XORs, paid fresh on all 8 zsave-seeded dispatches per
candidate. Not a WSJT-X-fidelity issue — `osd174_91.f90`'s own `genmrb`
is `integer*1` too; this is a genuine improvement beyond WSJT-X's own
implementation. Confined to `osd_setup_ldpc174_91`'s internals only —
`OsdSetup`'s shape and every downstream consumer are byte-for-byte
unchanged. Verified via a new differential test asserting the packed
rewrite matches a frozen byte-per-bit reference across 5 seeded random
LLR vectors plus edge cases (all-zero, exact-tie).

## Effect / cost (cumulative across all 4 commits)

- `K1BZM DK8NE -10` decodes through the real production dispatch:
  `qso3_apon_subtract_jtdx_extras_diag` 5/6 → 6/6 JTDX extras.
- `osd_setup_ldpc174_91`: 113.5µs → 16.7µs/call (6.8×).
- Total OSD dispatch (setup + search): 131.6µs → 34.1µs/call (3.9×).
- Single-threaded blind decode of `qso3_busy.wav`: **1.27-1.30s (after
  commit 2) → 1.09-1.12s (after commit 4)** — matching jt9's own real
  ~1.1s.
- Still 22/22 decodes throughout, zero regressions at every step.
- One new near-ceiling phantom observed after commit 1 (freq 2570.25 Hz,
  `hard_errors=30`, ~1 Hz from real strong `W1FC F5BZB` — spectral
  leakage). Same class of tradeoff already accepted in this file's
  `OSD_HARDERRORS_MAX` 22→36 history.

## Test plan

- [x] `cargo test --workspace --release --features full`: 100% pass at
      every commit, no regressions.
- [x] New differential test (`packed_elimination_matches_byte_reference`):
      packed rewrite bit-identical to frozen byte-per-bit reference.
- [x] `cargo fmt --check`, `cargo clippy --all-targets --features full
      -- -D warnings -D clippy::perf`: clean at every commit.
- [x] no_std/fixed-point feature-matrix builds: clean.
- [x] `ft8_qso3_apon_recall.rs` (`qso3_apon_subtract_jtdx_extras_diag`):
      6/6 JTDX extras, up from 5/6, maintained through all 4 commits.
- [x] Wall-clock probe (`issue_182_postfix_wallclock_check`,
      single-threaded): 1.27-1.30s → 1.09-1.12s.

Closes #182