### PR TITLE
refactor(api)!: DecodeRequest::flat()/.staged() -> .sic_rounds(n)/.sic_early()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208) + embedded-poc `+esp` compile fix (#215) + `DecodeRequest`/`SniperRequest::depth` → `.osd(bool)` (breaking) + FT8 `WsjtxDepth`/`wsjtx_depth` jt9-comparison preset
+## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208) + embedded-poc `+esp` compile fix (#215) + `DecodeRequest`/`SniperRequest::depth` → `.osd(bool)` (breaking) + FT8 `WsjtxDepth`/`wsjtx_depth` jt9-comparison preset + `DecodeRequest::flat()`/`.staged()` → `.sic_rounds(n)`/`.sic_early()` (#218, breaking)
 
 ### Added
 
@@ -861,6 +861,57 @@
   own doc comment).
 
 ### Changed
+
+- **`DecodeRequest::flat()`/`.staged()` → `.sic_rounds(n)`/`.sic_early()`,
+  `SupportsFlatSic`/`SupportsStagedSic` → `SupportsSicRounds`/
+  `SupportsSicEarly`** (issue #218, breaking). The flat-SIC engine's
+  round count was hardcoded to 3 (`for ipass in 0..3` in
+  `sic_inner_passes_with_cache`, mirroring WSJT-X's `do ipass=1,npass`
+  with `npass` fixed) with no caller-tunable upper bound — the exact gap
+  `WsjtxDepth`'s own doc comment flagged: jt9 `-d1` runs SIC with
+  `npass=2` (vs. 3 for `-d2`/`-d3`), but neither `.flat()` nor
+  `.staged()` exposed a 2-vs-3-round knob, so `WsjtxDepth::D1` silently
+  ran the full 3 rounds instead of matching jt9 `-d1` exactly. Round
+  count is now a required argument on the strategy-selecting method
+  itself (`.sic_rounds(n)`, clamped 1..=3 — WSJT-X's own `npass`/`nsp`
+  never exceeds 3) rather than an independently-settable field, so
+  `.sic_rounds(_).sic_early()` — where the round count would be
+  silently ignored by the early-decode strategy — is structurally
+  unwritable rather than a compiling no-op. `WsjtxDepth::D1` now uses
+  `.sic_rounds(2)`, closing the gap; `D2`/`D3` use `.sic_early()`
+  (checkpoint structure is fixed at 3, not exposed as a knob).
+
+  Renamed rather than kept as an additive alias: `flat`/`staged`
+  described mfsk-core's own internal buffer-structure axis (single
+  full buffer vs. checkpoint-replayed growing prefixes), not
+  self-descriptive at a bare call site and not WSJT-X's own vocabulary.
+  `sic_early` borrows WSJT-X's actual term for the checkpoint mechanism
+  (`ndec_early`/`MAX_EARLY` in `ft8_decode.f90`, checkpointed at
+  `nzhsym` = 41/47/50 out of 79 symbols); `sic_rounds` avoids `pass`,
+  which is overloaded in WSJT-X's own source — FT8's `ft8_decode.f90`
+  `ipass`/`npass` *is* the subtraction loop, but FT4's `ft4_decode.f90`
+  reserves `ipass`/`npasses` for an unrelated AP-hint-variant loop
+  inside a single decode attempt, using `isp`/`nsp` for the actual
+  subtraction loop instead. `SupportsFlatSic`/`SupportsStagedSic` were
+  renamed alongside the methods they gate so a trait-bound compile
+  error names something a reader can connect back to the method they
+  called.
+
+  FT4's flat-SIC engine (`engine::pipeline::decode_frame_subtract`)
+  gained the same `.sic_rounds(n)` knob — its progressive-`sync_min`-
+  relaxation pass array (`&[1.0, 0.75, 0.5]`, mfsk-core's own
+  pre-migration design, not WSJT-X's) is now sliced to `n` rounds
+  rather than always iterated in full. FT4's SIC still isn't
+  WSJT-X-faithful in its own right (`ft4_decode.f90` uses a **fixed**
+  `syncmin=1.18` across rounds, the same fixed-threshold design FT8
+  already migrated to — see `flat_sic_inner`'s doc comment) — tracked
+  as a separate follow-up, out of scope here.
+
+  `.sic_rounds(3)` verified byte-identical to the pre-rename `.flat()`
+  default on `qso3_busy.wav` (20/20 matching decodes, checked against a
+  clean pre-#218 `main` worktree); new `tests/ft8_sic_rounds_recall.rs`
+  locks in both that golden and a `sic_rounds(1) ⊆ sic_rounds(2) ⊆
+  sic_rounds(3)` monotonicity invariant (measured 13/19/20 decodes).
 
 - **`DecodeRequest`/`SniperRequest::depth(DecodeDepth)` → `.osd(bool)`
   (breaking).** `LlrEffort` was a dead lever on host — its own doc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -912,6 +912,13 @@
   clean pre-#218 `main` worktree); new `tests/ft8_sic_rounds_recall.rs`
   locks in both that golden and a `sic_rounds(1) ⊆ sic_rounds(2) ⊆
   sic_rounds(3)` monotonicity invariant (measured 13/19/20 decodes).
+  `&[1.0, 0.75, 0.5][..max_rounds]` is genuinely new slicing logic on
+  FT4's side, not just a rename, and the FT8 golden above doesn't
+  exercise it — a self-contained (no external sample-tree dependency)
+  six-station synthetic scene in new `tests/ft4_sic_rounds_recall.rs`
+  covers the same monotonicity invariant there (measured 4/6/6
+  decodes; asserts `sic_rounds(1) < sic_rounds(3)` so the scenario
+  can't pass vacuously).
 
 - **`DecodeRequest`/`SniperRequest::depth(DecodeDepth)` → `.osd(bool)`
   (breaking).** `LlrEffort` was a dead lever on host — its own doc

--- a/docs/reference/LIBRARY.ja.md
+++ b/docs/reference/LIBRARY.ja.md
@@ -661,9 +661,10 @@ equalize / pipeline ドライバも同じスタイルで、プロトコル型を
   `.fft_cache(...)` (直前呼び出しの forward FFT を再利用)、
   プロトコルが `SupportsWideBandAp` を実装していれば `.ap_hint(...)`
   (FT8 のみ)、さらにプロトコルが対応していれば
-  `.flat()` / `.staged()` のいずれかで successive-interference-
-  cancellation 戦略を選択 (`SupportsFlatSic`: FT8+FT4、
-  `SupportsStagedSic`: FT8 のみ) をチェーンする。`.decode()` で
+  `.sic_rounds(n)` / `.sic_early()` のいずれかで successive-
+  interference-cancellation 戦略を選択 (`SupportsSicRounds`:
+  FT8+FT4、`n`は1..=3にクランプ。`SupportsSicEarly`: FT8のみ、
+  チェックポイント構造は3固定) をチェーンする。`.decode()` で
   `DecodeOutcome<P>` (`.results: Vec<P::DecodeResult>`、後続呼び出し用の
   `.fft_cache` も含む) を得る。
 * **`SniperRequest<P>`** — narrow-band、単一ターゲット探索。
@@ -688,11 +689,11 @@ FT8 API、§10) が位置引数として受け取る型。ただし `DecodeReque
 
 **`WsjtxDepth`** (`mfsk_core::ft8::decode::WsjtxDepth`、
 `DecodeRequest::<Ft8>::wsjtx_depth(...)`) は `.osd(...)` +
-`.flat()`/`.staged()` + `.ap_hint()` を、実際のWSJT-Xの`jt9 -d 1/2/3`
-CLIフラグに対応する3段階の named tier (`D1`/`D2`/`D3`) にまとめたもの
-——実際の`jt9`ビルドとのベンチマーク比較用。tierとbuilderメソッドの
-正確な対応、既知の限界（pass数・OSD強度がjt9と厳密には一致しない点）
-は型自身のdoc commentを参照。
+`.sic_rounds(n)`/`.sic_early()` + `.ap_hint()` を、実際のWSJT-Xの
+`jt9 -d 1/2/3` CLIフラグに対応する3段階の named tier (`D1`/`D2`/`D3`)
+にまとめたもの——実際の`jt9`ビルドとのベンチマーク比較用。tierと
+builderメソッドの正確な対応、既知の限界（OSD強度がjt9と厳密には
+一致しない点）は型自身のdoc commentを参照。
 
 ### DSP (`mfsk_core::engine::dsp`)
 

--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -680,9 +680,11 @@ points, §6.3/§6.5):
   already-decoded messages from an earlier pass), `.fft_cache(...)`
   (reuse a previous call's forward FFT), `.ap_hint(...)` where the
   protocol implements `SupportsWideBandAp` (FT8 only), and one of
-  `.flat()` / `.staged()` to pick a successive-interference-cancellation
-  strategy where the protocol supports it (`SupportsFlatSic`: FT8+FT4;
-  `SupportsStagedSic`: FT8 only). Call `.decode()` to get a
+  `.sic_rounds(n)` / `.sic_early()` to pick a
+  successive-interference-cancellation strategy where the protocol
+  supports it (`SupportsSicRounds`: FT8+FT4, `n` clamped 1..=3;
+  `SupportsSicEarly`: FT8 only, fixed 3-checkpoint structure). Call
+  `.decode()` to get a
   `DecodeOutcome<P>` (`.results: Vec<P::DecodeResult>`, plus
   `.fft_cache` for a follow-up call).
 * **`SniperRequest<P>`** — narrow-band, single-target search.
@@ -707,11 +709,11 @@ needed `LlrEffort::Minimal` (that variant exists solely for
 
 **`WsjtxDepth`** (`mfsk_core::ft8::decode::WsjtxDepth`,
 `DecodeRequest::<Ft8>::wsjtx_depth(...)`) bundles `.osd(...)` +
-`.flat()`/`.staged()` + `.ap_hint()` into three named tiers
+`.sic_rounds(n)`/`.sic_early()` + `.ap_hint()` into three named tiers
 (`D1`/`D2`/`D3`) mirroring real WSJT-X's `jt9 -d 1/2/3` CLI flag, for
 benchmarking against a real `jt9` build — see the type's own doc
 comment for the exact tier→builder-method mapping and its known
-limitations (pass-count and OSD-strength don't exactly match jt9's).
+limitations (OSD-strength doesn't exactly match jt9's).
 
 ### DSP (`mfsk_core::engine::dsp`)
 

--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -928,6 +928,12 @@ pub(crate) fn decode_frame_subtract<P: GenericPipelineProtocol>(
     depth: DecodeDepth,
     max_cand: usize,
     strictness: DecodeStrictness,
+    // Upper bound on SIC rounds, 1..=3 (`DecodeRequest::sic_rounds`
+    // already clamps to this range — not re-validated here, this
+    // function has exactly one caller). `passes.len() == 3`, so this
+    // slices the shared progressive-`sync_min`-relaxation schedule
+    // rather than iterating all of it.
+    max_rounds: usize,
     sync_q_min: u32,
     // Channel-aware LPF subtract tuning (issue #178/#179 FT4 port).
     // Protocol-specific — mirrors WSJT-X's per-protocol `NFILT`/
@@ -941,7 +947,7 @@ pub(crate) fn decode_frame_subtract<P: GenericPipelineProtocol>(
 ) -> Vec<DecodeResult> {
     let mut residual = audio.to_vec();
     let mut all_results: Vec<DecodeResult> = Vec::new();
-    let passes: &[f32] = &[1.0, 0.75, 0.5];
+    let passes: &[f32] = &[1.0, 0.75, 0.5][..max_rounds];
     let fec = P::Fec::default();
 
     for &factor in passes {

--- a/mfsk-core/src/fst4/decode.rs
+++ b/mfsk-core/src/fst4/decode.rs
@@ -13,8 +13,8 @@
 //!
 //! FST4 has no SIC (successive interference cancellation) path — no
 //! `SubtractCfg` exists for it, so
-//! [`SupportsFlatSic`](crate::msg::decode_request::SupportsFlatSic) is not
-//! implemented for any sub-mode (issue #193: new numerical work, not a
+//! [`SupportsSicRounds`](crate::msg::decode_request::SupportsSicRounds) is
+//! not implemented for any sub-mode (issue #193: new numerical work, not a
 //! refactor, kept out of this redesign's scope).
 
 use crate::engine::dsp::downsample::DownsampleCfg;

--- a/mfsk-core/src/ft4/decode.rs
+++ b/mfsk-core/src/ft4/decode.rs
@@ -16,7 +16,7 @@ use crate::msg::pipeline_ap;
 pub use crate::engine::pipeline::{DecodeDepth, DecodeResult, DecodeStrictness, FftCache};
 pub use crate::msg::ApHint;
 use crate::msg::decode_request::{
-    DecodeOutcome, DecodeRequest, FrameDecodable, SniperRequest, SupportsFlatSic,
+    DecodeOutcome, DecodeRequest, FrameDecodable, SniperRequest, SupportsSicRounds,
 };
 
 /// FT4 downsample configuration: 12 kHz → ~666.7 Hz baseband, covering four
@@ -130,7 +130,7 @@ impl FrameDecodable for Ft4 {
     }
 }
 
-impl SupportsFlatSic for Ft4 {
+impl SupportsSicRounds for Ft4 {
     fn __flat_sic(req: &DecodeRequest<'_, Self>) -> DecodeOutcome<Self> {
         let raw = pipeline::decode_frame_subtract::<Ft4>(
             req.audio,
@@ -143,6 +143,7 @@ impl SupportsFlatSic for Ft4 {
             req.depth,
             req.max_cand,
             req.strictness,
+            req.sic_rounds,
             SYNC_Q_MIN,
             // lpf_half/end-correction match WSJT-X `subtractft4.f90`:
             // NFILT=1400 (lpf_half=700), no end-correction. See
@@ -191,7 +192,7 @@ mod tests {
     use crate::msg::decode_request::DecodeRequest;
 
     /// Compile-time check that `DecodeRequest<Ft4>` accepts every `osd`
-    /// setting across single-pass, flat SIC, and sniper. No actual
+    /// setting across single-pass, `sic_rounds`, and sniper. No actual
     /// decoding happens — empty audio returns no candidates fast — but
     /// this guards against future signature drift.
     #[test]
@@ -203,7 +204,7 @@ mod tests {
                 .decode();
             let _ = DecodeRequest::<Ft4>::new(&empty, 100.0, 3000.0, 1.0, 5)
                 .osd(osd)
-                .flat()
+                .sic_rounds(3)
                 .decode();
             let _ = DecodeRequest::<Ft4>::sniper(&empty, 1500.0, 5)
                 .osd(osd)

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -22,8 +22,8 @@ use super::{
     sync::SyncCandidate,
 };
 use crate::msg::decode_request::{
-    DecodeOutcome, DecodeRequest, FrameDecodable, SniperRequest, SupportsFlatSic,
-    SupportsStagedSic, SupportsWideBandAp,
+    DecodeOutcome, DecodeRequest, FrameDecodable, SniperRequest, SupportsSicEarly,
+    SupportsSicRounds, SupportsWideBandAp,
 };
 
 // ────────────────────────────────────────────────────────────────────────────
@@ -380,30 +380,31 @@ fn decode_frame_inner(
 // ────────────────────────────────────────────────────────────────────────────
 // Multi-pass decode with signal subtraction
 
-/// The flat 3-pass + sequential SIC, mirroring the structure of
+/// The flat SIC (up to [`DecodeRequest::sic_rounds`] rounds, default and
+/// max of 3) plus sequential subtract, mirroring the structure of
 /// `decode_block::decode_block_multipass` (the embedded path) which is a
 /// faithful port of `lib/ft8/ft8b.f90:432-437`. Used by
-/// [`SupportsFlatSic`]'s `Ft8` impl (`.flat()`) and as
+/// [`SupportsSicRounds`]'s `Ft8` impl (`.sic_rounds()`) and as
 /// [`decode_frame_subtract_staged_with_ap_inner`]'s fallback for
 /// buffers too short to stage meaningfully.
 ///
 /// Two changes from the pre-v0.6.0 host implementation:
 ///
-/// 1. **Fixed `sync_min` across all 3 passes** (was 1.0 / 0.75 / 0.5).
-///    Progressive relaxation lets phantoms slip through later passes
+/// 1. **Fixed `sync_min` across all rounds** (was 1.0 / 0.75 / 0.5).
+///    Progressive relaxation lets phantoms slip through later rounds
 ///    when SIC artefacts dominate the residual; WSJT-X holds the
-///    threshold and skips later passes when no new decodes come out.
+///    threshold and skips later rounds when no new decodes come out.
 ///
-/// 2. **Sequential subtract within each pass** (was batch-after-pass).
+/// 2. **Sequential subtract within each round** (was batch-after-round).
 ///    Each accepted decode immediately subtracts from the residual so
-///    the *next* candidate in the same pass sees a cleaner spectrum.
+///    the *next* candidate in the same round sees a cleaner spectrum.
 ///    This is what surfaces -13 to -18 dB signals sitting beneath
 ///    strong neighbours (the JTDX-extras shape on `qso3_busy.wav`).
-///    Without sequential subtract, all candidates in a pass see the
+///    Without sequential subtract, all candidates in a round see the
 ///    same raw residual and weak signals stay masked.
 ///
-/// Pass termination matches WSJT-X: pass 2 skips when pass 1 returned
-/// 0 decodes; pass 3 skips when pass 2 returned no NEW decodes.
+/// Round termination matches WSJT-X: round 2 skips when round 1 returned
+/// 0 decodes; round 3 skips when round 2 returned no NEW decodes.
 #[allow(clippy::too_many_arguments)]
 fn flat_sic_inner(
     audio: &[i16],
@@ -417,6 +418,7 @@ fn flat_sic_inner(
     eq_mode: EqMode,
     ap_hint: Option<&ApHint>,
     precomputed_fft: Option<&[num_complex::Complex<f32>]>,
+    n_rounds: usize,
 ) -> (Vec<DecodeResult>, FftCache) {
     let mut residual = audio.to_vec();
     sic_inner_passes_with_cache(
@@ -431,17 +433,20 @@ fn flat_sic_inner(
         eq_mode,
         ap_hint,
         precomputed_fft,
+        n_rounds,
     )
 }
 
-/// Shared inner loop: up to 3 sub-passes of coarse_sync + per-candidate
-/// decode, subtracting each accepted decode from `residual` immediately
-/// (sequential, not batch-after-pass) so later candidates in the same
-/// sub-pass see a cleaner spectrum. This is WSJT-X's `ft8b.f90:432-437`
-/// `do ipass=1,npass` structure. Factored out of [`flat_sic_inner`] so
-/// [`decode_frame_subtract_staged_with_ap_inner`] can reuse it at
-/// checkpoint A and checkpoint C (issue #180) without duplicating the
-/// pass/dedup/subtract logic.
+/// Shared inner loop: up to `n_rounds` sub-passes of coarse_sync +
+/// per-candidate decode, subtracting each accepted decode from `residual`
+/// immediately (sequential, not batch-after-round) so later candidates in
+/// the same sub-pass see a cleaner spectrum. This is WSJT-X's
+/// `ft8b.f90:432-437` `do ipass=1,npass` structure. Factored out of
+/// [`flat_sic_inner`] so [`decode_frame_subtract_staged_with_ap_inner`] can
+/// reuse it at checkpoint A and checkpoint C (issue #180) without
+/// duplicating the pass/dedup/subtract logic — those checkpoint call sites
+/// always pass `n_rounds = 3` (checkpoint structure is fixed, not exposed
+/// as a caller-tunable knob; see [`SupportsSicEarly`]).
 ///
 /// `residual` is mutated in place (final state = fully subtracted).
 /// `known` seeds dedup against decodes from an earlier stage — those
@@ -459,25 +464,30 @@ fn sic_inner_passes(
     known: &[DecodeResult],
     eq_mode: EqMode,
     ap_hint: Option<&ApHint>,
+    n_rounds: usize,
 ) -> Vec<DecodeResult> {
     sic_inner_passes_with_cache(
         residual, freq_min, freq_max, sync_min, depth, max_cand, strictness, known, eq_mode,
-        ap_hint, None,
+        ap_hint, None, n_rounds,
     )
     .0
 }
 
 /// Like [`sic_inner_passes`] but also accepts a `precomputed_fft` cache
-/// (reused only on pass 0, and only when `residual` has not yet been
+/// (reused only on round 0, and only when `residual` has not yet been
 /// mutated by a subtraction the caller did before calling in — passing
 /// `Some(_)` alongside an already-subtracted `residual` would silently
 /// mismatch the cache against the audio it's meant to describe) and
-/// returns the pass-0 cache alongside the results, so a follow-up
+/// returns the round-0 cache alongside the results, so a follow-up
 /// pipelined call can reuse it in turn. This is the fix for issue #191:
 /// previously only the (dead-code, zero-caller)
 /// `decode_frame_subtract_with_known_and_ap` had *any* cache-reuse path,
-/// and it used its own unfixed flat-3-pass engine rather than this
-/// (shared by both `.flat()` and `.staged()`) one.
+/// and it used its own unfixed flat-3-round engine rather than this
+/// (shared by both `.sic_rounds()` and `.sic_early()`) one.
+///
+/// `n_rounds` — upper bound on SIC rounds, expected 1..=3
+/// (`DecodeRequest::sic_rounds` already clamps to this range for the
+/// `.sic_rounds()` path; checkpoint callers always pass `3`).
 #[allow(clippy::too_many_arguments)]
 fn sic_inner_passes_with_cache(
     residual: &mut [i16],
@@ -491,6 +501,7 @@ fn sic_inner_passes_with_cache(
     eq_mode: EqMode,
     ap_hint: Option<&ApHint>,
     precomputed_fft: Option<&[num_complex::Complex<f32>]>,
+    n_rounds: usize,
 ) -> (Vec<DecodeResult>, FftCache) {
     let mut all_results: Vec<DecodeResult> = Vec::new();
     let mut pass0_cache: Option<FftCache> = None;
@@ -505,7 +516,7 @@ fn sic_inner_passes_with_cache(
         crate::fec::ldpc::bp::BpScratch::<crate::fec::ldpc::params::Ldpc174_91Params, LlrT>::new();
 
     let mut prev_total: usize = 0;
-    for ipass in 0..3 {
+    for ipass in 0..n_rounds {
         if ipass >= 1 && all_results.len() == prev_total {
             break;
         }
@@ -704,10 +715,10 @@ fn decode_frame_subtract_staged_with_ap_inner(
 
     // Buffers shorter than checkpoint A can't be staged meaningfully —
     // there's no "early, incomplete" window smaller than the whole thing.
-    // Must call the *flat* fallback (`flat_sic_inner`), not `.staged()`
+    // Must call the *flat* fallback (`flat_sic_inner`), not `.sic_early()`
     // itself — that dispatches to this very function (issue #180), so
     // calling it here would recurse indefinitely (stack overflow, caught
-    // by `staged_with_ap_silence_shape`).
+    // by `sic_early_with_ap_silence_shape`).
     let _ = freq_hint;
     if audio.len() < A_SAMPLES {
         let (r, _) = flat_sic_inner(
@@ -722,6 +733,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
             eq_mode,
             ap_hint,
             None,
+            3,
         );
         return (r, audio.to_vec());
     }
@@ -756,6 +768,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
         &[],
         eq_mode,
         ap_hint,
+        3,
     );
     // Checkpoint A's own residual is not carried forward — only its
     // decoded results are (ft8_decode.f90 reloads `dd=iwave` fresh at
@@ -784,6 +797,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
             eq_mode,
             ap_hint,
             None,
+            3,
         );
         return (r, audio.to_vec());
     }
@@ -846,6 +860,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
         &early_results,
         eq_mode,
         ap_hint,
+        3,
     );
 
     let mut all_results = early_results;
@@ -970,15 +985,15 @@ impl FrameDecodable for Ft8 {
     }
 }
 
-impl SupportsFlatSic for Ft8 {
+impl SupportsSicRounds for Ft8 {
     fn __flat_sic(req: &DecodeRequest<'_, Self>) -> DecodeOutcome<Self> {
-        // Subtract caller-supplied `known` before pass 0, same rationale
-        // as `SupportsStagedSic::__staged_sic` below: without this, a
+        // Subtract caller-supplied `known` before round 0, same rationale
+        // as `SupportsSicEarly::__staged_sic` below: without this, a
         // strong `known` carrier continues to mask weaker signals
         // throughout the SIC loop (the exact issue #191 bug, previously
         // only reachable through the deleted, unfixed
         // `decode_frame_subtract_with_known_and_ap`). `precomputed_fft`
-        // can only be trusted for pass 0 once `known` is empty — reusing
+        // can only be trusted for round 0 once `known` is empty — reusing
         // it after this subtraction would silently mismatch the cache
         // against the now-modified audio.
         if req.known.is_empty() {
@@ -994,6 +1009,7 @@ impl SupportsFlatSic for Ft8 {
                 req.eq_mode,
                 req.ap_hint,
                 req.fft_cache.as_ref().map(FftCache::as_slice),
+                req.sic_rounds,
             );
             DecodeOutcome { results, fft_cache }
         } else {
@@ -1013,27 +1029,28 @@ impl SupportsFlatSic for Ft8 {
                 req.eq_mode,
                 req.ap_hint,
                 None,
+                req.sic_rounds,
             );
             DecodeOutcome { results, fft_cache }
         }
     }
 }
 
-impl SupportsStagedSic for Ft8 {
+impl SupportsSicEarly for Ft8 {
     /// The issue #191 fix: `decode_frame_subtract_with_known_and_ap` used
     /// to be the *only* entry point accepting `known`/`precomputed_fft`,
-    /// and it ran its own unfixed flat-3-pass engine instead of the
+    /// and it ran its own unfixed flat-3-round engine instead of the
     /// staged checkpoint one — missing every SIC-quality improvement
     /// (issue #178/#179/#180) landed since. `known` is now honoured by
-    /// *this* (staged) path directly: subtracted from the audio before
-    /// checkpoint A runs, so all three checkpoints see the cleaned
+    /// *this* (early-decode) path directly: subtracted from the audio
+    /// before checkpoint A runs, so all three checkpoints see the cleaned
     /// residual, then deduped from the final results.
     ///
     /// `precomputed_fft` is deliberately not reused here: every
     /// checkpoint operates on a truncated/zero-tailed buffer, never on
     /// the full original audio the cache was built from, so reusing it
-    /// would silently mismatch. (It *is* reused by [`SupportsFlatSic`]'s
-    /// impl above, whose single full-buffer pass 0 has the matching
+    /// would silently mismatch. (It *is* reused by [`SupportsSicRounds`]'s
+    /// impl above, whose single full-buffer round 0 has the matching
     /// shape.) Recomputing here is always correct, just not free.
     fn __staged_sic(req: &DecodeRequest<'_, Self>) -> DecodeOutcome<Self> {
         // `subtract_signal_lpf_refine_dt`, not the plain single-shot
@@ -1080,7 +1097,7 @@ impl SupportsStagedSic for Ft8 {
 /// |---|---|---|---|
 /// | this tier | `D1` | `D2` | `D3` |
 /// | OSD | off | on | on |
-/// | SIC | `.flat()` | `.staged()` | `.staged()` |
+/// | SIC | `.sic_rounds(2)` | `.sic_early()` | `.sic_early()` |
 /// | AP | — | — | `.ap_hint()` if supplied |
 ///
 /// Measured on `qso3_busy.wav` (this host, real local `jt9 -8 -dN`
@@ -1088,19 +1105,26 @@ impl SupportsStagedSic for Ft8 {
 ///
 /// | | jt9 | mfsk-core |
 /// |---|---|---|
-/// | D1 | 14 decodes / 370ms | 14 decodes / 237ms |
+/// | D1 | 14 decodes / 370ms | *(needs remeasurement — see below)* |
 /// | D2 | 19 decodes / 1040ms | 22 decodes / 1078ms |
 /// | D3 | 22 decodes / 2110ms | 22 decodes / 2991ms |
 ///
-/// jt9 `-d1` still runs SIC (`npass=2` vs. 3 for `-d2`/`-d3`,
-/// `ft8_decode.f90:172-173`) and jt9's own `ndepth==1` branch skips
+/// The mfsk-core D1 number above (`14 decodes / 237ms`, superseded)
+/// was measured before issue #218's `.sic_rounds(2)` fix — `D1`
+/// previously ran `.flat()`'s full 3 rounds (no round-count knob
+/// existed), not jt9 `-d1`'s actual `npass=2`. Re-measure against
+/// `qso3_busy.wav` once `.sic_rounds(2)` lands; expect fewer decodes
+/// and lower latency than the superseded number, not identical.
+///
+/// jt9 `-d1` runs SIC with `npass=2` (vs. 3 for `-d2`/`-d3`,
+/// `ft8_decode.f90:172-173`), and jt9's own `ndepth==1` branch skips
 /// the checkpoint-replay staging entirely (`ft8_decode.f90:97-103`) —
-/// structurally that's `.flat()` (single full-buffer SIC pass-set),
-/// not `.staged()`. `D2`/`D3` both go through checkpoint staging in
-/// jt9 (`npass=3` either way), so both map to `.staged()`. Neither
-/// `.flat()` nor `.staged()` exposes a 2-vs-3-pass knob, so `D1`'s
-/// pass count doesn't exactly match jt9's; lower `max_cand` if a
-/// closer time-budget match matters for your comparison.
+/// structurally that's `.sic_rounds()` (single full-buffer SIC
+/// round-set), not `.sic_early()`. `D2`/`D3` both go through checkpoint
+/// staging in jt9 (`npass=3` either way), so both map to
+/// `.sic_early()`. `D1` uses `.sic_rounds(2)` to match jt9 `-d1`'s
+/// `npass=2` exactly (previously this crate had no round-count knob at
+/// all, so `D1` ran the full 3 rounds — see issue #218).
 ///
 /// jt9 also varies `syncmin` per tier (1.6 for d1/d2, 1.3 for d3,
 /// `ft8_decode.f90:176-177`) and OSD *strength* is not just on/off in
@@ -1135,8 +1159,8 @@ impl<'a> DecodeRequest<'a, Ft8> {
         let mut req = Self::new(audio, freq_min, freq_max, sync_min, max_cand)
             .osd(!matches!(tier, WsjtxDepth::D1));
         req = match tier {
-            WsjtxDepth::D1 => req.flat(),
-            WsjtxDepth::D2 | WsjtxDepth::D3 => req.staged(),
+            WsjtxDepth::D1 => req.sic_rounds(2),
+            WsjtxDepth::D2 | WsjtxDepth::D3 => req.sic_early(),
         };
         if let (WsjtxDepth::D3, Some(ap)) = (tier, ap) {
             req = req.ap_hint(ap);
@@ -1209,37 +1233,37 @@ mod tests {
         assert!(!out1.fft_cache.is_empty());
     }
 
-    /// Compile-shape: `.staged()` accepts an AP hint and returns no
+    /// Compile-shape: `.sic_early()` accepts an AP hint and returns no
     /// decodes on silence.
     #[test]
-    fn staged_with_ap_silence_shape() {
+    fn sic_early_with_ap_silence_shape() {
         let audio = vec![0i16; 15 * 12_000];
         let ap = ApHint::new().with_call1("CQ").with_call2("W7VV");
 
         let r_none = DecodeRequest::<Ft8>::new(&audio, 200.0, 2800.0, 1.0, 10)
             .osd(false)
-            .staged()
+            .sic_early()
             .decode()
             .results;
         assert!(r_none.is_empty());
 
         let r_some = DecodeRequest::<Ft8>::new(&audio, 200.0, 2800.0, 1.0, 10)
             .osd(false)
-            .staged()
+            .sic_early()
             .ap_hint(&ap)
             .decode()
             .results;
         assert!(r_some.is_empty());
     }
 
-    /// Compile-shape: `.staged().known(&known).fft_cache(cache)` accepts
+    /// Compile-shape: `.sic_early().known(&known).fft_cache(cache)` accepts
     /// the full parameter set (known list + FFT cache + AP hint) and
     /// returns no decodes on silence — the issue #191 combination that
     /// used to be unreachable (only the buggy, now-deleted flat-only
     /// `decode_frame_subtract_with_known_and_ap` accepted `known`+cache
     /// at all).
     #[test]
-    fn staged_known_and_cache_silence_shape() {
+    fn sic_early_known_and_cache_silence_shape() {
         let audio = vec![0i16; 15 * 12_000];
         let ap = ApHint::new().with_call1("CQ").with_call2("JA1ABC");
         let known: Vec<DecodeResult> = Vec::new();
@@ -1250,7 +1274,7 @@ mod tests {
 
         let r_none = DecodeRequest::<Ft8>::new(&audio, 200.0, 2800.0, 1.0, 10)
             .osd(false)
-            .staged()
+            .sic_early()
             .known(&known)
             .fft_cache(cache.clone())
             .decode()
@@ -1259,7 +1283,7 @@ mod tests {
 
         let r_some = DecodeRequest::<Ft8>::new(&audio, 200.0, 2800.0, 1.0, 10)
             .osd(false)
-            .staged()
+            .sic_early()
             .known(&known)
             .fft_cache(cache)
             .ap_hint(&ap)
@@ -1281,9 +1305,9 @@ mod tests {
     /// runs. Without the fix, residual energy at f0 ≈ original input
     /// energy at f0. With the fix, it drops by an order of magnitude.
     /// Exercises the same `subtract_signal_lpf` + staged-checkpoint path
-    /// `SupportsStagedSic::__staged_sic` uses (see its doc comment).
+    /// `SupportsSicEarly::__staged_sic` uses (see its doc comment).
     #[test]
-    fn staged_subtracts_known_before_checkpoint_a() {
+    fn sic_early_subtracts_known_before_checkpoint_a() {
         use crate::ft8::wave_gen::{message_to_tones, tones_to_i16};
         use crate::msg::wsjt77::pack77;
 
@@ -1342,7 +1366,7 @@ mod tests {
         // Restrict the band to a 2 Hz window so the DFT loop stays cheap.
         let e_before = band_energy(&audio, f0 - 1.0, f0 + 1.0);
 
-        // Mirrors `SupportsStagedSic::__staged_sic`'s own upfront
+        // Mirrors `SupportsSicEarly::__staged_sic`'s own upfront
         // subtraction step exactly (same `subtract_signal_lpf` call),
         // then reuses the `_debug_residual` shim to observe the result.
         let mut audio_clean = audio.clone();
@@ -1377,8 +1401,8 @@ mod tests {
     }
 
     /// Regression test for the `eq_mode`/SIC gap (webft8 sniper-mode
-    /// investigation, 2026-07-26): `.flat()`/`.staged()` used to silently
-    /// hardcode `EqMode::Off` inside `sic_inner_passes`, dropping
+    /// investigation, 2026-07-26): `.sic_rounds()`/`.sic_early()` used to
+    /// silently hardcode `EqMode::Off` inside `sic_inner_passes`, dropping
     /// `DecodeRequest::eq_mode()` entirely for both SIC strategies even
     /// though the builder method compiled and looked like it worked.
     ///
@@ -1387,12 +1411,12 @@ mod tests {
     /// same shape `equalizer::tests::edge_attenuation_corrected` uses to
     /// validate the correction math), applied to the raw audio via an
     /// FFT-domain multiply so it exercises the real per-candidate decode
-    /// path, not just the isolated equalizer unit. `.staged()` (this test)
-    /// and `.flat()` share the same `sic_inner_passes` engine this fix
-    /// touches, so covering `.staged()` here is sufficient for both.
+    /// path, not just the isolated equalizer unit. `.sic_early()` (this test)
+    /// and `.sic_rounds()` share the same `sic_inner_passes` engine this fix
+    /// touches, so covering `.sic_early()` here is sufficient for both.
     ///
     /// Asserts `eq_mode(Local)` decodes a weak, edge-distorted signal that
-    /// `eq_mode(Off)` misses through the exact same `.staged()` call — the
+    /// `eq_mode(Off)` misses through the exact same `.sic_early()` call — the
     /// same shape as the `docs/bench.md`-style "BPF edge + AWGN" scenario,
     /// just self-contained (no external BPF/simulator crate). Fails again
     /// if the hardcoded `EqMode::Off` inside `sic_inner_passes` regresses.
@@ -1497,8 +1521,8 @@ mod tests {
     }
 
     /// Regression test for the `eq_mode`/SIC gap (webft8 sniper-mode
-    /// investigation, 2026-07-26): `.flat()`/`.staged()` used to silently
-    /// hardcode `EqMode::Off` inside `sic_inner_passes`, dropping
+    /// investigation, 2026-07-26): `.sic_rounds()`/`.sic_early()` used to
+    /// silently hardcode `EqMode::Off` inside `sic_inner_passes`, dropping
     /// `DecodeRequest::eq_mode()` entirely for both SIC strategies even
     /// though the builder method compiled and looked like it worked.
     ///
@@ -1507,10 +1531,10 @@ mod tests {
     /// 1000 Hz), calibrated against a real ground-truth sweep to a target
     /// SNR (-22 dB, WSJT-X convention) where `eq_mode(Off)` reliably
     /// misses the signal and `eq_mode(Local)` reliably recovers it through
-    /// `.staged()` — proving the fix actually reaches the SIC engine, not
+    /// `.sic_early()` — proving the fix actually reaches the SIC engine, not
     /// just that the builder method compiles.
     #[test]
-    fn staged_eq_mode_reaches_sic_engine() {
+    fn sic_early_eq_mode_reaches_sic_engine() {
         use crate::ft8::wave_gen::{message_to_tones, tones_to_f32};
         use crate::msg::wsjt77::pack77;
 
@@ -1579,7 +1603,7 @@ mod tests {
                 10,
             )
             .eq_mode(eq)
-            .staged()
+            .sic_early()
             .decode()
             .results;
             results.into_iter().find(|r| r.message77() == m77)
@@ -1593,7 +1617,7 @@ mod tests {
         assert!(
             find(EqMode::Local).is_some(),
             "expected eq_mode(Local) to decode the same BPF-edge signal \
-             that eq_mode(Off) misses through .staged() — eq_mode is not \
+             that eq_mode(Off) misses through .sic_early() — eq_mode is not \
              reaching the SIC engine"
         );
     }
@@ -3029,7 +3053,7 @@ mod tests {
         let ap = ApHint::new().with_call1("K1JT").with_call2("HA0DU");
         let results = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 1.3, 50)
             .strictness(DecodeStrictness::Normal)
-            .staged()
+            .sic_early()
             .ap_hint(&ap)
             .decode()
             .results;
@@ -3086,13 +3110,13 @@ mod tests {
         let path = std::path::Path::new(manifest).join("../embedded-poc/assets/qso3_busy.wav");
         let audio = load_wav_i16(&path).expect("load qso3_busy.wav");
 
-        // Blind decode only (no AP hint) -- staged SIC (`.staged()`) has
+        // Blind decode only (no AP hint) -- staged SIC (`.sic_early()`) has
         // been the default since #180/#183.
         for rep in 0..3 {
             let t0 = std::time::Instant::now();
             let results = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 0.8, 200)
                 .strictness(DecodeStrictness::Normal)
-                .staged()
+                .sic_early()
                 .decode()
                 .results;
             let elapsed = t0.elapsed();

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -698,6 +698,12 @@ pub(crate) fn decode_frame_subtract_staged_with_ap_debug_residual(
     )
 }
 
+/// Checkpoint SIC round count — always the full 3, never caller-tunable.
+/// The A/B/C checkpoint structure itself (not this) is what varies with
+/// signal availability; see [`SupportsSicEarly`]'s doc comment for why
+/// this axis has no `.sic_rounds()`-style knob.
+const CHECKPOINT_SIC_ROUNDS: usize = 3;
+
 #[allow(clippy::too_many_arguments)]
 fn decode_frame_subtract_staged_with_ap_inner(
     audio: &[i16],
@@ -733,7 +739,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
             eq_mode,
             ap_hint,
             None,
-            3,
+            CHECKPOINT_SIC_ROUNDS,
         );
         return (r, audio.to_vec());
     }
@@ -768,7 +774,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
         &[],
         eq_mode,
         ap_hint,
-        3,
+        CHECKPOINT_SIC_ROUNDS,
     );
     // Checkpoint A's own residual is not carried forward — only its
     // decoded results are (ft8_decode.f90 reloads `dd=iwave` fresh at
@@ -797,7 +803,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
             eq_mode,
             ap_hint,
             None,
-            3,
+            CHECKPOINT_SIC_ROUNDS,
         );
         return (r, audio.to_vec());
     }
@@ -860,7 +866,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
         &early_results,
         eq_mode,
         ap_hint,
-        3,
+        CHECKPOINT_SIC_ROUNDS,
     );
 
     let mut all_results = early_results;

--- a/mfsk-core/src/ft8/subtract.rs
+++ b/mfsk-core/src/ft8/subtract.rs
@@ -218,7 +218,7 @@ mod tests {
         let results = DecodeRequest::<Ft8>::new(&audio, 800.0, 1700.0, 1.0, 50)
             .osd(false)
             .strictness(DecodeStrictness::Normal)
-            .staged()
+            .sic_early()
             .decode()
             .results;
         let found_strong = results.iter().any(|r| r.message77() == msg_strong);

--- a/mfsk-core/src/msg/decode_request.rs
+++ b/mfsk-core/src/msg/decode_request.rs
@@ -5,7 +5,7 @@
 //! `decode_sniper*` suffix-exploded function families (31 public functions
 //! across the three protocols, before this module) into two generic
 //! builder types, `P: FrameDecodable` capability-gated so invalid
-//! combinations (e.g. staged SIC on FT4, which has no such engine) are
+//! combinations (e.g. `.sic_early()` on FT4, which has no such engine) are
 //! compile errors rather than runtime no-ops or silent panics.
 //!
 //! Lives in `msg` rather than `engine` because [`ApHint`] (a `msg::ap` type)
@@ -19,9 +19,9 @@
 //! (`engine::pipeline`/`msg::pipeline_ap`) FT4/FST4 share. `DecodeRequest`/
 //! `SniperRequest` don't need to know which: `decode()` just calls the
 //! dispatch function stashed in `self.strategy` (set by whichever gated
-//! builder method — `new`, `.flat()`, `.staged()` — was actually callable
-//! for this `P`, so an unsupported combination is a compile error, not a
-//! reachable runtime state).
+//! builder method — `new`, `.sic_rounds()`, `.sic_early()` — was actually
+//! callable for this `P`, so an unsupported combination is a compile
+//! error, not a reachable runtime state).
 
 use alloc::vec::Vec;
 
@@ -54,23 +54,25 @@ pub trait FrameDecodable: Protocol {
         Self: Sized;
 }
 
-/// Protocols with a calibrated flat 3-pass SIC (fixed sync_min, sequential
-/// subtract). FST4 has no `SubtractCfg` yet — enabling it there is new
-/// numerical work requiring WSJT-X-reference calibration, not a refactor,
-/// so it's deliberately not implemented here (tracked separately, issue
-/// #193).
-pub trait SupportsFlatSic: FrameDecodable {
+/// Protocols with a calibrated flat SIC (fixed sync_min, sequential
+/// subtract, up to 3 rounds — see [`DecodeRequest::sic_rounds`]). FST4 has
+/// no `SubtractCfg` yet — enabling it there is new numerical work requiring
+/// WSJT-X-reference calibration, not a refactor, so it's deliberately not
+/// implemented here (tracked separately, issue #193).
+pub trait SupportsSicRounds: FrameDecodable {
     #[doc(hidden)]
     fn __flat_sic(req: &DecodeRequest<'_, Self>) -> DecodeOutcome<Self>
     where
         Self: Sized;
 }
 
-/// Protocols with the jt9.f90 checkpoint-emulation staged SIC (issue
-/// #180). FT8 only today. Gated on capability, not identity — a future
+/// Protocols with the jt9.f90 checkpoint-emulation early decode (issue
+/// #180; WSJT-X's own name for this is `ndec_early`/`MAX_EARLY` in
+/// `ft8_decode.f90` — checkpointed at `nzhsym` = 41/47/50 out of 79
+/// symbols). FT8 only today. Gated on capability, not identity — a future
 /// protocol implementing the same checkpoint architecture just adds an
 /// `impl` here, no trait redesign needed (see issue #192).
-pub trait SupportsStagedSic: FrameDecodable {
+pub trait SupportsSicEarly: FrameDecodable {
     #[doc(hidden)]
     fn __staged_sic(req: &DecodeRequest<'_, Self>) -> DecodeOutcome<Self>
     where
@@ -119,6 +121,12 @@ pub struct DecodeRequest<'a, P: FrameDecodable> {
     pub(crate) ap_hint: Option<&'a ApHint>,
     pub(crate) known: &'a [P::DecodeResult],
     pub(crate) fft_cache: Option<FftCache>,
+    /// Only consulted by [`SupportsSicRounds::__flat_sic`] (set via
+    /// [`DecodeRequest::sic_rounds`]); ignored by every other strategy,
+    /// including [`SupportsSicEarly::__staged_sic`], whose checkpoint
+    /// structure is fixed. Not independently settable — see
+    /// `sic_rounds`'s doc comment for why.
+    pub(crate) sic_rounds: usize,
     strategy: fn(&DecodeRequest<'a, P>) -> DecodeOutcome<P>,
 }
 
@@ -145,6 +153,7 @@ impl<'a, P: FrameDecodable> DecodeRequest<'a, P> {
             ap_hint: None,
             known: &[],
             fft_cache: None,
+            sic_rounds: 3,
             strategy: P::__single_pass,
         }
     }
@@ -206,22 +215,39 @@ impl<'a, P: SupportsWideBandAp> DecodeRequest<'a, P> {
     }
 }
 
-impl<'a, P: SupportsFlatSic> DecodeRequest<'a, P> {
-    /// Flat 3-pass SIC: fixed `sync_min` across all passes, sequential
-    /// subtract (each accepted decode is subtracted before the next
-    /// candidate in the same pass is tried).
-    pub fn flat(mut self) -> Self {
+impl<'a, P: SupportsSicRounds> DecodeRequest<'a, P> {
+    /// One round = coarse-sync + per-candidate decode + subtract, over the
+    /// (shrinking) residual buffer. `n` is clamped to 1..=3 — WSJT-X's own
+    /// `npass`/`nsp` never exceeds 3. Fixed `sync_min` across rounds,
+    /// sequential subtract (each accepted decode is subtracted before the
+    /// next candidate in the same round is tried).
+    ///
+    /// Corresponds to WSJT-X FT8 `ft8_decode.f90:176` `ipass`/`npass` and
+    /// FT4 `ft4_decode.f90` `isp`/`nsp` — **not** FT4's separate
+    /// `ipass`/`npasses` AP-hint-variant loop inside a single candidate's
+    /// decode attempt, which is an unrelated concept that happens to reuse
+    /// the same word in WSJT-X's own source.
+    ///
+    /// `n` is folded into strategy selection (rather than an independently
+    /// settable field) so `.sic_rounds(_).sic_early()` can't compile a
+    /// combination where the round count is silently ignored — see issue
+    /// #218 for the design discussion.
+    pub fn sic_rounds(mut self, n: usize) -> Self {
         self.strategy = P::__flat_sic;
+        self.sic_rounds = n.clamp(1, 3);
         self
     }
 }
 
-impl<'a, P: SupportsStagedSic> DecodeRequest<'a, P> {
-    /// jt9.f90 checkpoint-emulation staged SIC (issue #180) — decodes
+impl<'a, P: SupportsSicEarly> DecodeRequest<'a, P> {
+    /// WSJT-X's early decode (`ft8_decode.f90`'s `ndec_early`/`MAX_EARLY`,
+    /// checkpointed at `nzhsym` = 41/47/50 out of 79 symbols): decodes
     /// progressively larger audio prefixes, subtracting earlier
     /// checkpoints' signals before the next, faithfully reproducing
-    /// WSJT-X's disk-decode architecture. Recall superset of `.flat()`.
-    pub fn staged(mut self) -> Self {
+    /// WSJT-X's disk-decode architecture. Recall superset of
+    /// `.sic_rounds()`. Checkpoint structure (A/B/C) is fixed — no
+    /// tunable count, matching jt9 `-d2`/`-d3`'s `npass=3` either way.
+    pub fn sic_early(mut self) -> Self {
         self.strategy = P::__staged_sic;
         self
     }

--- a/mfsk-core/tests/ft4_busy_band_fading_probe.rs
+++ b/mfsk-core/tests/ft4_busy_band_fading_probe.rs
@@ -61,7 +61,7 @@ use mfsk_core::msg::decode_request::DecodeRequest;
 
 /// Local shim matching the pre-#191 `ft4::decode::decode_frame_subtract`
 /// signature — this file has many call sites, easier to keep them
-/// unchanged than thread `.flat()` through each individually.
+/// unchanged than thread `.sic_rounds()` through each individually.
 fn decode_frame_subtract(
     audio: &[i16],
     freq_min: f32,
@@ -70,7 +70,7 @@ fn decode_frame_subtract(
     max_cand: usize,
 ) -> Vec<DecodeResult> {
     DecodeRequest::<Ft4>::new(audio, freq_min, freq_max, sync_min, max_cand)
-        .flat()
+        .sic_rounds(3)
         .decode()
         .results
 }

--- a/mfsk-core/tests/ft4_sic_rounds_recall.rs
+++ b/mfsk-core/tests/ft4_sic_rounds_recall.rs
@@ -1,0 +1,162 @@
+//! FT4 counterpart to `ft8_sic_rounds_recall.rs`: regression coverage
+//! for issue #218's `.sic_rounds(n)` on FT4's
+//! `engine::pipeline::decode_frame_subtract`, whose `&[1.0, 0.75,
+//! 0.5][..max_rounds]` slice is genuinely new logic (not just a
+//! rename) that the FT8-side golden/monotonicity test doesn't
+//! exercise at all.
+//!
+//! Self-contained synthetic scenario (no external WSJT-X sample tree
+//! dependency, unlike `ft4_wsjtx_samples.rs`) so this always runs in
+//! CI: six stations of varying amplitude, several close enough in
+//! frequency that sequential subtraction across rounds matters — the
+//! weakest pair only clears once a stronger neighbour has been
+//! subtracted in an earlier round.
+//!
+//! **`ft4_sic_rounds_recall_is_monotonic`** — `sic_rounds(1)`'s decode
+//! set must be a subset of `sic_rounds(2)`'s, which must be a subset
+//! of `sic_rounds(3)`'s, mirroring the FT8-side invariant. Also
+//! asserts `sic_rounds(3)` actually recovers more than `sic_rounds(1)`
+//! on this scene (i.e. the scenario is discriminating, not vacuously
+//! monotonic because every round already finds everything).
+//!
+//! Run:
+//! ```sh
+//! cargo test --release -p mfsk-core \
+//!     --features fft-rustfft,ft4 \
+//!     --test ft4_sic_rounds_recall -- --nocapture
+//! ```
+#![cfg(all(feature = "ft4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::collections::BTreeSet;
+
+use mfsk_core::engine::{FrameLayout, MessageCodec, MessageFields, ModulationParams};
+use mfsk_core::ft4::{Ft4, encode};
+use mfsk_core::msg::Wsjt77Message;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+#[allow(dead_code)]
+mod common;
+
+const NSPS: usize = <Ft4 as ModulationParams>::NSPS as usize;
+const NN: usize = <Ft4 as FrameLayout>::N_SYMBOLS as usize;
+const SLOT_SAMPLES: usize = 90_000; // 7.5 s x 12 kHz
+
+fn pack(call1: &str, call2: &str, grid: &str) -> [u8; 77] {
+    let bits = Wsjt77Message
+        .pack(&MessageFields {
+            call1: Some(call1.into()),
+            call2: Some(call2.into()),
+            grid: Some(grid.into()),
+            ..MessageFields::default()
+        })
+        .expect("pack succeeds");
+    let mut out = [0u8; 77];
+    out.copy_from_slice(&bits);
+    out
+}
+
+fn mix_i16(audio: &mut [i16], msg77: &[u8; 77], freq_hz: f32, amp: i16, pad: usize) {
+    let itone = encode::message_to_tones(msg77);
+    assert_eq!(itone.len(), NN);
+    let pcm = encode::tones_to_i16(&itone, freq_hz, amp);
+    assert_eq!(pcm.len(), NN * NSPS);
+    for (i, &s) in pcm.iter().enumerate() {
+        let idx = pad + i;
+        if idx >= audio.len() {
+            break;
+        }
+        let v = audio[idx] as i32 + s as i32;
+        audio[idx] = v.clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+    }
+}
+
+/// Six stations at three amplitude tiers, several close enough (20-40
+/// Hz, a couple of FT4 tone-spacings) that a weaker one only surfaces
+/// once a stronger neighbour has been subtracted in an earlier round.
+fn build_busy_scene(seed: u64) -> (Vec<i16>, Vec<[u8; 77]>) {
+    let pad = (<Ft4 as FrameLayout>::TX_START_OFFSET_S * 12_000.0) as usize;
+    let mut audio = vec![0i16; SLOT_SAMPLES];
+
+    let stations: &[(&str, &str, &str, f32, i16)] = &[
+        ("CQ", "JQ1AAA", "PM95", 500.0, 22_000),
+        ("CQ", "JQ1BBB", "PM96", 900.0, 22_000),
+        ("CQ", "JQ1CCC", "PM85", 1300.0, 18_000),
+        ("CQ", "JQ1DDD", "QN02", 1330.0, 8_000),
+        ("CQ", "JQ1EEE", "QN12", 1800.0, 14_000),
+        ("CQ", "JQ1FFF", "QN22", 1825.0, 5_500),
+    ];
+
+    let mut msgs = Vec::with_capacity(stations.len());
+    for (call1, call2, grid, freq, amp) in stations {
+        let msg = pack(call1, call2, grid);
+        mix_i16(&mut audio, &msg, *freq, *amp, pad);
+        msgs.push(msg);
+    }
+
+    let mut audio_f32: Vec<f32> = audio.iter().map(|&s| s as f32).collect();
+    common::channel::AwgnChannel::new(4500.0, seed).apply(&mut audio_f32);
+    let audio: Vec<i16> = audio_f32
+        .iter()
+        .map(|&s| s.clamp(i16::MIN as f32, i16::MAX as f32) as i16)
+        .collect();
+
+    (audio, msgs)
+}
+
+fn decode_messages(audio: &[i16], n_rounds: usize) -> BTreeSet<String> {
+    DecodeRequest::<Ft4>::new(audio, 100.0, 2700.0, 0.6, 50)
+        .sic_rounds(n_rounds)
+        .decode()
+        .results
+        .iter()
+        .filter_map(|r| {
+            let mut msg77 = [0u8; 77];
+            msg77.copy_from_slice(r.message77());
+            unpack77(&msg77)
+        })
+        .collect()
+}
+
+#[test]
+fn ft4_sic_rounds_recall_is_monotonic() {
+    let (audio, _msgs) = build_busy_scene(0);
+
+    let r1 = decode_messages(&audio, 1);
+    let r2 = decode_messages(&audio, 2);
+    let r3 = decode_messages(&audio, 3);
+
+    eprintln!("sic_rounds(1): {} decodes: {r1:?}", r1.len());
+    eprintln!("sic_rounds(2): {} decodes: {r2:?}", r2.len());
+    eprintln!("sic_rounds(3): {} decodes: {r3:?}", r3.len());
+
+    assert!(
+        r1.is_subset(&r2),
+        "sic_rounds(1) found a decode sic_rounds(2) missed: {:?}",
+        r1.difference(&r2).collect::<Vec<_>>()
+    );
+    assert!(
+        r2.is_subset(&r3),
+        "sic_rounds(2) found a decode sic_rounds(3) missed: {:?}",
+        r2.difference(&r3).collect::<Vec<_>>()
+    );
+    assert!(
+        r1.len() <= r2.len() && r2.len() <= r3.len(),
+        "recall not monotonic: r1={} r2={} r3={}",
+        r1.len(),
+        r2.len(),
+        r3.len()
+    );
+
+    // Scenario must actually discriminate between round counts — if
+    // round 1 already found everything round 3 does, the subset
+    // assertions above pass vacuously and this test isn't exercising
+    // `&[1.0, 0.75, 0.5][..max_rounds]`'s slicing at all.
+    assert!(
+        r1.len() < r3.len(),
+        "scenario not discriminating: sic_rounds(1) already matched \
+         sic_rounds(3) ({} decodes) — strengthen the close-frequency \
+         pairs so subtraction across rounds actually matters",
+        r3.len()
+    );
+}

--- a/mfsk-core/tests/ft4_sweep.rs
+++ b/mfsk-core/tests/ft4_sweep.rs
@@ -884,7 +884,7 @@ fn ft4_diag_candidate_cost_split() {
                 mfsk_core::msg::decode_request::DecodeRequest::<mfsk_core::ft4::Ft4>::new(
                     &audio, 100.0, 2700.0, 0.05, 2000,
                 )
-                .flat()
+                .sic_rounds(3)
                 .decode()
                 .results;
             let dt = t0.elapsed();

--- a/mfsk-core/tests/ft4_wsjtx_samples.rs
+++ b/mfsk-core/tests/ft4_wsjtx_samples.rs
@@ -111,7 +111,7 @@ fn ft4_wsjtx_sample_recall_vs_golden() {
     // replaced described the old search's redundancy-driven budget,
     // now obsolete.)
     let decodes = DecodeRequest::<Ft4>::new(&audio, 100.0, 2700.0, 0.05, 100)
-        .flat()
+        .sic_rounds(3)
         .decode()
         .results;
 

--- a/mfsk-core/tests/ft8_qso3_apon_recall.rs
+++ b/mfsk-core/tests/ft8_qso3_apon_recall.rs
@@ -251,7 +251,7 @@ fn qso3_apon_subtract_jtdx_extras_diag() {
 
     let decoded = DecodeRequest::<Ft8>::new(&slot, 100.0, 3000.0, 1.3, 50)
         .strictness(DecodeStrictness::Normal)
-        .staged()
+        .sic_early()
         .ap_hint(&ap)
         .decode()
         .results;

--- a/mfsk-core/tests/ft8_qso3_dk8ne_probe.rs
+++ b/mfsk-core/tests/ft8_qso3_dk8ne_probe.rs
@@ -47,7 +47,7 @@ fn try_context(label: &str, audio: &[i16], mycall: &str, hiscall: &str) -> BTree
     // Multi-pass + SIC + AP — the strongest AP-on recovery path we have.
     let decoded = DecodeRequest::<Ft8>::new(audio, 100.0, 3000.0, 1.3, 50)
         .strictness(DecodeStrictness::Normal)
-        .staged()
+        .sic_early()
         .ap_hint(&ap)
         .decode()
         .results;
@@ -111,7 +111,7 @@ fn try_context_for(label: &str, audio: &[i16], mycall: &str, hiscall: &str, targ
     let ap = ApHint::new().with_call1(mycall).with_call2(hiscall);
     let decoded = DecodeRequest::<Ft8>::new(audio, 100.0, 3000.0, 1.3, 50)
         .strictness(DecodeStrictness::Normal)
-        .staged()
+        .sic_early()
         .ap_hint(&ap)
         .decode()
         .results;

--- a/mfsk-core/tests/ft8_qso3_dl8yhr_probe.rs
+++ b/mfsk-core/tests/ft8_qso3_dl8yhr_probe.rs
@@ -77,7 +77,7 @@ fn probe_dl8yhr_decode_sweep() {
 
         let sub = DecodeRequest::<Ft8>::new(&audio, 200.0, 3000.0, dt_tol, max_cand)
             .strictness(DecodeStrictness::Normal)
-            .staged()
+            .sic_early()
             .decode()
             .results;
         let hit_sub = sub
@@ -87,7 +87,7 @@ fn probe_dl8yhr_decode_sweep() {
 
         let sub_deep = DecodeRequest::<Ft8>::new(&audio, 200.0, 3000.0, dt_tol, max_cand)
             .strictness(DecodeStrictness::Deep)
-            .staged()
+            .sic_early()
             .decode()
             .results;
         let hit_sub_deep = sub_deep

--- a/mfsk-core/tests/ft8_qso3_staged_sic_check.rs
+++ b/mfsk-core/tests/ft8_qso3_staged_sic_check.rs
@@ -91,11 +91,11 @@ const FLAT_PASS_GOLDEN: &[&str] = &[
 use common::load_wav_i16;
 
 #[test]
-fn staged_sic_matches_flat_pass_golden_floor() {
+fn sic_early_matches_sic_rounds_golden_floor() {
     let audio = load_wav_i16(Path::new(QSO3_PATH));
     let results = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 0.8, 200)
         .strictness(DecodeStrictness::Normal)
-        .staged()
+        .sic_early()
         .decode()
         .results;
     let msgs: BTreeSet<String> = results
@@ -134,8 +134,8 @@ fn staged_sic_matches_flat_pass_golden_floor() {
 
 /// Issue #191's actual reported bug, end to end: a two-phase pipelined
 /// caller (WebFT8's `decode_phase1`/`decode_phase2` shape) that hands a
-/// Phase-1 result set + FFT cache into a Phase-2 `.staged()` call must
-/// get the *same* staged-checkpoint engine `staged_sic_matches_flat_pass_golden_floor`
+/// Phase-1 result set + FFT cache into a Phase-2 `.sic_early()` call must
+/// get the *same* staged-checkpoint engine `sic_early_matches_sic_rounds_golden_floor`
 /// above exercises directly — not a separate, unfixed flat-only path.
 ///
 /// Before #191, `known`/`precomputed_fft` were only accepted by
@@ -143,11 +143,11 @@ fn staged_sic_matches_flat_pass_golden_floor() {
 /// none of issue #178/#179/#180's SIC-quality fixes — structurally
 /// unable to find `CQ DX DL8YHR JO41` regardless of `known`/cache
 /// content (its checkpoint-free structure is exactly what #180's doc
-/// comment above explains DL8YHR needs). `SupportsStagedSic`'s
+/// comment above explains DL8YHR needs). `SupportsSicEarly`'s
 /// `.known()`/`.fft_cache()` handling now routes through the same
-/// engine as the plain `.staged()` case, so this combination finds it.
+/// engine as the plain `.sic_early()` case, so this combination finds it.
 #[test]
-fn staged_with_known_and_cache_finds_dl8yhr() {
+fn sic_early_with_known_and_cache_finds_dl8yhr() {
     let audio = load_wav_i16(Path::new(QSO3_PATH));
 
     // Phase 1: a plain single-pass wide-band decode (no SIC) — the
@@ -174,7 +174,7 @@ fn staged_with_known_and_cache_finds_dl8yhr() {
     // exact combination issue #191 reported as unreachable.
     let phase2 = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 0.8, 200)
         .strictness(DecodeStrictness::Normal)
-        .staged()
+        .sic_early()
         .known(&phase1.results)
         .fft_cache(phase1.fft_cache)
         .decode();

--- a/mfsk-core/tests/ft8_qso3_subtract_fix_check.rs
+++ b/mfsk-core/tests/ft8_qso3_subtract_fix_check.rs
@@ -23,7 +23,7 @@ fn check_decode_frame_subtract_full_qso3() {
     let audio = load_wav_i16(Path::new(QSO3_PATH));
     let results = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 0.8, 200)
         .strictness(DecodeStrictness::Normal)
-        .staged()
+        .sic_early()
         .decode()
         .results;
     let msgs: BTreeSet<String> = results

--- a/mfsk-core/tests/ft8_qso3_sync_cv_iteration_correlation.rs
+++ b/mfsk-core/tests/ft8_qso3_sync_cv_iteration_correlation.rs
@@ -39,7 +39,7 @@ fn correlate_sync_cv_with_iteration_convergence() {
     let audio = load_wav_i16(Path::new(QSO3_PATH));
     let mut results = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 0.8, 200)
         .strictness(DecodeStrictness::Normal)
-        .staged()
+        .sic_early()
         .decode()
         .results;
     results.sort_by(|a, b| a.freq_hz.partial_cmp(&b.freq_hz).unwrap());

--- a/mfsk-core/tests/ft8_sic_rounds_recall.rs
+++ b/mfsk-core/tests/ft8_sic_rounds_recall.rs
@@ -1,0 +1,108 @@
+//! Regression tests for issue #218's `.sic_rounds(n)`/`.sic_early()`
+//! rename (was `.flat()`/`.staged()`) on the reference WAV
+//! (`samples/FT8/210703_133430.wav` = `embedded-poc/assets/qso3_busy.wav`).
+//!
+//! 1. **`sic_rounds_3_matches_pre_refactor_flat_golden`** — `.sic_rounds(3)`
+//!    (the new default-equivalent) must decode exactly the same 20-message
+//!    set the pre-#218 `.flat()` did. Verified directly against a clean
+//!    `main` worktree checkout at the commit this branch forked from
+//!    (`1ef7ecf`) before this golden was written — not just asserted.
+//! 2. **`sic_rounds_recall_is_monotonic`** — fewer rounds must never surface
+//!    a decode a higher round count misses: `sic_rounds(1)`'s message set
+//!    is a subset of `sic_rounds(2)`'s, which is a subset of
+//!    `sic_rounds(3)`'s. Guards the round-count knob itself, independent of
+//!    the exact golden list above (which will drift as unrelated SIC-quality
+//!    work lands; the subset relationship should not).
+//!
+//! Run:
+//! ```sh
+//! cargo test --release -p mfsk-core \
+//!     --features fft-rustfft,ft8 \
+//!     --test ft8_sic_rounds_recall -- --nocapture
+//! ```
+#![cfg(feature = "fft-rustfft")]
+
+use std::collections::BTreeSet;
+
+use mfsk_core::ft8::Ft8;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16;
+
+const QSO3_PATH: &str = asset_path!("qso3_busy.wav");
+
+/// Captured 2026-07-29 from both a pre-#218 `main` worktree's `.flat()`
+/// and this branch's `.sic_rounds(3)` on the same WAV/params — identical
+/// 20-entry sets confirmed byte-for-byte before this golden was written.
+const SIC_ROUNDS_3_GOLDEN: &[&str] = &[
+    "A92EE F5PSR -14",
+    "CQ EA2BFM IN83",
+    "CQ F5RXL IN94",
+    "K1BZM DK8NE -10",
+    "K1BZM EA3CJ JN01",
+    "K1BZM EA3GP -9",
+    "K1JT EA3AGB -15",
+    "K1JT HA0DU KN07",
+    "K1JT HA5WA 73",
+    "KD2UGC F6GCP R-23",
+    "N1API F2VX 73",
+    "N1API HA6FQ -23",
+    "N1JFU EA6EE R-7",
+    "N1PJT HB9CQK -10",
+    "W0RSJ EA3BMU RR73",
+    "W1DIG SV9CVY -14",
+    "W1FC F5BZB -8",
+    "WA2FZW DL5AXX RR73",
+    "WM3PEN EA6VQ -9",
+    "XE2X HA2NP RR73",
+];
+
+fn decode_messages(audio: &[i16], n_rounds: usize) -> BTreeSet<String> {
+    DecodeRequest::<Ft8>::new(audio, 100.0, 3000.0, 0.8, 60)
+        .sic_rounds(n_rounds)
+        .decode()
+        .results
+        .iter()
+        .filter_map(|r| unpack77(r.message77()))
+        .collect()
+}
+
+#[test]
+fn sic_rounds_3_matches_pre_refactor_flat_golden() {
+    let audio = load_wav_i16(QSO3_PATH);
+    let got = decode_messages(&audio, 3);
+    let want: BTreeSet<String> = SIC_ROUNDS_3_GOLDEN.iter().map(|s| s.to_string()).collect();
+    assert_eq!(
+        got, want,
+        "sic_rounds(3) diverged from the pre-#218 .flat() golden"
+    );
+}
+
+#[test]
+fn sic_rounds_recall_is_monotonic() {
+    let audio = load_wav_i16(QSO3_PATH);
+    let r1 = decode_messages(&audio, 1);
+    let r2 = decode_messages(&audio, 2);
+    let r3 = decode_messages(&audio, 3);
+
+    assert!(
+        r1.is_subset(&r2),
+        "sic_rounds(1) found a decode sic_rounds(2) missed: {:?}",
+        r1.difference(&r2).collect::<Vec<_>>()
+    );
+    assert!(
+        r2.is_subset(&r3),
+        "sic_rounds(2) found a decode sic_rounds(3) missed: {:?}",
+        r2.difference(&r3).collect::<Vec<_>>()
+    );
+    assert!(
+        r1.len() <= r2.len() && r2.len() <= r3.len(),
+        "recall not monotonic: r1={} r2={} r3={}",
+        r1.len(),
+        r2.len(),
+        r3.len()
+    );
+}

--- a/mfsk-core/tests/ft8_wsjtx_depth_ladder.rs
+++ b/mfsk-core/tests/ft8_wsjtx_depth_ladder.rs
@@ -45,7 +45,7 @@ const HISCALL: &str = "HA0DU";
 
 /// Soft recall floors — well below the reference table above, just
 /// enough to catch a catastrophic regression (e.g. a future change
-/// accidentally severing `.flat()`/`.staged()`/`.ap_hint()` from
+/// accidentally severing `.sic_rounds()`/`.sic_early()`/`.ap_hint()` from
 /// `wsjtx_depth`). Not a golden-exact-match test.
 const MIN_DECODES: [usize; 3] = [10, 15, 15];
 


### PR DESCRIPTION
## Summary
- `DecodeRequest::flat()`/`.staged()` → `.sic_rounds(n)`/`.sic_early()`; `SupportsFlatSic`/`SupportsStagedSic` → `SupportsSicRounds`/`SupportsSicEarly`. Round count moves from a hardcoded 3 to a required argument on the strategy-selecting method itself (clamped 1..=3), so a combination where it would be silently ignored by the early-decode strategy can't be written at all.
- `WsjtxDepth::D1` now uses `.sic_rounds(2)`, closing the gap the type's own doc comment already flagged (jt9 `-d1` runs `npass=2`; there was previously no knob to match it).
- FT4's `engine::pipeline::decode_frame_subtract` gained the same `.sic_rounds(n)` knob (slices its existing progressive-`sync_min`-relaxation pass array). FT4's own WSJT-X-fidelity gap (fixed vs. progressive `sync_min`) is unrelated pre-existing behavior, tracked separately, out of scope here.

## Verification
- `.sic_rounds(3)` checked byte-identical to the pre-rename `.flat()` default on `qso3_busy.wav` (20/20 matching decodes) against a clean pre-#218 `main` worktree checkout.
- New `tests/ft8_sic_rounds_recall.rs` locks in that golden plus a `sic_rounds(1) ⊆ sic_rounds(2) ⊆ sic_rounds(3)` monotonicity invariant (measured 13/19/20 decodes on the same WAV).
- Full workspace test suite green (`cargo test --release --all-features`), `scripts/pre-push-check.sh` (fmt + clippy `-D warnings -D clippy::perf`, full+internal-testing features) clean.

## Test plan
- [x] `cargo test --release --all-features` — all suites pass, 0 failures
- [x] `scripts/pre-push-check.sh` — fmt + clippy clean
- [x] `.sic_rounds(3)` vs pre-refactor `.flat()` byte-identical comparison against a clean `main` worktree
- [x] New monotonicity test (`ft8_sic_rounds_recall.rs`)

Closes #218.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018nw8N1DSTeXQkFFnBzyj34