### PR TITLE
perf(ft8,ft4): WSJT-X-faithful fine-sync tweak + fix FT4 subtract-refine regression (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -441,6 +441,139 @@
   regressions (full workspace `cargo test --release --features full`,
   `qso3_apon_subtract_jtdx_extras_diag` still 6/6 JTDX extras).
 
+- **`fine_refine_3stage` (`ft8/refine_fine.rs`) sped up ~45% by porting
+  WSJT-X's real Stage-B/C algorithm** (issue #182 follow-up). Pulling
+  real `jt9 -8 -d3`'s own `timer.out` breakdown found its BP+OSD stage
+  (`dec174_9`) was 65% of jt9's *own* total runtime — while our own
+  BP+OSD staircase (after the fixes above) was already ~2.5x faster
+  than jt9's, our `process_candidate` "prelude" (dominated by
+  `fine_refine_3stage`) still ran at ~2.2x jt9's own per-candidate rate
+  for the equivalent step. Root-caused by reading `lib/ft8/sync8d.f90`
+  and `lib/ft8/ft8b.f90:104-154` directly: our port's Stage-B/C
+  frequency sweep shifted the *entire* ~3200-sample `cd0` baseband
+  buffer per trial (11 trials/candidate, ~35,200 elements of work),
+  while WSJT-X's real algorithm tweaks only the **32-sample Costas
+  reference waveform** per trial (`ft8b.f90:133-140`'s `ctwk`,
+  multiplied into `sync8d.f90`'s cached `csync` before conjugating) and
+  never touches the data buffer at all — ~100x less arithmetic by
+  construction, not a missing optimization. `sync8d.f90`'s `save
+  first,twopi,csync` also confirmed WSJT-X caches its Costas reference
+  table once for the *entire process*, not once per candidate.
+
+  Two incremental fixes earlier in this same investigation (a
+  once-per-candidate Costas-table lookup, then an NCO-rotation
+  approximation for the data-shift with a tolerance-validated
+  differential test) had already cut wall-clock from ~966ms to ~753ms
+  single-threaded on `qso3_busy.wav` — real wins, but optimizing the
+  *wrong* algorithm faster rather than replacing it. Porting WSJT-X's
+  actual reference-tweak approach obsoletes both: the Costas table is
+  now cached for the process lifetime (`std::sync::OnceLock`, `no_std`
+  builds keep the once-per-candidate fallback), and the frequency sweep
+  tweaks a 32-element reference (`build_tweak`, mirroring `ctwk` exactly
+  — including the *non*-negated sign convention, since the tweak lands
+  on the conjugated reference rather than the data) instead of shifting
+  `cd0`. The old NCO-approximated `shift_freq` (and its `tmp` buffer
+  allocation) is deleted entirely — nothing left to call it.
+
+  Verified via a new differential test comparing the reference-tweak
+  formulation against a frozen copy of the exact data-shift approach it
+  replaces: measured max relative error `5.3e-6`, tighter than the
+  `1e-5` bound (this is floating-point reassociation of two
+  *exactly-equivalent* formulations, not an approximation — unlike the
+  NCO fix it replaces). All 5 pre-existing `fine_refine_3stage` tests
+  (including the sign-sensitive `freq_snap_positive_offset`/
+  `freq_snap_negative_offset`) pass unchanged. Also hoisted the same
+  "don't recompute a value that hasn't changed" fix into
+  `core::sync::fine_sync_power_per_block` (used for `sync_cv`,
+  shared across protocols) — FT8's 3 identical Costas sync blocks no
+  longer rebuild the same reference waveform 3x per call; content-equal
+  (not pointer-identity) caching keeps it correct for any `Protocol`.
+
+  **Result**: single-threaded blind decode of `qso3_busy.wav`:
+  **~753ms → ~682-719ms (avg ~700ms)** — ~39% faster than real
+  `jt9 -8 -d3`'s own ~1.1s total file decode time. Full workspace
+  regression (100% pass), `qso3_apon_subtract_jtdx_extras_diag` (still
+  6/6 JTDX extras), and the no_std/fixed-point feature matrix across
+  every protocol touched by the shared `core::sync.rs` change: all
+  clean.
+
+  Two smaller, related fixes landed in the same investigation: (1)
+  `process_candidate`'s prelude reordered so `sync_quality`'s
+  `nsync<=6` gate runs right after the cheap sync-symbol-only extraction
+  and before the expensive 58-data-symbol FFT extraction — `sync_quality`
+  never reads the data symbols, so the ~82% of candidates that fail this
+  gate on `qso3_busy.wav` no longer pay for work whose result is never
+  used. (2) `try_fallback`'s OSD dispatch now reuses the LLR variants
+  `process_one_candidate_inner`'s own BP staircase already computed
+  (`llra`/`llrd`/`llrb`/`llrc`) instead of a fresh `compute_llr`
+  recompute — that recompute previously only got skipped when an AP
+  hint was present (Gemini PR #81's original intent, avoiding a
+  *second* recompute between OSD and the AP loop), so blind decode (the
+  common case) always paid for nsym=3's full cost twice per
+  OSD-reaching candidate. Also cached `bp_step_select`'s
+  `MFSK_BP_KIND` env-var lookup (`std::sync::OnceLock`) instead of a
+  syscall-and-allocate `std::env::var` on every one of the up-to-4
+  BP calls per candidate — a debug-only A/B switch that never needs to
+  change mid-process.
+
+- **`core::dsp::subtract::refine_freq` sped up ~2.2x/call, fixing an FT4
+  decode-speed regression** (issue #182 follow-up). While re-verifying
+  every protocol's decode-speed benchmark row after the
+  `fine_refine_3stage` fix above (`core::sync.rs`'s cache hoist touches
+  every protocol), FT4's `decode_frame_subtract` golden-WAV wall-clock
+  turned out to have silently regressed from 48.8ms to ~526-576ms —
+  caused by an earlier, unrelated, already-merged commit (issues
+  #178-#180, migrating FT4 onto FT8's WSJT-X-faithful channel-aware LPF
+  subtract for recall-quality reasons) that was never re-benchmarked
+  afterward. Root-caused (not just documented) via temporary `Instant`
+  timers around the SIC subtract loop's two calls per accepted
+  candidate: `subtract_tones_lpf` was fine (already FFT-cached from
+  issue #180, <1ms/call); `refine_freq` cost ~35ms/call — essentially
+  the entire regression (×14 real decodes ≈ 490ms).
+
+  `refine_freq` grid-searches ±5Hz (FT4) / ±2.5Hz (FT8) at 0.1Hz
+  resolution to compensate for coarse-sync's bin-quantized carrier
+  estimate before subtracting. Every one of its ~50-100 evaluations
+  called `generate_iq` → `synth_complex_f32_into` fresh, fully
+  rebuilding the GFSK-shaped modulation (erf-based Gaussian pulse
+  table, `O(nsym·pulse_len)` per-symbol convolution, full `O(nwave)`
+  phase-integration + `sin`/`cos` loop) even though only the carrier
+  frequency differs between evaluations of one call — the same
+  "recompute something invariant across a search loop" bug pattern as
+  the `fine_refine_3stage` fix above, this time in the protocol-agnostic
+  subtract path shared by FT4 and FT8.
+
+  `generate_iq`'s carrier term is added uniformly to every sample before
+  phase integration, so `phi(k; f0) = phi_mod(k) + k·(2π·f0·dt)` — any
+  carrier is a pure linear phase ramp on top of the carrier-free
+  (tone-modulation-only) phase. Fixed by building the carrier-free
+  phasor once per `refine_freq` call and deriving each grid point via a
+  cheap per-sample NCO rotation + angle-addition instead of a full
+  resynthesis (`ls_amp_mag_tweaked`), with periodic rotor
+  renormalization to bound f32 drift over the ~59k (FT4) / ~334k (FT8)
+  sample buffers. Verified against the frozen full-resynthesis path
+  (`ls_amp_mag`, now `#[cfg(test)]`-only) with a differential test using
+  a combined absolute/relative tolerance — the LS amplitude has a comb
+  of deep correlation nulls a few tenths of a Hz apart where relative
+  error alone isn't meaningful — plus an argmax-preservation test
+  confirming the search still finds the true off-grid carrier.
+
+  **Result**: `refine_freq` ~35ms/call → ~15.7ms/call
+  (`RAYON_NUM_THREADS=1`, isolating per-call cost from thread count).
+  `decode_frame_subtract` real production wall-clock: multi-threaded
+  ~575.8ms → ~280ms, single-threaded ~893.6ms → ~602ms. Not a full
+  return to 48.8ms — the LPF subtract + freq-refine step is a
+  deliberate, permanent recall-quality cost (10/10 vs 0/10 on a
+  Rayleigh-faded-interferer scenario, `docs/notes/FT4_BENCHMARK.md`
+  section 13) that will always cost more than the pre-#178
+  constant-amplitude path; this fix removes the *redundant* part of
+  that cost, not the cost itself. Candidate count unchanged (31/31, no
+  redundancy) and recall unaffected (`ft4_wsjtx_sample_recall_vs_golden`
+  still 6/6). Also re-confirmed FT8's own SIC/JTDX golden suite
+  byte-identical (`qso3_apoff` 7/8+7 phantom, `qso3_jtdx` 18/18,
+  `qso3_apon` 6/6 JTDX extras) since `refine_freq` sits on FT8's subtract
+  path too.
+
 ### Changed
 
 - **Q65-60B/30A `decode_multi_period_for` sped up ~4×**

--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ collaborators), which remains the reference implementation — see
   FST4 is within 0.1-0.6 dB of WSJT-X's published thresholds across
   all five sub-modes; FT4's AWGN gap is ~0.3 dB; MSK144 matches a real
   WSJT-X `jt9` build on 25/28 AWGN cross-check cells exactly; FT8
-  scores 7/8 on the WSJT-X golden set and 17/18 against JTDX's; WSPR
-  and JT9 are 8/8 and 5/5 on their WSJT-X reference recordings. The
+  scores 7/8 on the WSJT-X golden set and 18/18 against JTDX's; WSPR
+  and JT9 are 8/8 and 7/7 on their WSJT-X reference recordings. The
   one exception is disclosed, not hidden: JT65 trails WSJT-X's
   stochastic `ftrsdap` decoder by ~7-8 dB at deep SNR, a gap that's
   root-caused but deliberately not closed (Q65 already covers the
@@ -347,11 +347,11 @@ sweep was generated and reproduced, in
 
 | Protocol | Golden-WAV recall | AWGN gap vs. WSJT-X |
 |----------|-------------------|----------------------|
-| FT8      | 7/8 (WSJT-X), 17/18 (JTDX) | CCIR fading gap closed |
+| FT8      | 7/8 (WSJT-X), 18/18 (JTDX) | CCIR fading gap closed |
 | FT4      | 6/6 | ~0.3 dB |
 | FST4     | 1/1 (FST4-60A) | 0.10-0.60 dB across 5 sub-modes |
 | WSPR     | 8/8 | matches published sensitivity floor |
-| JT9      | 5/5 | no measurable gap |
+| JT9      | 7/7 | no measurable gap |
 | JT65     | none available | **~7-8 dB** (known, deprioritized — see [#169](https://github.com/jl1nie/mfsk-core/issues/169)) |
 | Q65      | 2 real EME recordings | matches WSJT-X with AP hint; 2 sub-modes measurably beat WSJT-X's own plain decode |
 | MSK144   | 3/3 (incl. exact SNR match) | 25/28 cells exact match vs. a real `jt9` build |

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -23,7 +23,7 @@ Two kinds of numbers appear per protocol:
 | FT4      | 6/6 | AWGN ≈ −16.9 dB (WSJT-X: −17.5 dB, ~0.6 dB gap) | at parity |
 | FST4     | 1/1 (FST4-60A only) | 0.10-0.60 dB across 5 sub-modes | at parity |
 | WSPR     | 8/8 | AWGN 50% ≈ −29.8 dB, matches published sensitivity floor | at parity |
-| JT9      | 5/5 | AWGN 50% ≈ −26.3 dB, no measurable gap vs. `jt9 -9` | at parity |
+| JT9      | 7/7 | AWGN 50% ≈ −26.3 dB, no measurable gap vs. `jt9 -9` | at parity |
 | JT65     | none available | **~7-8 dB** at deep SNR | known gap, deprioritized |
 | Q65      | 2 real EME recordings | 0.2-1.4 dB vs. analytical target across 10 sub-modes; matches/beats WSJT-X's own decode with CQ-AP hint | at/above parity |
 | MSK144   | 3/3 (incl. exact SNR match) | AWGN 50% ≈ −5.2 to −5.8 dB, 25/28 cells exact match vs. a real `jt9` build | at parity |
@@ -39,7 +39,14 @@ Wall-clock time for one full decode call against each protocol's real
 WSJT-X-recorded golden WAV (see the recall sections below for which
 file and which decode function). Measured 2026-07-20, single run per
 row — treat as an order-of-magnitude reference, not an averaged
-benchmark.
+benchmark. Re-verified in full 2026-07-26 (each row re-run against its
+own protocol's real recall/timing harness) after the FT8 fine-sync
+refinement rewrite below (`fine_refine_3stage`'s reference-tweak
+port) and a cross-protocol Costas-reference caching hoist in
+`core::sync::fine_sync_power_per_block`: FT8 moved again (see its own
+row); every other row was confirmed unchanged within run-to-run noise
+(≤~15%) **except FT4**, which turned out to already be stale for an
+unrelated reason — see its row below.
 
 **Compute environment**: AMD Ryzen 9 9900X (12C/24T), 32 GB RAM,
 Ubuntu 24.04.2 LTS under WSL2 (kernel 6.6.87.2-microsoft-standard-WSL2),
@@ -49,9 +56,9 @@ is wall time on a many-core host, not a single-thread figure).
 
 | Protocol | Golden WAV | Slot length | Decode time |
 |---|---|---:|---:|
-| FT4 | 000000_000002.wav | 7.5 s | 0.049 s |
+| FT4 | 000000_000002.wav | 7.5 s | 0.28 s (was 0.049 s pre-#178-180, briefly regressed to ~0.53-0.58 s — see note) |
 | Q65-60D | 201212_1838.wav (10 GHz EME, fading metric) | 60 s | 0.08 s |
-| FT8 | qso3_busy.wav (16-signal busy band) | 15 s | 0.12 s |
+| FT8 | qso3_busy.wav (16-signal busy band) | 15 s | 0.10 s |
 | Q65-60B | 1296 MHz troposcatter ×1 slot (multi-period averaging) | 60 s | 0.12 s |
 | Q65-120D | 210117_0920.wav (rainscatter, fading metric) | 120 s | 0.12 s |
 | Q65-120E | 6 m ionoscatter (fading metric) | 120 s | 0.26 s |
@@ -69,6 +76,52 @@ Notes:
 - These are real-recording decode times, not synthetic sweeps — they
   reflect actual candidate density and search cost on real audio, not
   a clean-signal best case.
+- **FT8's `qso3_busy.wav` row dropped again, 0.12 s → ~0.10 s**
+  (2026-07-26), re-measured via `decode_block(&slot, 100.0, 3000.0,
+  1.3, DecodeDepth::BpVariantsAd, 15)` — the exact ship-config call
+  `ft8_qso3_apoff_recall.rs`'s `qso3_apoff_meets_wsjtx_golden_floor`
+  uses, matching this row's original 2026-07-25 methodology. Comes
+  from `fine_refine_3stage`'s rewrite (tweaks a small 32-sample Costas
+  reference waveform instead of shifting the whole 3200-sample `cd0`
+  baseband buffer per trial DF/DT, matching WSJT-X's real
+  `sync8d.f90`/`ft8b.f90:133-140` algorithm) plus a `core::sync.rs`
+  cross-protocol Costas-reference caching hoist — both trig-heavy-loop
+  fixes, not new algorithms. Recall byte-identical (7/8 golden, 7
+  phantom, 14 total on `qso3_apoff`; 18/18 on `qso3_jtdx`; 6/6 JTDX
+  AP-on multipass extras — see the FT8 section below for that last
+  number's own history). See `CHANGELOG.md` for the full investigation
+  (issue #182 follow-up).
+- **FT4's `000000_000002.wav` row was stale, then found regressed,
+  then fixed (issue #182).** First found 2026-07-26 while re-verifying
+  every row for the FT8 fix above: real wall-clock was ~0.53-0.58 s, not
+  the documented 0.049 s — not itself caused by that fix, bisected to
+  `7bc1684` / issues #178-#180 (already merged to `main` before this
+  pass started), which migrated FT4's `decode_frame_subtract` from a
+  cheap constant-amplitude subtract onto the same WSJT-X-faithful
+  channel-aware LPF subtract FT8 uses (`subtract_tones_lpf`,
+  `FT4_SUBTRACT`'s `lpf_half=700`/`GfskParams`) for recall-quality
+  reasons, without a corresponding re-measurement of this row.
+
+  Root cause: not `subtract_tones_lpf` (already FFT-cached, <1 ms/call)
+  but `core::dsp::subtract::refine_freq` — its ±5 Hz/0.1 Hz carrier
+  grid search (~101 evaluations/candidate) called `generate_iq` fresh
+  every evaluation, fully rebuilding the GFSK-shaped modulation
+  (erf-based pulse table, `O(nsym·pulse_len)` convolution, `O(nwave)`
+  `sin`/`cos` integration) even though only the carrier frequency
+  differs between evaluations — ~35 ms/call, ×14 real decodes ≈ 490 ms,
+  essentially the entire regression. Fixed by building the carrier-free
+  phasor once per call and applying each grid point via a cheap
+  per-sample NCO rotation instead of a full resynthesis
+  (`ls_amp_mag_tweaked`), verified against the frozen full-resynthesis
+  path with a differential + argmax-preservation test. `refine_freq`
+  dropped to ~15.7 ms/call; `decode_frame_subtract` wall-clock:
+  multi-threaded ~575.8 ms → ~280 ms, single-threaded ~893.6 ms →
+  ~602 ms. Not a full return to 48.8 ms — the LPF subtract + freq-refine
+  step is a deliberate, permanent recall-quality cost (see
+  `FT4_BENCHMARK.md` section 13's update for the full account); this fix
+  removes the *redundant* part of that cost, not the cost itself.
+  Candidate count unchanged (31, matching the 25× coarse-sync fix's own
+  numbers) and recall unaffected (still 6/6).
 - FT8's `qso3_busy.wav` was the outlier at **4.73 s** (busy band, 16
   simultaneous signals) until a profiling pass (2026-07-20) found the
   cost wasn't BP/OSD at all but `subtract_tones_lpf`'s successive-
@@ -346,10 +399,16 @@ trials) as a representative single sub-mode.
   same WAV, confirming it was always a real signal, just one
   mfsk-core's own broken SIC window was failing to clean up enough to
   reach. See issue #180 and PR #178 for the full investigation.
-- **Host AP-on multipass JTDX-extras: 5/6** via
-  `decode_frame_subtract_with_ap`. The remaining miss (`K1BZM DK8NE`,
-  fixed AP context `mycall=K1JT`/`hiscall=HA0DU`) needs a wider
-  AP-list / callsign hash table.
+- **Host AP-on multipass JTDX-extras: 6/6** via
+  `decode_frame_subtract_with_ap` (was 5/6 through 2026-07-25; the
+  remaining miss, `K1BZM DK8NE`, was never an AP-list breadth problem
+  — that hypothesis is retracted). Root cause was `osd_decode_npre1`
+  (WSJT-X's OSD `ndeep=2` dispatch) being fed raw channel LLR instead
+  of the BP-refined `bp_llr_zsum`, unlike WSJT-X's real
+  `decode174_91.f90` driver, which always hands OSD the post-BP LLR.
+  Fixed by threading the already-computed BP-refined LLR through to
+  the OSD call site instead of recomputing/reusing the pre-BP one
+  (issue [#182](https://github.com/jl1nie/mfsk-core/issues/182)).
 - **Embedded (M5StickS3, Xtensa LX7, fixed-point)**: 6/18 + 1 bonus =
   7 total on the same WAV, in ~1.19 s post-SlotEnd via the streaming
   pipeline. M5Stack Core2 (LX6): ~2.8 s.
@@ -373,8 +432,13 @@ Reproduce: `docs/notes/FT8_BENCHMARK.md`.
 ## FT4
 
 - **6/6 WSJT-X golden** (`samples/FT4/000000_000002.wav`), decoded in
-  **0.049 s** (was 1.20 s — see "Decode speed" notes above and
-  `FT4_BENCHMARK.md` section 13).
+  **~0.28 s** as of 2026-07-26 (briefly 0.049 s right after the
+  `getcandidates4.f90`-port fix, up from 1.20 s before it — see
+  "Decode speed" notes above and `FT4_BENCHMARK.md` section 13 — then a
+  later LPF-subtract migration re-inflated it to ~0.53-0.58 s via a
+  redundant-resynthesis bug in `refine_freq`, fixed same-day, issue
+  #182; see the "Decode speed" table's own FT4 note for the full
+  account).
 - **AWGN sensitivity gap: ~0.6 dB** (was ~0.3 dB before the coarse-sync
   algorithm swap, ~1.8 dB pre-0.7.3) — 50% recall crossing moved from
   −15.5 dB to −17.2 dB after a coherent Costas-block scorer fix and an
@@ -471,9 +535,13 @@ reference bandwidth).
 
 ## JT9
 
-- **5/5 WSJT-X golden** (`samples/JT9/130418_1742.wav`) via the full
+- **7/7 WSJT-X golden** (`samples/JT9/130418_1742.wav`) via the full
   WSJT-X-faithful softsym pipeline (`afc9` + `chkss2` + `xx0` mettab +
-  `sync9` per-freq collapse).
+  `sync9` per-freq collapse). This table previously said 5/5 — stale;
+  `jt9_wsjtx_samples.rs`'s own comment records 7/7 as of 2026-05-08,
+  well before this row was last touched. Found and corrected
+  2026-07-26 during an unrelated cross-protocol re-verification pass;
+  decode speed re-confirmed unchanged (0.33 s → 0.34 s, within noise).
 
 **AWGN sensitivity sweep** (`tests/jt9_sweep.rs`, `jt9sim`-driven,
 20 trials/SNR):

--- a/docs/notes/FT4_BENCHMARK.md
+++ b/docs/notes/FT4_BENCHMARK.md
@@ -601,6 +601,60 @@ accept, not a golden miss). `max_cand` in the golden test dropped
 2000→100 with byte-identical recall — 100 also happens to match WSJT-X's
 own `MAXCAND=100` in `ft4_decode.f90`, unplanned but reassuring symmetry.
 
+**Update (2026-07-26): this 48.8 ms figure went stale, then was fixed
+(issue #182).** Issues #178-#180 (see `FT8_BENCHMARK.md` section 8)
+migrated FT4's `decode_frame_subtract` from the cheap constant-amplitude
+subtract this section measured onto the same WSJT-X-faithful
+channel-aware LPF subtract FT8 uses, for recall-quality reasons — but
+this row was never re-measured afterward, and regressed to ~526-576 ms
+(median of several runs, both `decode_frame_subtract(&audio, 100.0,
+2700.0, 0.05, 100)` directly and via this file's own
+`ft4_diag_candidate_cost_split` instrumentation).
+
+Root cause (found by adding temporary `Instant` timers around the two
+calls the SIC subtract loop makes per accepted candidate): not
+`subtract_tones_lpf` itself (already FFT-cached from issue #180, <1 ms/
+call) but `core::dsp::subtract::refine_freq`, at ~35 ms/call × 14 real
+decodes ≈ 490 ms — essentially the entire regression. `refine_freq`
+grid-searches ±5 Hz at 0.1 Hz resolution (~101 evaluations) to compensate
+for `ft4_coarse_sync`'s ~5.2 Hz-bin carrier estimate before subtracting;
+every evaluation called `generate_iq` → `synth_complex_f32_into`, which
+rebuilt the **entire** GFSK-shaped modulation from scratch each time
+(erf-based Gaussian pulse table, `O(nsym·pulse_len)` per-symbol
+convolution, full `O(nwave)` phase-integration + `sin`/`cos` loop) even
+though only the carrier frequency differs between the 101 evaluations of
+one call — the same "recompute something invariant across a search
+loop" bug pattern as this file's `fine_refine_3stage` fix.
+
+**Fix**: `generate_iq`'s carrier term is added uniformly to every sample
+before phase integration, so `phi(k; f0) = phi_mod(k) + k·(2π·f0·dt)` —
+any carrier is a pure linear phase ramp on top of the carrier-free
+(tone-modulation-only) phase. `refine_freq` now builds the carrier-free
+phasor once per call and derives each grid point via a cheap per-sample
+NCO rotation + angle-addition instead of a full resynthesis
+(`ls_amp_mag_tweaked`, `core/dsp/subtract.rs`), with periodic rotor
+renormalization to bound f32 drift over the ~59k-sample buffer. Verified
+against the frozen full-resynthesis path with a differential test
+(`ls_amp_mag_tweaked_matches_full_resynthesis`, combined absolute/
+relative tolerance — the LS amplitude has a comb of deep correlation
+nulls a few tenths of a Hz apart, where relative error alone isn't a
+meaningful metric) and an argmax-preservation test
+(`refine_freq_finds_true_offgrid_carrier`).
+
+Measured result: `refine_freq` ~35 ms/call → ~15.7 ms/call
+(`RAYON_NUM_THREADS=1`, isolating the per-call cost from thread count).
+`decode_frame_subtract` real production wall-clock: multi-threaded
+(default rayon, matching how the original 48.8 ms figure was measured)
+~575.8 ms → **~280 ms**; single-threaded ~893.6 ms → **~602 ms**. Not a
+full return to 48.8 ms — the LPF subtract + frequency-refine step is a
+deliberate, permanent recall-quality addition (10/10 vs 0/10 on the
+Rayleigh-faded-interferer scenario noted above) that will always cost
+more than the pre-#178 constant-amplitude path; this fix removes the
+*redundant* part of that added cost, not the added cost itself. Candidate
+count unchanged (31/31, no redundancy) and recall unaffected (still
+6/6). See `BENCHMARKS.md`'s "Decode speed" table for the current
+headline number.
+
 **One real regression found and fixed, in the test suite, not
 production**: `ft4_roundtrip.rs`'s two clean-signal round-trip tests
 started failing. Root cause (confirmed via a temporary in-crate debug

--- a/docs/notes/FT8_BENCHMARK.md
+++ b/docs/notes/FT8_BENCHMARK.md
@@ -294,10 +294,24 @@ to FT4 (`subtractft4.f90` uses the identical window formula).
 
 **Result**: `ft8_qso3_jtdx_recall.rs` **17/18 → 18/18** — `WA2FZW DL5AXX
 RR73` now decodes, zero new phantoms, zero regressions on the WSJT-X
-8-entry golden (still 7/8, `K1BZM DK8NE` remains the one gap, unrelated —
-see the AP-list follow-up noted elsewhere in this doc) or the AP-on
-multipass JTDX-extras floor (still 5/6, same remaining miss). Full
-non-ignored suite green throughout.
+8-entry golden (still 7/8, `K1BZM DK8NE` remains the one gap — see
+issue #182 below) or the AP-on multipass JTDX-extras floor (still
+5/6, same remaining miss at the time). Full non-ignored suite green
+throughout.
+
+**Update (issue #182, 2026-07-26)**: `K1BZM DK8NE`'s gap was **not**
+an AP-list breadth problem, despite the "wider AP-list" hypothesis
+this section originally pointed to. Root cause was `osd_decode_npre1`
+(WSJT-X's OSD `ndeep=2` dispatch for this candidate's `q=11`) being
+fed raw channel LLR instead of the BP-refined `bp_llr_zsum`, unlike
+WSJT-X's real `decode174_91.f90` driver, which always hands OSD the
+post-BP LLR. Threading the already-computed BP-refined LLR through to
+the OSD call site (instead of recomputing/reusing the pre-BP one)
+closed it: the AP-on multipass JTDX-extras floor is now **6/6**, and
+the ship-config `ft8_qso3_jtdx_recall.rs` 18-entry check (which also
+routes through the same OSD call site) now recovers `K1BZM DK8NE`
+directly, no AP hint needed. See `CHANGELOG.md` for the full
+investigation.
 
 **Scope check — only in-band-SIC scenarios should move; section 4/7's
 `ft8_snr_sweep` was deliberately *not* re-run to confirm this.** That

--- a/docs/notes/ROADMAP.md
+++ b/docs/notes/ROADMAP.md
@@ -304,10 +304,13 @@ prose, see the closed issue / linked PR / `git log`):
 issue was reopened/re-closed across two separate pieces of work,
 FST4-60A golden lockdown then the remaining sub-modes.)
 
-The JTDX AP-on-multipass recall is now 5/6 (README's "What's solid"
-has the current number and mechanism) — the remaining miss
-(`K1BZM DK8NE`, for the test's fixed AP context) is a host-side win
-(needs a wider AP-list); no embedded issue filed yet.
+The JTDX AP-on-multipass recall is now 6/6 (was 5/6; see
+`BENCHMARKS.md`'s FT8 section for the current number and mechanism).
+The former remaining miss, `K1BZM DK8NE`, was closed by issue
+[#182](https://github.com/jl1nie/mfsk-core/issues/182) — an
+`osd_decode_npre1` LLR-fidelity gap (fed raw channel LLR instead of
+BP-refined `bp_llr_zsum`), not the AP-list breadth this note used to
+suspect.
 
 Architectural notes that did not graduate to issues:
 

--- a/mfsk-core/src/core/dsp/subtract.rs
+++ b/mfsk-core/src/core/dsp/subtract.rs
@@ -93,6 +93,12 @@ fn generate_iq(tones: &[u8], freq_hz: f32, cfg: &SubtractCfg) -> (Vec<f32>, Vec<
 /// LS amplitude magnitude for a candidate `(freq_hz, dt_sec)`. Returns
 /// `sqrt(a² + b²)` where `(a, b)` are the cos/sin LS projections of
 /// `audio` onto the GFSK reference at `freq_hz`. Higher = closer match.
+///
+/// `refine_freq` no longer calls this directly (see
+/// [`ls_amp_mag_tweaked`]) — kept `#[cfg(test)]`-only as the frozen,
+/// trusted full-resynthesis reference its differential test compares
+/// against.
+#[cfg(test)]
 fn ls_amp_mag(audio: &[i16], tones: &[u8], freq_hz: f32, dt_sec: f32, cfg: &SubtractCfg) -> f32 {
     let (w_cos, w_sin) = generate_iq(tones, freq_hz, cfg);
     let signed_start = ((cfg.base_offset_s + dt_sec) * cfg.sample_rate).round() as i64;
@@ -123,6 +129,97 @@ fn ls_amp_mag(audio: &[i16], tones: &[u8], freq_hz: f32, dt_sec: f32, cfg: &Subt
     ((a * a + b * b) as f32).sqrt()
 }
 
+/// Number of samples between rotor-magnitude renormalizations in
+/// [`ls_amp_mag_tweaked`]'s incremental NCO. Bounds f32 rounding drift
+/// over the ~59k (FT4) / ~334k (FT8) sample buffers `refine_freq`
+/// sweeps; cheap relative to the multiply-adds it guards (one `norm()`
+/// + divide every 256 samples).
+const NCO_RESYNC_SAMPLES: usize = 256;
+
+/// Same LS amplitude magnitude as [`ls_amp_mag`], but takes a
+/// precomputed carrier-free (`freq_hz = 0.0`) reference phasor
+/// `(base_cos, base_sin)` and applies `freq_hz` via a cheap per-sample
+/// NCO rotation instead of resynthesizing the whole GFSK waveform.
+///
+/// Valid because `generate_iq`'s carrier term is added *uniformly* to
+/// every entry of its internal phase-rate array before integration, so
+/// `phi(k; f0) = phi_mod(k) + k · (2π · f0 · dt)` — i.e. any carrier
+/// just adds a pure linear phase ramp on top of the carrier-free
+/// (tone-modulation-only) phase `phi_mod(k)` that `base_cos`/`base_sin`
+/// already encode. Rotating by that ramp via `nco(k) = exp(j · k · 2π ·
+/// f0 · dt)` and combining via the angle-addition identities
+/// (`cos(a+b)`, `sin(a+b)`) reproduces `generate_iq(tones, f0, cfg)`
+/// without repeating its `O(nsym · pulse_len)` Gaussian-pulse
+/// convolution or its `O(nwave)` `sin`/`cos` integration — both
+/// independent of `f0`, and (measured) the dominant cost of
+/// `refine_freq`'s ~50-100-point frequency grid search (issue #182:
+/// FT4's `decode_frame_subtract` regressed from 48.8ms to ~530ms after
+/// issues #178-180 wired `refine_freq` into FT4's subtract path; ~35ms
+/// of that was this resynthesis, repeated per real decode).
+fn ls_amp_mag_tweaked(
+    audio: &[i16],
+    base_cos: &[f32],
+    base_sin: &[f32],
+    freq_hz: f32,
+    dt_sec: f32,
+    dt: f32,
+    cfg: &SubtractCfg,
+) -> f32 {
+    let signed_start = ((cfg.base_offset_s + dt_sec) * cfg.sample_rate).round() as i64;
+    let (audio_off, ref_off) = if signed_start < 0 {
+        (0usize, (-signed_start) as usize)
+    } else {
+        (signed_start as usize, 0usize)
+    };
+    if ref_off >= base_cos.len() {
+        return 0.0;
+    }
+    let len = (base_cos.len() - ref_off).min(audio.len().saturating_sub(audio_off));
+    if len == 0 {
+        return 0.0;
+    }
+
+    let step_phase = 2.0 * PI * freq_hz * dt;
+    let (step_cos, step_sin) = (step_phase.cos(), step_phase.sin());
+    // Seed the rotor at absolute index `ref_off` (one trig call), then
+    // advance it by incremental complex multiply — matching the
+    // absolute-index carrier phase `generate_iq(tones, freq_hz, cfg)`
+    // would have produced at the same position.
+    let seed_phase = step_phase * ref_off as f32;
+    let (mut nco_re, mut nco_im) = (seed_phase.cos(), seed_phase.sin());
+
+    let (mut na, mut nb, mut da, mut db) = (0.0f64, 0.0f64, 0.0f64, 0.0f64);
+    for i in 0..len {
+        let bc = base_cos[ref_off + i];
+        let bs = base_sin[ref_off + i];
+        let c = bc * nco_re - bs * nco_im;
+        let s = bs * nco_re + bc * nco_im;
+
+        let rx = audio[audio_off + i] as f64;
+        na += rx * c as f64;
+        nb += rx * s as f64;
+        da += (c * c) as f64;
+        db += (s * s) as f64;
+
+        let (new_re, new_im) = (
+            nco_re * step_cos - nco_im * step_sin,
+            nco_re * step_sin + nco_im * step_cos,
+        );
+        nco_re = new_re;
+        nco_im = new_im;
+        if (i + 1) % NCO_RESYNC_SAMPLES == 0 {
+            let norm = (nco_re * nco_re + nco_im * nco_im).sqrt();
+            if norm > f32::EPSILON {
+                nco_re /= norm;
+                nco_im /= norm;
+            }
+        }
+    }
+    let a = if da > 0.0 { na / da } else { 0.0 };
+    let b = if db > 0.0 { nb / db } else { 0.0 };
+    ((a * a + b * b) as f32).sqrt()
+}
+
 /// Refine the carrier frequency around `freq_hz_init` by grid search,
 /// returning the freq that maximises the LS amplitude magnitude of the
 /// GFSK reference vs `audio`.
@@ -139,7 +236,9 @@ fn ls_amp_mag(audio: &[i16], tones: &[u8], freq_hz: f32, dt_sec: f32, cfg: &Subt
 /// host f32, embedded paths may use coarser steps for speed).
 ///
 /// Mirrors WSJT-X's `ft8b.f90` `sync8d` + `ctwk` step (32-element
-/// twiddle table over ±2.5 Hz).
+/// twiddle table over ±2.5 Hz). Builds the carrier-free GFSK reference
+/// once (`ls_amp_mag_tweaked`) rather than resynthesizing it at every
+/// grid step — see that function's doc comment for why this is safe.
 pub fn refine_freq(
     audio: &[i16],
     tones: &[u8],
@@ -150,12 +249,23 @@ pub fn refine_freq(
     step_hz: f32,
 ) -> f32 {
     debug_assert!(cfg.gfsk.is_some(), "refine_freq requires GFSK shaping");
+    let (base_cos, base_sin) = generate_iq(tones, 0.0, cfg);
+    let dt = 1.0 / cfg.sample_rate;
     let mut best_freq = freq_hz_init;
-    let mut best_amp = ls_amp_mag(audio, tones, freq_hz_init, dt_sec, cfg);
+    let mut best_amp =
+        ls_amp_mag_tweaked(audio, &base_cos, &base_sin, freq_hz_init, dt_sec, dt, cfg);
     let mut df = -radius_hz;
     while df <= radius_hz {
         if df.abs() > f32::EPSILON {
-            let a = ls_amp_mag(audio, tones, freq_hz_init + df, dt_sec, cfg);
+            let a = ls_amp_mag_tweaked(
+                audio,
+                &base_cos,
+                &base_sin,
+                freq_hz_init + df,
+                dt_sec,
+                dt,
+                cfg,
+            );
             if a > best_amp {
                 best_amp = a;
                 best_freq = freq_hz_init + df;
@@ -1012,6 +1122,150 @@ mod tests {
         assert!(
             drop_db < -30.0,
             "positive-DT subtract drop only {drop_db:.1} dB"
+        );
+    }
+
+    fn ft4_like_cfg() -> SubtractCfg {
+        SubtractCfg {
+            sample_rate: 12_000.0,
+            tone_spacing_hz: 20.833,
+            samples_per_symbol: 576,
+            base_offset_s: 0.5,
+            gfsk: Some(GfskParams {
+                bt: 1.0,
+                hmod: 1.0,
+                ramp_samples: 576 / 8,
+            }),
+        }
+    }
+
+    fn ft8_like_cfg() -> SubtractCfg {
+        SubtractCfg {
+            sample_rate: 12_000.0,
+            tone_spacing_hz: 6.25,
+            samples_per_symbol: 1920,
+            base_offset_s: 0.5,
+            gfsk: Some(GfskParams {
+                bt: 2.0,
+                hmod: 1.0,
+                ramp_samples: 1920 / 8,
+            }),
+        }
+    }
+
+    /// `ls_amp_mag_tweaked`'s NCO-rotation fast path must match
+    /// `ls_amp_mag`'s full-resynthesis result (issue #182's FT4
+    /// decode-speed fix) within a tight, measured relative tolerance
+    /// across both protocols' real `refine_freq` sweep ranges.
+    #[test]
+    fn ls_amp_mag_tweaked_matches_full_resynthesis() {
+        // `ls_amp_mag`'s LS amplitude has a comb of deep nulls a few
+        // tenths of a Hz apart (an inherent property of correlating a
+        // GFSK reference against itself at a near-but-not-exact carrier,
+        // not an artifact of either implementation) where a purely
+        // relative-error metric blows up even though the *absolute*
+        // discrepancy between the two implementations stays tiny
+        // relative to the signal's own amplitude scale. Use a combined
+        // absolute-or-relative tolerance, with the absolute floor tied
+        // to the known synth amplitude below (measured: away from
+        // nulls, relative error is ~0.001-2.3%; at nulls, absolute error
+        // stays under ~0.2% of the synth amplitude).
+        const AMPLITUDE: f32 = 8000.0;
+        const ABS_TOL: f32 = 1e-3 * AMPLITUDE;
+        const REL_TOL: f32 = 3e-2;
+        let mut max_abs_err = 0.0f32;
+        let mut max_rel_err = 0.0f32;
+
+        for (cfg, radius_hz, nsym) in [(ft4_like_cfg(), 5.0f32, 103), (ft8_like_cfg(), 2.5f32, 79)]
+        {
+            let tones: Vec<u8> = (0..nsym).map(|k| ((k * 3 + 1) % 8) as u8).collect();
+            let samples = {
+                let n = tones.len() * cfg.samples_per_symbol;
+                let mut out = vec![0.0f32; n];
+                let gfsk_cfg = crate::core::dsp::gfsk::GfskCfg {
+                    sample_rate: cfg.sample_rate,
+                    samples_per_symbol: cfg.samples_per_symbol,
+                    bt: cfg.gfsk.unwrap().bt,
+                    hmod: cfg.gfsk.unwrap().hmod,
+                    ramp_samples: cfg.gfsk.unwrap().ramp_samples,
+                };
+                crate::core::dsp::gfsk::synth_f32_into(
+                    &mut out, &tones, 1500.0, AMPLITUDE, &gfsk_cfg,
+                );
+                out
+            };
+            let offset = (cfg.base_offset_s * cfg.sample_rate) as usize;
+            let mut audio = vec![0i16; samples.len() + offset + 4000];
+            for (i, &s) in samples.iter().enumerate() {
+                audio[offset + i] = s.clamp(-32_768.0, 32_767.0) as i16;
+            }
+
+            let (base_cos, base_sin) = generate_iq(&tones, 0.0, &cfg);
+            let dt = 1.0 / cfg.sample_rate;
+
+            for dt_sec in [0.0f32, 0.15, -0.2] {
+                let mut df = -radius_hz;
+                while df <= radius_hz {
+                    let freq = 1500.0 + df;
+                    let expected = ls_amp_mag(&audio, &tones, freq, dt_sec, &cfg);
+                    let actual =
+                        ls_amp_mag_tweaked(&audio, &base_cos, &base_sin, freq, dt_sec, dt, &cfg);
+                    let abs_err = (actual - expected).abs();
+                    let rel_err = abs_err / expected.abs().max(f32::EPSILON);
+                    max_abs_err = max_abs_err.max(abs_err);
+                    if abs_err > ABS_TOL && rel_err > REL_TOL {
+                        panic!(
+                            "df={df} dt_sec={dt_sec}: expected={expected} actual={actual} \
+                             abs_err={abs_err} (tol {ABS_TOL}) rel_err={rel_err} (tol {REL_TOL})"
+                        );
+                    }
+                    if abs_err > ABS_TOL {
+                        // Away from a null (else the ABS_TOL branch above
+                        // would have already accepted it) — relative
+                        // error is meaningful here.
+                        max_rel_err = max_rel_err.max(rel_err);
+                    }
+                    df += 0.1;
+                }
+            }
+        }
+        eprintln!("MEASURED max_abs_err={max_abs_err} max_rel_err (away from nulls)={max_rel_err}");
+    }
+
+    /// `refine_freq` must still find the true off-grid carrier after
+    /// switching to the NCO-tweaked fast path, not just stay numerically
+    /// close to the old per-step resynthesis on average.
+    #[test]
+    fn refine_freq_finds_true_offgrid_carrier() {
+        let cfg = ft4_like_cfg();
+        let tones: Vec<u8> = (0..103).map(|k| ((k * 5 + 2) % 8) as u8).collect();
+        let freq_hz_init = 1500.0f32;
+        let freq_true = freq_hz_init + 1.7;
+
+        let samples = {
+            let n = tones.len() * cfg.samples_per_symbol;
+            let mut out = vec![0.0f32; n];
+            let g = cfg.gfsk.unwrap();
+            let gfsk_cfg = crate::core::dsp::gfsk::GfskCfg {
+                sample_rate: cfg.sample_rate,
+                samples_per_symbol: cfg.samples_per_symbol,
+                bt: g.bt,
+                hmod: g.hmod,
+                ramp_samples: g.ramp_samples,
+            };
+            crate::core::dsp::gfsk::synth_f32_into(&mut out, &tones, freq_true, 8000.0, &gfsk_cfg);
+            out
+        };
+        let offset = (cfg.base_offset_s * cfg.sample_rate) as usize;
+        let mut audio = vec![0i16; samples.len() + offset + 4000];
+        for (i, &s) in samples.iter().enumerate() {
+            audio[offset + i] = s.clamp(-32_768.0, 32_767.0) as i16;
+        }
+
+        let refined = refine_freq(&audio, &tones, freq_hz_init, 0.0, &cfg, 5.0, 0.1);
+        assert!(
+            (refined - freq_true).abs() <= 0.1 + 1e-3,
+            "refine_freq picked {refined}, expected within 0.1 Hz of true carrier {freq_true}"
         );
     }
 }

--- a/mfsk-core/src/core/sync.rs
+++ b/mfsk-core/src/core/sync.rs
@@ -633,17 +633,34 @@ pub fn fine_sync_power<P: Protocol>(cd0: &[Complex<f32>], i0: i32) -> f32 {
 }
 
 /// Per-block Costas correlation powers for diagnostics and the FT8 double-sync.
+///
+/// Caches `make_costas_ref`'s result across consecutive blocks that
+/// share the same (content-equal) `pattern` — FT8's 3 sync blocks all
+/// use the identical Costas array, so this avoids rebuilding the same
+/// `Vec<Vec<Complex<f32>>>` reference waveform 3x per call for no
+/// reason. Content equality (not pointer identity) so it's correct for
+/// any `Protocol`, not just ones whose blocks happen to share a
+/// `&'static` allocation (issue #182 follow-up — same "don't recompute
+/// a value that hasn't changed" pattern as `refine_fine.rs`'s Costas
+/// reference table, scoped to this smaller, protocol-generic case).
 pub fn fine_sync_power_per_block<P: Protocol>(cd0: &[Complex<f32>], i0: i32) -> Vec<f32> {
+    type CachedCsync = (&'static [u8], Vec<Vec<Complex<f32>>>);
     let d = SyncDims::of::<P>();
-    P::SYNC_MODE
-        .blocks()
-        .iter()
-        .map(|block| {
-            let csync = make_costas_ref(block.pattern, d.ds_spb);
-            let start = i0 + (block.start_symbol as usize * d.ds_spb) as i32;
-            score_costas_block(cd0, &csync, d.ds_spb, start)
-        })
-        .collect()
+    let blocks = P::SYNC_MODE.blocks();
+    let mut out = Vec::with_capacity(blocks.len());
+    let mut last: Option<CachedCsync> = None;
+    for block in blocks {
+        let csync = match &last {
+            Some((p, c)) if *p == block.pattern => c,
+            _ => {
+                last = Some((block.pattern, make_costas_ref(block.pattern, d.ds_spb)));
+                &last.as_ref().unwrap().1
+            }
+        };
+        let start = i0 + (block.start_symbol as usize * d.ds_spb) as i32;
+        out.push(score_costas_block(cd0, csync, d.ds_spb, start));
+    }
+    out
 }
 
 /// Parabolic peak interpolation: returns `(subsample_offset in [-0.5, 0.5], interpolated_peak)`.

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -544,6 +544,18 @@ fn process_candidate(
         alloc::vec![[crate::core::scalar::Cmplx::<f32>::default(); 8]; 79]
             .try_into()
             .unwrap();
+    // `sync_quality` only reads the 21 sync-block symbol positions
+    // (`P::SYNC_MODE.blocks()`, `core::llr::sync_quality_generic`) —
+    // never the 58 data symbols. Gate on `nsync <= 6` right after the
+    // `SyncOnly` fill, *before* paying for `DataOnly`'s per-symbol
+    // 32-pt FFTs (58 of the 79 symbols — the bulk of this function's
+    // per-candidate cost) and its own `downsample_cached` call. On
+    // `qso3_busy.wav`'s reference decode, ~82% of the up-to-1200
+    // candidates this function sees across a full staged decode get
+    // rejected at this gate — profiling found the pre-gate work was
+    // costing nearly as much in aggregate as the entire BP+OSD
+    // staircase combined, almost all of it wasted on candidates whose
+    // `DataOnly` symbols are never looked at (issue #182 follow-up).
     crate::ft8::decode_block::fill_symbol_spectra(
         &mut cs_raw,
         audio,
@@ -552,6 +564,10 @@ fn process_candidate(
         crate::ft8::decode_block::SymMask::SyncOnly,
         Some(fft_cache),
     );
+    let nsync = sync_quality(&cs_raw);
+    if nsync <= 6 {
+        return None;
+    }
     crate::ft8::decode_block::fill_symbol_spectra(
         &mut cs_raw,
         audio,
@@ -560,10 +576,6 @@ fn process_candidate(
         crate::ft8::decode_block::SymMask::DataOnly,
         Some(fft_cache),
     );
-    let nsync = sync_quality(&cs_raw);
-    if nsync <= 6 {
-        return None;
-    }
 
     // Per-candidate decode delegated to the unified inner — same
     // staircase + OSD + AP loop the embedded `decode_block` path

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1023,7 +1023,15 @@ fn bp_step_select<T: crate::core::scalar::LlrScalar>(
     max_iter: u32,
     verify: Option<fn(&[u8]) -> bool>,
 ) -> Option<crate::fec::ldpc::bp::BpResult> {
-    if std::env::var("MFSK_BP_KIND").as_deref() == Ok("nms") {
+    // `std::env::var` is a locked, allocating lookup — reading it fresh
+    // on every call (up to 4x per candidate: Steps 1/d/b/c) measurably
+    // added up across the hundreds of candidates a busy-band decode
+    // processes. Cache the one-time result; this env var is a debug
+    // A/B-comparison switch (see doc comment above), never expected to
+    // change mid-process. `once_cell` isn't a dependency here — a
+    // `std::sync::OnceLock<bool>` is sufficient and std-only.
+    static USE_NMS: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    if *USE_NMS.get_or_init(|| std::env::var("MFSK_BP_KIND").as_deref() == Ok("nms")) {
         return crate::fec::ldpc::bp::bp_decode_nms_with_scratch::<T>(
             bp_scratch, llr, None, max_iter, verify, NMS_ALPHA,
         );
@@ -1433,6 +1441,7 @@ pub(super) const WSJTX_NHARDERRORS_MAX: u32 = 36;
 ///   gain attenuation; embedded passes 0.0).
 #[allow(clippy::too_many_arguments)]
 #[allow(unused_variables)] // ap_hint / strictness only used under #[cfg(feature = "fft-rustfft")]
+#[allow(unused_assignments)] // llrb_arr/llrc_arr only read back under #[cfg(feature = "fft-rustfft")]
 pub(in crate::ft8) fn process_one_candidate_inner(
     cs_scratch: &[[Cmplx<f32>; 8]; 79],
     cand: &SyncCandidate,
@@ -1510,51 +1519,92 @@ pub(in crate::ft8) fn process_one_candidate_inner(
             accepted = Some((bp, 3));
         }
     }
-    // Variant b: lazy nsym=2 only.
+    // Variant b: lazy nsym=2 only. Kept outside the `if` (as
+    // `Option`) so a `BpAllOsd` candidate that falls through to Step 3
+    // can reuse it — see the `prefetched_llr` assembly below. Only
+    // read back under `fft-rustfft` (that assembly is gated on it);
+    // `fft-extern`/no_std builds compute and discard it — see the
+    // function's own `#[allow(unused_assignments)]`.
+    let mut llrb_arr: Option<[LlrT; LDPC_N]> = None;
     if accepted.is_none() && run_b {
-        let llrb_arr: [LlrT; LDPC_N] =
-            super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 2);
-        let bp_b = bp_step_select::<LlrT>(bp_scratch, &llrb_arr, bp_max_iter, Some(check_crc14));
+        let arr: [LlrT; LDPC_N] = super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 2);
+        let bp_b = bp_step_select::<LlrT>(bp_scratch, &arr, bp_max_iter, Some(check_crc14));
         if let Some(bp) = bp_b
             && bp.hard_errors <= WSJTX_NHARDERRORS_MAX
         {
             accepted = Some((bp, 1));
         }
+        llrb_arr = Some(arr);
     }
     // Variant c: lazy nsym=3 (the expensive one). Gated to the
     // host-default depths — `BpAllNoNsym3` / `BpVariantsAd` skip it
     // as the embedded post-SlotEnd dominant cost (~5× variant `b`)
-    // on busy-band reference WAVs (see DecodeDepth doc).
+    // on busy-band reference WAVs (see DecodeDepth doc). Same
+    // `Option`-hoist (and `fft-rustfft`-only readback) as `llrb_arr`
+    // above, for the same reason.
+    let mut llrc_arr: Option<[LlrT; LDPC_N]> = None;
     if accepted.is_none() && run_c {
-        let llrc_arr: [LlrT; LDPC_N] =
-            super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 3);
-        let bp_c = bp_step_select::<LlrT>(bp_scratch, &llrc_arr, bp_max_iter, Some(check_crc14));
+        let arr: [LlrT; LDPC_N] = super::super::llr::compute_llr_partial::<LlrT>(cs_scratch, 3);
+        let bp_c = bp_step_select::<LlrT>(bp_scratch, &arr, bp_max_iter, Some(check_crc14));
         if let Some(bp) = bp_c
             && bp.hard_errors <= WSJTX_NHARDERRORS_MAX
         {
             accepted = Some((bp, 2));
         }
+        llrc_arr = Some(arr);
     }
 
-    // Pre-compute the nsym=3 LLR once if BOTH the OSD fallback AND
-    // the AP loop will run on this candidate — both stages use the
-    // same `compute_llr(cs_scratch)` output and recomputing it twice
-    // is the dominant per-candidate cost when OSD fails into AP
-    // (Gemini PR #81 review). Gate: `accepted.is_none()` (Steps 1-2
-    // failed), `depth = BpAllOsd`, `q >= 12` (OSD will fire), and
-    // `ap_hint.is_some()` (AP will follow on OSD failure). On the
-    // embedded path `ap_hint` is always `None`, so this entire
-    // pre-compute is constant-folded away.
+    // Pre-compute the f32 `LlrSet` OSD needs, reusing Steps 1-2's own
+    // llra/llrd/llrb/llrc instead of a fresh `compute_llr(cs_scratch)`
+    // call whenever possible (issue #182 follow-up). For `BpAllOsd`
+    // depth, `run_b`/`run_c` are unconditionally `true`, so if we've
+    // reached this point with `accepted.is_none()` then *both*
+    // `llrb_arr` and `llrc_arr` above were computed — nothing here was
+    // ever skipped by an earlier success (that would have short-
+    // circuited `accepted` to `Some` already). On the non-`fixed-point`
+    // host build `LlrT = f32`, so `llr_a_fast`/`llrb_arr`/`llrc_arr`
+    // are *already* the exact `f32` values OSD needs — no recompute.
+    //
+    // Previously this only ever fired `if ap_hint.is_some()` (Gemini PR
+    // #81 review — avoiding a *second* `compute_llr` when both OSD and
+    // the AP loop would otherwise each compute their own), which meant
+    // blind decode (`ap_hint = None`, the common case) always paid for
+    // a full redundant `compute_llr(cs_scratch)` recompute inside
+    // `try_fallback` itself — nsym=3 alone is ~80% of that call's cost,
+    // paid twice (once here piecewise, once again wholesale) for every
+    // single candidate that reached OSD. Measured on `qso3_busy.wav`
+    // blind decode: this was a large fraction of OSD's real-world cost
+    // that a synthetic-LLR microbenchmark (which calls `osd_setup`/
+    // `osd_npre1_pass` directly, bypassing this recompute entirely)
+    // couldn't see.
     #[cfg(feature = "fft-rustfft")]
-    let prefetched_llr: Option<super::super::llr::LlrSet<f32>> = if accepted.is_none()
-        && matches!(depth, DecodeDepth::BpAllOsd)
-        && q >= 12
-        && ap_hint.is_some()
-    {
-        Some(super::super::llr::compute_llr(cs_scratch))
-    } else {
-        None
-    };
+    let prefetched_llr: Option<super::super::llr::LlrSet<f32>> =
+        if accepted.is_none() && matches!(depth, DecodeDepth::BpAllOsd) && q > 6 {
+            #[cfg(not(feature = "fixed-point"))]
+            {
+                match (llrb_arr, llrc_arr) {
+                    (Some(llrb), Some(llrc)) => Some(super::super::llr::LlrSet {
+                        llra: llr_a_fast.llra,
+                        llrb,
+                        llrc,
+                        llrd: llr_a_fast.llrd,
+                    }),
+                    // Defensive fallback — shouldn't happen for
+                    // `BpAllOsd` (see reasoning above), but a fresh
+                    // compute is still correct if it ever does.
+                    _ => Some(super::super::llr::compute_llr(cs_scratch)),
+                }
+            }
+            #[cfg(feature = "fixed-point")]
+            {
+                // Steps 1-2's llrb_arr/llrc_arr are Q11i16 here, not
+                // directly reusable as the f32 LlrSet OSD needs —
+                // still must recompute.
+                Some(super::super::llr::compute_llr(cs_scratch))
+            }
+        } else {
+            None
+        };
     #[cfg(not(feature = "fft-rustfft"))]
     let prefetched_llr: Option<super::super::llr::LlrSet<f32>> = None;
 

--- a/mfsk-core/src/ft8/refine_fine.rs
+++ b/mfsk-core/src/ft8/refine_fine.rs
@@ -8,33 +8,94 @@
 //! Three stages:
 //!
 //! 1. ±10 idt sample search at the candidate's initial frequency, using
-//!    `fine_sync_power` (= sync8d-equivalent Costas correlation power
-//!    summed over the 3 sync blocks).
+//!    `fine_sync_power_signed` (= sync8d-equivalent Costas correlation
+//!    power summed over the 3 sync blocks).
 //! 2. ±5 ifr × 0.5 Hz frequency sweep at the Stage-1 best `ibest`.
-//!    Applies a phasor `exp(-j·2π·delf·k·dt2)` to a working copy of cd0
-//!    (mathematically identical to WSJT-X's per-symbol `ctwk` multiplied
-//!    against the Costas reference inside `sync8d`). Tied score is broken
-//!    by smaller |delf| (favour the original frequency).
-//! 3. ±4 idt re-search on the frequency-shifted cd0.
+//!    Applies a 32-sample phasor tweak `exp(j·2π·delf·k·dt2)` to the
+//!    *reference* Costas waveform (mirrors WSJT-X's real `ctwk`
+//!    construction, `ft8b.f90:133-140`, multiplied against the cached
+//!    Costas reference inside `sync8d.f90`) — `cd0` itself is never
+//!    shifted. Tied score is broken by smaller |delf| (favour the
+//!    original frequency).
+//! 3. ±4 idt re-search, tweaked by the winning Stage-2 `delfbest`.
 //!
 //! The output `dt_sec` follows the host convention
 //! `(ibest - 0.5) / 200`. The caller decides whether to also accept
 //! sub-sample dt refinement (parabolic) on the final score; this module
 //! returns integer dt for closer match to WSJT-X.
 
-use alloc::vec;
-use alloc::vec::Vec;
-
 use num_complex::Complex;
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
+
+/// Precomputed reference phasor table for [`fine_sync_power_signed`]'s
+/// inner correlation loop: `ref_table[tone][j] = exp(i * 2π * tone/32 * j)`
+/// for `tone in 0..8`, `j in 0..32`. These 8×32 = 256 values are the
+/// *entire* space `fine_sync_power_signed` ever needs — `tone` is always
+/// one of the 8 fixed Costas tones (`ft8::params::COSTAS`) and `j` always
+/// runs 0..32 (`DS_SPB`), never anything candidate- or trial-dependent.
+/// Building this once per [`fine_refine_3stage`] call instead of
+/// recomputing `cos`/`sin` fresh on every one of its 41 calls (Stage
+/// A/B/C combined) cuts ~27,552 transcendental-function evaluations per
+/// candidate down to 256 — same values, not an approximation (issue
+/// #182 follow-up).
+type CostasRefTable = [[Complex<f32>; 32]; 8];
+
+fn build_costas_ref_table() -> CostasRefTable {
+    const DS_SPB: usize = 32;
+    let mut table = [[Complex::new(0.0_f32, 0.0); DS_SPB]; 8];
+    for (tone, row) in table.iter_mut().enumerate() {
+        let dphi = core::f32::consts::TAU * (tone as f32) / (DS_SPB as f32);
+        let mut phi = 0.0_f32;
+        for slot in row.iter_mut() {
+            *slot = Complex::new(phi.cos(), phi.sin());
+            phi += dphi;
+            if phi > core::f32::consts::PI {
+                phi -= core::f32::consts::TAU;
+            }
+        }
+    }
+    table
+}
+
+/// Process-lifetime-cached accessor for [`build_costas_ref_table`]
+/// (issue #182 follow-up) — mirrors WSJT-X `sync8d.f90`'s own
+/// `data first/.true.` + `save first,twopi,csync`: the reference table
+/// is computed **once for the whole process**, not once per candidate.
+/// Host (`std`) builds get the full match via `OnceLock`; `no_std`
+/// builds fall back to a fresh build per call (Phase 1's already-good
+/// once-per-candidate — no `OnceLock` without `std`, and embedded isn't
+/// this speed work's target).
+#[cfg(feature = "std")]
+fn costas_ref_table() -> &'static CostasRefTable {
+    static TABLE: std::sync::OnceLock<CostasRefTable> = std::sync::OnceLock::new();
+    TABLE.get_or_init(build_costas_ref_table)
+}
+#[cfg(not(feature = "std"))]
+fn costas_ref_table() -> CostasRefTable {
+    build_costas_ref_table()
+}
 
 /// Signed-`i` analogue of WSJT-X `sync8d`. Mirrors WSJT-X
 /// `sync8d.f90:43-45`: each Costas block contributes 0 when its
 /// start sample falls outside the cd0 window. This is the right
 /// behaviour for a candidate whose dt < -0.5 s — block 0 sits in
 /// truncated audio but blocks 1 / 2 are still valid.
-fn fine_sync_power_signed(cd0: &[Complex<f32>], i: i32) -> f32 {
+///
+/// `tweak`, when present, mirrors `sync8d.f90`'s `itwk=1` path
+/// (`csync2=ctwk*csync2`) — applied to the 32-sample *reference*
+/// waveform, not to `cd0`. This is how WSJT-X's real Stage-B/C
+/// frequency sweep works: `ft8b.f90:133-146` builds a 32-element
+/// `ctwk` tweak per trial and never touches the 3200-sample `cd0`
+/// data buffer at all. Our earlier port instead shifted the entire
+/// `cd0` per trial (~100x more arithmetic) — see [`build_tweak`]'s
+/// doc comment for the full story (issue #182 follow-up).
+fn fine_sync_power_signed(
+    cd0: &[Complex<f32>],
+    i: i32,
+    ref_table: &CostasRefTable,
+    tweak: Option<&[Complex<f32>; 32]>,
+) -> f32 {
     use crate::ft8::params::COSTAS;
     const DS_SPB: i32 = 32;
     let icos7: [u8; 7] = [3, 1, 4, 0, 6, 5, 2];
@@ -50,17 +111,21 @@ fn fine_sync_power_signed(cd0: &[Complex<f32>], i: i32) -> f32 {
             if start < 0 || start + DS_SPB > np2 {
                 continue;
             }
-            let dphi = core::f32::consts::TAU * (tone as f32) / (DS_SPB as f32);
+            let ref_row = &ref_table[tone as usize];
             let mut z = Complex::new(0.0_f32, 0.0);
-            let mut phi = 0.0_f32;
             for j in 0..DS_SPB {
                 let s = cd0[start as usize + j as usize];
-                let r = Complex::new(phi.cos(), phi.sin());
+                let r = ref_row[j as usize];
+                // `csync2 = ctwk*csync2` (Fortran) computed before the
+                // `conjg` below — multiply first, conjugate the
+                // product, matching sync8d.f90's actual operation
+                // order (mathematically equivalent to conjugating
+                // each factor separately, kept literal for traceability).
+                let r = match tweak {
+                    Some(t) => r * t[j as usize],
+                    None => r,
+                };
                 z += s * r.conj();
-                phi += dphi;
-                if phi > core::f32::consts::PI {
-                    phi -= core::f32::consts::TAU;
-                }
             }
             block_power += z.norm_sqr();
         }
@@ -91,18 +156,31 @@ pub struct FineRefine {
     pub score: f32,
 }
 
-/// Apply the phasor `exp(-j·2π·delf·k·dt2)` to `cd0[k]`, writing into
-/// `out`. `out` must have the same length as `cd0`. Computed with
-/// per-sample `cos`/`sin` (no accumulator) to keep f32 accuracy bounded
-/// for `delf · t_max ≈ 2.5 · 16 = 40` cycles.
-fn shift_freq(cd0: &[Complex<f32>], delf_hz: f32, out: &mut [Complex<f32>]) {
-    debug_assert_eq!(cd0.len(), out.len());
+/// Build the 32-element frequency-tweak reference waveform
+/// `exp(j·2π·delf·k·dt2)` for `k in 0..32`. Direct port of
+/// `ft8b.f90:133-140`'s `ctwk` construction — **not negated**
+/// (`dphi = +2π·delf·dt2`), matching the real Fortran exactly. The
+/// original per-candidate `shift_freq` (issue #182 Phase 2, since
+/// removed) shifted the entire ~3200-sample `cd0` buffer per trial —
+/// this instead builds a tiny 32-sample tweak applied to
+/// [`fine_sync_power_signed`]'s reference waveform, matching what
+/// WSJT-X's real `sync8d.f90` (`csync2=ctwk*csync2`) actually does:
+/// ~100x less arithmetic per trial (32 elements vs 3200), and exact
+/// rather than an NCO approximation, since 32 elements is cheap enough
+/// to just compute directly with `cos`/`sin`.
+fn build_tweak(delf_hz: f32) -> [Complex<f32>; 32] {
     let dt2 = 1.0 / DS_RATE;
-    for (k, (c, o)) in cd0.iter().zip(out.iter_mut()).enumerate() {
-        let phi = -core::f32::consts::TAU * delf_hz * (k as f32) * dt2;
-        let rot = Complex::new(phi.cos(), phi.sin());
-        *o = *c * rot;
+    let dphi = core::f32::consts::TAU * delf_hz * dt2;
+    let mut tweak = [Complex::new(0.0_f32, 0.0); 32];
+    let mut phi = 0.0_f32;
+    for slot in tweak.iter_mut() {
+        *slot = Complex::new(phi.cos(), phi.sin());
+        phi += dphi;
+        if phi > core::f32::consts::PI {
+            phi -= core::f32::consts::TAU;
+        }
     }
+    tweak
 }
 
 /// 3-stage fine refinement. Mirrors `ft8b.f90:104-150`.
@@ -113,8 +191,21 @@ fn shift_freq(cd0: &[Complex<f32>], delf_hz: f32, out: &mut [Complex<f32>]) {
 /// supported via `fine_sync_power_signed`, which mirrors WSJT-X
 /// `sync8d.f90:43-45` (zero contribution from any sync block whose
 /// samples fall outside the cd0 window).
+///
+/// Stage B/C sweep frequency by tweaking `fine_sync_power_signed`'s
+/// *reference* waveform (via `build_tweak`), never `cd0` itself —
+/// see `build_tweak`'s doc comment for why this matters (issue #182
+/// follow-up: matches real WSJT-X, ~100x less arithmetic than the
+/// data-shifting approach this replaced).
 pub fn fine_refine_3stage(cd0: &[Complex<f32>], initial_dt_sec: f32) -> FineRefine {
     debug_assert_eq!(cd0.len(), CD0_LEN);
+
+    // Process-lifetime cached on std builds, built fresh per call on
+    // no_std — see [`costas_ref_table`]'s doc comment.
+    #[cfg(feature = "std")]
+    let ref_table = costas_ref_table();
+    #[cfg(not(feature = "std"))]
+    let ref_table = &costas_ref_table();
 
     // ── Stage A: ±10 idt at the initial frequency ─────────────────────
     let i0 = ((initial_dt_sec + 0.5) * DS_RATE).round() as i32;
@@ -122,7 +213,7 @@ pub fn fine_refine_3stage(cd0: &[Complex<f32>], initial_dt_sec: f32) -> FineRefi
     let mut smax_a = f32::MIN;
     for delta in -10..=10_i32 {
         let i = i0 + delta;
-        let s = fine_sync_power_signed(cd0, i);
+        let s = fine_sync_power_signed(cd0, i, ref_table, None);
         if s > smax_a {
             smax_a = s;
             ibest_a = i;
@@ -131,15 +222,14 @@ pub fn fine_refine_3stage(cd0: &[Complex<f32>], initial_dt_sec: f32) -> FineRefi
 
     // ── Stage B: ±5 ifr × 0.5 Hz freq sweep at ibest_a ────────────────
     let mut delfbest = 0.0_f32;
-    let mut smax_b = fine_sync_power_signed(cd0, ibest_a);
-    let mut tmp: Vec<Complex<f32>> = vec![Complex::new(0.0, 0.0); cd0.len()];
+    let mut smax_b = fine_sync_power_signed(cd0, ibest_a, ref_table, None);
     for ifr in -5..=5_i32 {
         if ifr == 0 {
             continue;
         }
         let delf = ifr as f32 * 0.5;
-        shift_freq(cd0, delf, &mut tmp);
-        let s = fine_sync_power_signed(&tmp, ibest_a);
+        let tweak = build_tweak(delf);
+        let s = fine_sync_power_signed(cd0, ibest_a, ref_table, Some(&tweak));
         // Strict `>` keeps the smaller-|delf| value when scores tie
         // (favour the original frequency).
         if s > smax_b {
@@ -148,17 +238,13 @@ pub fn fine_refine_3stage(cd0: &[Complex<f32>], initial_dt_sec: f32) -> FineRefi
         }
     }
 
-    // ── Stage C: ±4 idt re-search on frequency-shifted cd0 ────────────
-    if delfbest.abs() > f32::EPSILON {
-        shift_freq(cd0, delfbest, &mut tmp);
-    } else {
-        tmp.copy_from_slice(cd0);
-    }
+    // ── Stage C: ±4 idt re-search, tweaked by delfbest ────────────────
+    let tweak_c = (delfbest.abs() > f32::EPSILON).then(|| build_tweak(delfbest));
     let mut ibest_c = ibest_a;
     let mut smax_c = f32::MIN;
     for delta in -4..=4_i32 {
         let i = ibest_a + delta;
-        let s = fine_sync_power_signed(&tmp, i);
+        let s = fine_sync_power_signed(cd0, i, ref_table, tweak_c.as_ref());
         if s > smax_c {
             smax_c = s;
             ibest_c = i;
@@ -179,6 +265,160 @@ mod tests {
     use crate::ft8::downsample::downsample;
     use crate::ft8::params::COSTAS;
     use crate::ft8::wave_gen::tones_to_f32;
+    use alloc::vec;
+    use alloc::vec::Vec;
+
+    /// Frozen per-sample-`cos`/`sin` reference copy of
+    /// `fine_sync_power_signed` as it existed before the
+    /// [`CostasRefTable`] lookup-table rewrite (issue #182 perf
+    /// follow-up). Do not "fix" this to match future changes to the
+    /// real function — it exists solely so
+    /// `ref_table_matches_per_sample_reference` can prove the table
+    /// rewrite produces bit-identical output.
+    fn fine_sync_power_signed_reference(cd0: &[Complex<f32>], i: i32) -> f32 {
+        const DS_SPB: i32 = 32;
+        let icos7: [u8; 7] = [3, 1, 4, 0, 6, 5, 2];
+        let np2 = cd0.len() as i32;
+        let mut total = 0.0_f32;
+        for block_off in [0_i32, 36, 72].iter().copied() {
+            let mut block_power = 0.0_f32;
+            for (k, &tone) in icos7.iter().enumerate() {
+                let start = i + block_off * DS_SPB + (k as i32) * DS_SPB;
+                if start < 0 || start + DS_SPB > np2 {
+                    continue;
+                }
+                let dphi = core::f32::consts::TAU * (tone as f32) / (DS_SPB as f32);
+                let mut z = Complex::new(0.0_f32, 0.0);
+                let mut phi = 0.0_f32;
+                for j in 0..DS_SPB {
+                    let s = cd0[start as usize + j as usize];
+                    let r = Complex::new(phi.cos(), phi.sin());
+                    z += s * r.conj();
+                    phi += dphi;
+                    if phi > core::f32::consts::PI {
+                        phi -= core::f32::consts::TAU;
+                    }
+                }
+                block_power += z.norm_sqr();
+            }
+            total += block_power;
+        }
+        total
+    }
+
+    /// Differential test (issue #182 perf follow-up): the
+    /// [`CostasRefTable`]-based `fine_sync_power_signed` must return
+    /// bit-identical scores to the frozen per-sample-cos/sin reference
+    /// above, across several real-shaped inputs (not just one), since
+    /// the two are supposed to compute the exact same values — not an
+    /// approximation.
+    #[test]
+    fn ref_table_matches_per_sample_reference() {
+        let ref_table = build_costas_ref_table();
+
+        let signal_slot = {
+            let tones = costas_only_tones();
+            let pcm_f32 = tones_to_f32(&tones, 1500.0, 0.5);
+            let mut slot = vec![0i16; 15 * 12_000];
+            let start = (0.5_f32 * 12_000.0).round() as usize;
+            for (i, &s) in pcm_f32.iter().enumerate() {
+                if start + i < slot.len() {
+                    slot[start + i] = (s * 16_000.0) as i16;
+                }
+            }
+            slot
+        };
+        let (cd0_signal, _) = downsample(&signal_slot, 1500.0, None);
+
+        let noise_slot: Vec<i16> = (0..15 * 12_000)
+            .map(|n| {
+                let x = (n as i64 * 2_654_435_761) as u32;
+                ((x >> 16) as i16).wrapping_sub(i16::MAX / 2)
+            })
+            .collect();
+        let (cd0_noise, _) = downsample(&noise_slot, 1500.0, None);
+
+        for (label, cd0) in [("signal", &cd0_signal), ("noise", &cd0_noise)] {
+            for i in [-10_i32, -3, 0, 5, 12, 1590, 1605] {
+                let expected = fine_sync_power_signed_reference(cd0, i);
+                let actual = fine_sync_power_signed(cd0, i, &ref_table, None);
+                assert_eq!(
+                    expected, actual,
+                    "{label} i={i}: table-lookup diverged from per-sample reference"
+                );
+            }
+        }
+    }
+
+    /// Frozen composition of the pre-this-change data-shift approach
+    /// (issue #182 follow-up, superseding Phase 2's NCO): shifts `cd0`
+    /// by `delf_hz` via exact per-sample `cos`/`sin` (the original
+    /// `shift_freq` body, before it was deleted in favour of
+    /// [`build_tweak`]'s reference-tweak approach), then scores it with
+    /// the untweaked per-sample reference. This is the last
+    /// known-correct implementation (validated end-to-end by the 5
+    /// `fine_refine_3stage` tests below) — the baseline the new
+    /// reference-tweak approach must match. Do not "fix" this to track
+    /// future changes to the real functions.
+    fn fine_sync_power_signed_via_data_shift_reference(
+        cd0: &[Complex<f32>],
+        i: i32,
+        delf_hz: f32,
+    ) -> f32 {
+        let dt2 = 1.0 / DS_RATE;
+        let mut shifted = vec![Complex::new(0.0_f32, 0.0); cd0.len()];
+        for (k, (c, o)) in cd0.iter().zip(shifted.iter_mut()).enumerate() {
+            let phi = -core::f32::consts::TAU * delf_hz * (k as f32) * dt2;
+            let rot = Complex::new(phi.cos(), phi.sin());
+            *o = *c * rot;
+        }
+        fine_sync_power_signed_reference(&shifted, i)
+    }
+
+    /// Differential test (issue #182 follow-up): the reference-tweak
+    /// `fine_sync_power_signed(..., Some(&build_tweak(delf)))` must
+    /// match the frozen data-shift reference above within a tight
+    /// tolerance. Unlike Phase 2's NCO (a genuine speed/accuracy trade,
+    /// needing a `1e-4` tolerance), this is two *exactly equivalent*
+    /// formulations of the same sum (tweak-then-conjugate-product vs
+    /// shift-then-correlate) — the only expected divergence is
+    /// floating-point reassociation, so the tolerance is tighter and
+    /// chosen empirically, not assumed, same discipline as Phase 1/2.
+    #[test]
+    fn tweak_matches_data_shift_reference_within_tolerance() {
+        const TWEAK_MAX_ERROR: f32 = 1e-5;
+        let ref_table = build_costas_ref_table();
+
+        let tones = costas_only_tones();
+        let pcm_f32 = tones_to_f32(&tones, 1500.0, 0.5);
+        let mut slot = vec![0i16; 15 * 12_000];
+        let start = (0.5_f32 * 12_000.0).round() as usize;
+        for (i, &s) in pcm_f32.iter().enumerate() {
+            if start + i < slot.len() {
+                slot[start + i] = (s * 16_000.0) as i16;
+            }
+        }
+        let (cd0, _) = downsample(&slot, 1500.0, None);
+
+        for ifr in -5_i32..=5 {
+            if ifr == 0 {
+                continue;
+            }
+            let delf = ifr as f32 * 0.5;
+            let tweak = build_tweak(delf);
+            for i in [-10_i32, -3, 0, 5, 12] {
+                let expected = fine_sync_power_signed_via_data_shift_reference(&cd0, i, delf);
+                let actual = fine_sync_power_signed(&cd0, i, &ref_table, Some(&tweak));
+                let denom = expected.max(1.0);
+                let rel_err = (actual - expected).abs() / denom;
+                assert!(
+                    rel_err < TWEAK_MAX_ERROR,
+                    "delf={delf} i={i}: tweak score {actual} vs data-shift reference \
+                     {expected}, relative error {rel_err} exceeds tolerance {TWEAK_MAX_ERROR}"
+                );
+            }
+        }
+    }
 
     /// Build a 79-symbol FT8 tone sequence with the 3 Costas blocks
     /// in their canonical positions. Data symbols (positions 7..36 and


### PR DESCRIPTION
## Summary

- Ports WSJT-X's real Stage-B/C fine-sync algorithm into `fine_refine_3stage` (`ft8/refine_fine.rs`): tweaks a 32-sample Costas reference waveform per trial instead of shifting the whole 3200-sample `cd0` buffer, matching `sync8d.f90`/`ft8b.f90:133-140` exactly. Costas reference table (and `core::sync.rs`'s per-block equivalent, shared across all protocols) now cached for the process lifetime instead of rebuilt per candidate/block.
- Root-causes and fixes a ~10x FT4 decode-speed regression (48.8ms → ~530ms) introduced by an earlier, unrelated LPF-subtract migration (#178-180): `core::dsp::subtract::refine_freq`'s ~50-100-point carrier grid search was fully re-synthesizing the GFSK waveform on every evaluation instead of applying the carrier via a cheap NCO tweak to a once-built carrier-free reference.
- Updates `docs/notes/BENCHMARKS.md`, `FT4_BENCHMARK.md`, `FT8_BENCHMARK.md`, `ROADMAP.md`, `README.md` with re-verified recall/speed numbers across every protocol (JT9 5/5→7/7, FT8 JTDX 17/18→18/18, FT4 speed regression documented and fixed).

## Measured results

- `qso3_busy.wav` single-threaded blind decode: ~753ms → ~700ms (~39% faster than real `jt9 -8 -d3`'s own ~1.1s).
- FT4 `decode_frame_subtract`: multi-threaded ~576ms → ~280ms, single-threaded ~894ms → ~602ms.
- Recall unaffected: FT4 6/6 golden, FT8 18/18 JTDX, 6/6 JTDX AP-on extras, 7/8 WSJT-X golden.

## Test plan

- [x] `cargo test --release --workspace --features full` — all green
- [x] New differential tests (`ls_amp_mag_tweaked_matches_full_resynthesis`, `refine_freq_finds_true_offgrid_carrier`, `tweak_matches_data_shift_reference_within_tolerance`) pass with measured tolerances
- [x] `ft4_wsjtx_sample_recall_vs_golden` 6/6, `ft8_qso3_jtdx_recall` 18/18, `ft8_qso3_apon_recall` 6/6 JTDX extras
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets --features full --no-deps -- -D warnings -D clippy::perf`
- [x] no_std/fixed-point feature-matrix builds (`alloc ft8`, `alloc ft8 fft-extern`, `alloc ft8 fft-extern fixed-point`, etc.)

https://claude.ai/code/session_01YNXfmPdG4JNELjUr8UiH8B