### PR TITLE
docs: bump stale quick-start dependency snippets to 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ runtime `register_protocol()`.
 ```toml
 # Cargo.toml
 [dependencies]
-mfsk-core = { version = "0.7", features = ["ft8", "ft4"] }
+mfsk-core = { version = "0.8", features = ["ft8", "ft4"] }
 ```
 
 New features and fixes land on `main` immediately as PRs merge, but

--- a/docs/reference/EMBEDDED.ja.md
+++ b/docs/reference/EMBEDDED.ja.md
@@ -101,7 +101,7 @@ worked example。
 
 ```toml
 [dependencies]
-mfsk-core = { version = "0.6", default-features = false, features = [
+mfsk-core = { version = "0.8", default-features = false, features = [
     "alloc",            # Vec / Box / String — decode 必須
     "ft8",              # FT8 protocol glue
     "fft-extern",       # 呼び出し側が FFT バックエンドを供給

--- a/docs/reference/EMBEDDED.md
+++ b/docs/reference/EMBEDDED.md
@@ -110,7 +110,7 @@ those off and pick the embedded baseline:
 
 ```toml
 [dependencies]
-mfsk-core = { version = "0.6", default-features = false, features = [
+mfsk-core = { version = "0.8", default-features = false, features = [
     "alloc",            # Vec / Box / String — required for decode
     "ft8",              # FT8 protocol glue
     "fft-extern",       # caller supplies the FFT backend

--- a/docs/reference/LIBRARY.ja.md
+++ b/docs/reference/LIBRARY.ja.md
@@ -915,7 +915,7 @@ FT8 モジュールは共有パイプラインの上に並列のエントリ群�
 
 ```toml
 [dependencies]
-mfsk-core = { version = "0.7", features = ["ft8", "ft4", "wspr"] }
+mfsk-core = { version = "0.8", features = ["ft8", "ft4", "wspr"] }
 ```
 
 必要なプロトコルのフィーチャーだけ有効にすれば十分。以下では複数を

--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -943,7 +943,7 @@ which inner steps they enable:
 
 ```toml
 [dependencies]
-mfsk-core = { version = "0.7", features = ["ft8", "ft4", "wspr"] }
+mfsk-core = { version = "0.8", features = ["ft8", "ft4", "wspr"] }
 ```
 
 Pull in only the protocol features you need; the examples below

--- a/mfsk-core/src/lib.rs
+++ b/mfsk-core/src/lib.rs
@@ -239,7 +239,7 @@
 //! ```toml
 //! # Cargo.toml
 //! [dependencies]
-//! mfsk-core = { version = "0.5", features = ["ft8", "ft4"] }
+//! mfsk-core = { version = "0.8", features = ["ft8", "ft4"] }
 //! ```
 //!
 //! Round-trip a synthesised FT8 frame through the decoder:
@@ -287,7 +287,7 @@
 //! ```toml
 //! # Cargo.toml — TX-only, no_std + alloc, no FFT backend needed
 //! [dependencies]
-//! mfsk-core = { version = "0.7", default-features = false, features = ["alloc", "ft8"] }
+//! mfsk-core = { version = "0.8", default-features = false, features = ["alloc", "ft8"] }
 //! ```
 //!
 //! Encoding (`message_to_tones` / `tones_to_i16`) never touches `std` — no


### PR DESCRIPTION
## Problem

0.8.0 shipped, but the "Quick start" **`mfsk-core = { version = "..." }` snippets** were left on old minors:

| Location | Was | 
|---|---|
| `mfsk-core/src/lib.rs:242` (crate-root Quick start) | `"0.5"` |
| `mfsk-core/src/lib.rs:290` | `"0.7"` |
| `README.md:100` | `"0.7"` |
| `docs/reference/LIBRARY.md` / `.ja.md` | `"0.7"` |
| `docs/reference/EMBEDDED.md` / `.ja.md` | `"0.6"` |

Cargo reads `version = "0.5"` as `>=0.5.0, <0.6.0`, so a reader copying the snippet pulls a **pre-0.8 release whose API doesn't match the new-API code shown right below it** (`DecodeRequest`, `message77()`, …). These are ` ```toml ` fences, not doctests, so `cargo test --doc` (which the code examples now run through, #cac28d6) never caught them.

The actual build manifests are fine — `[workspace.package] version = "0.8.0"` and the internal FFI path-dep pins (`mfsk-ffi`/`mfsk-ffi-ft8` → `mfsk-core "0.8"`, `mfsk-ffi-abi "0.8.0"`) were all bumped correctly at release. Only the doc *example* snippets — a hand-synced shadow of the crate version — were missed.

## Change

Bump every `mfsk-core = { version = "..." }` doc snippet to `"0.8"` (6 files, 7 lines). Diff is version strings only.

## Release note

Not cutting a 0.8.1 for this — rides to the next scheduled release per the biweekly cadence. crates.io's published 0.8.0 README stays as-is (immutable); GitHub reflects the fix on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Va6wS22HFoBhdaAi3iCny4)_