### PR TITLE
feat(bench): reproducible wasm +simd128 benchmark + profiling harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,12 +6,16 @@ on:
     # `embedded-poc/**` are stand-alone xtensa / cortex-m binary
     # crates with their own toolchains. Excluded from the host
     # workspace and not built by host CI; skip the workflow if the
-    # only changes are inside that tree.
+    # only changes are inside that tree. `bench/wasm/**` is the same
+    # deal for a different target (wasm32-unknown-unknown, issue #208)
+    # — a manual/periodic tool, not CI-gated.
     paths-ignore:
       - 'embedded-poc/**'
+      - 'bench/wasm/**'
   pull_request:
     paths-ignore:
       - 'embedded-poc/**'
+      - 'bench/wasm/**'
 
 env:
   CARGO_TERM_COLOR: always

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,12 @@ members  = ["mfsk-core", "mfsk-ffi", "mfsk-ffi-abi", "mfsk-ffi-ft8"]
 # Xtensa, etc). They depend on mfsk-core via a path dep but must not
 # be part of the host workspace — otherwise host `cargo build` would
 # try to compile them against the stable toolchain and fail.
-exclude  = ["embedded-poc"]
+#
+# `bench/wasm` is excluded for the same reason with a different target:
+# a wasm-bindgen harness for wasm32-unknown-unknown (issue #208), not
+# meant to build under a normal host `cargo build`/`cargo test` — see
+# bench/wasm/README.md.
+exclude  = ["embedded-poc", "bench/wasm"]
 resolver = "2"
 
 # Single source of truth for the crate version. `mfsk-core`,

--- a/bench/wasm/.cargo/config.toml
+++ b/bench/wasm/.cargo/config.toml
@@ -1,0 +1,8 @@
+# Scoped to this directory only (Cargo's config discovery walks up from
+# the crate being built) — the rest of the workspace is untouched. This
+# is the "+simd128 on" default, i.e. the config real-world consumers
+# should copy into their own project per README.md's "Building for
+# WebAssembly" section. build.sh's `--no-simd128` flag overrides this for
+# the before/after comparison; see README.md here for details.
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "target-feature=+simd128"]

--- a/bench/wasm/.gitignore
+++ b/bench/wasm/.gitignore
@@ -1,0 +1,2 @@
+/target
+/pkg

--- a/bench/wasm/.gitignore
+++ b/bench/wasm/.gitignore
@@ -1,2 +1,4 @@
 /target
 /pkg
+isolate-*.log
+profile.txt

--- a/bench/wasm/Cargo.toml
+++ b/bench/wasm/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "mfsk-wasm-bench"
+version = "0.0.0"
+edition = "2024"
+publish = false
+description = "Not part of the mfsk-core workspace (see root Cargo.toml exclude) — a standalone wasm-bindgen harness for measuring the effect of -C target-feature=+simd128 on FT8 decode under wasm32-unknown-unknown. See README.md."
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2"
+mfsk-core = { path = "../../mfsk-core", default-features = false, features = ["std", "ft8", "fft-rustfft"] }
+
+[profile.release]
+opt-level = 3
+lto = true

--- a/bench/wasm/Cargo.toml
+++ b/bench/wasm/Cargo.toml
@@ -15,3 +15,10 @@ mfsk-core = { path = "../../mfsk-core", default-features = false, features = ["s
 [profile.release]
 opt-level = 3
 lto = true
+
+# `wasm-pack build --profiling` (Stage C: node --prof) — keep wasm-opt's
+# optimizations but retain the name section via `-g`, so V8's tick
+# profiler resolves real function names instead of `wasm-function[N]`.
+# The plain `--release` path (Stage B: timing) intentionally omits `-g`.
+[package.metadata.wasm-pack.profile.profiling]
+wasm-opt = ['-O3', '-g']

--- a/bench/wasm/README.md
+++ b/bench/wasm/README.md
@@ -72,3 +72,24 @@ should be byte-identical between the two runs — that's the recall
 invariant any dense-kernel vectorization work (Stage D of the #208
 plan) must preserve; a difference there is a correctness bug, not
 noise.
+
+## Profiling (Stage C)
+
+```sh
+./build.sh --profiling
+node --prof bench.mjs 200      # more iterations = better sample resolution
+node --prof-process isolate-*-v8.log > profile.txt
+```
+
+`--profiling` alone isn't enough to get real function names out of
+`--prof-process` (you'd otherwise see `wasm-function[N]`) — two things
+have to both be true: rustc needs to emit name/debug info in the first
+place (`build.sh --profiling` sets `CARGO_PROFILE_RELEASE_DEBUG=2` for
+this), and `wasm-opt` needs to not strip the wasm `name` custom section
+afterwards (`Cargo.toml`'s `[package.metadata.wasm-pack.profile.profiling]`
+passes `-g` for this). Both are already wired up — just use
+`--profiling`, don't reach for `--dev` (unoptimized, not representative
+of the real hot-loop shape) to get symbols.
+
+Clean up `isolate-*.log` / `profile.txt` after — they're gitignored but
+sizeable and not useful past the investigation that produced them.

--- a/bench/wasm/README.md
+++ b/bench/wasm/README.md
@@ -1,0 +1,74 @@
+# mfsk-wasm-bench
+
+A minimal `wasm-bindgen` harness for measuring the effect of
+`-C target-feature=+simd128` on FT8 decode under
+`wasm32-unknown-unknown` (issue #208). Not a real API surface, not
+published, not a workspace member — see the root `Cargo.toml`'s
+`exclude` list for why.
+
+This is a manual/periodic investigative tool, not a CI gate: no
+`wasm32` target exists in this repo's CI today, and a timing check
+would be flaky on shared runners. Re-run it by hand when re-measuring
+the `+simd128` effect or profiling a candidate dense-kernel
+vectorization (Part 2 of #208).
+
+## Build
+
+Requires the `wasm32-unknown-unknown` rustup target, `wasm-pack`, and
+Node.js. Optionally `wasm-objdump` (from the [WABT] toolkit) to confirm
+vectorization took — `build.sh` runs this automatically and prints the
+count.
+
+```sh
+rustup target add wasm32-unknown-unknown
+cargo install wasm-pack
+
+./build.sh                 # +simd128 (the checked-in .cargo/config.toml default)
+./build.sh --no-simd128    # scalar baseline, for the before/after comparison
+./build.sh --profiling     # keep wasm name-section symbols, for `node --prof` (Stage C)
+```
+
+`--no-simd128` works by setting `RUSTFLAGS=""` for that build, which
+wins over `.cargo/config.toml`'s `target.wasm32-unknown-unknown.rustflags`
+per Cargo's documented precedence (env var > target-triple config).
+Verified empirically 2026-07-28: `+simd128` build emits ~8700
+`v128`/`f32x4`/`i32x4` instructions in the compiled `.wasm`, the
+`--no-simd128` build emits 0. `build.sh` prints this count on every
+build — don't trust a comparison run without checking it.
+
+[WABT]: https://github.com/WebAssembly/wabt
+
+## Run
+
+```sh
+node bench.mjs [runs]
+```
+
+Defaults to `runs=7` and the repo's own committed
+`embedded-poc/assets/qso3_busy.wav` fixture (also
+`ft8_qso3_full_parity_recall.rs`'s golden WAV — known-correct decode,
+so you can eyeball recall alongside timing, not just watch the number
+move). Prints one warmup call's decode output (message|freq_hz|dt_sec
+per line) followed by `runs` steady-state timings and their median.
+
+To reproduce the exact numbers from issue #208 / `docs/notes/BENCHMARKS.md`'s
+WASM section, point at the WAVs used there — `sim_busy_band.wav` /
+`sim_extreme_hard.wav`, `ft8sim`-generated stress WAVs from a sibling
+`webft8` checkout, not committed to this repo:
+
+```sh
+MFSK_BENCH_WAV=/path/to/sim_busy_band.wav node bench.mjs
+```
+
+## Example before/after
+
+```sh
+./build.sh --no-simd128 && node bench.mjs
+./build.sh              && node bench.mjs
+```
+
+Compare the two `median:` lines. Decode output (the message lines)
+should be byte-identical between the two runs — that's the recall
+invariant any dense-kernel vectorization work (Stage D of the #208
+plan) must preserve; a difference there is a correctness bug, not
+noise.

--- a/bench/wasm/bench.mjs
+++ b/bench/wasm/bench.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+// Node driver for the mfsk-wasm-bench harness (issue #208).
+//
+// Usage:
+//   node bench.mjs [runs]
+//   MFSK_BENCH_WAV=/path/to/file.wav node bench.mjs [runs]
+//
+// Loads pkg/mfsk_wasm_bench.js (built via ./build.sh, wasm-pack --target
+// nodejs) and times `decode_wav()` over a fixture WAV, printing the
+// median wall-clock time of `runs` steady-state calls (default 7,
+// discarding one warmup call first) plus the decode output itself so a
+// human can eyeball recall alongside timing.
+//
+// Defaults to embedded-poc/assets/qso3_busy.wav (committed, CI-safe,
+// known-correct golden decode). Point MFSK_BENCH_WAV at a local copy of
+// sim_busy_band.wav / sim_extreme_hard.wav (the WAVs used for issue
+// #208's own numbers — not committed to this repo, see README.md) to
+// reproduce those exact figures.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function parseWavMonoI16(buf) {
+  if (buf.toString("ascii", 0, 4) !== "RIFF" || buf.toString("ascii", 8, 12) !== "WAVE") {
+    throw new Error("not a RIFF/WAVE file");
+  }
+  let offset = 12;
+  let fmt = null;
+  let data = null;
+  while (offset + 8 <= buf.length) {
+    const id = buf.toString("ascii", offset, offset + 4);
+    const size = buf.readUInt32LE(offset + 4);
+    const body = offset + 8;
+    if (id === "fmt ") {
+      fmt = {
+        audioFormat: buf.readUInt16LE(body),
+        numChannels: buf.readUInt16LE(body + 2),
+        sampleRate: buf.readUInt32LE(body + 4),
+        bitsPerSample: buf.readUInt16LE(body + 14),
+      };
+    } else if (id === "data") {
+      data = buf.subarray(body, body + size);
+    }
+    offset = body + size + (size % 2);
+  }
+  if (!fmt || !data) throw new Error("missing fmt/data chunk");
+  if (fmt.audioFormat !== 1 || fmt.bitsPerSample !== 16) {
+    throw new Error(`expected 16-bit PCM, got format=${fmt.audioFormat} bits=${fmt.bitsPerSample}`);
+  }
+  const samplesAllChannels = new Int16Array(
+    data.buffer,
+    data.byteOffset,
+    data.byteLength / 2,
+  );
+  if (fmt.numChannels === 1) return samplesAllChannels;
+  // Downmix to mono by taking channel 0 — golden fixtures here are mono,
+  // this is just a safety net if pointed at a stereo file.
+  const mono = new Int16Array(samplesAllChannels.length / fmt.numChannels);
+  for (let i = 0; i < mono.length; i++) mono[i] = samplesAllChannels[i * fmt.numChannels];
+  return mono;
+}
+
+function median(xs) {
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+async function main() {
+  const runs = Number(process.argv[2] ?? 7);
+  const wavPath =
+    process.env.MFSK_BENCH_WAV ??
+    path.join(__dirname, "../../embedded-poc/assets/qso3_busy.wav");
+
+  const { decode_wav } = await import(path.join(__dirname, "pkg/mfsk_wasm_bench.js"));
+
+  const audio = parseWavMonoI16(readFileSync(wavPath));
+  console.log(`WAV: ${wavPath} (${audio.length} samples)`);
+
+  // Warmup — discarded, not steady-state.
+  const warmupOut = decode_wav(audio);
+
+  const times = [];
+  for (let i = 0; i < runs; i++) {
+    const t0 = performance.now();
+    decode_wav(audio);
+    times.push(performance.now() - t0);
+  }
+
+  console.log(`runs: ${times.map((t) => t.toFixed(1)).join(", ")} ms`);
+  console.log(`median: ${median(times).toFixed(1)} ms`);
+  console.log("decodes (from warmup run):");
+  console.log(warmupOut || "(none)");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/bench/wasm/build.sh
+++ b/bench/wasm/build.sh
@@ -13,6 +13,7 @@ cd "$(dirname "$0")"
 
 WASM_PACK_ARGS=(--target nodejs)
 RUSTFLAGS_OVERRIDE=()
+ENV_OVERRIDE=()
 
 for arg in "$@"; do
   case "$arg" in
@@ -22,10 +23,17 @@ for arg in "$@"; do
       # this disables the checked-in +simd128 default for comparison
       # builds. Verified via the wasm-objdump line below on every build —
       # don't trust this flag silently, check the printed count.
-      RUSTFLAGS_OVERRIDE=(env RUSTFLAGS=)
+      RUSTFLAGS_OVERRIDE=(RUSTFLAGS=)
       ;;
     --profiling)
+      # --profiling alone still strips the wasm "name" custom section
+      # (wasm-opt's default; see [package.metadata.wasm-pack.profile.profiling]
+      # in Cargo.toml for the -g override that keeps it) — but rustc also
+      # needs to be told to emit DWARF/name info in the first place, which
+      # a plain release build doesn't. Without both, `node --prof-process`
+      # resolves everything as `wasm-function[N]` instead of real symbols.
       WASM_PACK_ARGS=(--target nodejs --profiling)
+      ENV_OVERRIDE+=(CARGO_PROFILE_RELEASE_DEBUG=2)
       ;;
     *)
       echo "unknown arg: $arg" >&2
@@ -34,7 +42,7 @@ for arg in "$@"; do
   esac
 done
 
-"${RUSTFLAGS_OVERRIDE[@]}" wasm-pack build "${WASM_PACK_ARGS[@]}"
+env "${RUSTFLAGS_OVERRIDE[@]}" "${ENV_OVERRIDE[@]}" wasm-pack build "${WASM_PACK_ARGS[@]}"
 
 echo -n "v128/f32x4/i32x4 instruction count: "
 wasm-objdump -d pkg/mfsk_wasm_bench_bg.wasm | grep -cE 'v128|f32x4|i32x4' || true

--- a/bench/wasm/build.sh
+++ b/bench/wasm/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Build the mfsk-wasm-bench harness for wasm32-unknown-unknown, Node target.
+#
+# Usage:
+#   ./build.sh                 # +simd128 (from .cargo/config.toml)
+#   ./build.sh --no-simd128    # scalar baseline, for the before/after comparison
+#   ./build.sh --profiling     # keep wasm name section for `node --prof` (Stage C)
+#
+# Requires: wasm-pack, the wasm32-unknown-unknown rustup target,
+# wasm-objdump (from the WABT toolkit) for the verification line below.
+set -euo pipefail
+cd "$(dirname "$0")"
+
+WASM_PACK_ARGS=(--target nodejs)
+RUSTFLAGS_OVERRIDE=()
+
+for arg in "$@"; do
+  case "$arg" in
+    --no-simd128)
+      # Empty RUSTFLAGS env var wins over target.*.rustflags in
+      # .cargo/config.toml (Cargo's documented precedence), which is how
+      # this disables the checked-in +simd128 default for comparison
+      # builds. Verified via the wasm-objdump line below on every build —
+      # don't trust this flag silently, check the printed count.
+      RUSTFLAGS_OVERRIDE=(env RUSTFLAGS=)
+      ;;
+    --profiling)
+      WASM_PACK_ARGS=(--target nodejs --profiling)
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      exit 1
+      ;;
+  esac
+done
+
+"${RUSTFLAGS_OVERRIDE[@]}" wasm-pack build "${WASM_PACK_ARGS[@]}"
+
+echo -n "v128/f32x4/i32x4 instruction count: "
+wasm-objdump -d pkg/mfsk_wasm_bench_bg.wasm | grep -cE 'v128|f32x4|i32x4' || true

--- a/bench/wasm/src/lib.rs
+++ b/bench/wasm/src/lib.rs
@@ -1,0 +1,34 @@
+//! Thin wasm-bindgen wrapper around mfsk-core's FT8 decode entry point,
+//! for the Node-based `+simd128` before/after benchmark. Not a real API
+//! surface — see `bench/wasm/README.md`.
+
+use mfsk_core::ft8::Ft8;
+use mfsk_core::ft8::decode::DecodeDepth;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+use wasm_bindgen::prelude::*;
+
+/// Decode one FT8 slot from mono 16-bit PCM samples.
+///
+/// Mirrors `mfsk-core/tests/ft8_sweep.rs`'s `decode_wav_ft8` call shape
+/// (`DecodeRequest::<Ft8>::new(audio, 100.0, 3000.0, 0.8, 50).depth(FULL)`)
+/// so the benchmark exercises the same pipeline the crate's own tests do.
+///
+/// Returns one `message|freq_hz|dt_sec` line per decode, newline-joined —
+/// good enough for `bench.mjs` to print/diff, not a real API contract.
+#[wasm_bindgen]
+pub fn decode_wav(audio: &[i16]) -> String {
+    let outcome = DecodeRequest::<Ft8>::new(audio, 100.0, 3000.0, 0.8, 50)
+        .depth(DecodeDepth::FULL)
+        .decode();
+
+    outcome
+        .results
+        .iter()
+        .map(|d| {
+            let msg = unpack77(d.message77()).unwrap_or_default();
+            format!("{msg}|{:.1}|{:.2}", d.freq_hz, d.dt_sec)
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}


### PR DESCRIPTION
## Summary
- Adds `bench/wasm/`, a standalone (workspace-excluded, like `embedded-poc/`) `wasm-bindgen` crate wrapping the same `DecodeRequest<Ft8>` call `mfsk-core`'s own `ft8_sweep.rs` test uses, plus a Node driver (`bench.mjs`) and `build.sh` with a `--no-simd128` toggle for the before/after `+simd128` comparison.
- Wires up `node --prof` profiling support (`build.sh --profiling`), including the two things needed to actually get readable function names out of `--prof-process` instead of `wasm-function[N]` (`CARGO_PROFILE_RELEASE_DEBUG=2` + keeping `wasm-opt`'s name section via `-g`).
- Not wired into CI (no wasm32 target there today, timing checks are flaky on shared runners) — a manual/periodic tool per #208's own "measure, don't guess" framing.

Verified end-to-end: `+simd128` build emits ~8700 `v128`/`f32x4`/`i32x4` instructions vs 0 without; decode output is byte-identical between the two builds on the committed `qso3_busy.wav` fixture; `node --prof` resolves real `mfsk_core::` symbols.

Part of #208 (Part 2 kickoff — profiling infrastructure). The profiling run itself surfaced an unexpected, bigger finding (an FFT-plan-recaching bug unrelated to SIMD, ~12% of decode time) — filed/fixed separately, see follow-up PR.

## Test plan
- [x] `./build.sh`, `./build.sh --no-simd128`, `./build.sh --profiling` all build and produce the expected instruction counts / name sections
- [x] `node bench.mjs` decode output identical across `+simd128` on/off
- [x] `node --prof` + `--prof-process` resolves real function symbols

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqxRCEE16vYwN3jJXoeDXG