### PR TITLE
perf(llr): vectorize fill_bmet_for_nsym under wasm +simd128

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211)
+## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208)
 
 ### Added
 
@@ -1775,6 +1775,29 @@
   wasm-specific, the same redundant work happens on every target. Golden
   recall unchanged: FT8 full-parity 8/8, AP-off 7/8 (7 phantom, 14
   total), JTDX 18/18 (1 extra) — byte-identical to pre-fix.
+- **`engine::llr::fill_bmet_for_nsym`'s max-reduction loop rewritten to
+  actually vectorize under `wasm32 +simd128`** (#208 Stage D). The
+  per-element `if (i >> bit_sel) & 1 == 1 { max_one[..] = v } else {
+  max_zero[..] = v }` blocked LLVM's vectorizer two ways at once:
+  branchy per-lane control flow, and an `i`-outer/`bit_sel`-inner loop
+  nest that would need outer-loop vectorization LLVM doesn't attempt
+  here. Making the branch branchless (feed `f32::NEG_INFINITY` to
+  whichever accumulator the bit doesn't select, then an unconditional
+  `max()`) alone changed nothing — confirmed empirically via
+  `wasm-objdump`, the compiled region's `v128` count was unchanged.
+  Swapping the loop order (`bit_sel` outer, `i` inner — a flat
+  reduction over `s2` with a loop-invariant `bit_sel`) combined with
+  the branchless rewrite is what actually unblocked it: 40 → 86 `v128`
+  ops in the function's compiled region. This was the a-priori top
+  Part-2 target from #208's dense-kernel survey, but profiling (Stage
+  C) found its real ceiling is small (~2.9% of total decode time,
+  `qso3_busy.wav`, wasm), well below what a `node --prof` flat profile
+  found in an unrelated FFT-plan-caching bug (#211, fixed separately)
+  — wall-clock impact here is within run-to-run measurement noise even
+  though the vectorization itself is real and verified.
+  Byte-identical recall on all three FT8 golden regressions
+  (full-parity 8/8, AP-off 7/8/7-phantom/14-total, JTDX 18/18/1-extra)
+  and the full `--features full` test suite.
 
 ## 0.7.4 — MSK144 decode (#25)
 

--- a/mfsk-core/src/engine/llr.rs
+++ b/mfsk-core/src/engine/llr.rs
@@ -290,23 +290,44 @@ fn fill_bmet_for_nsym<P: Protocol, S: SpecScalar>(
             for (s2_i, entry) in s2.iter_mut().zip(&table) {
                 *s2_i = (entry.re * entry.re + entry.im * entry.im).sqrt();
             }
-            // Single pass over `s2` updating every bit position's
-            // running max-when-1 / max-when-0 together, instead of the
-            // previous `2 * (ibmax + 1)` independent full scans (one
+            // Updates every bit position's running max-when-1 /
+            // max-when-0 in one sweep, instead of the previous
+            // `2 * (ibmax + 1)` independent full scans (one
             // `filter().fold()` pair per bit position) — `nt * (ibmax +
             // 1)` element visits here vs. `2 * (ibmax + 1) * nt` before.
+            //
+            // Loop order is `bit_sel` outer, `i` inner (issue #208 Stage
+            // D — swapped from the original `i`-outer/`bit_sel`-inner
+            // nesting). With `i` outer, LLVM would need to vectorize
+            // across `i` while re-running the whole (runtime-bounded)
+            // `bit_sel` loop per lane — an outer-loop vectorization it
+            // doesn't attempt here regardless of the inner branch shape
+            // (confirmed empirically: making the original branch
+            // branchless without also flipping the loop order left the
+            // compiled `v128` count for this function unchanged). With
+            // `bit_sel` outer, the inner loop is a single flat max-
+            // reduction over `s2` with a loop-invariant `bit_sel` and a
+            // regular period-`2^(bit_sel+1)` predicate on `i` — the
+            // classic shape LLVM's inner-loop vectorizer handles, and
+            // the branchless select (`f32::NEG_INFINITY` fed to
+            // whichever accumulator the bit doesn't select, then an
+            // unconditional `max()`) is what lets it lower the
+            // per-element predicate to a vector compare-and-blend
+            // instead of scalarizing. Confirmed via `wasm-objdump`.
             let mut max_one = [f32::NEG_INFINITY; MAX_IBMAX_PLUS_1];
             let mut max_zero = [f32::NEG_INFINITY; MAX_IBMAX_PLUS_1];
-            for (i, &v) in s2.iter().enumerate() {
-                for bit_sel in 0..=ibmax {
-                    if (i >> bit_sel) & 1 == 1 {
-                        if v > max_one[bit_sel] {
-                            max_one[bit_sel] = v;
-                        }
-                    } else if v > max_zero[bit_sel] {
-                        max_zero[bit_sel] = v;
-                    }
+            for bit_sel in 0..=ibmax {
+                let mut mo = f32::NEG_INFINITY;
+                let mut mz = f32::NEG_INFINITY;
+                for (i, &v) in s2.iter().enumerate() {
+                    let bit_is_one = (i >> bit_sel) & 1 == 1;
+                    let v_for_one = if bit_is_one { v } else { f32::NEG_INFINITY };
+                    let v_for_zero = if bit_is_one { f32::NEG_INFINITY } else { v };
+                    mo = mo.max(v_for_one);
+                    mz = mz.max(v_for_zero);
                 }
+                max_one[bit_sel] = mo;
+                max_zero[bit_sel] = mz;
             }
             for ib in 0..=ibmax {
                 let bit_idx = i_bit_base + ib;


### PR DESCRIPTION
## Summary
- `engine::llr::fill_bmet_for_nsym`'s max-reduction loop (the a-priori top dense-kernel target from #208's survey) had two independent vectorization blockers: a per-element branch, and an `i`-outer/`bit_sel`-inner loop nest requiring outer-loop vectorization LLVM doesn't attempt here.
- Branchless rewrite alone changed **nothing** — verified via `wasm-objdump`, worth calling out since it contradicted the initial guess. Loop interchange (`bit_sel` outer, `i` inner) combined with the branchless rewrite is what actually unblocked vectorization: 40 → 86 `v128` ops in the function's compiled region.
- Profiling (#208 Stage C, `node --prof`) had already shown this function's ceiling is small — ~2.9% of total wasm decode time — well below an unrelated FFT-plan-caching bug found in the same pass (#211, fixed separately, ~12.5%). Wall-clock impact here is within run-to-run measurement noise even though the vectorization itself is real and instruction-level-verified.

## Test plan
- [x] `cargo check -p mfsk-core --features full`
- [x] `cargo fmt --all -- --check`, `cargo clippy --features full,internal-testing --all-targets -- -D warnings -D clippy::perf`
- [x] All three FT8 golden regressions: full-parity 8/8, AP-off 7/8/7-phantom/14-total, JTDX 18/18/1-extra — byte-identical to documented baseline
- [x] Full `cargo test --release -p mfsk-core --features full,internal-testing`: 61/61 test-result blocks passed, zero failures (covers FT4/FST4/WSPR/JT9/JT65/Q65/MSK144 too, since this function is shared)
- [x] `wasm-objdump` before/after on the specific function region: 40 → 86 `v128`/`f32x4`/`i32x4` ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqxRCEE16vYwN3jJXoeDXG