### PR TITLE
perf(ft4): shrink refine_freq's search radius, closing residual issue #182 FT4 regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -574,6 +574,46 @@
   `qso3_apon` 6/6 JTDX extras) since `refine_freq` sits on FT8's subtract
   path too.
 
+- **`refine_freq`'s search radius was 5x too wide, closing out the FT4
+  decode-speed regression** (issue #182 follow-up). The NCO fix above
+  cut `refine_freq` from ~35ms/call to ~15.7-16.2ms/call, but FT4's
+  `decode_frame_subtract` golden-WAV wall-clock was still ~280ms — 5.7x
+  the pre-#178 baseline of 48.8ms. Isolated `refine_freq` /
+  `subtract_tones_lpf` with a standalone microbenchmark (14 calls each,
+  matching the golden WAV's real accepted-decode count): `refine_freq`
+  alone was 227ms of the 280ms total (81%), `subtract_tones_lpf` only
+  13ms (already FFT-cached). The NCO fix reduced *per-evaluation* cost;
+  the *evaluation count* (101/call, ±5Hz radius at 0.1Hz step) was
+  untouched.
+
+  Cross-checked the call site's "+/-5 Hz refine radius…matches WSJT-X"
+  comment against `lib/ft4/subtractft4.f90` directly: WSJT-X's
+  `subtractft4` has **no frequency-refine step at all** — it subtracts
+  directly at the decoded `f0`, no grid search. The comment's "matches
+  WSJT-X" claim was wrong; `refine_freq` compensates for mfsk-core's own
+  coarse-frequency resolution, not anything WSJT-X does in its subtract
+  path. The ±5Hz figure traced to `refine_freq`'s generic doc comment
+  (written for `core::sync::coarse_sync`'s ~2.93Hz FFT-bin uncertainty)
+  and was never re-derived after FT4 moved onto `ft4_coarse_sync` +
+  `core::sync2d::ft4_sync_search` (issue #72). Reading `ft4_sync_search`'s
+  df search line by line: both its coarse (`idf` step 3) and fine (`si`
+  step 1) passes only ever produce integer-Hz `df` values, so the
+  `freq_hz` `refine_freq` receives is always within ±0.5Hz of the true
+  continuous optimum by construction — a much tighter bound than the
+  ±2.5Hz the borrowed comment assumed.
+
+  Fix: `ft4::decode::decode_frame_subtract_with_options`'s
+  `refine_freq_radius_hz` `5.0 → 1.0` (0.1Hz step unchanged — the
+  response's mainlobe is well under 1Hz wide for a ~7.5s tone train, so
+  widening the step risks skipping it; only the radius was oversized).
+  Cuts the grid 101 → 21 evaluations/call. **Result**: golden-WAV
+  `decode_frame_subtract` wall-clock **280ms → 110ms** (~2.5x further,
+  2.3x off the 48.8ms floor vs. 5.7x before this fix), recall
+  byte-identical (6/6 golden, 14/14 total decodes). The Rayleigh-fading
+  busy-band regression guard the LPF-subtract migration (#177-179) was
+  built to fix (`ft4_busy_band_fading_probe.rs::busy_band_fading_baseline`)
+  stayed 10/10. See `docs/notes/FT4_BENCHMARK.md` section 16.
+
 ### Changed
 
 - **Q65-60B/30A `decode_multi_period_for` sped up ~4×**

--- a/docs/notes/BENCHMARKS.md
+++ b/docs/notes/BENCHMARKS.md
@@ -56,7 +56,7 @@ is wall time on a many-core host, not a single-thread figure).
 
 | Protocol | Golden WAV | Slot length | Decode time |
 |---|---|---:|---:|
-| FT4 | 000000_000002.wav | 7.5 s | 0.28 s (was 0.049 s pre-#178-180, briefly regressed to ~0.53-0.58 s — see note) |
+| FT4 | 000000_000002.wav | 7.5 s | 0.11 s (was 0.049 s pre-#178-180, briefly regressed to ~0.53-0.58 s then ~0.28 s — see note) |
 | Q65-60D | 201212_1838.wav (10 GHz EME, fading metric) | 60 s | 0.08 s |
 | FT8 | qso3_busy.wav (16-signal busy band) | 15 s | 0.10 s |
 | Q65-60B | 1296 MHz troposcatter ×1 slot (multi-period averaging) | 60 s | 0.12 s |
@@ -122,6 +122,29 @@ Notes:
   removes the *redundant* part of that cost, not the cost itself.
   Candidate count unchanged (31, matching the 25× coarse-sync fix's own
   numbers) and recall unaffected (still 6/6).
+
+  **Follow-up, same day: `refine_freq` was still 81% of the 280 ms**
+  (227 ms of it, isolated via a standalone microbenchmark) even after the
+  NCO fix above — the fix cut *per-evaluation* cost, not the *evaluation
+  count* (still 101 evaluations/call, ±5 Hz radius at 0.1 Hz step).
+  Cross-checking the call site's own "+/-5 Hz refine radius…matches
+  WSJT-X" comment against `lib/ft4/subtractft4.f90` found the comment
+  wrong: WSJT-X's `subtractft4` has no frequency-refine step at all, so
+  there was nothing to match. The ±5 Hz figure actually came from
+  `refine_freq`'s generic doc comment (written for `coarse_sync`'s
+  ~2.93 Hz FFT-bin uncertainty) and was never re-derived after FT4 moved
+  onto `ft4_coarse_sync` + `ft4_sync_search` (section 7/13), whose df
+  search (`core::sync2d::ft4_sync_search`) only ever produces
+  integer-Hz offsets — bounding the true optimum to within ±0.5 Hz of
+  the reported freq by construction, tighter than the ±2.5 Hz the old
+  comment assumed. Shrunk `refine_freq_radius_hz` `5.0 → 1.0` (kept the
+  0.1 Hz step — the response's mainlobe is well under 1 Hz wide, so
+  widening the step risks skipping it), cutting the grid 101 → 21
+  evaluations/call. **280 ms → 110 ms** (~2.5x further, ~2.3x off the
+  48.8 ms pre-#178 floor now vs. 5.7x before this pass), recall
+  byte-identical (6/6 golden, 14/14 total decodes) and the
+  `ft4_busy_band_fading_probe.rs` Rayleigh-fading regression guard
+  unchanged at 10/10. See `FT4_BENCHMARK.md` section 16.
 - FT8's `qso3_busy.wav` was the outlier at **4.73 s** (busy band, 16
   simultaneous signals) until a profiling pass (2026-07-20) found the
   cost wasn't BP/OSD at all but `subtract_tones_lpf`'s successive-

--- a/docs/notes/FT4_BENCHMARK.md
+++ b/docs/notes/FT4_BENCHMARK.md
@@ -779,3 +779,75 @@ different corpus or a different score quantity.
 
 Full non-ignored suite (922 passed) and `-D clippy::perf -D warnings`
 green both before and after the revert.
+
+## 16. `refine_freq`'s search radius was 5x too wide (issue #182 follow-up, 2026-07-26)
+
+Follow-up to section 13's update: issue #182 (`FT8_BENCHMARK.md`, same-day
+`fine_refine_3stage` port) fixed `refine_freq`'s dominant cost — full GFSK
+resynthesis per grid point — by switching to a per-sample NCO tweak of a
+once-built carrier-free reference (`ls_amp_mag_tweaked`). That dropped
+`refine_freq` from ~35 ms/call to ~15.7-16.2 ms/call and
+`decode_frame_subtract`'s golden-WAV wall-clock from ~530-580 ms to
+~280 ms — a real fix, but still 5.7x the pre-#178 baseline of 48.8 ms, and
+the user-reported "still slow" symptom this section addresses.
+
+Re-measured with a standalone microbenchmark isolating `refine_freq` /
+`subtract_tones_lpf` from the rest of `decode_frame_subtract` (14 calls
+each, matching the golden WAV's real accepted-decode count):
+`refine_freq` alone accounted for 227 ms of the 280 ms total (81%,
+16.2 ms/call); `subtract_tones_lpf` only 13 ms (5%, already FFT-cached
+per issue #180). Confirms `refine_freq`'s ±5 Hz/0.1 Hz grid (101
+evaluations/call) — not `subtract_tones_lpf` — is still the bottleneck
+after the NCO fix; the NCO fix cut *per-evaluation* cost, not the
+*evaluation count*.
+
+**Root cause of the evaluation count being unnecessarily large**: cross-
+checked `refine_freq`'s call-site comment ("+/-5 Hz refine radius" —
+claimed to match WSJT-X) against `lib/ft4/subtractft4.f90` directly.
+WSJT-X's `subtractft4` has **no frequency-refine step at all** — it
+synthesizes the reference at the decoded `f0` and subtracts directly, no
+grid search, no `ctwk`-style tweak (that mechanism is FT8-only,
+`sync8d.f90`, and operates during *sync*, not *subtract*). The call-site
+comment's "matches WSJT-X" claim was simply wrong; `refine_freq` is an
+mfsk-core-specific step compensating for this codebase's own coarse-sync
+frequency resolution, not a port of anything WSJT-X does in the subtract
+path.
+
+The ±5 Hz figure traces to `refine_freq`'s own doc comment, written
+against the *generic* `core::sync::coarse_sync`'s ~2.93 Hz FFT-bin
+resolution ("recommend 2.5 Hz to cover one bin either side"). But FT4
+stopped using that generic coarse-sync path back in section 13
+(`ft4_coarse_sync`, a `getcandidates4.f90` port with its own, different
+bin structure) — and more directly, `r.freq_hz` going into `refine_freq`
+is `process_candidate_basic`'s post-`ft4_sync_search` refined value
+(section 7's own fix), not a raw coarse-sync bin. Reading
+`core::sync2d::ft4_sync_search`'s df search (`core/sync2d.rs`) line by
+line: both its coarse pass (`idf` in `-12..=12` step 3) and fine pass
+(`si` in `-4..=4` step 1) only ever produce **integer-Hz** `df` values —
+the reported `freq_hz` is always `candidate.freq_hz + <integer>`. That
+bounds the true continuous optimum to within ±0.5 Hz of the reported
+value by construction — a much tighter guarantee than the generic
+coarse-sync comment's ±2.5 Hz assumed, and the ±5 Hz radius was never
+re-derived when FT4 moved onto this tighter-bound path.
+
+**Fix**: `ft4/decode.rs`'s `decode_frame_subtract_with_options` call
+site — `refine_freq_radius_hz` `5.0 → 1.0` (kept the existing 0.1 Hz
+step, since the mainlobe of `ls_amp_mag_tweaked`'s frequency response is
+narrow enough — well under 1 Hz for a ~7.5 s tone train — that widening
+the *step* risks skipping over it entirely; only the *radius* was
+oversized). Cuts the grid from 101 to 21 evaluations/call, a margin of
+0.5 Hz still on each side of the ±0.5 Hz quantization bound above.
+
+**Measured**: golden WAV `decode_frame_subtract` wall-clock **280.3 ms →
+110.2 ms** (~2.5x), recall byte-identical (6/6 golden, 14/14 total
+decodes, same messages/freq/dt as before). The section-11-referenced
+busy-band Rayleigh-fading regression guard (`ft4_busy_band_fading_probe.rs
+::busy_band_fading_baseline`, the exact scenario the LPF-subtract
+migration in issues #177-179 was built to fix) stayed **10/10** target
+recoveries. Full non-ignored suite and `-D clippy::perf -D warnings`
+green. Cumulative from the pre-#178 baseline: 48.8 ms → 110.2 ms (2.3x
+remaining gap) — the residual is the LPF subtract + freq-refine step's
+now-irreducible cost (21 `ls_amp_mag_tweaked` evaluations + one
+`subtract_tones_lpf` FFT pair per real decode), a deliberate
+recall-quality addition per section 13's original update, not redundant
+work.

--- a/mfsk-core/src/ft4/decode.rs
+++ b/mfsk-core/src/ft4/decode.rs
@@ -210,13 +210,32 @@ pub fn decode_frame_subtract_with_options(
         DecodeStrictness::Normal,
         REFINE_STEPS,
         SYNC_Q_MIN,
-        // Matches WSJT-X `subtractft4.f90`: NFILT=1400 (lpf_half=700),
-        // no end-correction, +/-5 Hz refine radius. See
+        // lpf_half/end-correction match WSJT-X `subtractft4.f90`:
+        // NFILT=1400 (lpf_half=700), no end-correction. See
         // `ft4::subtract::{LPF_HALF_SAMPLES, subtract_signal_lpf,
         // refine_signal_freq}` for the same constants used elsewhere.
+        //
+        // WSJT-X's own `subtractft4` has no frequency-refine step at
+        // all — it subtracts directly at the decoded `f0`. mfsk-core's
+        // `refine_freq` call above exists to compensate for this
+        // codebase's own `r.freq_hz` being integer-Hz-quantized
+        // (`core::sync2d::ft4_sync_search`'s df search only ever
+        // produces integer Hz offsets — see its `idf`/`si` loops), not
+        // to replicate anything WSJT-X does. That quantization bounds
+        // the true continuous optimum to within ±0.5 Hz of the
+        // reported freq, so a ±1.0 Hz radius (with 0.5 Hz margin) is
+        // sufficient — the previous ±5.0 Hz was carried over from
+        // `coarse_sync`'s ~2.93 Hz FFT-bin uncertainty, a different
+        // (and much coarser) mechanism `ft4_coarse_sync` replaced for
+        // FT4 back in `FT4_BENCHMARK.md` section 13, without this
+        // radius being re-derived for the new, tighter bound (issue
+        // #182 follow-up). Cuts `refine_freq`'s 0.1 Hz grid search from
+        // 101 to 21 evaluations per call — the dominant remaining cost
+        // in `decode_frame_subtract` after the NCO fix (~16 ms/call ×
+        // 14 real decodes ≈ 227 ms of the golden WAV's 280 ms total).
         700,
         false,
-        5.0,
+        1.0,
     )
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #185 (issue #182). Yesterday's NCO fix cut `refine_freq`'s per-evaluation cost (~35ms → ~15.7-16.2ms/call) but left the *evaluation count* untouched — it stayed 101 evaluations/call (±5 Hz radius at 0.1 Hz step), so FT4's `decode_frame_subtract` golden-WAV wall-clock was still ~280ms, 5.7x the pre-#178 baseline of 48.8ms.

- Isolated `refine_freq`/`subtract_tones_lpf` with a standalone microbenchmark (14 calls each, matching the golden WAV's real accepted-decode count): `refine_freq` alone was **227ms of the 280ms total (81%)**; `subtract_tones_lpf` only 13ms (already FFT-cached).
- Cross-checked the call site's "+/-5 Hz refine radius…matches WSJT-X" comment against `lib/ft4/subtractft4.f90` directly — **WSJT-X's own `subtractft4` has no frequency-refine step at all**. The comment's premise was wrong; `refine_freq` compensates for mfsk-core's own coarse-frequency resolution, not anything WSJT-X does in its subtract path.
- The ±5 Hz figure traced to `refine_freq`'s generic doc comment (written for `coarse_sync`'s ~2.93 Hz FFT-bin uncertainty) and was never re-derived after FT4 moved onto `ft4_coarse_sync` + `ft4_sync_search` (issue #72). Reading `ft4_sync_search`'s df search line by line: both its coarse and fine passes only ever produce **integer-Hz** offsets, so the freq going into `refine_freq` is always within ±0.5 Hz of the true continuous optimum by construction — a much tighter bound than the borrowed ±2.5 Hz comment assumed.

## Fix

`ft4::decode::decode_frame_subtract_with_options`'s `refine_freq_radius_hz`: `5.0 → 1.0` (0.1 Hz step unchanged — the response's mainlobe is well under 1 Hz wide for a ~7.5s tone train, so widening the step risks skipping it; only the radius was oversized). Cuts the grid from 101 to 21 evaluations/call.

**Result**: golden-WAV `decode_frame_subtract` wall-clock **280ms → 110ms** (~2.5x further, 2.3x off the 48.8ms floor now vs. 5.7x before this fix).

## Test plan

- [x] `ft4_wsjtx_sample_recall_vs_golden`: 6/6 golden, 14/14 total decodes — byte-identical
- [x] `ft4_busy_band_fading_probe::busy_band_fading_baseline` (the Rayleigh-fading regression guard the LPF-subtract migration in #177-179 was built to fix): 10/10 unchanged
- [x] `ft4_subtract_pipeline::subtract_reveals_hidden_ft4_signal`: passes
- [x] Full non-ignored suite (`cargo test --release --features full`): 0 failed
- [x] `-D clippy::perf -D warnings`: clean
- [x] Docs updated: `docs/notes/FT4_BENCHMARK.md` section 16, `docs/notes/BENCHMARKS.md` decode-speed table + note, `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E3hxnabdmvS1KBuz92BUQw