### PR TITLE
docs: explain gated DecodeRequest builder methods at the call site (#230, #231)

### DIFF
--- a/docs/reference/LIBRARY.ja.md
+++ b/docs/reference/LIBRARY.ja.md
@@ -858,24 +858,24 @@ dedupe)、`decode_frame_subtract::<P>` (3-pass SIC ドライバ)、
 subtract) を使用。旧 `subtract_signal_weighted` /
 `qsb_partial_gain` 系は削除済。
 
-`DecodeStrictness` (`Strict`/`Normal`/`Deep`) は 4 つのメソッドを持つ
-が、プロトコルごとに「実際に効くか」が異なる — `.strictness(...)`
-が何かを変えるかどうかは呼び出し先次第なので注意:
+`DecodeStrictness` (`Strict`/`Normal`/`Deep`) は 3 つのメソッドを持つ
+(4 つ目の `osd_score_min()` — OSD 実行前の coarse-sync スコアゲート
+— は issue #230 で完全に削除済み: FST4・FT4 両方でバイパスされてお
+り、どのプロトコルにも生きた呼び出し元が残っていなかったため)。
+プロトコルごとに「実際に効くか」が異なる — `.strictness(...)` が何
+かを変えるかどうかは呼び出し先次第なので注意:
 
-* `osd_score_min()` / `osd_max_errors()` — OSD 実行前の coarse-sync
-  スコアしきい値と、OSD 後の硬判定エラー上限ゲート (`osd_depth` 別)。
-  **実質 FT4 専用。** `osd_score_min` は FST4・FT4 両方でバイパス済み
-  (`engine/pipeline.rs` の `bypass_osd_score_min` — FST4 は WSJT-X 自
-  身の FST4 受理判定 `fst4_decode.f90:570`: `nharderrors >= 0 &&
-  unpk77_success` に合わせて CRC-24 のみを信頼、スコア事前フィルタ
-  なし。FT4 も同じ症状に独立して行き当たり同じバイパスを適用)。
-  `osd_max_errors` は FST4 バイパスのままだが FT4 では**生きている**
-  — 実際の `ft4sim` AWGN/CCIR sweep で再較正済み (issue #72、
-  2026-07-18)。もはや FT8 較正値のプレースホルダーではない。**名前
-  に反して、FT8 はこの 2 メソッドをこれまで一度も呼んでいなかった**
-  — FT8 自身の OSD dispatch は hardcoded 定数を使っていた (下記
-  `ft8_nharderrors_max` 参照)。旧版の本ドキュメントが「FT8 較正値」
-  と誤って説明していた箇所を訂正。
+* `osd_max_errors()` — OSD 後の硬判定エラー上限ゲート (`osd_depth`
+  別)。**実質 FT4 専用。** FST4 ではバイパス済み
+  (`engine/pipeline.rs` の `is_fst4` — FST4 は WSJT-X 自身の FST4
+  受理判定 `fst4_decode.f90:570`: `nharderrors >= 0 &&
+  unpk77_success` に合わせて CRC-24 のみを信頼、そのようなゲートは
+  無し) だが FT4 では**生きている** — 実際の `ft4sim` AWGN/CCIR
+  sweep で再較正済み (issue #72、2026-07-18)。もはや FT8 較正値の
+  プレースホルダーではない。**名前に反して、FT8 はこのメソッドを
+  これまで一度も呼んでいなかった** — FT8 自身の OSD dispatch は
+  hardcoded 定数を使っていた (下記 `ft8_nharderrors_max` 参照)。旧版
+  の本ドキュメントが「FT8 較正値」と誤って説明していた箇所を訂正。
 * `ap_max_errors(locked_bits)` — AP 付き decode の硬判定エラー上限、
   locked-bit 数で段階化。FT8 の per-candidate AP loop と FT4/FST4 の
   AP sniper (`msg::pipeline_ap`) 双方で生きている — 両呼び出し箇所で

--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -887,24 +887,24 @@ uses `subtract_signal_lpf` (WSJT-X-style channel-aware subtract) as of
 0.6.2; the previous `subtract_signal_weighted` / `qsb_partial_gain`
 path has been removed.
 
-`DecodeStrictness` (`Strict`/`Normal`/`Deep`) exposes four methods,
-with different live-per-protocol scope — check which apply before
-assuming `.strictness(...)` does anything for a given call:
+`DecodeStrictness` (`Strict`/`Normal`/`Deep`) exposes three methods
+(a fourth, `osd_score_min()` — a pre-OSD coarse-sync-score gate — was
+removed outright in issue #230: bypassed for both FST4 and FT4, it had
+no live caller left on any protocol), with different live-per-protocol
+scope — check which apply before assuming `.strictness(...)` does
+anything for a given call:
 
-* `osd_score_min()` / `osd_max_errors()` — pre-OSD coarse-sync-score
-  gate and post-OSD hard-error ceiling, `osd_depth`-tiered. **FT4-only
-  in practice.** `osd_score_min` is bypassed entirely for both FST4
-  and FT4 (`bypass_osd_score_min` in `engine/pipeline.rs` — FST4
-  trusts CRC-24 alone, matching WSJT-X's own FST4 acceptance test
-  `fst4_decode.f90:570`: `nharderrors >= 0 && unpk77_success`, no
-  score pre-filter; FT4 hit the identical symptom independently and
-  got the same bypass). `osd_max_errors` is FST4-bypassed too but
-  *live* for FT4, retuned against a real `ft4sim` AWGN/CCIR sweep
-  (issue #72, 2026-07-18) — no longer a placeholder copy of an FT8
-  calibration. **Despite the name, FT8 has never actually called
-  either method** — its own OSD dispatch used hardcoded constants
-  instead (see `ft8_nharderrors_max` below); an earlier version of
-  this doc incorrectly described these as FT8-calibrated.
+* `osd_max_errors()` — post-OSD hard-error ceiling, `osd_depth`-tiered.
+  **FT4-only in practice.** FST4-bypassed (`is_fst4` in
+  `engine/pipeline.rs` — FST4 trusts CRC-24 alone, matching WSJT-X's
+  own FST4 acceptance test `fst4_decode.f90:570`: `nharderrors >= 0 &&
+  unpk77_success`, no such gate) but *live* for FT4, retuned against a
+  real `ft4sim` AWGN/CCIR sweep (issue #72, 2026-07-18) — no longer a
+  placeholder copy of an FT8 calibration. **Despite the name, FT8 has
+  never actually called this method** — its own OSD dispatch used
+  hardcoded constants instead (see `ft8_nharderrors_max` below); an
+  earlier version of this doc incorrectly described it as
+  FT8-calibrated.
 * `ap_max_errors(locked_bits)` — AP-assisted decode hard-error
   ceiling, graded by locked-bit count. Live for FT8's per-candidate AP
   loop and the FT4/FST4 AP sniper (`msg::pipeline_ap`) alike —

--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -210,9 +210,9 @@ fn osd_escalation_gates_impl<P: Protocol>() -> (u32, u32) {
 
 /// Decode strictness: trades off sensitivity vs false-positive rate.
 ///
-/// `process_candidate_basic` bypasses both `osd_score_min` and
-/// `osd_max_errors` for FST4 (see the `is_fst4` gate below — issue #146:
-/// WSJT-X's own FST4 decoder has no such gates), so in practice these
+/// `process_candidate_basic` bypasses `osd_max_errors` for FST4 (see the
+/// `is_fst4` gate below — issue #146: WSJT-X's own FST4 decoder has no
+/// such gate), so in practice these
 /// numbers are FT4-exclusive. `Normal` (FT4's hardcoded strictness,
 /// issue #72) was retuned 2026-07-18 against a `ft4sim` AWGN/CCIR sweep
 /// (`docs/notes/FT4_BENCHMARK.md`) — no longer a placeholder copy of the
@@ -248,17 +248,6 @@ impl DecodeStrictness {
             (Self::Deep, 3) => 30,
             (Self::Deep, 4) => 36,
             (Self::Deep, _) => 40,
-        }
-    }
-
-    /// Minimum coarse-sync score to enter OSD fallback.
-    ///
-    /// `Normal` retuned alongside `osd_max_errors` above (issue #72).
-    pub fn osd_score_min(self) -> f32 {
-        match self {
-            Self::Strict => 3.0,
-            Self::Normal => 1.8,
-            Self::Deep => 2.0,
         }
     }
 
@@ -609,49 +598,31 @@ fn process_candidate_basic_impl<P: GenericPipelineProtocol>(
             variants.push((&llr_set.llrc, 2));
             variants.push((&llr_set.llrd, 3));
 
-            // WSJT-X's own FST4 decoder (`fst4_decode.f90`) has neither of
-            // the gates below: `decode240_101` is called unconditionally
-            // after BP fails (no coarse-sync-score pre-filter), and its
-            // only acceptance test is `nharderrors.ge.0 .and.
-            // unpk77_success` (`fst4_decode.f90:570`) — i.e. "OSD
-            // converged to a CRC-24-verified codeword", full stop, no
-            // upper bound on how many bits OSD had to flip to get there.
-            // `osd_score_min`/`osd_max_errors` are FT8-calibrated
-            // (doc'd as "can re-tune later", issue #72) and were never
-            // re-tuned for FST4: near its own sensitivity threshold,
-            // every real candidate's coarse-sync score sat below
-            // `osd_score_min` (blocking OSD entirely) and every OSD
-            // result that *did* run had a CRC-verified hard-error count
-            // above `osd_max_errors` (rejected despite being provably
-            // correct) — issue #146. Bypass both for FST4 to match
-            // WSJT-X: attempt OSD whenever plain BP fails (still gated on
-            // `nsync` the same as every other protocol), and trust the
-            // CRC-24 verification inside `decode_soft` alone.
+            // WSJT-X's own FST4 decoder (`fst4_decode.f90`) has no
+            // post-OSD hard-error gate: `decode240_101` is called
+            // unconditionally after BP fails, and its only acceptance
+            // test is `nharderrors.ge.0 .and. unpk77_success`
+            // (`fst4_decode.f90:570`) — i.e. "OSD converged to a
+            // CRC-24-verified codeword", full stop, no upper bound on how
+            // many bits OSD had to flip to get there. `osd_max_errors` is
+            // FT8-calibrated (doc'd as "can re-tune later", issue #72)
+            // and was never re-tuned for FST4: near its own sensitivity
+            // threshold, every OSD result that did run had a
+            // CRC-verified hard-error count above `osd_max_errors`
+            // (rejected despite being provably correct) — issue #146.
+            // Bypass it for FST4 to match WSJT-X: trust the CRC-24
+            // verification inside `decode_soft` alone.
+            //
+            // (A parallel pre-OSD *attempt* score gate, `osd_score_min`,
+            // used to sit here too, bypassed for both FST4 and FT4 for
+            // the identical reason — issue #146/#72 section 12. It ended
+            // up with no live caller on any protocol once both bypassed
+            // it and was removed outright, issue #230.)
             let is_fst4 = P::ID == super::ProtocolId::Fst4;
-            // FT4 hit the identical `osd_score_min` symptom FST4 already
-            // worked around: `cand.score` is `coarse_sync`'s non-coherent
-            // score (unrelated to the coherent `ft4_sync_search` score
-            // computed above), and `1.8` was tuned against it back when
-            // that was the only score in play (section 5/6). Empirically
-            // confirmed (`ft4_diag_weak_trials`, issue #72,
-            // `docs/notes/FT4_BENCHMARK.md` section 12): 13/17 currently-
-            // failing near-crossing AWGN candidates have `cand.score <
-            // 1.8` and so never even attempt OSD, despite all 17 clearing
-            // WSJT-X's own `syncmin=1.2` easily (real signals, not
-            // noise). WSJT-X's own FT4 decoder has no OSD-attempt score
-            // gate at all either (`decode174_91` runs BP+OSD together,
-            // governed by `ndepth`, not by a score check) — bypass
-            // `osd_score_min` for FT4 too, same as FST4, keeping
-            // `osd_max_errors` (a real hard-error ceiling, not a stale-
-            // quantity gate) as the false-accept safety net.
-            let bypass_osd_score_min = is_fst4 || P::ID == super::ProtocolId::Ft4;
             // See `osd_escalation_gates`'s doc comment for the full
             // derivation/history of these two thresholds.
             let (osd_attempt_min, osd_depth3_min) = osd_escalation_gates::<P>();
-            if depth.osd
-                && nsync >= osd_attempt_min
-                && (bypass_osd_score_min || cand.score >= strictness.osd_score_min())
-            {
+            if depth.osd && nsync >= osd_attempt_min {
                 let freq_dup = known
                     .iter()
                     .any(|r| (r.freq_hz - cand.freq_hz).abs() < 20.0);

--- a/mfsk-core/src/msg/decode_request.rs
+++ b/mfsk-core/src/msg/decode_request.rs
@@ -55,10 +55,21 @@ pub trait FrameDecodable: Protocol {
 }
 
 /// Protocols with a calibrated flat SIC (fixed sync_min, sequential
-/// subtract, up to 3 rounds — see [`DecodeRequest::sic_rounds`]). FST4 has
-/// no `SubtractCfg` yet — enabling it there is new numerical work requiring
-/// WSJT-X-reference calibration, not a refactor, so it's deliberately not
-/// implemented here (tracked separately, issue #193).
+/// subtract, up to 3 rounds — see [`DecodeRequest::sic_rounds`]). FT8/FT4
+/// only — not any FST4 sub-mode.
+///
+/// This isn't an unfinished mfsk-core port: WSJT-X's own `fst4_decode.f90`
+/// has no subtract/SIC path at all (confirmed directly against the WSJT-X
+/// source), because FST4 targets point-to-point links (EME/troposcatter/
+/// LF-MF) rather than WSPR/FT8-style crowded shared bands where
+/// simultaneous-signal collisions are the normal case — upstream never
+/// needed it. If FST4 SIC is ever added (tracked separately, issue #193),
+/// the short sub-modes (FST4-15/30, whose SNR regime sits close to FT8's
+/// — matching issue #143's own scoping to just those two) are the more
+/// plausible candidates than the long ones (FST4-120/300): the existing
+/// LPF-based gain-tracking subtract approach has a real tension there
+/// between the long averaging window deep SNR needs and the short window
+/// real fading (EME libration, ionospheric variation) needs.
 pub trait SupportsSicRounds: FrameDecodable {
     #[doc(hidden)]
     fn __flat_sic(req: &DecodeRequest<'_, Self>) -> DecodeOutcome<Self>
@@ -209,6 +220,13 @@ impl<'a, P: FrameDecodable> DecodeRequest<'a, P> {
 
 impl<'a, P: SupportsWideBandAp> DecodeRequest<'a, P> {
     /// A-priori callsign/grid/report hint applied to every candidate.
+    ///
+    /// `Ft8` only — see [`SupportsWideBandAp`]'s doc comment for why
+    /// (FT4/FST4's AP sniper has an early-exit-after-first-hit
+    /// optimization only valid for single-target search, so wide-band AP
+    /// there would be new, unvalidated capability). For FT4/FST4/Q65, use
+    /// [`SniperRequest::ap_hint`] instead — narrow-band AP is already
+    /// validated for all three.
     pub fn ap_hint(mut self, ap: &'a ApHint) -> Self {
         self.ap_hint = Some(ap);
         self
@@ -232,6 +250,10 @@ impl<'a, P: SupportsSicRounds> DecodeRequest<'a, P> {
     /// settable field) so `.sic_rounds(_).sic_early()` can't compile a
     /// combination where the round count is silently ignored — see issue
     /// #218 for the design discussion.
+    ///
+    /// Implemented for `Ft8`/`Ft4` only — not any FST4 sub-mode; see
+    /// [`SupportsSicRounds`]'s doc comment for why (an upstream WSJT-X
+    /// absence, not an mfsk-core gap).
     pub fn sic_rounds(mut self, n: usize) -> Self {
         self.strategy = P::__flat_sic;
         self.sic_rounds = n.clamp(1, 3);
@@ -247,6 +269,12 @@ impl<'a, P: SupportsSicEarly> DecodeRequest<'a, P> {
     /// WSJT-X's disk-decode architecture. Recall superset of
     /// `.sic_rounds()`. Checkpoint structure (A/B/C) is fixed — no
     /// tunable count, matching jt9 `-d2`/`-d3`'s `npass=3` either way.
+    ///
+    /// `Ft8` only — FT4/FST4 have no equivalent checkpoint architecture
+    /// to port (see [`SupportsSicEarly`]'s doc comment). For FT4, use
+    /// [`DecodeRequest::sic_rounds`] instead — a recall subset of the
+    /// same underlying idea (flat multi-pass SIC) without the checkpoint
+    /// structure.
     pub fn sic_early(mut self) -> Self {
         self.strategy = P::__staged_sic;
         self

--- a/mfsk-core/tests/ft4_sweep.rs
+++ b/mfsk-core/tests/ft4_sweep.rs
@@ -500,10 +500,12 @@ fn ft4_diag_weak_trials() {
 /// `try_decode_at` that mirrors `process_candidate_basic`'s LLR/BP/OSD
 /// tail (symbol_spectra -> sync_quality -> BP variants -> OSD) for an
 /// explicit `(freq_hz, i0)` rather than re-running the full search — the
-/// gate is intentionally permissive (skips the `cand.score >=
-/// osd_score_min` check) to give a segment-2/3 rescue its best possible
-/// chance. A rescue here means WSJT-X's literal per-segment retry
-/// structure is worth porting; a clean floor rules it out for pure AWGN.
+/// gate is intentionally permissive (no pre-OSD score check — matches
+/// production since issue #230 removed the `osd_score_min` gate this
+/// diagnostic used to skip around) to give a segment-2/3 rescue its best
+/// possible chance. A rescue here means WSJT-X's literal per-segment
+/// retry structure is worth porting; a clean floor rules it out for pure
+/// AWGN.
 #[test]
 #[ignore = "manual diagnostic — 3-segment Δt-search retry hypothesis (issue #72)"]
 fn ft4_diag_segment_retry() {
@@ -672,11 +674,12 @@ fn ft4_diag_segment_retry() {
                     if seg_idx > 0 && s2.score < smax1 {
                         continue;
                     }
-                    // Same OSD-attempt score gate production uses
-                    // (`cand.score >= strictness.osd_score_min()`,
-                    // `core/pipeline.rs`) — BP is still attempted
-                    // unconditionally either way, matching production.
-                    let allow_osd = c.score >= DecodeStrictness::Normal.osd_score_min();
+                    // Production has no pre-OSD score gate at all since
+                    // issue #230 (`osd_score_min` removed — it had no
+                    // live caller). Always attempt OSD once BP fails,
+                    // matching production; BP itself is still attempted
+                    // unconditionally either way.
+                    let allow_osd = true;
                     if let Some((hard_errors, msg77)) =
                         try_decode_at(&cd0, s2.freq_hz, c.freq_hz, s2.i0, ds_rate, allow_osd)
                     {


### PR DESCRIPTION
## Summary

Persona-grounded re-review of #230/#231's original proposals found the real friction wasn't quite where either issue first pointed.

- **#230** (`DecodeStrictness`'s four methods conflated behind one un-gated knob): the internal method-conflation part is `pub(crate)`/`internal-testing`-gated, invisible to every external consumer, so the capability-trait-splitting half of that proposal was built, verified, then deliberately not landed — see the issue for the full trace. Only the confirmed-dead `osd_score_min()` is removed here.
- **#231** (`DecodeRequest::ap_hint` FT8-only vs `SniperRequest::ap_hint` covering FT8/FT4/FST4/Q65, undocumented): fixed, but at the actual point of contact (the method's own rustdoc, what docs.rs/IDE hover show) rather than only in `LIBRARY.md` as originally proposed.

## What changed

`mfsk-core/src/msg/decode_request.rs` (doc comments only, no behavior change):

- `DecodeRequest::ap_hint` — now states it's FT8-only and why, and points to `SniperRequest::ap_hint` for FT4/FST4/Q65.
- `DecodeRequest::sic_rounds` — now states FT8/FT4 only, not FST4.
- `SupportsSicRounds` trait doc — corrected: FST4's missing SIC isn't an unfinished mfsk-core port. WSJT-X's own `fst4_decode.f90` has no subtract/SIC path at all (verified directly against the WSJT-X source) — an inherited upstream absence, not a gap. Noted FST4-15/30 as more plausible candidates than FST4-120/300 if this is ever pursued (matches issue #193's own scoping).
- `DecodeRequest::sic_early` — now states FT8-only, points to `.sic_rounds()` as the FT4 alternative.

`mfsk-core/src/engine/pipeline.rs` — `DecodeStrictness::osd_score_min()` removed (bypassed unconditionally for both FST4 and FT4, never called by FT8 either — confirmed dead on every protocol).

`docs/reference/LIBRARY.md`/`LIBRARY.ja.md` §4 updated to match.

`tests/ft4_sweep.rs` — the one direct caller of `osd_score_min()` updated to match (a manual diagnostic test, `#[ignore]`).

## Verification

- `cargo check`/`cargo clippy --all-targets`/`cargo doc --no-deps` — zero warnings, both `--features full` and `--features full,internal-testing`.
- `cargo test --release --features full,internal-testing --lib` — 375 passed, 0 failed.
- Real-WAV recall tests (`ft4_wsjtx_sample_recall_vs_golden`, `fst4_60_wsjtx_sample_recall_vs_golden`, `ft8_qso3_jtdx_recall`, `ft8_qso3_apon_recall`, `ft4_sic_rounds_recall_is_monotonic`) all pass — confirms zero behavior change.

Closes #230, closes #231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)