### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ resolver = "2"
 # CHANGELOG). `release.yml`'s tag-vs-Cargo.toml check reads this
 # field directly.
 [workspace.package]
-version = "0.8.0"
+version = "0.8.1"

--- a/README.md
+++ b/README.md
@@ -627,7 +627,7 @@ reference:
 
 ## Status
 
-**Latest published tag: `v0.8.0`** — API is deliberately not frozen:
+**Latest published tag: `v0.8.1`** — API is deliberately not frozen:
 breaking changes follow cargo-style minor bumps, while a new
 protocol/mode addition on its own is patch-level (e.g. MSK144 shipped
 as `0.7.4`, not `0.8.0`) — minor bumps mark more structural changes.


### PR DESCRIPTION
## Summary

- Bumps the workspace version 0.8.0 → 0.8.1 for #227 (decode-side `snr_db` for WSPR/JT65/JT9/Q65), the only change accumulated on `main` since `v0.8.0` (2026-07-30).
- No in-workspace dependency-version-pin edits needed (unlike the 0.7.4 → 0.8.0 minor bump): `mfsk-ffi/Cargo.toml`'s `mfsk-core version = "0.8"` and `mfsk-ffi-ft8/Cargo.toml`'s `version = "0.8.0"` pins both already accept 0.8.1 under Cargo's default caret semantics.
- README's Status section now points at `v0.8.1`.

Follows the same pattern as #222 (`chore(release): 0.8.0`).

## Test plan

- [x] `cargo check --workspace --features full`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features full,internal-testing --no-deps -- -D warnings -D clippy::perf`
- [x] `cargo build -p mfsk-ffi --release`

After merge: tag `v0.8.1` at the merge SHA and push, per `CLAUDE.md`'s release sequence — CD (`release.yml`) handles the `cargo publish` + FFI artifact build + GitHub release from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T622inHccDA5nsqnDmWvzF