### PR TITLE
fix(embedded): update DecodeResult.message77 field access to method call

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/compute_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/compute_bench.rs
@@ -225,7 +225,7 @@ fn decode_one(slot: &[i16], max_cand: usize, _dt_grid: u8, _df_grid: u8, _q_thre
         (t5 - t0) as f64 / 1e6,
     );
     for (i, r) in results.iter().enumerate() {
-        if let Some(text) = unpack77(&r.message77) {
+        if let Some(text) = unpack77(r.message77()) {
             log::info!(
                 "    [{i}]  {:>4.0} Hz  SNR={:>5.1} dB  e={}  '{}'",
                 r.freq_hz,

--- a/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
+++ b/embedded-poc/embedded-shared/src/apps/rx_wavsim.rs
@@ -148,7 +148,7 @@ pub fn run_sweep(wavs: &'static [&'static [u8]], cfgs: &'static [RxSweepCfg]) ->
         );
 
         for (i, r) in results.iter().enumerate() {
-            if let Some(text) = unpack77(&r.message77) {
+            if let Some(text) = unpack77(r.message77()) {
                 log::info!(
                     "    [{i}]  {:>4.0} Hz  SNR={:>5.1} dB  e={}  '{}'",
                     r.freq_hz,

--- a/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-core2-app/src/decode_pipeline.rs
@@ -142,7 +142,7 @@ pub fn run() -> ! {
         let mut had_response_this_slot = false;
         if let Ok(mut ui) = UI.lock() {
             for r in results.iter() {
-                if let Some(text) = unpack77(&r.message77) {
+                if let Some(text) = unpack77(r.message77()) {
                     let mut msg: heapless::String<22> = heapless::String::new();
                     let take = text.len().min(msg.capacity());
                     let _ = msg.push_str(&text[..take]);

--- a/embedded-poc/m5stack-cores3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-cores3-app/src/decode_pipeline.rs
@@ -136,7 +136,7 @@ pub fn run_with_source<F: FnOnce(QueueHandle_t)>(source_spawn: F) -> ! {
         let mut had_response_this_slot = false;
         if let Ok(mut ui) = UI.lock() {
             for r in results.iter() {
-                if let Some(text) = unpack77(&r.message77) {
+                if let Some(text) = unpack77(r.message77()) {
                     let mut msg: heapless::String<22> = heapless::String::new();
                     let take = text.len().min(msg.capacity());
                     let _ = msg.push_str(&text[..take]);

--- a/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
+++ b/embedded-poc/m5stack-s3-app/src/decode_pipeline.rs
@@ -446,7 +446,7 @@ where
         let mut had_response_this_slot = false;
         if let Ok(mut ui) = UI.lock() {
             for r in results.iter() {
-                if let Some(text) = unpack77(&r.message77) {
+                if let Some(text) = unpack77(r.message77()) {
                     let mut msg: heapless::String<22> = heapless::String::new();
                     let take = text.len().min(msg.capacity());
                     let _ = msg.push_str(&text[..take]);


### PR DESCRIPTION
## Summary
Issue #206's public-API review tracking listed "embedded-poc +esp check still owed" — `core`→`engine` rename and #194's `DecodeResult` unification landed with embedded-poc's compilation only textually updated, never actually verified (no `+esp` toolchain was available in the environment those PRs were done in).

Installed `espup` + the Xtensa toolchain and ran `cargo check` across all four `embedded-poc` crates. Found one real regression from #194: `DecodeResult::message77` moved from a struct field to a `message77()` accessor over the boxed `info` field, but 5 call sites in `embedded-poc` (workspace-excluded, not caught by host CI) still used `&r.message77` as a field access:
- `embedded-shared/src/apps/compute_bench.rs`
- `embedded-shared/src/apps/rx_wavsim.rs`
- `m5stack-s3-app/src/decode_pipeline.rs`
- `m5stack-core2-app/src/decode_pipeline.rs`
- `m5stack-cores3-app/src/decode_pipeline.rs`

Trivial fix at each: `&r.message77` → `r.message77()`.

## Test plan
- [x] Fresh `espup install`, `cargo check` on all four `embedded-poc` crates (`m5stack-s3-app`, `m5stack-core2-app`, `m5stack-cores3-app`, `m5stack-s3` compute-bench) — all compile clean (one pre-existing, unrelated `unused_unsafe` warning in `compute_bench.rs`, not touched by this fix)
- [ ] Not flashed to real hardware (this session has no physical M5Stack device) — a `cargo check` pass, not a flash-verified fix; flag if on-device behavior needs separate confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqxRCEE16vYwN3jJXoeDXG