### PR TITLE
feat: decode-side snr_db for WSPR/JT65/JT9/Q65 (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208) + embedded-poc `+esp` compile fix (#215) + `DecodeRequest`/`SniperRequest::depth` → `.osd(bool)` (breaking) + FT8 `WsjtxDepth`/`wsjtx_depth` jt9-comparison preset + `DecodeRequest::flat()`/`.staged()` → `.sic_rounds(n)`/`.sic_early()` (#218, breaking) + FT8 `DecodeStrictness` wiring for the non-AP decode path (#221)
+## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208) + embedded-poc `+esp` compile fix (#215) + `DecodeRequest`/`SniperRequest::depth` → `.osd(bool)` (breaking) + FT8 `WsjtxDepth`/`wsjtx_depth` jt9-comparison preset + `DecodeRequest::flat()`/`.staged()` → `.sic_rounds(n)`/`.sic_early()` (#218, breaking) + FT8 `DecodeStrictness` wiring for the non-AP decode path (#221) + decode-side `snr_db` for WSPR/JT65/JT9/Q65 (#226, breaking)
 
 ### Added
 
@@ -859,6 +859,68 @@
   host figure in top-level summary tables (they're different code
   paths by construction now, not a temporary gap — see `DecodeDepth`'s
   own doc comment).
+
+- **`snr_db: f32` on `WsprResult`, `Jt65Result`, `Jt9Result`, and
+  `Q65Result`** (issue #226, breaking — new required struct field on
+  four public types). FT8/FT4/FST4 already share `engine::pipeline::
+  DecodeResult`, which carries `snr_db`; MSK144 has its own
+  (`SlotDecode::snr_db`, WSJT-X `mskrtd.f90` formula). The other four
+  WSJT-family decoders had **no** decode-side signal-quality field at
+  all — `mfsk-ffi`'s `push_simple` (used for WSPR, and the fixed-
+  alignment JT9/JT65 FFI entry points) was hardcoding `snr_db: 0.0`
+  for every one of them, which is why the gap wasn't visible from the
+  FFI surface. Filed after WebFT8 tried to wire up Q65 QSO-exchange
+  reports ("+NN"/"-NN") and found there was no SNR to report from —
+  auditing the sibling protocols for the same gap (prompted by "is a
+  missing field like this really just one mode's bug?") turned up all
+  three others too.
+
+  - **WSPR**: `wspr::coarse_baseband::BasebandCandidate` already
+    computed a wsprd-calibrated candidate SNR (`10·log10(smspec) −
+    26.3`, `wsprd.c:1093`) during coarse search — it was being
+    discarded before reaching `WsprResult`. `decode_scan`/
+    `decode_scan_subtract` now thread it through; direct
+    `decode_at`/`decode_at_baseband`/`decode_at_baseband_nblocks`
+    calls (no coarse candidate to derive it from) report `0.0`.
+  - **JT65** and **Q65**: new decode-side estimate — signal = power at
+    each data symbol's decoded tone, noise = mean power of the other
+    63 tones in the same per-symbol FFT bin (same "opposite-tone"
+    shape as `engine::llr::compute_snr_db_generic`, FT8/FT4/FST4),
+    converted to WSJT-X's 2500 Hz reference bandwidth via `10·log10
+    (2500/tone_spacing_hz)` — cross-checked against FT8's literal
+    `-27 dB` @ 6.25 Hz and wsprd's literal `-26.3 dB` @ ~5.1 Hz, both
+    within ~1 dB of that formula, so expect similar-order accuracy
+    pending real calibration. Q65's four wide-energies decode paths
+    (fast-fading metric, grid search) get a layout-aware variant of
+    the same estimator; Q65's info-symbols are re-encoded back to the
+    63-symbol channel codeword via `Q65Codec::encode` to know which
+    tone was "decoded" at each slot (AP-list paths use the winning
+    candidate codeword directly, no re-encode needed).
+  - **JT9**: same signal/noise decomposition, but **not** WSJT-X
+    2500 Hz-referenced — `jt9::softsym`'s `downsam9`→`peakdt9`→
+    `symspec2` pipeline runs the per-symbol power through AGC scaling,
+    an unnormalised IFFT, and a coherent sample sum before the tone
+    comparison, so the tone-spacing bandwidth offset that works for
+    JT65/Q65 doesn't apply; an initial attempt that borrowed it
+    produced an implausible reading (clean noiseless synth ≈ −4 dB).
+    `Jt9Result::snr_db` is documented as relative-only: useful to
+    compare JT9 decodes against each other, not against the other
+    protocols' dB2500 values.
+  - Caught in testing: the shared floor/ratio formula returned the
+    **-24 dB floor** for a perfectly clean noiseless synth signal
+    across all three new estimators, because an exactly-orthogonal
+    synthetic tone can leave literally zero measured power in the
+    non-signal bins — "no measurable noise" (the *best* case), which
+    the original floor-on-zero-noise branch (mirroring `engine::llr::
+    compute_snr_db_generic`'s existing behavior) reported as the
+    *worst* case instead. Fixed by returning a `+49 dB` ceiling
+    (matching WSJT-X's own display-clamp convention) when noise is
+    zero and signal isn't, in `q65::rx::snr_db_from_sig_noi`,
+    `jt65::rx`, and `jt9::softsym::symspec2_from_ss2`.
+  - `mfsk-ffi`'s `push_simple` now takes `snr_db` explicitly (WSPR and
+    Q65 pass the real value; the JT9/JT65 fixed-alignment entry points
+    still pass `0.0` — that path uses the bare `decode_at`, which has
+    no SNR estimate available, not `decode_scan`).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,72 @@
 # Changelog
 
-## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208) + embedded-poc `+esp` compile fix (#215) + `DecodeRequest`/`SniperRequest::depth` → `.osd(bool)` (breaking) + FT8 `WsjtxDepth`/`wsjtx_depth` jt9-comparison preset + `DecodeRequest::flat()`/`.staged()` → `.sic_rounds(n)`/`.sic_early()` (#218, breaking) + FT8 `DecodeStrictness` wiring for the non-AP decode path (#221) + decode-side `snr_db` for WSPR/JT65/JT9/Q65 (#226, breaking)
+## 0.8.1 — decode-side `snr_db` for WSPR/JT65/JT9/Q65 (#226)
+
+### Added
+
+- **`snr_db: f32` on `WsprResult`, `Jt65Result`, `Jt9Result`, and
+  `Q65Result`** (issue #226, breaking — new required struct field on
+  four public types). FT8/FT4/FST4 already share `engine::pipeline::
+  DecodeResult`, which carries `snr_db`; MSK144 has its own
+  (`SlotDecode::snr_db`, WSJT-X `mskrtd.f90` formula). The other four
+  WSJT-family decoders had **no** decode-side signal-quality field at
+  all — `mfsk-ffi`'s `push_simple` (used for WSPR, and the fixed-
+  alignment JT9/JT65 FFI entry points) was hardcoding `snr_db: 0.0`
+  for every one of them, which is why the gap wasn't visible from the
+  FFI surface. Filed after WebFT8 tried to wire up Q65 QSO-exchange
+  reports ("+NN"/"-NN") and found there was no SNR to report from —
+  auditing the sibling protocols for the same gap (prompted by "is a
+  missing field like this really just one mode's bug?") turned up all
+  three others too.
+
+  - **WSPR**: `wspr::coarse_baseband::BasebandCandidate` already
+    computed a wsprd-calibrated candidate SNR (`10·log10(smspec) −
+    26.3`, `wsprd.c:1093`) during coarse search — it was being
+    discarded before reaching `WsprResult`. `decode_scan`/
+    `decode_scan_subtract` now thread it through; direct
+    `decode_at`/`decode_at_baseband`/`decode_at_baseband_nblocks`
+    calls (no coarse candidate to derive it from) report `0.0`.
+  - **JT65** and **Q65**: new decode-side estimate — signal = power at
+    each data symbol's decoded tone, noise = mean power of the other
+    63 tones in the same per-symbol FFT bin (same "opposite-tone"
+    shape as `engine::llr::compute_snr_db_generic`, FT8/FT4/FST4),
+    converted to WSJT-X's 2500 Hz reference bandwidth via `10·log10
+    (2500/tone_spacing_hz)` — cross-checked against FT8's literal
+    `-27 dB` @ 6.25 Hz and wsprd's literal `-26.3 dB` @ ~5.1 Hz, both
+    within ~1 dB of that formula, so expect similar-order accuracy
+    pending real calibration. Q65's four wide-energies decode paths
+    (fast-fading metric, grid search) get a layout-aware variant of
+    the same estimator; Q65's info-symbols are re-encoded back to the
+    63-symbol channel codeword via `Q65Codec::encode` to know which
+    tone was "decoded" at each slot (AP-list paths use the winning
+    candidate codeword directly, no re-encode needed).
+  - **JT9**: same signal/noise decomposition, but **not** WSJT-X
+    2500 Hz-referenced — `jt9::softsym`'s `downsam9`→`peakdt9`→
+    `symspec2` pipeline runs the per-symbol power through AGC scaling,
+    an unnormalised IFFT, and a coherent sample sum before the tone
+    comparison, so the tone-spacing bandwidth offset that works for
+    JT65/Q65 doesn't apply; an initial attempt that borrowed it
+    produced an implausible reading (clean noiseless synth ≈ −4 dB).
+    `Jt9Result::snr_db` is documented as relative-only: useful to
+    compare JT9 decodes against each other, not against the other
+    protocols' dB2500 values.
+  - Caught in testing: the shared floor/ratio formula returned the
+    **-24 dB floor** for a perfectly clean noiseless synth signal
+    across all three new estimators, because an exactly-orthogonal
+    synthetic tone can leave literally zero measured power in the
+    non-signal bins — "no measurable noise" (the *best* case), which
+    the original floor-on-zero-noise branch (mirroring `engine::llr::
+    compute_snr_db_generic`'s existing behavior) reported as the
+    *worst* case instead. Fixed by returning a `+49 dB` ceiling
+    (matching WSJT-X's own display-clamp convention) when noise is
+    zero and signal isn't, in `q65::rx::snr_db_from_sig_noi`,
+    `jt65::rx`, and `jt9::softsym::symspec2_from_ss2`.
+  - `mfsk-ffi`'s `push_simple` now takes `snr_db` explicitly (WSPR and
+    Q65 pass the real value; the JT9/JT65 fixed-alignment entry points
+    still pass `0.0` — that path uses the bare `decode_at`, which has
+    no SNR estimate available, not `decode_scan`).
+
+## 0.8.0 — JT65 decode-chain bug fix (#24) + JT9 AWGN SNR sweep + Q65-15A/120D/120E/300A + fine-timing sensitivity fix + CQ-AP-hint parity note (#171) + BASIS removal (#162, breaking FFI change) + FT8 `DecodeDepth` redesign + auto-AP removal (issue #182 follow-up, breaking) + CCIR moderate/poor sweep gap closed (#190) + `DecodeRequest`/`SniperRequest` consolidation (#191, breaking) + `core::pipeline` dead-code cleanup (#192, breaking) + pre-#191 raw decode API demotion (#203, breaking) + `core` → `engine` module rename (#206, breaking) + FT8/FT4/FST4 `DecodeResult` unification (#194, breaking) + sealed `FecCodec` (#198) + Q65 `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder migration (#204, breaking) + unified `mfsk-ffi`/`mfsk-ffi-ft8` C-ABI conventions via new `mfsk-ffi-abi` shared crate (#205, breaking) + WSPR/JT9/JT65/Q65 decode-result naming convention (#206, breaking) + `downsample_cached` FFT-plan caching fix (#211) + wasm `+simd128` LLR vectorization (#208) + embedded-poc `+esp` compile fix (#215) + `DecodeRequest`/`SniperRequest::depth` → `.osd(bool)` (breaking) + FT8 `WsjtxDepth`/`wsjtx_depth` jt9-comparison preset + `DecodeRequest::flat()`/`.staged()` → `.sic_rounds(n)`/`.sic_early()` (#218, breaking) + FT8 `DecodeStrictness` wiring for the non-AP decode path (#221)
 
 ### Added
 
@@ -859,68 +925,6 @@
   host figure in top-level summary tables (they're different code
   paths by construction now, not a temporary gap — see `DecodeDepth`'s
   own doc comment).
-
-- **`snr_db: f32` on `WsprResult`, `Jt65Result`, `Jt9Result`, and
-  `Q65Result`** (issue #226, breaking — new required struct field on
-  four public types). FT8/FT4/FST4 already share `engine::pipeline::
-  DecodeResult`, which carries `snr_db`; MSK144 has its own
-  (`SlotDecode::snr_db`, WSJT-X `mskrtd.f90` formula). The other four
-  WSJT-family decoders had **no** decode-side signal-quality field at
-  all — `mfsk-ffi`'s `push_simple` (used for WSPR, and the fixed-
-  alignment JT9/JT65 FFI entry points) was hardcoding `snr_db: 0.0`
-  for every one of them, which is why the gap wasn't visible from the
-  FFI surface. Filed after WebFT8 tried to wire up Q65 QSO-exchange
-  reports ("+NN"/"-NN") and found there was no SNR to report from —
-  auditing the sibling protocols for the same gap (prompted by "is a
-  missing field like this really just one mode's bug?") turned up all
-  three others too.
-
-  - **WSPR**: `wspr::coarse_baseband::BasebandCandidate` already
-    computed a wsprd-calibrated candidate SNR (`10·log10(smspec) −
-    26.3`, `wsprd.c:1093`) during coarse search — it was being
-    discarded before reaching `WsprResult`. `decode_scan`/
-    `decode_scan_subtract` now thread it through; direct
-    `decode_at`/`decode_at_baseband`/`decode_at_baseband_nblocks`
-    calls (no coarse candidate to derive it from) report `0.0`.
-  - **JT65** and **Q65**: new decode-side estimate — signal = power at
-    each data symbol's decoded tone, noise = mean power of the other
-    63 tones in the same per-symbol FFT bin (same "opposite-tone"
-    shape as `engine::llr::compute_snr_db_generic`, FT8/FT4/FST4),
-    converted to WSJT-X's 2500 Hz reference bandwidth via `10·log10
-    (2500/tone_spacing_hz)` — cross-checked against FT8's literal
-    `-27 dB` @ 6.25 Hz and wsprd's literal `-26.3 dB` @ ~5.1 Hz, both
-    within ~1 dB of that formula, so expect similar-order accuracy
-    pending real calibration. Q65's four wide-energies decode paths
-    (fast-fading metric, grid search) get a layout-aware variant of
-    the same estimator; Q65's info-symbols are re-encoded back to the
-    63-symbol channel codeword via `Q65Codec::encode` to know which
-    tone was "decoded" at each slot (AP-list paths use the winning
-    candidate codeword directly, no re-encode needed).
-  - **JT9**: same signal/noise decomposition, but **not** WSJT-X
-    2500 Hz-referenced — `jt9::softsym`'s `downsam9`→`peakdt9`→
-    `symspec2` pipeline runs the per-symbol power through AGC scaling,
-    an unnormalised IFFT, and a coherent sample sum before the tone
-    comparison, so the tone-spacing bandwidth offset that works for
-    JT65/Q65 doesn't apply; an initial attempt that borrowed it
-    produced an implausible reading (clean noiseless synth ≈ −4 dB).
-    `Jt9Result::snr_db` is documented as relative-only: useful to
-    compare JT9 decodes against each other, not against the other
-    protocols' dB2500 values.
-  - Caught in testing: the shared floor/ratio formula returned the
-    **-24 dB floor** for a perfectly clean noiseless synth signal
-    across all three new estimators, because an exactly-orthogonal
-    synthetic tone can leave literally zero measured power in the
-    non-signal bins — "no measurable noise" (the *best* case), which
-    the original floor-on-zero-noise branch (mirroring `engine::llr::
-    compute_snr_db_generic`'s existing behavior) reported as the
-    *worst* case instead. Fixed by returning a `+49 dB` ceiling
-    (matching WSJT-X's own display-clamp convention) when noise is
-    zero and signal isn't, in `q65::rx::snr_db_from_sig_noi`,
-    `jt65::rx`, and `jt9::softsym::symspec2_from_ss2`.
-  - `mfsk-ffi`'s `push_simple` now takes `snr_db` explicitly (WSPR and
-    Q65 pass the real value; the JT9/JT65 fixed-alignment entry points
-    still pass `0.0` — that path uses the bare `decode_at`, which has
-    no SNR estimate available, not `decode_scan`).
 
 ### Changed
 

--- a/docs/reference/LIBRARY.ja.md
+++ b/docs/reference/LIBRARY.ja.md
@@ -977,20 +977,23 @@ assert!(!decodes.is_empty(), "ラウンドトリップは復号できるはず")
 for d in decodes {
     match d.message {
         WsprMessage::Type1 { callsign, grid, power_dbm } => {
-            println!("{:7.2} Hz  {} {} {}dBm", d.freq_hz, callsign, grid, power_dbm);
+            println!("{:7.2} Hz  {:+.0} dB  {} {} {}dBm", d.freq_hz, d.snr_db, callsign, grid, power_dbm);
         }
         WsprMessage::Type2 { callsign, power_dbm } => {
-            println!("{:7.2} Hz  {} {}dBm", d.freq_hz, callsign, power_dbm);
+            println!("{:7.2} Hz  {:+.0} dB  {} {}dBm", d.freq_hz, d.snr_db, callsign, power_dbm);
         }
         WsprMessage::Type3 { callsign_hash, grid6, power_dbm } => {
             // ハッシュは過去の Type-1 受信から解決できる場合がある
-            println!("{:7.2} Hz  <#{:05x}> {} {}dBm",
-                     d.freq_hz, callsign_hash, grid6, power_dbm);
+            println!("{:7.2} Hz  {:+.0} dB  <#{:05x}> {} {}dBm",
+                     d.freq_hz, d.snr_db, callsign_hash, grid6, power_dbm);
         }
     }
 }
 # }
 ```
+
+`snr_db` は粗同期の段階で計算済みの wsprd 準拠 SNR (dB, 2500 Hz
+基準) — wsprd 自身がスポットに添えて報告する値と同じもの。
 
 `decode_scan_default` が粗同期 (周波数×時刻探索) を込みでスロット全体を
 スキャンする。周波数・開始サンプルが既知の場合は
@@ -1053,7 +1056,7 @@ let audio_f32 = synthesize_standard("CQ", "K1ABC", "FN42", 12_000, 1270.0, 0.3)
 let decodes = decode_scan_default(&audio_f32, 12_000);
 assert!(!decodes.is_empty(), "ラウンドトリップは復号できるはず");
 for d in decodes {
-    println!("{:7.2} Hz  {}", d.freq_hz, d.message);
+    println!("{:7.2} Hz  {:+.0} dB  {}", d.freq_hz, d.snr_db, d.message);
 }
 # }
 ```
@@ -1061,6 +1064,16 @@ for d in decodes {
 JT65 はさらに `decode_at_with_erasures` を提供しており、
 低 SNR 環境で RS 消失復号が通常デコーダでは落とすフレームを
 回復できる。
+
+`Jt65Result::snr_db` と JT9 の `Jt9Result::snr_db` はどちらも、
+各シンボルで復号されたトーンの電力と他トーンの電力比から算出する
+decode 側の推定値。JT65 側は Q65 と同じ方法で WSJT-X の 2500 Hz
+基準帯域に変換しているが、JT9 側は変換していない —
+`jt9::softsym` の downsam9 → peakdt9 → symspec2 パイプラインは
+AGC スケーリング・非正規化 IFFT・コヒーレント和を経ており、
+JT65/Q65 で成立する帯域幅オフセットがそのまま適用できないため。
+`Jt9Result::snr_db` は相対値としてのみ扱うこと (JT9 同士の比較には
+使えるが、他プロトコルの `snr_db` とは比較不可)。
 
 ## 7. ランタイム registry と trait 面の検証
 

--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -1006,19 +1006,23 @@ assert!(!decodes.is_empty(), "roundtrip must decode");
 for d in decodes {
     match d.message {
         WsprMessage::Type1 { callsign, grid, power_dbm } => {
-            println!("{:7.2} Hz  {} {} {}dBm", d.freq_hz, callsign, grid, power_dbm);
+            println!("{:7.2} Hz  {:+.0} dB  {} {} {}dBm", d.freq_hz, d.snr_db, callsign, grid, power_dbm);
         }
         WsprMessage::Type2 { callsign, power_dbm } => {
-            println!("{:7.2} Hz  {} {}dBm", d.freq_hz, callsign, power_dbm);
+            println!("{:7.2} Hz  {:+.0} dB  {} {}dBm", d.freq_hz, d.snr_db, callsign, power_dbm);
         }
         WsprMessage::Type3 { callsign_hash, grid6, power_dbm } => {
-            println!("{:7.2} Hz  <#{:05x}> {} {}dBm",
-                     d.freq_hz, callsign_hash, grid6, power_dbm);
+            println!("{:7.2} Hz  {:+.0} dB  <#{:05x}> {} {}dBm",
+                     d.freq_hz, d.snr_db, callsign_hash, grid6, power_dbm);
         }
     }
 }
 # }
 ```
+
+`snr_db` is a wsprd-calibrated candidate SNR (dB, 2500 Hz reference)
+carried through from the coarse search — the same figure wsprd
+itself reports next to a spot.
 
 `decode_scan_default` runs the (frequency × time) coarse search over
 the whole slot internally. If the frequency and start sample are
@@ -1083,7 +1087,7 @@ let audio_f32 = synthesize_standard("CQ", "K1ABC", "FN42", 12_000, 1270.0, 0.3)
 let decodes = decode_scan_default(&audio_f32, 12_000);
 assert!(!decodes.is_empty(), "roundtrip must decode");
 for d in decodes {
-    println!("{:7.2} Hz  {}", d.freq_hz, d.message);
+    println!("{:7.2} Hz  {:+.0} dB  {}", d.freq_hz, d.snr_db, d.message);
 }
 # }
 ```
@@ -1091,6 +1095,14 @@ for d in decodes {
 JT65 additionally offers `decode_at_with_erasures` for low-SNR
 signals where RS erasure decoding can recover frames that the
 standard decoder misses.
+
+`Jt65Result::snr_db` and JT9's `Jt9Result::snr_db` are both
+decode-side estimates from the per-symbol signal-tone vs. other-tones
+power ratio; JT65's is converted to WSJT-X's 2500 Hz reference
+bandwidth the same way Q65's is, but JT9's is **not** — its
+multi-stage AGC/IFFT/coherent-sum pipeline doesn't reduce to a simple
+bandwidth offset, so `Jt9Result::snr_db` is relative-only (compare JT9
+decodes against each other, not against other protocols' `snr_db`).
 
 ## 7. Runtime registry & trait-surface verification
 

--- a/mfsk-core/src/jt65/mod.rs
+++ b/mfsk-core/src/jt65/mod.rs
@@ -97,6 +97,37 @@ pub fn decode_at(
     crate::msg::Jt72Codec::default().unpack(&payload, &DecodeContext::default())
 }
 
+/// Like [`decode_at`] but also returns the decode-side SNR estimate
+/// from [`rx::demodulate_aligned_with_confidence_and_snr`]. Used by
+/// [`decode_scan`] to populate [`Jt65Result::snr_db`]; kept private
+/// since [`decode_at`]'s return type is part of the stable surface
+/// mirrored by `jt9::decode_at`.
+fn decode_at_with_snr(
+    audio: &[f32],
+    sample_rate: u32,
+    start_sample: usize,
+    base_freq_hz: f32,
+) -> Option<(crate::msg::Jt72Message, f32)> {
+    use crate::engine::{DecodeContext, MessageCodec};
+
+    let (received, _conf, snr_db) = rx::demodulate_aligned_with_confidence_and_snr(
+        audio,
+        sample_rate,
+        start_sample,
+        base_freq_hz,
+    )?;
+    let rs = Rs63_12::new();
+    let (info, _nerr) = rs.decode_jt65(&received)?;
+    let mut payload = [0u8; 72];
+    for (i, bit) in payload.iter_mut().enumerate() {
+        let word = info[i / 6];
+        let shift = 5 - (i % 6);
+        *bit = (word >> shift) & 1;
+    }
+    let msg = crate::msg::Jt72Codec::default().unpack(&payload, &DecodeContext::default())?;
+    Some((msg, snr_db))
+}
+
 /// Decode a JT65 signal at a known alignment, trying progressively
 /// larger erasure counts until Reed-Solomon converges or the bound
 /// is exhausted. Unlike [`decode_at`], this method exploits
@@ -181,6 +212,11 @@ pub struct Jt65Result {
     pub message: crate::msg::Jt72Message,
     pub freq_hz: f32,
     pub start_sample: usize,
+    /// Decode-side SNR estimate in dB (WSJT-X 2500 Hz reference
+    /// bandwidth convention) — see
+    /// [`rx::demodulate_aligned_with_confidence_and_snr`] for the
+    /// formula and its calibration caveat.
+    pub snr_db: f32,
 }
 
 /// Scan an audio buffer for JT65 frames at any (freq, time) within
@@ -198,7 +234,8 @@ pub fn decode_scan(
     let cands = search::coarse_search(audio, sample_rate, nominal_start_sample, params);
     let mut seen: Vec<Jt65Result> = Vec::new();
     for c in cands {
-        let Some(msg) = decode_at(audio, sample_rate, c.start_sample, c.freq_hz) else {
+        let Some((msg, snr_db)) = decode_at_with_snr(audio, sample_rate, c.start_sample, c.freq_hz)
+        else {
             continue;
         };
         let dup = seen.iter().any(|prev| {
@@ -211,6 +248,7 @@ pub fn decode_scan(
                 message: msg,
                 freq_hz: c.freq_hz,
                 start_sample: c.start_sample,
+                snr_db,
             });
         }
     }

--- a/mfsk-core/src/jt65/rx.rs
+++ b/mfsk-core/src/jt65/rx.rs
@@ -41,7 +41,7 @@ pub fn demodulate_aligned(
     let mut scratch = vec![Complex::new(0f32, 0f32); fft.get_inplace_scratch_len()];
     let mut buf: Vec<Complex<f32>> = vec![Complex::new(0f32, 0f32); nsps];
 
-    let (syms, _conf) = demodulate_aligned_with_confidence_inner(
+    let (syms, _conf, _snr_db) = demodulate_aligned_with_confidence_inner(
         audio,
         sample_rate,
         start_sample,
@@ -68,6 +68,31 @@ pub fn demodulate_aligned_with_confidence(
     start_sample: usize,
     base_freq_hz: f32,
 ) -> Option<([u8; 63], [f32; 63])> {
+    let (syms, conf, _snr_db) =
+        demodulate_aligned_with_confidence_and_snr(audio, sample_rate, start_sample, base_freq_hz)?;
+    Some((syms, conf))
+}
+
+/// Like [`demodulate_aligned_with_confidence`] but also returns a
+/// decode-side SNR estimate (dB): signal = power at each symbol's
+/// winning tone, noise = mean power of the other 63 candidate tones
+/// in the same symbol slot (same "opposite-bin" logic as
+/// [`crate::engine::llr::compute_snr_db_generic`] for FT8/FT4/FST4,
+/// generalised from a single opposite tone to a 63-tone average since
+/// JT65's data alphabet has no natural comb midpoint). Converted to
+/// WSJT-X's 2500 Hz reference bandwidth by `10·log10(2500/df)`, the
+/// same bandwidth-normalisation shape as FT8's `-27 dB` and wsprd's
+/// `-26.3 dB` constants (`engine/llr.rs`, `wspr/coarse_baseband.rs`) —
+/// **not independently calibrated** against a real JT65 signal corpus
+/// (`jt65sim` isn't buildable in this environment; see
+/// `tests/jt65_sweep.rs`), so treat as accurate to roughly ±1-2 dB
+/// versus WSJT-X's own JT65 SNR readout until validated.
+pub fn demodulate_aligned_with_confidence_and_snr(
+    audio: &[f32],
+    sample_rate: u32,
+    start_sample: usize,
+    base_freq_hz: f32,
+) -> Option<([u8; 63], [f32; 63], f32)> {
     let nsps = (sample_rate as f32 * <Jt65 as ModulationParams>::SYMBOL_DT).round() as usize;
     let df = sample_rate as f32 / nsps as f32;
     let base_bin = (base_freq_hz / df).round() as usize;
@@ -102,11 +127,13 @@ fn demodulate_aligned_with_confidence_inner(
     buf: &mut [Complex<f32>],
     scratch: &mut [Complex<f32>],
     fft: &dyn rustfft::Fft<f32>,
-) -> Option<([u8; 63], [f32; 63])> {
+) -> Option<([u8; 63], [f32; 63], f32)> {
     // Walk 126 symbol windows. Data positions (NPRC[i] == 0) each get
     // argmax of 64 data-tone magnitudes (+ runner-up for confidence).
     let mut symbols = [0u8; 63];
     let mut conf = [0f32; 63];
+    let mut xsig_sum = 0.0f32;
+    let mut xnoi_sum = 0.0f32;
     let mut k = 0usize;
     for sym_idx in 0..126 {
         let sym_start = start_sample + sym_idx * nsps;
@@ -120,9 +147,11 @@ fn demodulate_aligned_with_confidence_inner(
         let mut best_tone = 0u8;
         let mut best_pwr = f32::NEG_INFINITY;
         let mut second_pwr = f32::NEG_INFINITY;
+        let mut total_pwr = 0.0f32;
         for tone in 0u8..64 {
             let bin = base_bin + 2 + tone as usize;
             let p = buf[bin].norm_sqr();
+            total_pwr += p;
             if p > best_pwr {
                 second_pwr = best_pwr;
                 best_pwr = p;
@@ -137,6 +166,8 @@ fn demodulate_aligned_with_confidence_inner(
         } else {
             0.0
         };
+        xsig_sum += best_pwr;
+        xnoi_sum += (total_pwr - best_pwr) / 63.0;
         k += 1;
     }
     debug_assert_eq!(k, 63);
@@ -152,7 +183,34 @@ fn demodulate_aligned_with_confidence_inner(
             }
         }
     }
-    Some((symbols, conf_perm))
+
+    const SNR_FLOOR_DB: f32 = -24.0;
+    // WSJT-X's own display convention ceiling. Also the answer when
+    // `xnoi_sum` is (near) exactly zero: a perfectly clean synthetic
+    // signal sampled with an integer number of cycles per FFT window
+    // can leave *zero* measurable leakage in the non-winning tones —
+    // that means "no measurable noise" (best case), not the worst
+    // case the floor implies. See the identical fix + explanation in
+    // `q65::rx::snr_db_from_sig_noi`.
+    const SNR_CEIL_DB: f32 = 49.0;
+    let snr_db = if xnoi_sum < f32::EPSILON {
+        if xsig_sum < f32::EPSILON {
+            SNR_FLOOR_DB
+        } else {
+            SNR_CEIL_DB
+        }
+    } else {
+        let ratio = xsig_sum / xnoi_sum - 1.0;
+        if ratio <= 0.001 {
+            SNR_FLOOR_DB
+        } else {
+            let bw_offset_db =
+                10.0 * (2500.0 / <Jt65 as ModulationParams>::TONE_SPACING_HZ).log10();
+            (10.0 * ratio.log10() - bw_offset_db).clamp(SNR_FLOOR_DB, SNR_CEIL_DB)
+        }
+    };
+
+    Some((symbols, conf_perm, snr_db))
 }
 
 #[cfg(test)]

--- a/mfsk-core/src/jt9/decode.rs
+++ b/mfsk-core/src/jt9/decode.rs
@@ -47,7 +47,7 @@ pub fn decode_at_baseband_with_fft(big_fft: &AudioFft, freq_hz: f32) -> Option<J
     if !sync.is_finite() || sync < 1.0 {
         return None;
     }
-    let (schk, llrs) = llrs_from_c5(&c3);
+    let (schk, llrs, snr_db) = llrs_from_c5(&c3);
     if !schk.is_finite() || schk < 1.5 {
         return None;
     }
@@ -71,6 +71,7 @@ pub fn decode_at_baseband_with_fft(big_fft: &AudioFft, freq_hz: f32) -> Option<J
         message: msg,
         freq_hz: freq_corrected,
         start_sample,
+        snr_db,
     })
 }
 
@@ -156,7 +157,7 @@ mod gate_diag {
                 let afc = super::super::softsym::afc9(&mut c3);
                 super::super::softsym::twkfreq_poly(&mut c3, [afc.a0, afc.a1, 0.0]);
                 let sync = (afc.syncpk + 1.0) / 4.0;
-                let (schk, llrs) = super::super::softsym::llrs_from_c5(&c3);
+                let (schk, llrs, _snr_db) = super::super::softsym::llrs_from_c5(&c3);
 
                 let mut hits = Vec::new();
                 for &lim in &[10_000u64, 30_000, 100_000] {

--- a/mfsk-core/src/jt9/mod.rs
+++ b/mfsk-core/src/jt9/mod.rs
@@ -75,6 +75,18 @@ pub struct Jt9Result {
     pub message: crate::msg::Jt72Message,
     pub freq_hz: f32,
     pub start_sample: usize,
+    /// Decode-side SNR estimate in dB, from the softsym pipeline's
+    /// per-symbol signal-tone vs. other-tones power ratio. **Not**
+    /// WSJT-X's 2500 Hz-referenced convention (unlike the FT8/FT4/
+    /// FST4/JT65/WSPR/Q65 `snr_db` fields) — the multi-stage AGC/IFFT/
+    /// coherent-sum gain chain in `softsym.rs` doesn't reduce to a
+    /// simple bandwidth offset the way a single per-symbol FFT bin
+    /// does, and deriving the correct one needs either WSJT-X's own
+    /// JT9 SNR formula or an empirical `jt9sim` corpus (unavailable in
+    /// this environment). Useful for comparing JT9 decodes against
+    /// each other; not comparable in absolute terms to other modes'
+    /// `snr_db`. See `symspec2_from_ss2` in `softsym.rs`.
+    pub snr_db: f32,
 }
 
 /// Scan an audio buffer for any JT9 frames: runs coarse (freq, time)

--- a/mfsk-core/src/jt9/softsym.rs
+++ b/mfsk-core/src/jt9/softsym.rs
@@ -246,7 +246,7 @@ pub fn chkss2(ss2: &[[f32; 85]; 9]) -> f32 {
 /// `NSPSD` samples per symbol, then compute max-log-MAP LLRs from
 /// the resulting `ss3[0..7][0..69]` table. Returns 207 LLRs in
 /// channel-symbol (interleaved) order.
-fn symspec2_from_ss2(ss2: &[[f32; 85]; 9]) -> [f32; 207] {
+fn symspec2_from_ss2(ss2: &[[f32; 85]; 9]) -> ([f32; 207], f32) {
     // Build ss3[0..7][0..69] = power for data-tone i+1, data-symbol m+1.
     let mut ss3 = [[0.0f32; 69]; 8];
     for i in 1..9usize {
@@ -260,7 +260,14 @@ fn symspec2_from_ss2(ss2: &[[f32; 85]; 9]) -> [f32; 207] {
     }
 
     // Baseline: average of the seven non-max ss3 entries per symbol.
+    // Also accumulate the same signal (winning tone) / noise (mean of
+    // the other 7 tones) sums used for `snr_db` below — same
+    // opposite-tone-average shape as JT65's
+    // `demodulate_aligned_with_confidence_and_snr` and
+    // `compute_snr_db_generic` (FT8/FT4/FST4).
     let mut ss_total = 0.0f32;
+    let mut xsig_sum = 0.0f32;
+    let mut xnoi_sum = 0.0f32;
     for j in 0..69 {
         let mut smax = 0.0f32;
         let mut col_sum = 0.0f32;
@@ -272,6 +279,8 @@ fn symspec2_from_ss2(ss2: &[[f32; 85]; 9]) -> [f32; 207] {
             col_sum += v;
         }
         ss_total += col_sum - smax;
+        xsig_sum += smax;
+        xnoi_sum += (col_sum - smax) / 7.0;
     }
     let ave = (ss_total / (69.0 * 7.0)).max(1e-9);
     for col in ss3.iter_mut() {
@@ -279,6 +288,43 @@ fn symspec2_from_ss2(ss2: &[[f32; 85]; 9]) -> [f32; 207] {
             *v /= ave;
         }
     }
+
+    // NOT a WSJT-X 2500 Hz-referenced dB figure: unlike JT65 (one
+    // per-symbol FFT bin ≡ TONE_SPACING_HZ of noise bandwidth, so a
+    // `10·log10(2500/df)` offset is well-defined), `ss3` here has
+    // already passed through `downsam9`'s AGC scaling (`fac =
+    // 1/√avenoise`), an unnormalised IFFT, and `peakdt9`'s NSPSD=16
+    // coherent sum — the effective noise bandwidth those stages imply
+    // isn't simply the tone spacing, and re-deriving it needs either
+    // the real WSJT-X `jt9.f90` SNR formula or an empirical jt9sim
+    // corpus (unavailable in this environment; see
+    // `tests/jt9_sweep.rs`). A first attempt that borrowed JT65's
+    // bandwidth-offset shape produced an implausible reading
+    // (clean noiseless synth ≈ −4 dB) — this raw ratio is reported
+    // instead so the value stays honestly relative-only rather than
+    // silently wrong: use it to compare JT9 decodes against each
+    // other, not against FT8/JT65/WSPR/Q65's dB2500-referenced values.
+    const SNR_FLOOR_DB: f32 = -24.0;
+    // Ceiling also doubles as the answer when `xnoi_sum` is (near)
+    // exactly zero: a perfectly clean synthetic signal can leave zero
+    // measurable leakage in the other 7 tones — "no measurable noise"
+    // (best case), not the floor. See the identical fix + explanation
+    // in `q65::rx::snr_db_from_sig_noi`.
+    const SNR_CEIL_DB: f32 = 49.0;
+    let snr_db = if xnoi_sum < f32::EPSILON {
+        if xsig_sum < f32::EPSILON {
+            SNR_FLOOR_DB
+        } else {
+            SNR_CEIL_DB
+        }
+    } else {
+        let ratio = xsig_sum / xnoi_sum - 1.0;
+        if ratio <= 0.001 {
+            SNR_FLOOR_DB
+        } else {
+            (10.0 * ratio.log10()).clamp(SNR_FLOOR_DB, SNR_CEIL_DB)
+        }
+    };
 
     // Max-log-MAP LLRs. WSJT-X convention: positive ⇒ bit=1 likely.
     // We adopt the OPPOSITE sign (positive ⇒ bit=0) to stay
@@ -327,22 +373,24 @@ fn symspec2_from_ss2(ss2: &[[f32; 85]; 9]) -> [f32; 207] {
         }
     }
 
-    out_207
+    (out_207, snr_db)
 }
 
 /// Full pipeline: feed `c5` into `symspec2`, deinterleave the
 /// resulting 207 LLRs in place, drop the padding bit, and return
 /// the 206 LLRs ready for `ConvFano232::decode_soft`. Also returns
 /// the [`chkss2`] sync-quality score so callers can apply the
-/// WSJT-X two-stage gate before invoking the Fano decoder.
-pub fn llrs_from_c5(c5: &[Complex<f32>]) -> (f32, [f32; 206]) {
+/// WSJT-X two-stage gate before invoking the Fano decoder, and a
+/// decode-side SNR estimate (dB) — see the doc comment inside
+/// [`symspec2_from_ss2`] for the formula and its calibration caveat.
+pub fn llrs_from_c5(c5: &[Complex<f32>]) -> (f32, [f32; 206], f32) {
     let ss2 = compute_ss2(c5);
     let schk = chkss2(&ss2);
-    let s207 = symspec2_from_ss2(&ss2);
+    let (s207, snr_db) = symspec2_from_ss2(&ss2);
     let mut s206 = [0f32; 206];
     s206.copy_from_slice(&s207[..206]);
     deinterleave_llrs(&mut s206);
-    (schk, s206)
+    (schk, s206, snr_db)
 }
 
 /// `twkfreq` (polynomial WSJT-X form): apply
@@ -573,7 +621,7 @@ mod tests {
                 grid,
                 sc
             );
-            let (_schk, llrs) = llrs_from_c5(&c3);
+            let (_schk, llrs, _snr_db) = llrs_from_c5(&c3);
             let res = ConvFano232
                 .decode_soft(&llrs, &FecOpts::default())
                 .unwrap_or_else(|| panic!("Fano failed for {} {} {}", c1, c2, grid));
@@ -796,7 +844,7 @@ mod tests {
             sc
         );
 
-        let (_schk, llrs) = llrs_from_c5(&c3);
+        let (_schk, llrs, _snr_db) = llrs_from_c5(&c3);
         let res = ConvFano232
             .decode_soft(&llrs, &FecOpts::default())
             .expect("Fano must converge on clean synth via WSJT-X-faithful pipeline");

--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -200,6 +200,118 @@ pub struct Q65Result {
     pub start_sample: usize,
     /// BP iterations consumed by the QRA decoder.
     pub iterations: u32,
+    /// Decode-side SNR estimate in dB (WSJT-X 2500 Hz reference
+    /// bandwidth convention) — see [`snr_db_narrow`]/[`snr_db_wide`].
+    /// Closes issue #226.
+    pub snr_db: f32,
+}
+
+/// Shared floor/ratio/dB-conversion step for [`snr_db_narrow`] and
+/// [`snr_db_wide`]: `10·log10(xsig/xnoi − 1) − bw_offset_db`, clamped
+/// to a −24 dB floor — the same shape as
+/// [`crate::engine::llr::compute_snr_db_generic`] (FT8/FT4/FST4) and
+/// [`crate::jt65::rx::demodulate_aligned_with_confidence_and_snr`].
+fn snr_db_from_sig_noi(xsig: f32, xnoi: f32, bw_offset_db: f32) -> f32 {
+    const SNR_FLOOR_DB: f32 = -24.0;
+    // WSJT-X's own display convention ceiling (see e.g. WebFT8's
+    // `_autoReport()` clamp cited in issue #226). Also serves as this
+    // function's answer when `xnoi` is (near) exactly zero: for a
+    // perfectly clean synthetic signal sampled with an integer number
+    // of cycles per FFT window, DFT orthogonality can leave *zero*
+    // measurable leakage in the non-signal bins — that means "no
+    // measurable noise", the best case, not the worst. Reporting the
+    // floor there (an earlier version of this function did) is
+    // backwards, caught by `q65::rx::tests` decoding a noiseless
+    // synth and reading `-24 dB` instead of a very clean number.
+    const SNR_CEIL_DB: f32 = 49.0;
+    if xnoi < f32::EPSILON {
+        return if xsig < f32::EPSILON {
+            SNR_FLOOR_DB
+        } else {
+            SNR_CEIL_DB
+        };
+    }
+    let ratio = xsig / xnoi - 1.0;
+    if ratio <= 0.001 {
+        return SNR_FLOOR_DB;
+    }
+    (10.0 * ratio.log10() - bw_offset_db).clamp(SNR_FLOOR_DB, SNR_CEIL_DB)
+}
+
+/// Bandwidth-normalisation offset to WSJT-X's 2500 Hz reference:
+/// `10·log10(2500/df)` where `df` is the per-tone FFT bin bandwidth —
+/// same derivation as JT65's estimate (cross-checked against FT8's
+/// literal `-27 dB` @ 6.25 Hz and wsprd's literal `-26.3 dB` @ ~5.1 Hz,
+/// both within ~1 dB of this formula). Valid for Q65 because
+/// [`extract_data_energies`] puts each tone in exactly one per-symbol
+/// FFT bin, same as JT65's single-FFT demod — unlike JT9's multi-stage
+/// AGC/IFFT/coherent-sum pipeline, where this shape does *not* hold
+/// (see `jt9::softsym::symspec2_from_ss2`).
+fn q65_bw_offset_db<P: ModulationParams>() -> f32 {
+    10.0 * (2500.0 / P::TONE_SPACING_HZ).log10()
+}
+
+/// Decode-side SNR from **narrow** per-symbol energies
+/// ([`extract_data_energies`] / [`averaged_data_energies`] layout,
+/// `energies[64*k + t]`): signal = power at each data symbol's
+/// decoded tone (from `codeword`, the 63-symbol channel codeword —
+/// either re-encoded via [`fec::qra::Q65Codec::encode`] from the
+/// recovered info symbols, or the winning AP-list candidate), noise =
+/// mean power of the other 63 tones in the same symbol slot.
+fn snr_db_narrow<P: ModulationParams>(energies: &[f32], codeword: &[i32]) -> f32 {
+    let mut xsig = 0.0f32;
+    let mut xnoi = 0.0f32;
+    for (k, &sym) in codeword.iter().enumerate() {
+        let t = sym as usize;
+        if t >= 64 || 64 * (k + 1) > energies.len() {
+            continue;
+        }
+        let row = &energies[64 * k..64 * (k + 1)];
+        let sig = row[t];
+        let total: f32 = row.iter().sum();
+        xsig += sig;
+        xnoi += (total - sig) / 63.0;
+    }
+    snr_db_from_sig_noi(xsig, xnoi, q65_bw_offset_db::<P>())
+}
+
+/// Like [`snr_db_narrow`] but for the **wide** per-symbol energies
+/// layout from [`extract_data_energies_wide`] /
+/// [`averaged_data_energies_wide`] (used by every fast-fading-metric
+/// decode path). Each tone's bin sits at row offset `64 + tone *
+/// bins_per_tone` within the `64 * (2 + bins_per_tone)`-wide window —
+/// see [`extract_data_energies_wide`]'s doc comment for the layout
+/// derivation.
+fn snr_db_wide<P: ModulationParams>(energies: &[f32], sample_rate: u32, codeword: &[i32]) -> f32 {
+    let nsps = (sample_rate as f32 * P::SYMBOL_DT).round() as usize;
+    let df = sample_rate as f32 / nsps as f32;
+    let bins_per_tone = (P::TONE_SPACING_HZ / df).round().max(1.0) as usize;
+    let bins_per_symbol = 64 * (2 + bins_per_tone);
+    let mut xsig = 0.0f32;
+    let mut xnoi = 0.0f32;
+    for (k, &sym) in codeword.iter().enumerate() {
+        let t = sym as usize;
+        if t >= 64 || bins_per_symbol * (k + 1) > energies.len() {
+            continue;
+        }
+        let row = &energies[bins_per_symbol * k..bins_per_symbol * (k + 1)];
+        let mut sig = 0.0f32;
+        let mut total = 0.0f32;
+        for tone in 0..64usize {
+            let idx = 64 + tone * bins_per_tone;
+            if idx >= row.len() {
+                continue;
+            }
+            let v = row[idx];
+            total += v;
+            if tone == t {
+                sig = v;
+            }
+        }
+        xsig += sig;
+        xnoi += (total - sig) / 63.0;
+    }
+    snr_db_from_sig_noi(xsig, xnoi, q65_bw_offset_db::<P>())
 }
 
 /// Decode a Q65 signal at a known `(start_sample, base_freq_hz)`
@@ -276,11 +388,16 @@ fn decode_at_inner<P: ModulationParams>(
     let bits77 = unpack_symbols_to_bits77(&info_syms);
     let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
 
+    let mut codeword = [0_i32; 63];
+    codec.encode(&info_syms, &mut codeword);
+    let snr_db = snr_db_narrow::<P>(&energies, &codeword);
+
     Some(Q65Result {
         message: text,
         freq_hz: base_freq_hz,
         start_sample,
         iterations,
+        snr_db,
     })
 }
 
@@ -339,11 +456,16 @@ pub(crate) fn decode_at_fading_for<P: ModulationParams>(
     let bits77 = unpack_symbols_to_bits77(&info_syms);
     let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
 
+    let mut codeword = [0_i32; 63];
+    codec.encode(&info_syms, &mut codeword);
+    let snr_db = snr_db_wide::<P>(&energies, sample_rate, &codeword);
+
     Some(Q65Result {
         message: text,
         freq_hz: base_freq_hz,
         start_sample,
         iterations,
+        snr_db,
     })
 }
 
@@ -423,10 +545,12 @@ pub(crate) fn decode_at_with_ap_list_for<P: ModulationParams>(
     QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, &energies, 63, default_es_no_metric());
 
     let codec = Q65Codec::new(&QRA15_65_64_IRR_E23);
-    let (_idx, info_syms) = codec.decode_with_codeword_list(&intrinsics, candidates)?;
+    let (idx, info_syms) = codec.decode_with_codeword_list(&intrinsics, candidates)?;
 
     let bits77 = unpack_symbols_to_bits77(&info_syms);
     let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
+
+    let snr_db = snr_db_narrow::<P>(&energies, &candidates[idx]);
 
     Some(Q65Result {
         message: text,
@@ -436,6 +560,7 @@ pub(crate) fn decode_at_with_ap_list_for<P: ModulationParams>(
         // callers can still distinguish "decoded via templates" from
         // "decoded via BP" if they care.
         iterations: 0,
+        snr_db,
     })
 }
 
@@ -722,11 +847,15 @@ fn decode_at_grid_for<P: ModulationParams>(
                 let Some(text) = Q65Message.unpack(&bits77, &DecodeContext::default()) else {
                     continue;
                 };
+                let mut codeword = [0_i32; 63];
+                codec.encode(&info_syms, &mut codeword);
+                let snr_db = snr_db_wide::<P>(&energies, sample_rate, &codeword);
                 return Some(Q65Result {
                     message: text,
                     freq_hz: freq_shift,
                     start_sample: shifted_start,
                     iterations,
+                    snr_db,
                 });
             }
         }
@@ -862,16 +991,19 @@ fn decode_averaged_ap_list_for<P: ModulationParams>(
     QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, &energies, 63, default_es_no_metric());
 
     let codec = Q65Codec::new(&QRA15_65_64_IRR_E23);
-    let (_idx, info_syms) = codec.decode_with_codeword_list(&intrinsics, candidates)?;
+    let (idx, info_syms) = codec.decode_with_codeword_list(&intrinsics, candidates)?;
 
     let bits77 = unpack_symbols_to_bits77(&info_syms);
     let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
+
+    let snr_db = snr_db_narrow::<P>(&energies, &candidates[idx]);
 
     Some(Q65Result {
         message: text,
         freq_hz: base_freq_hz,
         start_sample,
         iterations: 0,
+        snr_db,
     })
 }
 
@@ -889,6 +1021,7 @@ fn decode_averaged_ap_list_for<P: ModulationParams>(
 /// 6 times over.
 fn decode_fading_with_energies<P: ModulationParams>(
     energies: &[f32],
+    sample_rate: u32,
     start_sample: usize,
     base_freq_hz: f32,
     b90_ts: f32,
@@ -915,11 +1048,16 @@ fn decode_fading_with_energies<P: ModulationParams>(
     let bits77 = unpack_symbols_to_bits77(&info_syms);
     let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
 
+    let mut codeword = [0_i32; 63];
+    codec.encode(&info_syms, &mut codeword);
+    let snr_db = snr_db_wide::<P>(energies, sample_rate, &codeword);
+
     Some(Q65Result {
         message: text,
         freq_hz: base_freq_hz,
         start_sample,
         iterations,
+        snr_db,
     })
 }
 
@@ -946,11 +1084,16 @@ fn decode_averaged_plain_for<P: ModulationParams>(
     let bits77 = unpack_symbols_to_bits77(&info_syms);
     let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
 
+    let mut codeword = [0_i32; 63];
+    codec.encode(&info_syms, &mut codeword);
+    let snr_db = snr_db_narrow::<P>(&energies, &codeword);
+
     Some(Q65Result {
         message: text,
         freq_hz: base_freq_hz,
         start_sample,
         iterations,
+        snr_db,
     })
 }
 
@@ -1065,6 +1208,7 @@ pub(crate) fn decode_multi_period_for<P: ModulationParams>(
                     for &model in &fading_models {
                         if let Some(d) = decode_fading_with_energies::<P>(
                             &energies,
+                            sample_rate,
                             cand.start_sample,
                             cand.freq_hz,
                             b90,

--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -201,8 +201,9 @@ pub struct Q65Result {
     /// BP iterations consumed by the QRA decoder.
     pub iterations: u32,
     /// Decode-side SNR estimate in dB (WSJT-X 2500 Hz reference
-    /// bandwidth convention) — see [`snr_db_narrow`]/[`snr_db_wide`].
-    /// Closes issue #226.
+    /// bandwidth convention), from the per-symbol signal-tone vs.
+    /// other-tones power ratio (`snr_db_narrow`/`snr_db_wide` in
+    /// `q65::rx`). Closes issue #226.
     pub snr_db: f32,
 }
 

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -10,7 +10,7 @@ use crate::msg::WsprMessage;
 
 #[cfg(any())]
 use super::search::coarse_search;
-use super::search::{SearchParams, SyncCandidate}; // kept for synth round-trip lib tests
+use super::search::SearchParams;
 
 /// One successful WSPR decode.
 #[derive(Clone, Debug)]
@@ -33,6 +33,16 @@ pub struct WsprResult {
     /// `decode_scan_subtract` to reconstruct the 162-channel-symbol
     /// stream and subtract the signal from the audio for SIC.
     pub info_bits: [u8; 50],
+    /// wsprd-calibrated SNR estimate (dB, WSPR→2500 Hz reference
+    /// bandwidth), from the coarse-search candidate that produced this
+    /// decode — same `10·log10(smspec) − 26.3` formula wsprd itself
+    /// reports next to a spot (`wsprd.c:1093`, see
+    /// [`super::coarse_baseband::BasebandCandidate::snr_db`]). Set by
+    /// [`decode_scan`] / [`decode_scan_subtract`], which always go
+    /// through the coarse search; direct [`decode_at`] /
+    /// [`decode_at_baseband`] / [`decode_at_baseband_nblocks`] calls
+    /// have no coarse candidate to derive it from and leave this `0.0`.
+    pub snr_db: f32,
 }
 
 /// Decode one WSPR frame at a known (freq, start_sample). Returns `None`
@@ -213,6 +223,7 @@ pub fn decode_at_baseband_nblocks(
             start_sample: lag_audio.max(0) as usize,
             dt_sec,
             info_bits,
+            snr_db: 0.0,
         };
         let he = hard_errors;
         match message {
@@ -298,19 +309,11 @@ pub fn decode_scan(
     // baseband path. Kept the legacy module for synth round-trip
     // tests; not invoked here.
     let _ = nominal_shifted;
-    let mut cands: Vec<SyncCandidate> = bb_cands
-        .iter()
-        .map(|c| SyncCandidate {
-            start_sample: c.start_sample,
-            freq_hz: c.freq_hz,
-            score: c.sync,
-        })
-        .collect();
-    cands.sort_unstable_by(|a, b| {
-        b.score
-            .partial_cmp(&a.score)
-            .unwrap_or(core::cmp::Ordering::Equal)
-    });
+    // `coarse_baseband` already returns candidates sorted by sync score
+    // descending — no remap/re-sort needed; keeping `BasebandCandidate`
+    // itself (rather than the legacy `SyncCandidate`) preserves each
+    // candidate's `snr_db` through to the decode below.
+    let mut cands = bb_cands;
     cands.truncate(params.max_candidates);
     let _audio = &padded[..]; // shadow so all downstream reads use padded buffer
     let mut seen: Vec<WsprResult> = Vec::new();
@@ -366,6 +369,7 @@ pub fn decode_scan(
         let start_refined = d.start_sample;
         d.dt_sec = (start_refined as i64 - pad as i64) as f32 / sample_rate as f32 - 1.0;
         d.start_sample = start_refined.saturating_sub(pad);
+        d.snr_db = c.snr_db;
         let dup = seen.iter().any(|prev| {
             prev.message == d.message
                 && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ
@@ -430,6 +434,7 @@ pub fn decode_scan(
             let start_refined = d.start_sample;
             d.dt_sec = (start_refined as i64 - pad as i64) as f32 / sample_rate as f32 - 1.0;
             d.start_sample = start_refined.saturating_sub(pad);
+            d.snr_db = c.snr_db;
             let dup = seen.iter().any(|prev| {
                 prev.message == d.message
                     && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -8,9 +8,9 @@ use alloc::vec::Vec;
 
 use crate::msg::WsprMessage;
 
+use super::search::SearchParams;
 #[cfg(any())]
 use super::search::coarse_search;
-use super::search::SearchParams;
 
 /// One successful WSPR decode.
 #[derive(Clone, Debug)]

--- a/mfsk-ffi/src/lib.rs
+++ b/mfsk-ffi/src/lib.rs
@@ -418,8 +418,8 @@ fn push_ft4(r: &ft4::DecodeResult, vec: &mut Vec<MfskResult>) {
     vec.push(rec);
 }
 
-fn push_simple(freq_hz: f32, dt_sec: f32, text: String, vec: &mut Vec<MfskResult>) {
-    let mut rec = empty_result(freq_hz, dt_sec, 0.0, 0, 0);
+fn push_simple(freq_hz: f32, dt_sec: f32, snr_db: f32, text: String, vec: &mut Vec<MfskResult>) {
+    let mut rec = empty_result(freq_hz, dt_sec, snr_db, 0, 0);
     write_text(&mut rec.text, &text);
     vec.push(rec);
 }
@@ -689,6 +689,7 @@ fn decode_wspr(audio: &[f32], out: &mut MfskResultList) -> MfskStatus {
         push_simple(
             d.freq_hz,
             d.start_sample as f32 / 12_000.0,
+            d.snr_db,
             d.message.to_string(),
             &mut vec,
         );
@@ -700,20 +701,24 @@ fn decode_wspr(audio: &[f32], out: &mut MfskResultList) -> MfskStatus {
 /// JT9 decode at the canonical 1500 Hz carrier, slot-aligned at sample 0.
 /// Callers that want (freq × time) search should build that on top of
 /// `mfsk_core::jt9::decode_at` directly — the FFI takes the fixed-alignment
-/// path because it's the one the roundtrip test needs.
+/// path because it's the one the roundtrip test needs. This path uses the
+/// bare `decode_at` (not `decode_scan`/`Jt9Result`), which has no SNR
+/// estimate available; `snr_db` is `0.0` here, unlike `decode_jt9` (Q65-style
+/// scan) which would carry a real value if wired up.
 fn decode_jt9_aligned(audio: &[f32], out: &mut MfskResultList) -> MfskStatus {
     let mut vec: Vec<MfskResult> = Vec::new();
     if let Some(msg) = mfsk_core::jt9::decode_at(audio, 12_000, 0, 1500.0) {
-        push_simple(1500.0, 0.0, msg.to_string(), &mut vec);
+        push_simple(1500.0, 0.0, 0.0, msg.to_string(), &mut vec);
     }
     finalise(vec, out);
     MfskStatus::Ok
 }
 
+/// See [`decode_jt9_aligned`] — same fixed-alignment / no-SNR caveat.
 fn decode_jt65_aligned(audio: &[f32], out: &mut MfskResultList) -> MfskStatus {
     let mut vec: Vec<MfskResult> = Vec::new();
     if let Some(msg) = mfsk_core::jt65::decode_at(audio, 12_000, 0, 1270.0) {
-        push_simple(1270.0, 0.0, msg.to_string(), &mut vec);
+        push_simple(1270.0, 0.0, 0.0, msg.to_string(), &mut vec);
     }
     finalise(vec, out);
     MfskStatus::Ok
@@ -727,6 +732,7 @@ fn push_q65_decode(d: &mfsk_core::q65::Q65Result, vec: &mut Vec<MfskResult>) {
     push_simple(
         d.freq_hz,
         d.start_sample as f32 / 12_000.0,
+        d.snr_db,
         d.message.clone(),
         vec,
     );


### PR DESCRIPTION
## Summary

- FT8/FT4/FST4 already share `engine::pipeline::DecodeResult` (has `snr_db`); MSK144 has its own (`SlotDecode::snr_db`). The other four WSJT-family decoders — **WSPR, JT65, JT9, Q65** — had no decode-side signal-quality field at all. `mfsk-ffi`'s `push_simple` was hardcoding `snr_db: 0.0` for all of them, which is why the gap wasn't visible from the FFI surface.
- Filed as #226 after WebFT8 tried to wire up Q65 QSO-exchange reports ("+NN"/"-NN") and found nothing to report from. Auditing the sibling protocols for the same gap turned up WSPR, JT65, and JT9 too.
- **WSPR**: threads the wsprd-calibrated candidate SNR (already computed during coarse search, previously discarded) into `WsprResult`.
- **JT65 / Q65**: new estimate — signal-tone vs. other-tones power ratio, converted to WSJT-X's 2500 Hz reference bandwidth (cross-checked against FT8's and wsprd's own constants, ~1 dB agreement).
- **JT9**: same decomposition, but left relative-only (not 2500 Hz referenced) — its multi-stage AGC/IFFT/coherent-sum pipeline doesn't reduce to a simple bandwidth offset; an initial attempt that borrowed JT65's formula produced an implausible clean-synth reading (~-4 dB).
- Caught during testing: a shared floor/ceiling bug where exactly-zero measured noise (perfect FFT-bin orthogonality on a noiseless synth signal) was reported as the -24 dB floor instead of a high-SNR ceiling. Fixed across all three new estimators.
- `mfsk-ffi`'s `push_simple` now takes `snr_db` explicitly instead of hardcoding `0.0`.

Breaking (new required field on 4 public structs), but low practical impact — these are decoder-output types constructed only inside the crate, never via external struct literals. Targeted at a **0.8.1 patch** release (v0.8.0 shipped 2026-07-30) per discussion with the maintainer.

## Test plan

- [x] `cargo test -p mfsk-core --features full,internal-testing --lib` — 375 passed, 0 failed
- [x] `cargo test -p mfsk-ffi --release` — 19 passed (q65_ffi + wsjt_ffi)
- [x] `cargo test --doc -p mfsk-core --features full` — 31 passed (incl. updated WSPR/JT9/JT65 examples in `docs/reference/LIBRARY.md` + `.ja.md`)
- [x] Manual sanity check: clean noiseless synth signals read plausible high SNR (WSPR ~40 dB, JT65 ~19 dB, JT9 ~27 dB, Q65 ceiling 49 dB) rather than the floor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T622inHccDA5nsqnDmWvzF