### PR TITLE
chore(release): 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ resolver = "2"
 # CHANGELOG). `release.yml`'s tag-vs-Cargo.toml check reads this
 # field directly.
 [workspace.package]
-version = "0.7.4"
+version = "0.8.0"

--- a/README.md
+++ b/README.md
@@ -627,13 +627,12 @@ reference:
 
 ## Status
 
-**Latest published tag: `v0.7.4`** — `main` has since accumulated
-`0.8.0`-bound content (unreleased, see `CHANGELOG.md`'s top section).
-API is deliberately not frozen: breaking changes follow cargo-style
-minor bumps, while a new protocol/mode addition on its own is
-patch-level (e.g. MSK144 shipped as `0.7.4`, not `0.8.0`) — minor
-bumps mark more structural changes. See `CHANGELOG.md` for the
-per-release breakdown and `docs/notes/ROADMAP.md` for open follow-ups.
+**Latest published tag: `v0.8.0`** — API is deliberately not frozen:
+breaking changes follow cargo-style minor bumps, while a new
+protocol/mode addition on its own is patch-level (e.g. MSK144 shipped
+as `0.7.4`, not `0.8.0`) — minor bumps mark more structural changes.
+See `CHANGELOG.md` for the per-release breakdown and
+`docs/notes/ROADMAP.md` for open follow-ups.
 
 **Release cadence**: PRs merge to `main` continuously — CHANGELOG.md's
 top section always reflects the latest unreleased state, so tracking

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -53,8 +53,8 @@ embedded-fixed-point = [
 embedded-runtime = []
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.7.4", default-features = false }
-mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.7.4" }
+mfsk-core = { path = "../mfsk-core", version = "0.8.0", default-features = false }
+mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.8.0" }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/mfsk-ffi/Cargo.toml
+++ b/mfsk-ffi/Cargo.toml
@@ -11,8 +11,8 @@ name       = "mfsk"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.7", features = ["full"] }
-mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.7.4" }
+mfsk-core = { path = "../mfsk-core", version = "0.8", features = ["full"] }
+mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.8.0" }
 
 [build-dependencies]
 cbindgen = "0.29"


### PR DESCRIPTION
## Summary
- Bumps the workspace version 0.7.4 → 0.8.0 (`mfsk-core`, `mfsk-ffi`, `mfsk-ffi-abi`, `mfsk-ffi-ft8` all inherit via `version.workspace = true`)
- Updates the two in-workspace version pins (`mfsk-ffi`/`mfsk-ffi-ft8`'s path-dependency `version = "0.7..."` on `mfsk-core`/`mfsk-ffi-abi`) that would otherwise break `cargo check --workspace` once `mfsk-core` moves to 0.8.0
- Updates README's Status section to point at `v0.8.0` as the latest published tag

CHANGELOG.md's `## 0.8.0` section is already fully written (accumulated across the individual PRs merged since v0.7.4) — no changes needed there.

**Do not tag until this merges** — merge first, then `git tag v0.8.0 <merge-sha>` + `git push origin v0.8.0` per CLAUDE.md's release sequence, which triggers the CD publish workflow.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo clippy --features full,internal-testing --no-deps -- -D warnings -D clippy::perf`
- [x] `cargo test --lib --features full` (375 passed)
- [x] `cargo test --doc` (default + full, 31 passed)
- [x] `cargo publish --dry-run -p mfsk-core --features full`
- [x] `cargo build -p mfsk-ffi --release`
- [x] `cargo check --workspace --features full` (confirms the version-pin fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0114Nhc2R36V17DwTkBTcZqo