### PR TITLE
fix(ci): unblock main — skip #180/#182 diagnostics when local jt9 dump absent; refresh README to DecodeRequest API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,10 @@ mfsk-core = { git = "https://github.com/jl1nie/mfsk-core", branch = "main", feat
 Synthesise an FT8 frame and decode it back:
 
 ```rust
-use mfsk_core::ft8::{
-    decode::{decode_frame, DecodeDepth},
-    wave_gen::{message_to_tones, tones_to_i16},
-};
+use mfsk_core::ft8::Ft8;
+use mfsk_core::ft8::decode::DecodeDepth;
+use mfsk_core::ft8::wave_gen::{message_to_tones, tones_to_i16};
+use mfsk_core::msg::decode_request::DecodeRequest;
 use mfsk_core::msg::wsjt77::{pack77, unpack77};
 
 // 1. Synthesise an FT8 frame and pad it into a 15-second slot.
@@ -129,7 +129,17 @@ let end = (start + frame.len()).min(audio.len());
 audio[start..end].copy_from_slice(&frame[..end - start]);
 
 // 2. Decode it back.
-for r in decode_frame(&audio, 100.0, 3_000.0, 1.0, None, DecodeDepth::FULL, 50) {
+let results = DecodeRequest::<Ft8>::new(
+    &audio,
+    /* freq_min */ 100.0,
+    /* freq_max */ 3_000.0,
+    /* sync_min */ 1.0,
+    /* max_cand */ 50,
+)
+.depth(DecodeDepth::FULL)
+.decode()
+.results;
+for r in &results {
     if let Some(text) = unpack77(&r.message77) {
         println!("{:7.1} Hz  dt={:+.2} s  SNR={:+.0} dB  {}",
                  r.freq_hz, r.dt_sec, r.snr_db, text);
@@ -142,11 +152,13 @@ decode it back. Each protocol module documents its own top-level entry
 points and carries its own Quick example:
 
 - [`mfsk_core::ft8`](https://docs.rs/mfsk-core/latest/mfsk_core/ft8/)
-  — `decode_frame` + `decode_sniper_ap` (narrow-band "sniper" mode)
+  — `DecodeRequest::<Ft8>` (wide-band) + `SniperRequest::<Ft8>`
+  (narrow-band "sniper" mode)
 - [`mfsk_core::ft4`](https://docs.rs/mfsk-core/latest/mfsk_core/ft4/)
-  — `decode_frame`
+  — `DecodeRequest::<Ft4>`
 - [`mfsk_core::fst4`](https://docs.rs/mfsk-core/latest/mfsk_core/fst4/)
-  — FST4-60A `decode_frame`; other sub-modes via `decode_frame_for::<Fst4s120>` etc.
+  — `DecodeRequest::<Fst4s60>` (FST4-60A); other sub-modes via
+  `DecodeRequest::<Fst4s120>` etc.
 - [`mfsk_core::wspr`](https://docs.rs/mfsk-core/latest/mfsk_core/wspr/)
   — `decode::decode_scan_default`
 - [`mfsk_core::jt9`](https://docs.rs/mfsk-core/latest/mfsk_core/jt9/)

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -2496,7 +2496,17 @@ mod tests {
             None,
         );
 
-        let jt9_bytes = std::fs::read("/tmp/jt9_post_sic_dd.raw").expect("read jt9 residual dump");
+        let jt9_bytes = match std::fs::read("/tmp/jt9_post_sic_dd.raw") {
+            Ok(b) => b,
+            Err(_) => {
+                eprintln!(
+                    "skipping issue_180_dk8ne_data_symbol_comparison: \
+                     /tmp/jt9_post_sic_dd.raw (WSJT-X jt9 post-SIC residual dump) \
+                     not present — this is a local-only diagnostic input"
+                );
+                return;
+            }
+        };
         let jt9_residual: Vec<i16> = jt9_bytes
             .chunks_exact(2)
             .map(|c| i16::from_le_bytes([c[0], c[1]]))
@@ -2655,7 +2665,17 @@ mod tests {
             None,
         );
 
-        let jt9_bytes = std::fs::read("/tmp/jt9_post_sic_dd.raw").expect("read jt9 residual dump");
+        let jt9_bytes = match std::fs::read("/tmp/jt9_post_sic_dd.raw") {
+            Ok(b) => b,
+            Err(_) => {
+                eprintln!(
+                    "skipping issue_182_dk8ne_llr_reliability_comparison: \
+                     /tmp/jt9_post_sic_dd.raw (WSJT-X jt9 post-SIC residual dump) \
+                     not present — this is a local-only diagnostic input"
+                );
+                return;
+            }
+        };
         let jt9_residual: Vec<i16> = jt9_bytes
             .chunks_exact(2)
             .map(|c| i16::from_le_bytes([c[0], c[1]]))


### PR DESCRIPTION
## Why

`main`'s CI has been **red since 2026-07-25** (last green: 07-25 11:32), which blocks the upcoming 0.8.0 release — `release.yml` gates the crates.io publish on the same commit's CI going green (`wait-for-ci`), so a `v0.8.0` tag pushed against a red `main` would never publish.

## Root cause

The `Test (catchall characterization)` CI job runs `cargo test --lib -- --ignored`, which executes **every** `#[ignore]`'d lib test. Two of them —
`ft8::decode::tests::issue_180_dk8ne_data_symbol_comparison` and
`issue_182_dk8ne_llr_reliability_comparison` — read `/tmp/jt9_post_sic_dd.raw` (a WSJT-X `jt9` post-SIC residual dump that only exists on the developer's machine) via `std::fs::read(...).expect(...)`, so they panic in CI. This is the exact out-of-tree-asset foot-gun `CLAUDE.md` warns about.

## Changes

- **`ft8/decode.rs`** — the two diagnostics now `match` on the read and early-return with a skip message when the dump is absent, mirroring the existing guard at `decode.rs:2179`. When a developer has the dump locally, the comparison runs unchanged. This is what turns `main` green again.
- **`README.md`** — the quick-start FT8 round-trip example and the per-protocol entry-point list still referenced the `ft8::decode::decode_frame` / `decode_sniper_ap` / `ft4::decode_frame` / `fst4::decode_frame_for` family that #191 removed in favour of `DecodeRequest<P>` / `SniperRequest<P>`. README isn't a doctest, so it drifted without a CI signal. Rewrote the example to match `ft8/mod.rs`'s (doctested) canonical `DecodeRequest::<Ft8>::new(...).depth(...).decode().results` usage so the 0.8.0 crates.io / docs.rs landing page is consistent with the API that release ships.

## Verification

Ran the two fixed tests with `RUSTFLAGS="-D warnings"`:

```
cargo test -p mfsk-core --features full --release --lib -- --ignored \
    issue_180_dk8ne_data_symbol_comparison issue_182_dk8ne_llr_reliability_comparison
```

→ both skip cleanly and report `ok` (2 passed; 0 failed), no warnings. Full CI will confirm the `catchall characterization` job is green.

## Scope note

This PR only unblocks CI + fixes doc drift. The actual release-cut mechanics (workspace version bump 0.7.4 → 0.8.0, dating the CHANGELOG `0.8.0` heading) are deliberately **not** included — those belong to the release PR itself, per the biweekly cadence in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)