### PR TITLE
docs: fix post-#206 staleness + missing #215 CHANGELOG entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208)
+## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208) + embedded-poc `+esp` compile fix (#215)
 
 ### Added
 
@@ -1798,6 +1798,16 @@
   Byte-identical recall on all three FT8 golden regressions
   (full-parity 8/8, AP-off 7/8/7-phantom/14-total, JTDX 18/18/1-extra)
   and the full `--features full` test suite.
+- **`embedded-poc` didn't compile against the real `+esp` Xtensa
+  toolchain** (#215) — #194's `DecodeResult.message77` field→method
+  change wasn't propagated there, since `embedded-poc` is
+  workspace-excluded and never built by host CI. 5 call sites still
+  used `&r.message77` as a field: `embedded-shared/src/apps/{compute_bench,rx_wavsim}.rs`
+  and each app's `decode_pipeline.rs`
+  (`m5stack-s3-app`/`m5stack-core2-app`/`m5stack-cores3-app`). Found by
+  installing `espup` fresh and running `cargo check` across all four
+  `embedded-poc` crates — closes the "embedded-poc +esp check still
+  owed" item from #206. All four now compile clean.
 
 ## 0.7.4 — MSK144 decode (#25)
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ let results = DecodeRequest::<Ft8>::new(
 .decode()
 .results;
 for r in &results {
-    if let Some(text) = unpack77(&r.message77) {
+    if let Some(text) = unpack77(r.message77()) {
         println!("{:7.1} Hz  dt={:+.2} s  SNR={:+.0} dB  {}",
                  r.freq_hz, r.dt_sec, r.snr_db, text);
     }

--- a/docs/reference/EMBEDDED.ja.md
+++ b/docs/reference/EMBEDDED.ja.md
@@ -17,9 +17,9 @@ DSP / FEC パイプライン全体は **scalar trait** でパラメータ化さ�
 おり、同じソースが host 側 f32 パスと組込側整数パスのいずれにも
 **コード重複なし** で compile される:
 
-- [`core::scalar::SpecScalar`] — spectrogram / DFT 出力 scalar
+- [`engine::scalar::SpecScalar`] — spectrogram / DFT 出力 scalar
   (host は `f32`、embedded cs 格納は `Q14i16`)。
-- [`core::scalar::LlrScalar`] — wide-accumulator 付き LLR scalar
+- [`engine::scalar::LlrScalar`] — wide-accumulator 付き LLR scalar
   (host は `f32`、組込 BP は **`Q11i16` + i32 wide accumulator**、
   0.6.2 以降。0.5.x までは `Q3i8` だった。拡張の動機は host
   fixed-point + rustfft sweep (pre-0.6.3 計測 — 0.6.3 の OSD
@@ -33,8 +33,8 @@ DSP / FEC パイプライン全体は **scalar trait** でパラメータ化さ�
   ただし実機 embedded の上乗せは 1 件のみ (6/18 → 7 total) —
   残る host gap は LLR scalar ではなく組込パイプラインの他要素
   (NSTEP-half、coarse-sync 簡略化、`fine_refine_pass1` 無し) が
-  律速。`Q3i8` 型は比較経路用に `core::scalar` に残置)。
-- [`core::scalar::Cmplx<S>`] — `SpecScalar` 上のジェネリック複素数。
+  律速。`Q3i8` 型は比較経路用に `engine::scalar` に残置)。
+- [`engine::scalar::Cmplx<S>`] — `SpecScalar` 上のジェネリック複素数。
   0.6.3 (cleanup β.5) 以降は `num_complex::Complex<S>` の type
   alias、組込整数パスと host f32 パスで同じ複素演算実装を共有。
 - `compute_llr_generic<P, S, T>`、`compute_snr_db_generic<P, S>`、
@@ -51,7 +51,7 @@ DSP / FEC パイプライン全体は **scalar trait** でパラメータ化さ�
 | Component | Generic over | Fixed-point switch 配線済み? |
 |---|---|---|
 | LDPC BP NMS (`fec::ldpc::bp`) | `LlrScalar` | ✅ `fixed-point` 経由 |
-| LLR 計算 (`core::llr`) | `SpecScalar` × `LlrScalar` | ✅ `fixed-point` 経由 |
+| LLR 計算 (`engine::llr`) | `SpecScalar` × `LlrScalar` | ✅ `fixed-point` 経由 |
 | BP scratch pool (`BpScratch<P, T>`) | `LdpcParams` × `LlrScalar` | ✅ — FT8 LDPC(174,91) と FST4/uvpacket LDPC(240,101) で機能 |
 | FT8 spectrogram + DFT (`ft8::decode_block`) | `SpecScalar` × `AudioSample` | ✅ `fixed-point` 経由 |
 | **FT4 / WSPR / Q65 / JT9 / JT65** | (host f32 のみ) | ❌ — これらは現状 `decode_block` を通っていない |
@@ -133,14 +133,14 @@ Feature リファレンス:
 | `alloc` | `extern crate alloc` + Vec / Box。 | 全 decode パス。 |
 | `fft-extern` | `mfsk_core_make_default_fft_planner` extern fn (i16 用 `_planner16` も) 経由の FFT バックエンド。 | 任意の組込ターゲット。 |
 | `fft-rustfft` | rustfft を FFT バックエンドに。 | Host 専用。 |
-| `fixed-point` | 組込整数パイプライン: u16 spectrogram + i16 内部 DFT + Q11i16 LLR + 整数 NMS BP。`nstep-half` を含意。(0.5.x は `Q3i8` だったが、host fixed-point + rustfft で `qso3_busy.wav` の recall が f32 16/18 → Q3i8 9/18 と落ちる LLR 解像度律速が判明、0.6.2 で `Q11i16` に拡張。`Q3i8` 型は比較経路用に `core::scalar` に残置。) | 任意の組込ターゲット — host f32 に近い recall (1/2048 LSB)、PSRAM 帯域半減、~12 KB BP scratch (Q11i16、0.6.2 以降)。 |
+| `fixed-point` | 組込整数パイプライン: u16 spectrogram + i16 内部 DFT + Q11i16 LLR + 整数 NMS BP。`nstep-half` を含意。(0.5.x は `Q3i8` だったが、host fixed-point + rustfft で `qso3_busy.wav` の recall が f32 16/18 → Q3i8 9/18 と落ちる LLR 解像度律速が判明、0.6.2 で `Q11i16` に拡張。`Q3i8` 型は比較経路用に `engine::scalar` に残置。) | 任意の組込ターゲット — host f32 に近い recall (1/2048 LSB)、PSRAM 帯域半減、~12 KB BP scratch (Q11i16、0.6.2 以降)。 |
 | `nstep-half` | spectrogram カラムレートを NSTEP = NSPS/2 (WSJT-X 忠実な NSPS/4 でなく)。 | `fixed-point` で自動有効。host ビルドで組込パスを明示的に simulate する以外では独立に enable しない。 |
 | `parallel` | Rayon 並列 candidate 処理。 | Host 専用。組込では常に off (`std::thread` 無し)。 |
 | `profile-coarse` | coarse_sync sub-stage timing を常時 stderr 出力。 | 診断専用。 |
 
 ## FFT extern Rust 契約
 
-`mfsk_core::core::fft::FftPlanner` (および i16 パス用
+`mfsk_core::engine::fft::FftPlanner` (および i16 パス用
 `FftPlanner16`) が decode パスの FFT trait。`fft-extern` 配下では
 リンクされたバイナリが 2 つの `extern "Rust"` factory 関数を提供
 することを要求する:
@@ -148,14 +148,14 @@ Feature リファレンス:
 ```rust
 #[unsafe(no_mangle)]
 pub extern "Rust" fn mfsk_core_make_default_fft_planner()
-    -> Box<dyn mfsk_core::core::fft::FftPlanner>
+    -> Box<dyn mfsk_core::engine::fft::FftPlanner>
 {
     Box::new(MyEspDspPlanner::new())
 }
 
 #[unsafe(no_mangle)]
 pub extern "Rust" fn mfsk_core_make_default_fft_planner16()
-    -> Box<dyn mfsk_core::core::fft::FftPlanner16>
+    -> Box<dyn mfsk_core::engine::fft::FftPlanner16>
 {
     Box::new(MyEspDspPlanner16::new())
 }
@@ -219,8 +219,8 @@ scratch 引数そのものを削除して仕上げた — 新規統合では scr
 | Stage | Format | Range | File |
 |---|---|---|---|
 | Spectrogram cell | u16 (mag²) | `>> FP_SPEC_SHIFT (12)`、0.6.4 以降飽和 | `ft8::decode_block::spectrogram::Spectrogram` |
-| Symbol cs | `Cmplx<f32>` (デフォルト) または `Cmplx<Q14i16>` (`fixed-point`) | f32 無制限、Q14 ±2 | `core::scalar::Cmplx` (`num_complex::Complex` の type alias) |
-| LLR | f32 (host) または **Q11i16** (`fixed-point`、0.6.2 以降 — 0.5.x は `Q3i8`。解像度律速の recall 天井を解消するため拡張) | f32 無制限、Q11i16 ±16 (~1/2048 LSB) (Q3i8 ±16 (~1/8 LSB) は `core::scalar` に比較経路用として残置) | `core::scalar::LlrScalar` |
+| Symbol cs | `Cmplx<f32>` (デフォルト) または `Cmplx<Q14i16>` (`fixed-point`) | f32 無制限、Q14 ±2 | `engine::scalar::Cmplx` (`num_complex::Complex` の type alias) |
+| LLR | f32 (host) または **Q11i16** (`fixed-point`、0.6.2 以降 — 0.5.x は `Q3i8`。解像度律速の recall 天井を解消するため拡張) | f32 無制限、Q11i16 ±16 (~1/2048 LSB) (Q3i8 ±16 (~1/8 LSB) は `engine::scalar` に比較経路用として残置) | `engine::scalar::LlrScalar` |
 | BP messages | T (LLR と同じ) | — | `fec::ldpc::bp::bp_decode_generic_nms_with_scratch` |
 
 ## C / C++ / 非 Rust ESP-IDF プロジェクトからの利用 (`mfsk-ffi-ft8`)

--- a/docs/reference/EMBEDDED.md
+++ b/docs/reference/EMBEDDED.md
@@ -18,9 +18,9 @@ The whole DSP / FEC pipeline is parameterised by **scalar traits**, so
 the same source compiles to either a host-friendly f32 path or an
 embedded-friendly integer path **with no duplicated code**:
 
-- [`core::scalar::SpecScalar`] — spectrogram / DFT-output scalar
+- [`engine::scalar::SpecScalar`] — spectrogram / DFT-output scalar
   (`f32` on host; `Q14i16` for embedded cs storage).
-- [`core::scalar::LlrScalar`] — LLR scalar with wide-accumulator
+- [`engine::scalar::LlrScalar`] — LLR scalar with wide-accumulator
   type (`f32` on host; **`Q11i16` with i32 wide accumulator** for
   embedded BP, since 0.6.2 — was `Q3i8` in 0.5.x. The widening
   was driven by the host f32-vs-`Q3i8` sweep on `qso3_busy.wav`
@@ -37,8 +37,8 @@ embedded-friendly integer path **with no duplicated code**:
   coarse-sync simplifications, no `fine_refine_pass1`), not by the
   LLR scalar. BP scratch doubles from ~6 KB to ~12 KB, still inside
   the S3 / Core2 internal-DRAM budget. `Q3i8` stays in
-  `core::scalar` for the comparison path).
-- [`core::scalar::Cmplx<S>`] — generic complex over a `SpecScalar`.
+  `engine::scalar` for the comparison path).
+- [`engine::scalar::Cmplx<S>`] — generic complex over a `SpecScalar`.
   As of 0.6.3 (cleanup β.5) this is a type alias for
   `num_complex::Complex<S>`, so the embedded integer path and the
   host f32 path share the same complex algebra implementation.
@@ -56,7 +56,7 @@ and optimisations land once and apply everywhere.
 | Component | Generic over | Fixed-point switch wired? |
 |---|---|---|
 | LDPC BP NMS (`fec::ldpc::bp`) | `LlrScalar` | ✅ via `fixed-point` |
-| LLR computation (`core::llr`) | `SpecScalar` × `LlrScalar` | ✅ via `fixed-point` |
+| LLR computation (`engine::llr`) | `SpecScalar` × `LlrScalar` | ✅ via `fixed-point` |
 | BP scratch pool (`BpScratch<P, T>`) | `LdpcParams` × `LlrScalar` | ✅ — works for FT8 LDPC(174,91) and FST4/uvpacket LDPC(240,101) |
 | FT8 spectrogram + DFT (`ft8::decode_block`) | `SpecScalar` × `AudioSample` | ✅ via `fixed-point` |
 | **FT4 / WSPR / Q65 / JT9 / JT65** | (host f32 only) | ❌ — these protocols don't go through `decode_block` today |
@@ -143,14 +143,14 @@ Feature reference:
 | `alloc` | `extern crate alloc` + Vec / Box. | All decode paths. |
 | `fft-extern` | FFT backend via `mfsk_core_make_default_fft_planner` extern fn (and the i16 variant `_planner16`). | Any embedded target. |
 | `fft-rustfft` | rustfft as the FFT backend. | Host only. |
-| `fixed-point` | Embedded integer pipeline: u16 spectrogram + i16 internal DFT + Q11i16 LLR + integer NMS BP. Implies `nstep-half`. (Was `Q3i8` in 0.5.x — 0.6.2 widened the LLR to `Q11i16` because host fixed-point + rustfft hit 16/18 on `qso3_busy.wav` with f32 but only 9/18 with `Q3i8`; the resolution step was the recall ceiling, not anything DSP-side. `Q3i8` stays in `core::scalar` for the comparison path.) | Any embedded target — close to host f32 recall (1/2048 LSB LLR resolution), halved PSRAM bandwidth, ~12 KB BP scratch (Q11i16, post-0.6.2). |
+| `fixed-point` | Embedded integer pipeline: u16 spectrogram + i16 internal DFT + Q11i16 LLR + integer NMS BP. Implies `nstep-half`. (Was `Q3i8` in 0.5.x — 0.6.2 widened the LLR to `Q11i16` because host fixed-point + rustfft hit 16/18 on `qso3_busy.wav` with f32 but only 9/18 with `Q3i8`; the resolution step was the recall ceiling, not anything DSP-side. `Q3i8` stays in `engine::scalar` for the comparison path.) | Any embedded target — close to host f32 recall (1/2048 LSB LLR resolution), halved PSRAM bandwidth, ~12 KB BP scratch (Q11i16, post-0.6.2). |
 | `nstep-half` | NSTEP = NSPS/2 (vs WSJT-X-faithful NSPS/4) for the spectrogram column rate. | Auto-enabled by `fixed-point`. Don't enable independently on a host build unless you're explicitly simulating the embedded path. |
 | `parallel` | Rayon-parallel candidate processing. | Host only. Always off on embedded (no `std::thread`). |
 | `profile-coarse` | Always emits coarse_sync sub-stage timings to stderr. | Diagnosis only. |
 
 ## The FFT extern Rust contract
 
-`mfsk_core::core::fft::FftPlanner` (and `FftPlanner16` for the i16
+`mfsk_core::engine::fft::FftPlanner` (and `FftPlanner16` for the i16
 path) is the decode path's FFT trait. Under `fft-extern`, the library
 expects the linked binary to provide two `extern "Rust"` factory
 functions:
@@ -158,14 +158,14 @@ functions:
 ```rust
 #[unsafe(no_mangle)]
 pub extern "Rust" fn mfsk_core_make_default_fft_planner()
-    -> Box<dyn mfsk_core::core::fft::FftPlanner>
+    -> Box<dyn mfsk_core::engine::fft::FftPlanner>
 {
     Box::new(MyEspDspPlanner::new())
 }
 
 #[unsafe(no_mangle)]
 pub extern "Rust" fn mfsk_core_make_default_fft_planner16()
-    -> Box<dyn mfsk_core::core::fft::FftPlanner16>
+    -> Box<dyn mfsk_core::engine::fft::FftPlanner16>
 {
     Box::new(MyEspDspPlanner16::new())
 }
@@ -232,8 +232,8 @@ never need to think about scratch placement here at all.
 | Stage | Format | Range | File |
 |---|---|---|---|
 | Spectrogram cell | u16 (mag²) | `>> FP_SPEC_SHIFT (12)`, saturated since 0.6.4 | `ft8::decode_block::spectrogram::Spectrogram` |
-| Symbol cs | `Cmplx<f32>` (default) or `Cmplx<Q14i16>` (`fixed-point`) | f32 unbounded; Q14 ±2 | `core::scalar::Cmplx` (type alias for `num_complex::Complex`) |
-| LLR | f32 (host) or **Q11i16** (`fixed-point`, since 0.6.2 — was `Q3i8` in 0.5.x; widened to address the resolution-limited recall ceiling) | f32 unbounded; Q11i16 ±16 with ~1/2048 LSB (Q3i8 ±16 with ~1/8 LSB stays in `core::scalar` for the comparison path) | `core::scalar::LlrScalar` |
+| Symbol cs | `Cmplx<f32>` (default) or `Cmplx<Q14i16>` (`fixed-point`) | f32 unbounded; Q14 ±2 | `engine::scalar::Cmplx` (type alias for `num_complex::Complex`) |
+| LLR | f32 (host) or **Q11i16** (`fixed-point`, since 0.6.2 — was `Q3i8` in 0.5.x; widened to address the resolution-limited recall ceiling) | f32 unbounded; Q11i16 ±16 with ~1/2048 LSB (Q3i8 ±16 with ~1/8 LSB stays in `engine::scalar` for the comparison path) | `engine::scalar::LlrScalar` |
 | BP messages | T (same as LLR) | — | `fec::ldpc::bp::bp_decode_generic_nms_with_scratch` |
 
 ## Using from C / C++ / non-Rust ESP-IDF projects (`mfsk-ffi-ft8`)

--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -45,10 +45,10 @@ while broadening the set of platforms that can host it.
 Protocol-independent algorithms — DSP, sync, LLR, the equaliser,
 LDPC BP / OSD, Fano convolutional decoding, Reed-Solomon erasure
 decoding, and the shared parts of the message codec — live in the
-`core`, `fec`, and `msg` modules. Each protocol is a comparatively
+`engine`, `fec`, and `msg` modules. Each protocol is a comparatively
 small zero-sized type (ZST) that declares its own constants and the
-specific FEC / message codec it uses. The pipeline is expressed as
-`decode_frame::<P>()`, taking `P: Protocol` as a compile-time type
+specific FEC / message codec it uses. The pipeline is driven through
+`DecodeRequest::<P>` (§4), taking `P: Protocol` as a compile-time type
 parameter so that monomorphisation produces specialised code per
 protocol. The abstraction does not add runtime cost.
 
@@ -149,7 +149,8 @@ exercise:
    paths through the same FEC. They are listed in §3:
    plain AWGN BP, AP-hint BP, fast-fading metric, AP-list
    template matching, and multi-period EMA averaging. Each is a
-   distinct entry-point function generic over the sub-mode ZST; the
+   builder method combination on `DecodeRequest`/`SniperRequest`/
+   `MultiPeriodRequest`, generic over the sub-mode ZST; the
    underlying FEC and message codec are shared.
 
 Where WSPR proved that *FEC family + message width + sync mode*
@@ -170,7 +171,7 @@ differences: a coarse-sync → LLR → FEC pipeline running over one
 fixed-length slot, with 0..N frames sitting at (or near) a known
 nominal offset. **MSK144** (issue #25) breaks both halves of that
 assumption at once, and rather than force a fit, `msk144::decode`
-is its own top-level driver — it never touches `core::pipeline`,
+is its own top-level driver — it never touches `engine::pipeline`,
 `ModulationParams`, or `FrameLayout`, and no ZST implements
 `Protocol` for it at all. This is a step further than WSPR or Q65:
 those still adopt the trait surface (§0.5) even where their real
@@ -182,7 +183,7 @@ trait surface itself.
    with a half-sine pulse. `ModulationParams`'s tone-index /
    Gray-map / GFSK-shaping model has no useful mapping onto that
    waveform. The modulator and matched-filter demodulator live in
-   `core::dsp::msk` as plain functions, not a trait impl.
+   `engine::dsp::msk` as plain functions, not a trait impl.
 2. **Not a static slot.** Every other protocol assumes a frame sits
    at a known nominal offset inside one fixed-length slot buffer.
    MSK144 instead repeats its 864-sample (72 ms) frame continuously
@@ -193,7 +194,7 @@ trait surface itself.
    two-tone spectral scan) plus `msk144::sync::msk144_sync` (a joint
    CFO/symbol-timing matched-filter correlation) do that scanning,
    ported from WSJT-X's `msk144spd.f90`/`msk144sync.f90` — not from
-   `core::sync::coarse_sync`.
+   `engine::sync::coarse_sync`.
 
 What it *does* share with the rest of the library: the 77-bit
 `pack77`/`unpack77` message payload (`msg::wsjt77`, completely
@@ -216,13 +217,15 @@ architecture doesn't cost recall.
 
 ```
 mfsk_core
-├── core/             Protocol traits, DSP, sync, LLR, equaliser, pipeline
+├── engine/           Protocol traits, DSP, sync, LLR, equaliser, pipeline
 │   ├── protocol.rs     ModulationParams / FrameLayout / Protocol / FecCodec / MessageCodec
 │   ├── dsp/            resample · downsample · gfsk · subtract · msk · analytic
 │   ├── sync.rs         coarse_sync / refine_candidate
 │   ├── llr.rs          symbol_spectra / compute_llr / sync_quality
 │   ├── equalize.rs     equalize_local (Wiener per-tone)
 │   └── pipeline.rs     decode_frame / decode_frame_subtract / process_candidate_basic
+│                       (pub(crate) internals — see §4; call via
+│                       msg::decode_request::DecodeRequest/SniperRequest)
 ├── fec/              FecCodec implementations
 │   ├── ldpc/           LDPC(174, 91)  — FT8, FT4 (bp.rs / osd.rs / params.rs / tables.rs)
 │   ├── ldpc240_101/    LDPC(240, 101) — FST4
@@ -239,6 +242,9 @@ mfsk_core
 │       ├── npfwht.rs      Non-binary Walsh-Hadamard transform helpers
 │       └── pdmath.rs      Probability-domain BP math helpers
 ├── msg/              Message codecs
+│   ├── decode_request.rs DecodeRequest / SniperRequest — the public decode
+│   │                     entry point for FT8/FT4/FST4 (§4, replaces the
+│   │                     pre-0.8.0 decode_frame*/decode_sniper* families)
 │   ├── wsjt77.rs       77-bit WSJT message (pack / unpack) — FT8, FT4, FST4, Q65, MSK144
 │   ├── wspr.rs         50-bit WSPR Types 1 / 2 / 3
 │   ├── jt72.rs         72-bit JT message — JT9, JT65
@@ -280,7 +286,7 @@ mfsk_core
 
 Each protocol module is gated behind a feature flag (`ft8`, `ft4`,
 `fst4`, `wspr`, `jt9`, `jt65`, `q65`, `msk144`, `packet-bytes`,
-`uvpacket`). The `core`, `fec`, `msg` and `registry` modules are
+`uvpacket`). The `engine`, `fec`, `msg` and `registry` modules are
 always available.
 
 The `mfsk-ffi` sibling crate in this workspace builds a C ABI
@@ -289,7 +295,7 @@ same crate.
 
 #### `FecCodec` is symbol-agnostic
 
-The `FecCodec` trait surface (`core/protocol.rs`) speaks in **bits**:
+The `FecCodec` trait surface (`engine/protocol.rs`) speaks in **bits**:
 `&[u8]` info / codeword, `&[f32]` bit-LLRs, `K` and `N` counted in
 bits. The four FEC families above include two non-binary codes —
 Reed-Solomon over GF(2⁶) for JT65 and QRA over GF(2⁶) for Q65 — which
@@ -361,9 +367,9 @@ Two concrete cases show how the three traits combine on a real ZST.
 message codec with FT8:
 
 ```rust
-use mfsk_core::core::protocol::*;
+use mfsk_core::engine::protocol::*;
 use mfsk_core::fec::Ldpc174_91; // re-exported from fec::ldpc
-use mfsk_core::msg::wsjt77::Wsjt77Message;
+use mfsk_core::msg::Wsjt77Message;
 
 pub struct Ft4;
 
@@ -438,16 +444,16 @@ impl Protocol for Wspr {
 ```
 
 Calling code just passes the ZST as a type argument —
-`decode_frame::<Ft4>(...)` or the WSPR-specific
-`wspr::decode::decode_scan_default(...)` — and the trait composition
-pulls in the appropriate FEC, message codec, and sync mode
-automatically.
+`DecodeRequest::<Ft4>::new(...).decode()` (§4, §6.2) or the
+WSPR-specific `wspr::decode::decode_scan_default(...)` — and the
+trait composition pulls in the appropriate FEC, message codec, and
+sync mode automatically.
 
 ### Monomorphisation & zero cost
 
-All hot-path functions (`core::sync::coarse_sync::<P>`,
-`core::llr::compute_llr::<P>`,
-`core::pipeline::process_candidate_basic::<P>`, …) take
+All hot-path functions (`engine::sync::coarse_sync::<P>`,
+`engine::llr::compute_llr::<P>`,
+`engine::pipeline::process_candidate_basic::<P>`, …) take
 `P: Protocol` as a **compile-time** type parameter. rustc
 monomorphises one copy per concrete protocol; LLVM sees a
 fully-specialised function and inlines the trait constants as
@@ -469,7 +475,7 @@ existing infrastructure it can reuse.
    the other FST4 sub-modes). Define a new ZST and swap the numeric
    constants (`NTONES`, `NSPS`, `TONE_SPACING_HZ`, `SYNC_MODE`, and
    the sync pattern). `Fec` and `Msg` can be type aliases to the
-   existing implementations, and the full `decode_frame::<P>()`
+   existing implementations, and the full `DecodeRequest::<P>`
    pipeline runs unchanged.
 
 2. **New FEC but same message** (e.g. a different LDPC size). Add
@@ -499,73 +505,81 @@ existing infrastructure it can reuse.
 ## 3. Decoder strategies (Q65 case study)
 
 Most protocols in this library expose a single decoder entry point:
-`decode_frame::<P>` for the FT family, `wspr::decode::decode_scan_default`
+`DecodeRequest::<P>` for the FT family (§4, "The public decode entry
+point"), `wspr::decode::decode_scan_default`
 for WSPR, etc. Q65 is the first wired protocol where a single FEC
 frame can be approached through several legitimately different
 receiver chains, each trading runtime cost against a different kind
-of channel pathology. They live side by side as parallel
-function families in `mfsk_core::q65::rx`, each generic over the
-sub-mode ZST.
+of channel pathology.
 
-A point worth flagging up front: the single-candidate point-decode
-functions (`decode_at_for`, `decode_at_fading_for`, …) and the
-scanning functions that wrap them (`decode_scan_for`,
-`decode_scan_fading_for`, …) are *not* the same algorithm behind two
-call shapes. `decode_at_for` really is the plain Bessel-I0 metric.
-But `decode_scan_for` / `decode_scan_with_ap_for` — the family nearly
-every real caller uses — route each coarse-search candidate through
-`decode_at_with_fine_timing_for`, which always runs a WSJT-X-faithful
-`(Δf, Δt, b90)` grid search using the fast-fading metric with
-`FadingModel::Lorentzian`, ported from `q65_loops.f90` /
-`q65_dec_q012`. That mirrors WSJT-X's own automatic decoder, which
-never actually runs a plain-AWGN-only Bessel pass for its default
-scan either. So "AWGN" and "fast-fading" are best read as two
-distinct *entry-point families* (point vs. scan), not two cleanly
-separate front ends picked by channel type — the scan path already
-assumes some amount of fading by default, and the dedicated
-fast-fading entry points below exist for when the caller wants to
-pick a specific `(b90_ts, model)` explicitly instead.
+As of issue #204, these are exposed through three generic builders in
+`mfsk_core::q65::decode_request` — `DecodeRequest<P>` (wide-band
+scan), `SniperRequest<P>` (single known `(start_sample, base_freq_hz)`,
+built via `DecodeRequest::sniper` or `SniperRequest::new` directly),
+and `MultiPeriodRequest<P>` (averaged multi-slot decode) — mirroring
+`msg::decode_request`'s FT8/FT4/FST4 shape (§4), generic over a
+sealed `Q65SubMode` marker implemented for all ten sub-mode ZSTs. The
+underlying `q65::rx` functions this section used to reference directly
+(`decode_at_for`, `decode_scan_for`, …) are `pub(crate)` — the builders
+are the public entry point. `.ap_hint()`, `.ap_list()`, `.fading()` are
+plain inherent methods (not capability-gated marker traits like
+`SupportsWideBandAp`) since every Q65 sub-mode supports every
+capability uniformly.
 
-| When                                                   | Strategy                              | Entry point                                                          | Threshold gain |
+A point worth flagging up front: `SniperRequest::decode()` with no
+capability set (`decode_at_for` internally) really is the plain
+Bessel-I0 metric — the point-decode-only baseline. But
+`DecodeRequest::decode()` with no capability set (`decode_scan_for`
+internally) — the shape nearly every real caller uses — routes each
+coarse-search candidate through a WSJT-X-faithful `(Δf, Δt, b90)` grid
+search using the fast-fading metric with `FadingModel::Lorentzian`,
+ported from `q65_loops.f90` / `q65_dec_q012`. That mirrors WSJT-X's own
+automatic decoder, which never actually runs a plain-AWGN-only Bessel
+pass for its default scan either. So "AWGN" and "fast-fading" are best
+read as two distinct *entry-point families* (sniper vs. scan), not two
+cleanly separate front ends picked by channel type — the scan path
+already assumes some amount of fading by default, and `.fading()`
+exists for when the caller wants to pick a specific `(b90_ts, model)`
+explicitly instead.
+
+| When                                                   | Strategy                              | Builder call                                                          | Threshold gain |
 |---------------------------------------------------------|----------------------------------------|------------------------------------------------------------------------|----------------|
-| Single known candidate, unknown content                | AWGN Bessel + BP (point-decode only)   | `decode_at_for<P>`                                                     | baseline       |
-| Default scan — unknown channel, unknown content         | `(Δf,Δt,b90)` grid search + Lorentzian fading BP | `decode_scan_for<P>` / `decode_scan_with_ap_for<P>`             | WSJT-X-faithful default |
-| Known callsign(s) or report, terrestrial channel        | AP-hint BP                             | `decode_at_with_ap_for<P>` / `decode_scan_with_ap_for<P>`              | ~2 dB          |
-| Doppler-spread channel, explicit model (microwave EME, ≥10 Hz spread) | Fast-fading metric + BP, caller-picked `(b90_ts, FadingModel)` | `decode_at_fading_for<P>` / `decode_scan_fading_for<P>` | 5–8 dB on spread channels |
-| Known call pair, no QSO context, terrestrial            | AP-list template matching              | `decode_at_with_ap_list_for<P>` / `decode_scan_with_ap_list_for<P>`    | ~3 dB          |
-| Weak/ionoscatter signal spanning several T/R periods    | Multi-period EMA averaging (3-stage cascade) | `decode_multi_period_for<P>` / `decode_multi_period`             | recovers signals no single-period strategy can |
+| Single known candidate, unknown content                | AWGN Bessel + BP (point-decode only)   | `SniperRequest::<P>::new(...).decode()`                                | baseline       |
+| Default scan — unknown channel, unknown content         | `(Δf,Δt,b90)` grid search + Lorentzian fading BP | `DecodeRequest::<P>::new(...).decode()`                        | WSJT-X-faithful default |
+| Known callsign(s) or report, terrestrial channel        | AP-hint BP                             | `.ap_hint(&ap)` on either builder                                      | ~2 dB          |
+| Doppler-spread channel, explicit model (microwave EME, ≥10 Hz spread) | Fast-fading metric + BP, caller-picked `(b90_ts, FadingModel)` | `.fading(model, b90_ts)` on either builder | 5–8 dB on spread channels |
+| Known call pair, no QSO context, terrestrial            | AP-list template matching              | `.ap_list(&candidates)` on either builder                             | ~3 dB          |
+| Weak/ionoscatter signal spanning several T/R periods    | Multi-period EMA averaging (3-stage cascade) | `MultiPeriodRequest::<P>::new(...).decode()`                     | recovers signals no single-period strategy can |
 
-**AWGN Bessel + BP** (`decode_at_for`) is the textbook single-shot
-path: per-symbol FFT energies become probability vectors via the
-Bessel-I0 metric, then non-binary belief propagation runs on the QRA
-code. Falls back gracefully on any channel reasonably close to
-additive Gaussian noise — but note it is the *point-decode* API only;
-see the note above for why the scan family doesn't stay on this front
-end.
+**AWGN Bessel + BP** (`SniperRequest` with no capability set) is the
+textbook single-shot path: per-symbol FFT energies become probability
+vectors via the Bessel-I0 metric, then non-binary belief propagation
+runs on the QRA code. Falls back gracefully on any channel reasonably
+close to additive Gaussian noise — but note it is the *point-decode*
+shape only; see the note above for why the scan family doesn't stay on
+this front end.
 
-**AP-hint BP** clamps the intrinsic probability vectors at known
-information-bit positions before BP. A correct hint shifts the BP
-fixed-point closer to the truth; a wrong hint typically fails to
-converge rather than misdecoding (the CRC catches what's left).
-Construct the hint via `mfsk_core::msg::ApHint` (`with_call1`,
+**AP-hint BP** (`.ap_hint(&ap)`) clamps the intrinsic probability
+vectors at known information-bit positions before BP. A correct hint
+shifts the BP fixed-point closer to the truth; a wrong hint typically
+fails to converge rather than misdecoding (the CRC catches what's
+left). Construct the hint via `mfsk_core::msg::ApHint` (`with_call1`,
 `with_call2`, `with_grid`, `with_report`).
 
-**Fast-fading metric** replaces the Bessel front end with a
-spread-aware alternative, calibrated against a caller-chosen
-`FadingModel::Gaussian` or `FadingModel::Lorentzian` shape (the
-model is an explicit parameter on `decode_at_fading_for` /
-`decode_scan_fading_for`, not a fixed calibration). Required for
-microwave EME where lunar libration spreads each tone over
-10–60 Hz: the 10 GHz EME reference recording in
+**Fast-fading metric** (`.fading(model, b90_ts)`) replaces the Bessel
+front end with a spread-aware alternative, calibrated against a
+caller-chosen `FadingModel::Gaussian` or `FadingModel::Lorentzian`
+shape. Required for microwave EME where lunar libration spreads each
+tone over 10–60 Hz: the 10 GHz EME reference recording in
 `samples/Q65/60D_EME_10GHz/` decodes via this path but produces zero
 hits with the plain Bessel front end. `b90_ts` is the spread
 bandwidth × symbol period (typical: 0.05 = near-AWGN, 1.0 = moderate,
 5.0+ = severe).
 
-**AP-list template matching** does *not* run BP. Instead, the
-generator `q65::ap_list::standard_qso_codewords(my_call, his_call,
-his_grid)` pre-encodes the WSJT-X "full AP list" — 206 standard
-exchanges that a known callsign pair can legally produce
+**AP-list template matching** (`.ap_list(&candidates)`) does *not* run
+BP. Instead, the generator `q65::ap_list::standard_qso_codewords(my_call,
+his_call, his_grid)` pre-encodes the WSJT-X "full AP list" — 206
+standard exchanges that a known callsign pair can legally produce
 (`MYCALL HISCALL`, `MYCALL HISCALL RRR/RR73/73`, `CQ HISCALL grid`,
 plus the 200-entry SNR ladder). The decoder picks the candidate
 whose log-likelihood under the soft observations exceeds a
@@ -573,28 +587,24 @@ size-adjusted threshold, or returns `None`. Useful when the
 application has a known callsign pair but no QSO state — and at
 SNR −25 dB (1 dB below the published Q65-30A threshold), the
 test sweep shows AP-list decodes 6/6 frames where plain BP fails
-0/6.
+0/6. `.ap_list()` and `.fading()` are mutually exclusive in the
+underlying engine; `.decode()` resolves precedence as
+ap_list > fading (+ ap_hint) > ap_hint > plain.
 
-**Multi-period EMA averaging** (`decode_multi_period_for` /
-`decode_multi_period`) mirrors WSJT-X's `iavg=1`/`iavg=2` averaged
-decode from `q65_decode.f90` — the strategy that lets ionoscatter and
-weak EME signals decode when no single-period strategy above can. It
-maintains an exponential moving average of the per-slot spectrogram
-(time constant `min(navg, 4)`) across consecutive T/R periods and, at
-each slot, tries a 3-stage decode ladder against the averaged
-energies: (1) AP-list, when the caller supplies a plausible
-call/grid pair; (2) fast-fading BP sweeping `b90·Ts ∈ {3, 8, 15}` ×
-`{Gaussian, Lorentzian}`; (3) plain Bessel BP as a last-resort AWGN
-fallback. Returns at most one decode per slot, deduped by
-`(message, ±4 Hz freq)`. Not yet exposed via `mfsk-ffi` — Rust API
-only as of writing.
-
-**Composing strategies.** Fast-fading and AP-list compose: the
-fast-fading metric produces intrinsic vectors that
-`Q65Codec::decode_with_codeword_list` accepts directly. Wiring a
-combined `decode_at_fading_with_ap_list_for<P>` is a small additive
-change; for now, callers do the composition explicitly via the
-lower-level primitives (`intrinsics_fast_fading` + `Q65Codec`).
+**Multi-period EMA averaging** (`MultiPeriodRequest`) mirrors
+WSJT-X's `iavg=1`/`iavg=2` averaged decode from `q65_decode.f90` —
+the strategy that lets ionoscatter and weak EME signals decode when
+no single-period strategy above can. Takes `&[&[f32]]` (one buffer
+per T/R slot) rather than a single audio buffer. It maintains an
+exponential moving average of the per-slot spectrogram (time constant
+`min(navg, 4)`) across consecutive T/R periods and, at each slot,
+tries a 3-stage decode ladder against the averaged energies: (1)
+AP-list, when `.ap_list()` was set; (2) fast-fading BP sweeping
+`b90·Ts ∈ {3, 8, 15}` × `{Gaussian, Lorentzian}`; (3) plain Bessel BP
+as a last-resort AWGN fallback (no separate `.fading()`/`.ap_hint()`
+on this builder — the ladder always runs). Returns at most one decode
+per slot, deduped by `(message, ±4 Hz freq)`. Not yet exposed via
+`mfsk-ffi` — Rust API only as of writing.
 
 The C ABI exposes four of the strategies above one-for-one as
 `mfsk_q65_decode`, `mfsk_q65_decode_with_ap`, `mfsk_q65_decode_fading`
@@ -604,13 +614,13 @@ parameter so any of the ten sub-modes is reachable from C/C++/Kotlin;
 (`Gaussian` / `Lorentzian`) parameter (§8). Multi-period averaging is
 not yet part of the C ABI.
 
-## 4. Shared primitives (`core`)
+## 4. Shared primitives (`engine`)
 
 ### Receive pipeline at a glance
 
 The complete receive flow for any wired protocol — from raw audio
 samples to decoded message text — is a chain of free functions in
-the `core` submodules below, parameterised by `P: Protocol`:
+the `engine` submodules below, parameterised by `P: Protocol`:
 
 ```text
 ┌─────────┐  coarse_sync   ┌──────────────┐  refine_candidate  ┌──────────┐
@@ -638,11 +648,11 @@ the `core` submodules below, parameterised by `P: Protocol`:
 ```
 
 There is no `Demodulator` or `Receiver` trait. The receive path is
-realised as free functions in `core::sync`, `core::llr`,
-`core::equalize`, `core::pipeline`, each generic over `P: Protocol`.
+realised as free functions in `engine::sync`, `engine::llr`,
+`engine::equalize`, `engine::pipeline`, each generic over `P: Protocol`.
 Monomorphisation produces per-protocol code identical to a hand-
 written decoder, without forcing every protocol to implement an
-n-method receive interface. `core::llr::compute_llr<P>` is the soft
+n-method receive interface. `engine::llr::compute_llr<P>` is the soft
 demapper: it lives as a free fn rather than a `Protocol::demap()`
 method because the spectral extraction (`symbol_spectra`), the four
 WSJT-style LLR variants (a/b/c/d) and the equaliser feed into it as
@@ -651,7 +661,40 @@ equalisation and the pipeline driver — all of them take the
 protocol type as a parameter and read `P`'s associated constants
 (`NTONES`, `NSPS`, `SYNC_MODE`, …) directly.
 
-### DSP (`mfsk_core::core::dsp`)
+### The public decode entry point: `DecodeRequest` / `SniperRequest`
+
+The engine functions in the diagram above (`coarse_sync`,
+`decode_frame`, `process_candidate_basic`, …) are internal —
+`pub(crate)` since issue #191/#203. Applications drive them through
+two generic builders in `mfsk_core::msg::decode_request`, implemented
+for `Ft8`, `Ft4`, and every FST4 sub-mode (the `FrameDecodable`
+marker trait; Q65/WSPR/JT65/JT9/uvpacket keep their own bespoke entry
+points, §6.3/§6.5):
+
+* **`DecodeRequest<P>`** — wide-band search over `freq_min..freq_max`.
+  `DecodeRequest::<P>::new(audio, freq_min, freq_max, sync_min,
+  max_cand)`, then chain `.depth(...)`, `.strictness(...)`,
+  `.eq_mode(...)`, `.known(...)` (skip/subtract already-decoded
+  messages from an earlier pass), `.fft_cache(...)` (reuse a previous
+  call's forward FFT), `.ap_hint(...)` where the protocol implements
+  `SupportsWideBandAp` (FT8 only), and one of `.flat()` / `.staged()`
+  to pick a successive-interference-cancellation strategy where the
+  protocol supports it (`SupportsFlatSic`: FT8+FT4; `SupportsStagedSic`:
+  FT8 only). Call `.decode()` to get a `DecodeOutcome<P>` (`.results:
+  Vec<P::DecodeResult>`, plus `.fft_cache` for a follow-up call).
+* **`SniperRequest<P>`** — narrow-band, single-target search.
+  `DecodeRequest::<P>::sniper(audio, target_freq_hz, max_cand)` or
+  `SniperRequest::<P>::new(...)` directly; `.depth(...)`,
+  `.strictness(...)`, `.eq_mode(...)`, and `.ap_hint(...)` where the
+  protocol's message codec implements `WsjtApCompatible` (no SIC
+  variant — sniper mode is inherently single-candidate). `.decode()`
+  returns the same `DecodeOutcome<P>` shape.
+
+This replaced FT8's `decode_frame*`/`decode_frame_subtract*`/
+`decode_sniper*` family (15 public functions) and FT4/FST4's own
+suffix-exploded equivalents — see §6.2/§6.4 for worked examples.
+
+### DSP (`mfsk_core::engine::dsp`)
 
 | Module           | Purpose                                                     |
 |------------------|-------------------------------------------------------------|
@@ -666,7 +709,7 @@ from trait constants alone. Protocol modules expose module-level
 constants for each — `ft8::downsample::FT8_CFG`,
 `ft4::decode::FT4_DOWNSAMPLE`, etc.
 
-### Sync (`mfsk_core::core::sync`)
+### Sync (`mfsk_core::engine::sync`)
 
 * `coarse_sync::<P>(audio, freq_min, freq_max, …)` — UTC-aligned 2D
   peak search over `P::SYNC_MODE.blocks()` for non-FT8 protocols.
@@ -680,12 +723,12 @@ constants for each — `ft8::downsample::FT8_CFG`,
 > `mfsk_core::ft8::decode_block::coarse_sync` (graduated to public
 > API alongside `compute_spectrogram`) — the older
 > `ft8::sync::coarse_sync` thin wrapper has been removed. Calling
-> `core::sync::coarse_sync::<Ft8>` is still the right path for
-> hand-rolled non-default usage but the high-level
-> `ft8::decode::decode_frame*` entry points all dispatch via
-> `decode_block::coarse_sync`. See §10 for the FT8-specific notes.
+> `engine::sync::coarse_sync::<Ft8>` is still the right path for
+> hand-rolled non-default usage but `DecodeRequest::<Ft8>`/
+> `SniperRequest::<Ft8>` (§4) dispatch via `decode_block::coarse_sync`
+> internally. See §10 for the FT8-specific notes.
 
-### Sync2D — FT4 / FST4 full-slot coherent sync search (`mfsk_core::core::sync2d`)
+### Sync2D — FT4 / FST4 full-slot coherent sync search (`mfsk_core::engine::sync2d`)
 
 Two protocol-specific full-slot coherent searches live here, both
 ported from WSJT-X and both scored via a **phase-continuous** Costas
@@ -715,7 +758,7 @@ full-slot search instead — a local window anchored on the coarse-sync
 candidate's position couldn't recover cases where that non-coherent Δt
 estimate was wrong by more than the window's own radius.
 
-`core::sync::coarse_sync::<P>` also gained an FST4-only augmentation
+`engine::sync::coarse_sync::<P>` also gained an FST4-only augmentation
 in the same pass: a bin can enter the candidate list either via the
 existing short-time Costas-grid threshold *or* by clearing a
 full-slot non-coherent 4-tone power check modelled on WSJT-X's
@@ -727,7 +770,7 @@ dropped there) but is a real WSJT-X-faithful coverage improvement for
 busy/wideband scans with many co-channel candidates competing for a
 fixed-size list.
 
-### LLR (`mfsk_core::core::llr`)
+### LLR (`mfsk_core::engine::llr`)
 
 * `symbol_spectra::<P>(cd0, i_start)` — per-symbol FFT bins (generic
   path; FT8 callers should prefer
@@ -743,20 +786,28 @@ fixed-size list.
   the FT8 default).
 * `sync_quality::<P>(cs)` — hard-decision sync symbol count.
 
-### Equalise (`mfsk_core::core::equalize`)
+### Equalise (`mfsk_core::engine::equalize`)
 
 * `equalize_local::<P>(cs)` — per-tone Wiener equaliser driven by
   `P::SYNC_MODE.blocks()` pilot observations; linearly extrapolates any tones
   that Costas doesn't visit.
 
-### Pipeline (`mfsk_core::core::pipeline`)
+### Pipeline (`mfsk_core::engine::pipeline`)
 
-* `decode_frame::<P>(...)` — coarse sync → parallel process_candidate → dedupe.
-* `decode_frame_subtract::<P>(...)` — 3-pass SIC driver. The SIC step
-  uses `subtract_signal_lpf` (WSJT-X-style channel-aware subtract)
-  as of 0.6.2; the previous `subtract_signal_weighted` /
-  `qsb_partial_gain` path has been removed.
-* `process_candidate_basic::<P>(...)` — single-candidate BP+OSD.
+`decode_frame::<P>` (coarse sync → parallel process_candidate →
+dedupe), `decode_frame_subtract::<P>` (3-pass SIC driver), and
+`process_candidate_basic::<P>` (single-candidate BP+OSD) are the raw
+engine functions underneath the pipeline — but as of issue #191/#203
+they are **`pub(crate)`** (or `pub` only under the non-default
+`internal-testing` feature, used by the crate's own test binaries).
+Application code should not call them directly; use
+`msg::decode_request::DecodeRequest`/`SniperRequest` instead (see
+"The public decode entry point" above), which wrap these same
+functions behind a builder. `decode_frame_subtract`
+uses `subtract_signal_lpf` (WSJT-X-style channel-aware subtract) as of
+0.6.2; the previous `subtract_signal_weighted` / `qsb_partial_gain`
+path has been removed.
+
 * `DecodeStrictness::osd_score_min()` / `osd_max_errors()` — pre-OSD
   coarse-sync-score gate and post-OSD hard-error ceiling. Calibrated
   against FT8 real-WAV recall (2026-04-07) and, until 0.7.1, silently
@@ -797,7 +848,7 @@ which inner steps they enable:
   itself (graduated to public API in 0.6.0).
 * `fill_symbol_spectra` / `fill_symbol_spectra_goertzel` — per-symbol
   FFT extraction directly from audio (replaces the cd0 +
-  `core::llr::symbol_spectra` two-step that older code used).
+  `engine::llr::symbol_spectra` two-step that older code used).
 
 ## 5. Feature flags
 
@@ -831,10 +882,10 @@ enable several for illustration.
 ### 6.2 FT8 decode — minimal example
 
 ```rust
-use mfsk_core::ft8::{
-    decode::{decode_frame, DecodeDepth},
-    wave_gen::{message_to_tones, tones_to_i16},
-};
+use mfsk_core::ft8::Ft8;
+use mfsk_core::ft8::decode::DecodeDepth;
+use mfsk_core::ft8::wave_gen::{message_to_tones, tones_to_i16};
+use mfsk_core::msg::decode_request::DecodeRequest;
 use mfsk_core::msg::wsjt77::{pack77, unpack77};
 
 // 1. Synthesise an FT8 frame and pad it into a 15-second slot.
@@ -848,10 +899,13 @@ for (i, &s) in frame.iter().enumerate() {
     if start + i < audio.len() { audio[start + i] = s; }
 }
 
-// 2. Decode it back.
-for r in decode_frame(&audio, 100.0, 3_000.0, 1.0, None,
-                      DecodeDepth::FULL, 50) {
-    if let Some(text) = unpack77(&r.message77) {
+// 2. Decode it back. new(audio, freq_min, freq_max, sync_min, max_cand).
+let results = DecodeRequest::<Ft8>::new(&audio, 100.0, 3_000.0, 1.0, 50)
+    .depth(DecodeDepth::FULL)
+    .decode()
+    .results;
+for r in &results {
+    if let Some(text) = unpack77(r.message77()) {
         println!("{:7.1} Hz  dt={:+.2} s  SNR={:+.0} dB  {}",
                  r.freq_hz, r.dt_sec, r.snr_db, text);
     }
@@ -898,17 +952,24 @@ start_sample, freq_hz)` bypasses the scan.
 
 ### 6.4 Sniper mode + AP hint
 
-Narrowing the search to ±500 Hz and supplying an a-priori hint lets
-the decoder recover weaker signals:
+Narrowing the search to ±250 Hz around a known target frequency and
+supplying an a-priori hint lets the decoder recover weaker signals —
+intended for use after a 500 Hz hardware BPF, or when hunting one
+known station:
 
 ```rust
-use mfsk_core::ft8::decode::{decode_sniper_ap, DecodeDepth, ApHint};
-use mfsk_core::core::equalize::EqMode;
+use mfsk_core::ft8::Ft8;
+use mfsk_core::ft8::decode::{DecodeDepth, EqMode, ApHint};
+use mfsk_core::msg::decode_request::SniperRequest;
 
 let ap = ApHint::new().with_call1("CQ").with_call2("JA1ABC");
-for r in decode_sniper_ap(&audio, /*target_hz*/ 1000.0,
-                          DecodeDepth::FULL, /*max_cand*/ 15,
-                          EqMode::Local, Some(&ap)) {
+let results = SniperRequest::<Ft8>::new(&audio, /*target_hz*/ 1000.0, /*max_cand*/ 15)
+    .depth(DecodeDepth::FULL)
+    .eq_mode(EqMode::Local)
+    .ap_hint(&ap)
+    .decode()
+    .results;
+for r in &results {
     // …
 }
 ```
@@ -920,8 +981,8 @@ stopped justifying the 2× per-candidate cost (issue #73). Callers
 that want the old two-pass behaviour invoke the decoder twice
 explicitly with `Local` then `Off`.
 
-The FT4 equivalent is `ft4::decode::decode_sniper_ap` with a similar
-signature.
+`SniperRequest::<Ft4>` works the same way (`FrameDecodable` is
+implemented for both).
 
 ### 6.5 JT9 / JT65
 

--- a/docs/reference/UVPACKET.ja.md
+++ b/docs/reference/UVPACKET.ja.md
@@ -60,7 +60,7 @@ WSJT 系に対して適切な scope を持っている」。
 | `MessageCodec` | **意図的に bypass** (バイトパイプ — 構造化 codec 不要) |
 | `WsjtApCompatible` | **意図的に bypass** (uvpacket には AP の概念がない) |
 | `Protocol::ID` / `ModulationParams` 定数 | **decorative** (自前 TX/RX パイプラインからは参照されない) |
-| 汎用 `core::pipeline::decode_frame::<P>` | **使っていない** (専用 `uvpacket::rx`) |
+| 汎用 `engine::pipeline::decode_frame::<P>` | **使っていない** (専用 `uvpacket::rx`) |
 
 ### 結論 — trait は WSJT 系のために意図的に specific
 

--- a/docs/reference/UVPACKET.md
+++ b/docs/reference/UVPACKET.md
@@ -62,7 +62,7 @@ right-sized for WSJT."*
 | `MessageCodec` | **deliberately bypassed** (byte-pipe: no structured codec needed) |
 | `WsjtApCompatible` | **deliberately bypassed** (uvpacket has no AP concept) |
 | `Protocol::ID` / `ModulationParams` trait constants | **decorative** — not consulted by the bespoke TX/RX pipeline |
-| Generic `core::pipeline::decode_frame::<P>` | **not used** (bespoke `uvpacket::rx`) |
+| Generic `engine::pipeline::decode_frame::<P>` | **not used** (bespoke `uvpacket::rx`) |
 
 ### Conclusion — the traits are intentionally WSJT-specific
 


### PR DESCRIPTION
## Summary
Follow-up to the release-readiness audit: this cycle's API churn (#191-#215) left several docs behind.

- `README.md:143` — same `&r.message77` field-access bug #215 fixed in embedded-poc (method since #194).
- `docs/reference/EMBEDDED.md` / `.ja.md` — 12 stale `core::` module-path references each, renamed to `engine::` in #206. Left the one correctly-historical `core::dotprod` mention alone (describes an already-removed module by its name at time of removal), and the unrelated `dual_core::` module untouched.
- `docs/reference/UVPACKET.md` / `.ja.md` — 1 stale `core::` reference each.
- `CHANGELOG.md` — added the missing #215 entry.
- **`docs/reference/LIBRARY.md`** — full rewrite, not mechanical. This was the crate's own hand-written API reference and had drifted furthest: ~20 `core::`/bare `core` references, zero mention of `DecodeRequest`/`SniperRequest` anywhere, and its own code examples called `decode_frame`/`decode_sniper_ap`/`process_candidate_basic` directly — all `pub(crate)`-only since #203, so copying them produced a compile error. Same bug one level deeper in the Q65 decoder-strategies section (§3): every `q65::rx` function it named as an "entry point" is `pub(crate)` since #204's builder migration. Also found and fixed a pre-existing bug unrelated to this cycle: `use mfsk_core::msg::wsjt77::Wsjt77Message` was already wrong — the type lives at `msg::Wsjt77Message`. Rewrote around the real API: a new "public decode entry point" subsection introduces `DecodeRequest`/`SniperRequest`, §6's examples use the real builder chain, §3's Q65 table/prose reference the `q65::decode_request` builders.

`docs/reference/LIBRARY.ja.md` is now the same staleness the English version had — tracked as a separate follow-up (translate this rewrite, or handle independently).

## Test plan
- Docs-only change, no code touched.
- Every rewritten Rust code example in `LIBRARY.md` was verified by actually compiling it against the real crate (scratch binary linking `mfsk-core` with `ft8`/`ft4`/`q65`/`wspr`/`jt65`/`jt9` features), not eyeballed — this is what caught the `Wsjt77Message` import bug.
- Verified no `mfsk-core`/`mfsk_core` crate-name references were accidentally mangled by the `core::`→`engine::` regex (checked `dual_core::`, `mfsk-core::`, `mfsk_core::` all survived intact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KqxRCEE16vYwN3jJXoeDXG