### PR TITLE
perf(dsp): cache downsample_cached's FFT planner instead of rebuilding per call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking)
+## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211)
 
 ### Added
 
@@ -1752,6 +1752,29 @@
   ms → ~165-175 ms (~6-7× faster than real `jt9 -8 -d3`'s ~1.1-1.2 s).
   See `FT8_BENCHMARK.md` section 11 for the full trace and cost
   investigation.
+- **`engine::dsp::downsample::downsample_cached` rebuilt its inverse-FFT
+  plan (twiddle table) from scratch on every call instead of reusing one
+  across a session** (#211), found while profiling the wasm `+simd128`
+  benchmark harness (#208, Stage C — `node --prof` with real function
+  symbols). Called once per FT8 candidate (~90×/slot), it constructed a
+  fresh `default_planner()` and called `plan_inverse(cfg.fft2_size)`
+  every time, even though `fft2_size` never varies within a decode
+  session — discarding `rustfft::FftPlanner`'s own per-size cache each
+  call and rebuilding the twiddle table via scalar `sin`/`cos`/`rem_pio2`.
+  Same anti-pattern already fixed twice nearby (`SYMBOL_FFT_32` in
+  `fill_symbol_spectra.rs`, `subtract_tones_lpf_fft`'s filter-response
+  plan above) — `default_planner()`'s own doc comment already says to
+  "reuse the same instance across all decodes in a session so rustfft's
+  twiddle cache hits," this call site just didn't. Fixed with a
+  `std`-gated `thread_local!` planner, reused across calls on the same
+  thread; `no_std`/`fft-extern` (embedded) callers are unaffected — the
+  only hot-loop caller (`fill_symbol_spectra_via_cd0`) is itself
+  `fft-rustfft`-gated. Measured impact: ~12.5% of total wasm decode
+  wall-clock (`node --prof` flat profile, `qso3_busy.wav`), bigger than
+  any dense-kernel SIMD target found in the same profiling pass; not
+  wasm-specific, the same redundant work happens on every target. Golden
+  recall unchanged: FT8 full-parity 8/8, AP-off 7/8 (7 phantom, 14
+  total), JTDX 18/18 (1 extra) — byte-identical to pre-fix.
 
 ## 0.7.4 — MSK144 decode (#25)
 

--- a/mfsk-core/src/engine/dsp/downsample.rs
+++ b/mfsk-core/src/engine/dsp/downsample.rs
@@ -35,7 +35,49 @@ use num_complex::Complex;
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
 
-use crate::engine::fft::default_planner;
+use crate::engine::fft::{FftPlanner, default_planner};
+
+// `default_planner()`'s own doc comment says to "reuse the same instance
+// across all decodes in a session so rustfft's twiddle cache hits" — but
+// `build_fft_cache`/`downsample_cached` used to construct a fresh one on
+// every call instead. `downsample_cached` alone is called once per FT8
+// candidate (~30 cand × 3 pass = ~90×/slot, see
+// `fill_symbol_spectra_via_cd0`'s neighboring `SYMBOL_FFT_32` comment for
+// the same anti-pattern already fixed at a different call site), so every
+// call rebuilt the `fft2_size`-point inverse-FFT plan's twiddle table
+// from scratch via scalar sin/cos, even though `fft2_size` never varies
+// within a decode session. A wasm --prof profile (issue #208, Stage C)
+// attributed ~12% of total decode wall-clock to exactly this — bigger
+// than any dense-kernel vectorization target found in that pass. Fixed
+// the same way `subtract_tones_lpf_fft`'s filter-response FFT plan was
+// (see docs/notes/BENCHMARKS.md, 2026-07-25 entry): cache the planner
+// itself, not just its output, keyed by nothing since one thread only
+// ever needs one live planner regardless of how many distinct sizes it's
+// asked to plan (rustfft's own `FftPlanner` caches per size internally).
+//
+// `std`-gated because `thread_local!` needs std; `no_std` (embedded,
+// `fft-extern`) callers keep constructing a fresh planner per call —
+// those call sites don't reach this function at all today (FT8's
+// `fill_symbol_spectra_via_cd0`, the only `downsample_cached` caller in
+// the hot per-candidate loop, is itself `fft-rustfft`-gated), so this is
+// out of scope for embedded rather than a regression there.
+#[cfg(feature = "std")]
+std::thread_local! {
+    static DOWNSAMPLE_PLANNER: core::cell::RefCell<Box<dyn FftPlanner>> =
+        core::cell::RefCell::new(default_planner());
+}
+
+#[cfg(feature = "std")]
+#[inline]
+fn with_default_planner<R>(f: impl FnOnce(&mut dyn FftPlanner) -> R) -> R {
+    DOWNSAMPLE_PLANNER.with_borrow_mut(|planner| f(planner.as_mut()))
+}
+
+#[cfg(not(feature = "std"))]
+#[inline]
+fn with_default_planner<R>(f: impl FnOnce(&mut dyn FftPlanner) -> R) -> R {
+    f(default_planner().as_mut())
+}
 
 /// Runtime parameters shared by [`downsample`], [`downsample_cached`], and
 /// [`build_fft_cache`]. Callers typically keep one instance per protocol.
@@ -87,8 +129,7 @@ pub fn build_fft_cache(audio: &[i16], cfg: &DownsampleCfg) -> Vec<Complex<f32>> 
         .chain(iter::repeat(Complex::new(0.0, 0.0)))
         .take(cfg.fft1_size)
         .collect();
-    let mut planner = default_planner();
-    planner.plan_forward(cfg.fft1_size).process(&mut x);
+    with_default_planner(|planner| planner.plan_forward(cfg.fft1_size).process(&mut x));
     x
 }
 
@@ -116,7 +157,6 @@ pub fn downsample_cached(
     cfg: &DownsampleCfg,
 ) -> Vec<Complex<f32>> {
     debug_assert_eq!(fft_cache.len(), cfg.fft1_size);
-    let mut planner = default_planner();
 
     let df = cfg.bin_hz();
     let baud = cfg.tone_spacing_hz;
@@ -158,7 +198,7 @@ pub fn downsample_cached(
     c1.rotate_left(shift);
 
     // Inverse FFT.
-    planner.plan_inverse(cfg.fft2_size).process(&mut c1);
+    with_default_planner(|planner| planner.plan_inverse(cfg.fft2_size).process(&mut c1));
 
     // Combined scale factor.
     let fac = 1.0 / ((cfg.fft1_size as f32) * (cfg.fft2_size as f32)).sqrt();


### PR DESCRIPTION
## Summary
- `engine::dsp::downsample::downsample_cached` constructed a fresh `default_planner()` and called `plan_inverse(cfg.fft2_size)` on **every** call, even though `fft2_size` never varies within a decode session. Called ~90×/slot from FT8's per-candidate `fill_symbol_spectra_via_cd0`, this rebuilt the inverse-FFT twiddle table via scalar `sin`/`cos`/`rem_pio2` from scratch every time — the same anti-pattern already fixed for `SYMBOL_FFT_32` and `subtract_tones_lpf_fft`'s filter plan, just missed here.
- Found while profiling the wasm `+simd128` benchmark harness (#208, Stage C — `node --prof` with real symbols, see #210). ~12.5% of total decode wall-clock, bigger than any dense-kernel SIMD target found in that pass. Not wasm-specific — helps every target.
- Fix: a `std`-gated `thread_local!` planner reused across calls, matching `default_planner()`'s own documented intended usage. `no_std`/`fft-extern` (embedded) is untouched — the only hot-loop caller is `fft-rustfft`-gated.

Closes #211.

## Test plan
- [x] `cargo check -p mfsk-core --features full`
- [x] `cargo check` under `--no-default-features --features alloc,ft8,fft-extern` (no_std path)
- [x] `ft8_qso3_full_parity_recall`: 8/8 golden (unchanged)
- [x] `ft8_qso3_apoff_recall`: 7/8 golden, 7 phantom, 14 total (byte-identical to documented baseline)
- [x] `ft8_qso3_jtdx_recall --ignored`: 18/18, 1 extra (byte-identical to documented baseline)
- [x] `bench/wasm`: ~15% additional speedup on top of `+simd128` (55ms vs 65ms median, `qso3_busy.wav`), decode output byte-identical before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqxRCEE16vYwN3jJXoeDXG