### PR TITLE
perf(ft8,fst4): decode hot-path waste elimination + caching (no measured wall-clock win, corrected)

### DIFF
--- a/mfsk-core/src/engine/dsp/downsample.rs
+++ b/mfsk-core/src/engine/dsp/downsample.rs
@@ -69,13 +69,13 @@ std::thread_local! {
 
 #[cfg(feature = "std")]
 #[inline]
-fn with_default_planner<R>(f: impl FnOnce(&mut dyn FftPlanner) -> R) -> R {
+pub(crate) fn with_default_planner<R>(f: impl FnOnce(&mut dyn FftPlanner) -> R) -> R {
     DOWNSAMPLE_PLANNER.with_borrow_mut(|planner| f(planner.as_mut()))
 }
 
 #[cfg(not(feature = "std"))]
 #[inline]
-fn with_default_planner<R>(f: impl FnOnce(&mut dyn FftPlanner) -> R) -> R {
+pub(crate) fn with_default_planner<R>(f: impl FnOnce(&mut dyn FftPlanner) -> R) -> R {
     f(default_planner().as_mut())
 }
 

--- a/mfsk-core/src/engine/llr.rs
+++ b/mfsk-core/src/engine/llr.rs
@@ -14,7 +14,7 @@ use num_complex::Complex;
 use num_traits::Float;
 
 use super::Protocol;
-use crate::engine::fft::default_planner;
+use crate::engine::dsp::downsample::with_default_planner;
 use crate::engine::scalar::{Cmplx, ComplexSpec, LlrScalar, SpecScalar};
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -97,8 +97,16 @@ pub fn symbol_spectra<P: Protocol>(cd0: &[Complex<f32>], i_start: i32) -> Vec<Cm
     let n_sym = P::N_SYMBOLS as usize;
     let ds_spb = (P::NSPS / P::NDOWN) as usize;
 
-    let mut planner = default_planner();
-    let fft = planner.plan_forward(ds_spb);
+    // Reuse the same thread_local planner `downsample_cached` caches
+    // (#211) instead of building a fresh one every call — rustfft's own
+    // `FftPlanner` caches per size internally, so sharing one instance
+    // across both call sites' different sizes is free. `symbol_spectra`
+    // runs once per candidate from `engine/pipeline.rs` and
+    // `msg/pipeline_ap.rs`, rebuilding this size's twiddle table from
+    // scratch every time before this fix (smaller than
+    // `downsample_cached`'s FFT, so a smaller absolute cost per call,
+    // but the same anti-pattern at the same call frequency).
+    let fft = with_default_planner(|planner| planner.plan_forward(ds_spb));
 
     // cs is spec-scalar storage (`Cmplx<f32>`); buf is an FFT scratch
     // (`Complex<f32>`) — the alias makes them the same machine type

--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -23,6 +23,7 @@ use super::llr::{
     compute_llr_fast, compute_llr_partial, compute_snr_db, descramble_info, symbol_spectra,
     sync_quality,
 };
+use super::protocol::BpPooledFec;
 use super::sync::{SyncCandidate, coarse_sync, fine_sync_power_per_block};
 use super::tx::codeword_to_itone;
 use super::{FecCodec, FecOpts, MessageCodec, Protocol};
@@ -361,9 +362,17 @@ impl DecodeResult {
 /// `pub` only under the `internal-testing` feature (issue #203) — see
 /// [`decode_frame`]'s doc comment for the feature-gating rationale.
 #[cfg(feature = "internal-testing")]
-pub trait GenericPipelineProtocol: Protocol {}
+pub trait GenericPipelineProtocol: Protocol
+where
+    Self::Fec: BpPooledFec,
+{
+}
 #[cfg(not(feature = "internal-testing"))]
-pub(crate) trait GenericPipelineProtocol: Protocol {}
+pub(crate) trait GenericPipelineProtocol: Protocol
+where
+    Self::Fec: BpPooledFec,
+{
+}
 
 // ──────────────────────────────────────────────────────────────────────────
 // Per-candidate processing
@@ -386,7 +395,10 @@ pub fn process_candidate_basic<P: GenericPipelineProtocol>(
     known: &[DecodeResult],
     eq_mode: EqMode,
     sync_q_min: u32,
-) -> Option<DecodeResult> {
+) -> Option<DecodeResult>
+where
+    P::Fec: BpPooledFec,
+{
     process_candidate_basic_impl::<P>(
         cand, fft_cache, cfg, depth, strictness, known, eq_mode, sync_q_min,
     )
@@ -406,7 +418,10 @@ pub(crate) fn process_candidate_basic<P: GenericPipelineProtocol>(
     known: &[DecodeResult],
     eq_mode: EqMode,
     sync_q_min: u32,
-) -> Option<DecodeResult> {
+) -> Option<DecodeResult>
+where
+    P::Fec: BpPooledFec,
+{
     process_candidate_basic_impl::<P>(
         cand, fft_cache, cfg, depth, strictness, known, eq_mode, sync_q_min,
     )
@@ -421,7 +436,10 @@ fn process_candidate_basic_impl<P: GenericPipelineProtocol>(
     known: &[DecodeResult],
     eq_mode: EqMode,
     sync_q_min: u32,
-) -> Option<DecodeResult> {
+) -> Option<DecodeResult>
+where
+    P::Fec: BpPooledFec,
+{
     let ntones = P::NTONES as usize;
     let n_sym = P::N_SYMBOLS as usize;
     let ds_rate = 12_000.0 / P::NDOWN as f32;
@@ -497,6 +515,12 @@ fn process_candidate_basic_impl<P: GenericPipelineProtocol>(
 
         let decode = |cs: &[Complex<f32>]| -> Option<DecodeResult> {
             let fec = P::Fec::default();
+            // Reused across every `decode_soft_pooled` call below (up to
+            // 15 for FST4's full LLR-variant × OSD-escalation ladder, 12
+            // for FT4) — one allocation per candidate instead of one per
+            // call. See `BpPooledFec`'s doc comment (issue #199/#201's
+            // shape, ported to the generic pipeline).
+            let mut bp_scratch = <P::Fec as BpPooledFec>::Scratch::default();
             let bp_opts = FecOpts {
                 bp_max_iter,
                 osd_depth: 0,
@@ -518,8 +542,8 @@ fn process_candidate_basic_impl<P: GenericPipelineProtocol>(
                     deinterleave_llr_vec(v, table);
                 }
             };
-            let try_bp = |llr: &Vec<f32>, pass_id: u8| -> Option<DecodeResult> {
-                let mut r = fec.decode_soft(llr, &bp_opts)?;
+            let mut try_bp = |llr: &Vec<f32>, pass_id: u8| -> Option<DecodeResult> {
+                let mut r = fec.decode_soft_pooled(llr, &bp_opts, &mut bp_scratch)?;
                 let itone = encode_tones_for_snr::<P>(&r.info, &fec);
                 let snr_db = compute_snr_db::<P>(cs, &itone);
                 // FT4 pre-LDPC scramble (WSJT-X `genft4.f90:64`): undo
@@ -636,7 +660,8 @@ fn process_candidate_basic_impl<P: GenericPipelineProtocol>(
                         ..FecOpts::default()
                     };
                     for (llr, _) in &variants {
-                        if let Some(mut r) = fec.decode_soft(llr, &osd_opts) {
+                        if let Some(mut r) = fec.decode_soft_pooled(llr, &osd_opts, &mut bp_scratch)
+                        {
                             if !is_fst4 && r.hard_errors >= strictness.osd_max_errors(osd_depth) {
                                 continue;
                             }
@@ -665,7 +690,9 @@ fn process_candidate_basic_impl<P: GenericPipelineProtocol>(
                             ..FecOpts::default()
                         };
                         for (llr, _) in &variants {
-                            if let Some(mut r) = fec.decode_soft(llr, &osd4_opts) {
+                            if let Some(mut r) =
+                                fec.decode_soft_pooled(llr, &osd4_opts, &mut bp_scratch)
+                            {
                                 if !is_fst4 && r.hard_errors >= strictness.osd_max_errors(4) {
                                     continue;
                                 }
@@ -800,7 +827,10 @@ pub fn decode_frame<P: GenericPipelineProtocol>(
     strictness: DecodeStrictness,
     eq_mode: EqMode,
     sync_q_min: u32,
-) -> (Vec<DecodeResult>, FftCache) {
+) -> (Vec<DecodeResult>, FftCache)
+where
+    P::Fec: BpPooledFec,
+{
     decode_frame_impl::<P>(
         audio, cfg, freq_min, freq_max, sync_min, freq_hint, depth, max_cand, strictness, eq_mode,
         sync_q_min,
@@ -823,7 +853,10 @@ pub(crate) fn decode_frame<P: GenericPipelineProtocol>(
     strictness: DecodeStrictness,
     eq_mode: EqMode,
     sync_q_min: u32,
-) -> (Vec<DecodeResult>, FftCache) {
+) -> (Vec<DecodeResult>, FftCache)
+where
+    P::Fec: BpPooledFec,
+{
     decode_frame_impl::<P>(
         audio, cfg, freq_min, freq_max, sync_min, freq_hint, depth, max_cand, strictness, eq_mode,
         sync_q_min,
@@ -842,7 +875,10 @@ fn decode_frame_impl<P: GenericPipelineProtocol>(
     strictness: DecodeStrictness,
     eq_mode: EqMode,
     sync_q_min: u32,
-) -> (Vec<DecodeResult>, FftCache) {
+) -> (Vec<DecodeResult>, FftCache)
+where
+    P::Fec: BpPooledFec,
+{
     // FT4's own coarse-candidate stage (`engine::ft4_coarse::ft4_coarse_sync`,
     // a faithful `getcandidates4.f90` port) replaces the generic 2-D
     // (freq × lag) Costas-correlation search: WSJT-X's FT4 candidate
@@ -953,7 +989,10 @@ pub(crate) fn decode_frame_subtract<P: GenericPipelineProtocol>(
     lpf_half: usize,
     lpf_endcorrection: bool,
     refine_freq_radius_hz: f32,
-) -> Vec<DecodeResult> {
+) -> Vec<DecodeResult>
+where
+    P::Fec: BpPooledFec,
+{
     let mut residual = audio.to_vec();
     let mut all_results: Vec<DecodeResult> = Vec::new();
     let passes: &[f32] = &[1.0, 0.75, 0.5][..max_rounds];

--- a/mfsk-core/src/engine/protocol.rs
+++ b/mfsk-core/src/engine/protocol.rs
@@ -492,6 +492,16 @@ pub trait FecCodec: sealed::Sealed + Default + 'static {
 /// set (Rust's `private_bounds` lint) — not because any external
 /// caller ever names `BpPooledFec` itself; the bound is satisfied
 /// automatically by `P: GenericPipelineProtocol` alone.
+///
+/// `#[allow(dead_code)]`: unlike `GenericPipelineProtocol` (an empty
+/// marker trait, nothing for the lint to flag), this trait has a real
+/// method (`decode_soft_pooled`). Under a feature set with no protocol
+/// that reaches `GenericPipelineProtocol`'s generic pipeline (e.g.
+/// `--no-default-features`, `--features wspr`) nothing ever calls it,
+/// even though `impl BpPooledFec for Ldpc174_91`/`Ldpc240_101` are
+/// unconditionally compiled — caught by CI's `-D warnings` build
+/// matrix, not by the `full`/`full,internal-testing` combo this was
+/// developed against.
 #[cfg(feature = "internal-testing")]
 pub trait BpPooledFec: FecCodec {
     /// Reusable working memory for [`Self::decode_soft_pooled`] —
@@ -510,6 +520,7 @@ pub trait BpPooledFec: FecCodec {
     ) -> Option<FecResult>;
 }
 #[cfg(not(feature = "internal-testing"))]
+#[allow(dead_code)] // see the `internal-testing` branch's doc comment above
 pub(crate) trait BpPooledFec: FecCodec {
     type Scratch: Default;
 

--- a/mfsk-core/src/engine/protocol.rs
+++ b/mfsk-core/src/engine/protocol.rs
@@ -466,6 +466,61 @@ pub trait FecCodec: sealed::Sealed + Default + 'static {
     fn decode_soft(&self, llr: &[f32], opts: &FecOpts) -> Option<FecResult>;
 }
 
+/// `Fec` codecs with a pooled-scratch `decode_soft` sibling (perf
+/// review: `engine::pipeline::process_candidate_basic_impl`'s LLR/OSD
+/// staircase calls `decode_soft` up to 15× per FST4 candidate, 12× for
+/// FT4, each allocating ~9 fresh `Vec`s internally with no pooling —
+/// the same shape of problem `fec::ldpc::bp::BpScratch`/issue #199/#201
+/// already fixed for FT8's own `NormalizedMinSum` kernel, just never
+/// ported to the generic pipeline or to the `SumProduct` kernel
+/// [`FecOpts::default`] actually selects). Not on the sealed
+/// [`FecCodec`] itself — that would force a `Scratch` type onto
+/// `Q65Fec`/`ConvFano`/`Ldpc128_90` too, none of which want LDPC BP
+/// scratch. Implemented for `Ldpc174_91`/`Ldpc240_101`
+/// (`crate::fec::ldpc`/`crate::fec::ldpc240_101`) only — the two `Fec`
+/// types `Ft4` and every FST4 sub-mode actually use. Lives next to
+/// [`FecCodec`] (not in `engine::pipeline`, where it's consumed) so
+/// its implementors — `fec::ldpc`/`fec::ldpc240_101` — don't need a
+/// new dependency on `engine::pipeline`, only their existing one on
+/// this module.
+///
+/// `pub` only under the `internal-testing` feature (issue #203) —
+/// mirrors `engine::pipeline::GenericPipelineProtocol`'s own gating,
+/// since that trait's `where Self::Fec: BpPooledFec` bound needs
+/// `BpPooledFec` to be at least as visible as whatever visibility
+/// `GenericPipelineProtocol`-bounded functions have on a given feature
+/// set (Rust's `private_bounds` lint) — not because any external
+/// caller ever names `BpPooledFec` itself; the bound is satisfied
+/// automatically by `P: GenericPipelineProtocol` alone.
+#[cfg(feature = "internal-testing")]
+pub trait BpPooledFec: FecCodec {
+    /// Reusable working memory for [`Self::decode_soft_pooled`] —
+    /// concretely `fec::ldpc::bp::BpScratch` for both current
+    /// implementors.
+    type Scratch: Default;
+
+    /// [`FecCodec::decode_soft`] with caller-provided scratch, reused
+    /// across every call for one candidate instead of reallocated per
+    /// call.
+    fn decode_soft_pooled(
+        &self,
+        llr: &[f32],
+        opts: &FecOpts,
+        scratch: &mut Self::Scratch,
+    ) -> Option<FecResult>;
+}
+#[cfg(not(feature = "internal-testing"))]
+pub(crate) trait BpPooledFec: FecCodec {
+    type Scratch: Default;
+
+    fn decode_soft_pooled(
+        &self,
+        llr: &[f32],
+        opts: &FecOpts,
+        scratch: &mut Self::Scratch,
+    ) -> Option<FecResult>;
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Message codec
 // ──────────────────────────────────────────────────────────────────────────

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -577,6 +577,70 @@ pub fn coarse_sync<P: Protocol>(
 // Fine sync (Costas correlation on downsampled complex baseband)
 // ──────────────────────────────────────────────────────────────────────────
 
+// Small fixed-capacity cross-call cache for `make_costas_ref`'s output,
+// keyed by content equality on `(pattern, ds_spb)`. 2 slots is enough
+// for every pattern combination that exists in this crate today: FT8/
+// FT4 reuse one pattern across all their sync blocks (already cached
+// *within* one `fine_sync_power_per_block` call, see that function's
+// own doc comment), FST4 alternates exactly two (SYNC_A/SYNC_B) — so 2
+// slots never thrash for any protocol actually wired here. Perf review:
+// `fine_sync_power_per_block` runs once per candidate from three call
+// sites (`ft8/decode.rs`, `engine/pipeline.rs`, `msg/pipeline_ap.rs`),
+// and the within-call cache above always started empty — every call
+// rebuilt each pattern's trig table from scratch even when the
+// previous call used the identical `(pattern, ds_spb)` pair. Making
+// the cache persist across calls (same idea as #211's FFT-planner
+// cache) skips that recomputation; the clone on a cache hit is a
+// memcpy of already-computed values, much cheaper than the sin/cos
+// calls it replaces. This also fixes `refine_candidate`'s AP/sniper-
+// path loop for free: it calls `fine_sync_power` (→ this function) at
+// every one of ~83 offsets (`msg/pipeline_ap.rs`'s `REFINE_STEPS`),
+// previously rebuilding the same Costas reference from scratch at each
+// one despite it never depending on the loop variable — no separate
+// fix needed there once this cache exists.
+#[cfg(feature = "std")]
+type CostasRefCacheEntry = (&'static [u8], usize, Vec<Vec<Complex<f32>>>);
+
+#[cfg(feature = "std")]
+std::thread_local! {
+    static COSTAS_REF_CACHE: core::cell::RefCell<Vec<CostasRefCacheEntry>> =
+        const { core::cell::RefCell::new(Vec::new()) };
+}
+
+/// [`make_costas_ref`] with a small cross-call cache — see
+/// `COSTAS_REF_CACHE`'s doc comment. `pattern` must be `'static` (true
+/// of every real caller: `Protocol::SYNC_MODE.blocks()` entries are all
+/// `const`/`static` table data) so the cache can hold a reference to it
+/// past this call's return.
+#[cfg(feature = "std")]
+fn cached_costas_ref(pattern: &'static [u8], ds_spb: usize) -> Vec<Vec<Complex<f32>>> {
+    COSTAS_REF_CACHE.with_borrow_mut(|cache| {
+        if let Some((_, _, csync)) = cache
+            .iter()
+            .find(|(p, d, _)| *p == pattern && *d == ds_spb)
+        {
+            return csync.clone();
+        }
+        let csync = make_costas_ref(pattern, ds_spb);
+        if cache.len() >= 2 {
+            cache.remove(0);
+        }
+        cache.push((pattern, ds_spb, csync.clone()));
+        csync
+    })
+}
+
+/// `no_std` (embedded, `fft-extern`) fallback — `thread_local!` needs
+/// `std`. Those builds don't reach this hot path today anyway (every
+/// `fine_sync_power_per_block` caller is on the host `fft-rustfft`
+/// path), so a plain uncached rebuild is fine here, matching
+/// `downsample_cached`'s own `no_std` fallback (`engine/dsp/
+/// downsample.rs`).
+#[cfg(not(feature = "std"))]
+fn cached_costas_ref(pattern: &'static [u8], ds_spb: usize) -> Vec<Vec<Complex<f32>>> {
+    make_costas_ref(pattern, ds_spb)
+}
+
 /// Build complex sinusoidal references (one per Costas tone) for a sync block.
 pub fn make_costas_ref(pattern: &[u8], ds_spb: usize) -> Vec<Vec<Complex<f32>>> {
     pattern
@@ -653,7 +717,7 @@ pub fn fine_sync_power_per_block<P: Protocol>(cd0: &[Complex<f32>], i0: i32) -> 
         let csync = match &last {
             Some((p, c)) if *p == block.pattern => c,
             _ => {
-                last = Some((block.pattern, make_costas_ref(block.pattern, d.ds_spb)));
+                last = Some((block.pattern, cached_costas_ref(block.pattern, d.ds_spb)));
                 &last.as_ref().unwrap().1
             }
         };

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -615,10 +615,7 @@ std::thread_local! {
 #[cfg(feature = "std")]
 fn cached_costas_ref(pattern: &'static [u8], ds_spb: usize) -> Vec<Vec<Complex<f32>>> {
     COSTAS_REF_CACHE.with_borrow_mut(|cache| {
-        if let Some((_, _, csync)) = cache
-            .iter()
-            .find(|(p, d, _)| *p == pattern && *d == ds_spb)
-        {
+        if let Some((_, _, csync)) = cache.iter().find(|(p, d, _)| *p == pattern && *d == ds_spb) {
             return csync.clone();
         }
         let csync = make_costas_ref(pattern, ds_spb);

--- a/mfsk-core/src/fec/ldpc/bp.rs
+++ b/mfsk-core/src/fec/ldpc/bp.rs
@@ -780,10 +780,11 @@ pub fn bp_llr_zsum<P: LdpcParams>(llr: &[f32], n_iter: u32) -> Vec<f32> {
 
 /// [`bp_llr_zsum`] with caller-provided scratch — eliminates the 5-Vec
 /// per-call allocation churn (`tov`/`toc`/`tanhtoc`/`zn`/`zsum`) on both
-/// this function's call sites: [`crate::fec::Ldpc240_101::decode_soft`]
-/// (every FST4 candidate that reaches OSD, via
-/// [`crate::engine::pipeline`]'s [`BpPooledFec::decode_soft_pooled`])
-/// and FT8's `ft8::decode_block::osd_strategy::try_fallback` (8× per
+/// this function's call sites: `Ldpc240_101::decode_soft` (every FST4
+/// candidate that reaches OSD, via `engine::protocol::BpPooledFec::
+/// decode_soft_pooled` — not a doc link since that trait is `pub(crate)`
+/// outside the `internal-testing` feature) and FT8's
+/// `ft8::decode_block::osd_strategy::try_fallback` (8× per
 /// OSD-attempted candidate).
 ///
 /// Returns a borrow of `scratch`'s `zsum` buffer instead of an owned
@@ -985,8 +986,8 @@ pub struct BpScratch<P: LdpcParams, T: LlrScalar> {
 impl<P: LdpcParams, T: LlrScalar> BpScratch<P, T> {
     /// Allocate the seven scratch buffers at the right capacities for
     /// `P`. Single instance can be reused across many BP calls.
-    /// `tanhtoc`/`zsum` start empty — see [`Self::ensure_tanhtoc`] /
-    /// [`Self::ensure_zsum`].
+    /// `tanhtoc`/`zsum` start empty — grown lazily on first use by the
+    /// (private) `ensure_tanhtoc`/`ensure_zsum` helpers.
     pub fn new() -> Self {
         let n = P::N;
         let m_checks = P::M;

--- a/mfsk-core/src/fec/ldpc/bp.rs
+++ b/mfsk-core/src/fec/ldpc/bp.rs
@@ -422,6 +422,263 @@ pub fn bp_decode_generic_kind<P: LdpcParams>(
     None
 }
 
+/// [`bp_decode_generic_kind`] with caller-provided scratch — eliminates
+/// the ~9-Vec per-call allocation churn on whichever kernel is actually
+/// selected, `SumProduct` included (unlike [`bp_decode_generic_nms_with_scratch`],
+/// which only pools the `NormalizedMinSum`/`OffsetMinSum` kernels —
+/// `FecOpts::default()`'s `bp_kind` is `SumProduct`, and neither FT4 nor
+/// any FST4 sub-mode overrides it, so this is the kernel the generic
+/// pipeline's `decode_soft_pooled` ([`crate::engine::pipeline`]) and
+/// FT8's own host-default `bp_step_select` path actually need pooled).
+///
+/// Body is [`bp_decode_generic_kind`]'s, mechanically scratch-threaded
+/// the same way [`bp_decode_generic_nms_with_scratch`] already
+/// scratch-threaded [`bp_decode_generic_nms`] — not a new pattern.
+pub fn bp_decode_generic_kind_with_scratch<P: LdpcParams>(
+    scratch: &mut BpScratch<P, f32>,
+    llr: &[f32],
+    ap_mask: Option<&[bool]>,
+    max_iter: u32,
+    verify: Option<fn(&[u8]) -> bool>,
+    kind: BpKind,
+) -> Option<BpResult> {
+    debug_assert_eq!(llr.len(), P::N, "llr length must equal P::N");
+    if let Some(m) = ap_mask {
+        debug_assert_eq!(m.len(), P::N, "ap_mask length must equal P::N");
+    }
+
+    let n = P::N;
+    let m_checks = P::M;
+    let k = P::K;
+    let max_row = P::MAX_ROW;
+
+    scratch.reset();
+    if matches!(kind, BpKind::SumProduct) {
+        scratch.ensure_tanhtoc();
+    }
+    let BpScratch {
+        tov,
+        toc,
+        tanhtoc,
+        min1,
+        min2,
+        idx_min1,
+        sign_xor,
+        zn,
+        cw,
+        ..
+    } = scratch;
+
+    // Initial messages: each check node receives the raw LLR for the
+    // bits it tests.
+    for j in 0..m_checks {
+        let nrw_j = P::nrw(j) as usize;
+        for i in 0..nrw_j {
+            let bit = P::nm(j, i) as usize;
+            toc[j * max_row + i] = llr[bit];
+        }
+    }
+
+    let mut ncnt = 0u32;
+    let mut nclast = 0u32;
+
+    for iter in 0..=max_iter {
+        // Variable-node update: zn = llr + Σ tov, except AP-locked
+        // bits hold their LLR fixed.
+        for i in 0..n {
+            let ap = ap_mask.is_some_and(|mm| mm[i]);
+            if !ap {
+                let mut sum = 0.0f32;
+                for k_ in 0..NCW {
+                    sum += tov[i * NCW + k_];
+                }
+                zn[i] = llr[i] + sum;
+            } else {
+                zn[i] = llr[i];
+            }
+        }
+
+        // Hard decisions.
+        for i in 0..n {
+            cw[i] = if zn[i] > 0.0 { 1 } else { 0 };
+        }
+
+        // Count parity-violating checks.
+        let mut ncheck = 0u32;
+        for i in 0..m_checks {
+            let nrw_i = P::nrw(i) as usize;
+            let mut parity = 0u8;
+            for s in 0..nrw_i {
+                parity ^= cw[P::nm(i, s) as usize];
+            }
+            if parity != 0 {
+                ncheck += 1;
+            }
+        }
+
+        if ncheck == 0 {
+            let mut decoded = vec![0u8; k];
+            decoded.copy_from_slice(&cw[..k]);
+            let accept = match verify {
+                Some(f) => f(&decoded),
+                None => true,
+            };
+            if accept {
+                let mut hard_errors = 0u32;
+                for i in 0..n {
+                    if (cw[i] == 1) != (llr[i] > 0.0) {
+                        hard_errors += 1;
+                    }
+                }
+                let mut message77 = [0u8; 77];
+                message77.copy_from_slice(&decoded[..77]);
+                // Codeword is small (174 / 240 bytes); clone instead of
+                // moving so the scratch's `cw` Vec stays in the pool.
+                return Some(BpResult {
+                    message77,
+                    info: decoded,
+                    codeword: cw.clone(),
+                    hard_errors,
+                    iterations: iter,
+                });
+            }
+        }
+
+        // Stall detector: same heuristic as the WSJT-X reference.
+        if iter > 0 {
+            if ncheck < nclast {
+                ncnt = 0;
+            } else {
+                ncnt += 1;
+            }
+            if ncnt >= 5 && iter >= 10 && ncheck > 15 {
+                return None;
+            }
+        }
+        nclast = ncheck;
+
+        // Check-to-variable message update (extrinsic info).
+        for j in 0..m_checks {
+            let nrw_j = P::nrw(j) as usize;
+            for i in 0..nrw_j {
+                let ibj = P::nm(j, i) as usize;
+                let mut msg = zn[ibj];
+                let mn_ibj = P::mn(ibj);
+                for kk in 0..NCW {
+                    if mn_ibj[kk] as usize == j {
+                        msg -= tov[ibj * NCW + kk];
+                    }
+                }
+                toc[j * max_row + i] = msg;
+            }
+        }
+
+        match kind {
+            BpKind::SumProduct => {
+                // tanh half-message cache.
+                for i in 0..m_checks {
+                    let nrw_i = P::nrw(i) as usize;
+                    for k_ in 0..nrw_i {
+                        tanhtoc[i * max_row + k_] = (-toc[i * max_row + k_] / 2.0).tanh();
+                    }
+                }
+
+                // Variable-to-check message update via 2·atanh(∏ tanh(L/2)).
+                for j in 0..n {
+                    let mn_j = P::mn(j);
+                    for k_ in 0..NCW {
+                        let ichk = mn_j[k_] as usize;
+                        let nrw_ichk = P::nrw(ichk) as usize;
+                        let mut tmn = 1.0f32;
+                        for s in 0..nrw_ichk {
+                            let bit = P::nm(ichk, s) as usize;
+                            if bit != j {
+                                tmn *= tanhtoc[ichk * max_row + s];
+                            }
+                        }
+                        tov[j * NCW + k_] = 2.0 * platanh(-tmn);
+                    }
+                }
+            }
+            BpKind::NormalizedMinSum { .. } | BpKind::OffsetMinSum { .. } => {
+                for i in 0..m_checks {
+                    let nrw_i = P::nrw(i) as usize;
+                    let mut m1 = f32::INFINITY;
+                    let mut m2 = f32::INFINITY;
+                    let mut imin = 0_usize;
+                    let mut sx = false;
+                    for s in 0..nrw_i {
+                        let v = toc[i * max_row + s];
+                        if v < 0.0 {
+                            sx = !sx;
+                        }
+                        let av = v.abs();
+                        if av < m1 {
+                            m2 = m1;
+                            m1 = av;
+                            imin = s;
+                        } else if av < m2 {
+                            m2 = av;
+                        }
+                    }
+                    min1[i] = m1;
+                    min2[i] = m2;
+                    idx_min1[i] = imin as u32;
+                    sign_xor[i] = sx;
+                }
+
+                let alpha_eff = match kind {
+                    BpKind::NormalizedMinSum { alpha } => alpha,
+                    _ => 1.0,
+                };
+                let beta = match kind {
+                    BpKind::OffsetMinSum { beta } => beta,
+                    _ => 0.0,
+                };
+                let is_offset = matches!(kind, BpKind::OffsetMinSum { .. });
+
+                for j in 0..n {
+                    let mn_j = P::mn(j);
+                    for k_ in 0..NCW {
+                        let ichk = mn_j[k_] as usize;
+                        let nrw_ichk = P::nrw(ichk) as usize;
+                        let mut my_slot = nrw_ichk;
+                        for s in 0..nrw_ichk {
+                            if P::nm(ichk, s) as usize == j {
+                                my_slot = s;
+                                break;
+                            }
+                        }
+                        let my_v = if my_slot < nrw_ichk {
+                            toc[ichk * max_row + my_slot]
+                        } else {
+                            0.0
+                        };
+                        let my_neg = my_v < 0.0;
+                        let nrw_odd = (nrw_ichk & 1) != 0;
+                        let extrinsic_sign_neg = sign_xor[ichk] ^ my_neg ^ nrw_odd;
+
+                        let mag = if my_slot < nrw_ichk && my_slot as u32 == idx_min1[ichk] {
+                            min2[ichk]
+                        } else {
+                            min1[ichk]
+                        };
+
+                        let scaled = if is_offset {
+                            (mag - beta).max(0.0)
+                        } else {
+                            alpha_eff * mag
+                        };
+                        tov[j * NCW + k_] = if extrinsic_sign_neg { -scaled } else { scaled };
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}
+
 /// WSJT-X `decode240_101`'s OSD fallback does not feed OSD the raw
 /// channel LLR — it feeds the running sum `zsum = Σ_{i=0}^{n_iter} zn_i`
 /// of the variable-node soft estimate across the *first few* BP
@@ -521,6 +778,107 @@ pub fn bp_llr_zsum<P: LdpcParams>(llr: &[f32], n_iter: u32) -> Vec<f32> {
     zsum
 }
 
+/// [`bp_llr_zsum`] with caller-provided scratch — eliminates the 5-Vec
+/// per-call allocation churn (`tov`/`toc`/`tanhtoc`/`zn`/`zsum`) on both
+/// this function's call sites: [`crate::fec::Ldpc240_101::decode_soft`]
+/// (every FST4 candidate that reaches OSD, via
+/// [`crate::engine::pipeline`]'s [`BpPooledFec::decode_soft_pooled`])
+/// and FT8's `ft8::decode_block::osd_strategy::try_fallback` (8× per
+/// OSD-attempted candidate).
+///
+/// Returns a borrow of `scratch`'s `zsum` buffer instead of an owned
+/// `Vec` — this doesn't just pool the allocation, it eliminates it:
+/// [`crate::fec::ldpc::osd::osd_decode_generic`] (FST4's call site)
+/// already takes `&[f32]`, so the borrow passes straight through with
+/// zero copies. FT8's call site needs a fixed-size array
+/// (`osd_decode_npre1`/`osd_decode_npre1_npre2`) and still
+/// `copy_from_slice`s, but from this borrow instead of from a
+/// freshly-heap-allocated `Vec` — 4 of the original 5 allocations
+/// still go away there.
+pub fn bp_llr_zsum_with_scratch<'s, P: LdpcParams>(
+    scratch: &'s mut BpScratch<P, f32>,
+    llr: &[f32],
+    n_iter: u32,
+) -> &'s [f32] {
+    let n = P::N;
+    let m_checks = P::M;
+    let max_row = P::MAX_ROW;
+
+    scratch.reset();
+    scratch.ensure_tanhtoc();
+    scratch.ensure_zsum();
+    let BpScratch {
+        tov,
+        toc,
+        tanhtoc,
+        zn,
+        zsum,
+        ..
+    } = scratch;
+
+    for j in 0..m_checks {
+        let nrw_j = P::nrw(j) as usize;
+        for i in 0..nrw_j {
+            let bit = P::nm(j, i) as usize;
+            toc[j * max_row + i] = llr[bit];
+        }
+    }
+
+    for _iter in 0..=n_iter {
+        for i in 0..n {
+            let mut sum = 0.0f32;
+            for k_ in 0..NCW {
+                sum += tov[i * NCW + k_];
+            }
+            zn[i] = llr[i] + sum;
+        }
+        for i in 0..n {
+            zsum[i] += zn[i];
+        }
+
+        // Check-to-variable message update (extrinsic info).
+        for j in 0..m_checks {
+            let nrw_j = P::nrw(j) as usize;
+            for i in 0..nrw_j {
+                let ibj = P::nm(j, i) as usize;
+                let mut msg = zn[ibj];
+                let mn_ibj = P::mn(ibj);
+                for kk in 0..NCW {
+                    if mn_ibj[kk] as usize == j {
+                        msg -= tov[ibj * NCW + kk];
+                    }
+                }
+                toc[j * max_row + i] = msg;
+            }
+        }
+
+        for i in 0..m_checks {
+            let nrw_i = P::nrw(i) as usize;
+            for k_ in 0..nrw_i {
+                tanhtoc[i * max_row + k_] = (-toc[i * max_row + k_] / 2.0).tanh();
+            }
+        }
+
+        for j in 0..n {
+            let mn_j = P::mn(j);
+            for k_ in 0..NCW {
+                let ichk = mn_j[k_] as usize;
+                let nrw_ichk = P::nrw(ichk) as usize;
+                let mut tmn = 1.0f32;
+                for s in 0..nrw_ichk {
+                    let bit = P::nm(ichk, s) as usize;
+                    if bit != j {
+                        tmn *= tanhtoc[ichk * max_row + s];
+                    }
+                }
+                tov[j * NCW + k_] = 2.0 * platanh(-tmn);
+            }
+        }
+    }
+
+    &scratch.zsum
+}
+
 /// Backward-compatible LDPC(174,91) BP decode — pins
 /// [`bp_decode_generic`] to [`Ldpc174_91Params`]. Used by FT8's
 /// bespoke decode loop (which still consumes the shared LDPC
@@ -606,18 +964,29 @@ pub fn llr_f32_to_q11(x: f32) -> i16 {
 pub struct BpScratch<P: LdpcParams, T: LlrScalar> {
     tov: Vec<T>,
     toc: Vec<T>,
+    /// `SumProduct`-kernel tanh half-message cache — see
+    /// [`bp_decode_generic_kind_with_scratch`]. Empty until grown by
+    /// [`Self::ensure_tanhtoc`] on first use; NMS-only/embedded callers
+    /// that never touch the `SumProduct` path pay zero extra bytes.
+    tanhtoc: Vec<T>,
     min1: Vec<T>,
     min2: Vec<T>,
     idx_min1: Vec<u32>,
     sign_xor: Vec<bool>,
     zn: Vec<T::Wide>,
     cw: Vec<u8>,
+    /// [`bp_llr_zsum_with_scratch`]-only running sum. Empty until grown
+    /// by [`Self::ensure_zsum`] on first use; callers that never reach
+    /// the zsum-seeded OSD retry pay zero extra bytes.
+    zsum: Vec<T::Wide>,
     _p: core::marker::PhantomData<P>,
 }
 
 impl<P: LdpcParams, T: LlrScalar> BpScratch<P, T> {
     /// Allocate the seven scratch buffers at the right capacities for
     /// `P`. Single instance can be reused across many BP calls.
+    /// `tanhtoc`/`zsum` start empty — see [`Self::ensure_tanhtoc`] /
+    /// [`Self::ensure_zsum`].
     pub fn new() -> Self {
         let n = P::N;
         let m_checks = P::M;
@@ -625,12 +994,14 @@ impl<P: LdpcParams, T: LlrScalar> BpScratch<P, T> {
         Self {
             tov: vec![T::ZERO; n * NCW],
             toc: vec![T::ZERO; m_checks * max_row],
+            tanhtoc: Vec::new(),
             min1: vec![T::POS_INF_LIKE; m_checks],
             min2: vec![T::POS_INF_LIKE; m_checks],
             idx_min1: vec![0u32; m_checks],
             sign_xor: vec![false; m_checks],
             zn: vec![T::wide_zero(); n],
             cw: vec![0u8; n],
+            zsum: Vec::new(),
             _p: core::marker::PhantomData,
         }
     }
@@ -648,6 +1019,13 @@ impl<P: LdpcParams, T: LlrScalar> BpScratch<P, T> {
         for v in self.toc.iter_mut() {
             *v = T::ZERO;
         }
+        // Only touch tanhtoc once it's actually been grown — matches
+        // toc's semantics (every valid index gets unconditionally
+        // overwritten before it's read each iteration; this reset is
+        // defensive, matching toc's, not load-bearing).
+        for v in self.tanhtoc.iter_mut() {
+            *v = T::ZERO;
+        }
         for v in self.min1.iter_mut() {
             *v = T::POS_INF_LIKE;
         }
@@ -659,6 +1037,32 @@ impl<P: LdpcParams, T: LlrScalar> BpScratch<P, T> {
         }
         for v in self.sign_xor.iter_mut() {
             *v = false;
+        }
+    }
+
+    /// Grow `tanhtoc` to its required capacity on first use. No-op on
+    /// subsequent calls (capacity is fixed by `P`, and every element is
+    /// unconditionally overwritten before being read each iteration —
+    /// see [`Self::reset`]'s comment).
+    #[inline]
+    fn ensure_tanhtoc(&mut self) {
+        if self.tanhtoc.is_empty() {
+            self.tanhtoc = vec![T::ZERO; P::M * P::MAX_ROW];
+        }
+    }
+
+    /// Grow `zsum` to its required capacity on first use, and zero it
+    /// on every call — unlike `tanhtoc`, `zsum` is an accumulator that
+    /// must start fresh each [`bp_llr_zsum_with_scratch`] call, not a
+    /// fully-overwritten-per-iteration buffer.
+    #[inline]
+    fn ensure_zsum(&mut self) {
+        if self.zsum.is_empty() {
+            self.zsum = vec![T::wide_zero(); P::N];
+        } else {
+            for v in self.zsum.iter_mut() {
+                *v = T::wide_zero();
+            }
         }
     }
 }
@@ -961,5 +1365,118 @@ mod tests {
     #[test]
     fn crc14_known_vector() {
         assert_eq!(crc14(&[0u8; 12]), 0);
+    }
+
+    /// Deterministic pseudo-random LLR vectors (no external RNG dep) —
+    /// varied enough to exercise both convergence and non-convergence
+    /// across the scratch-vs-non-scratch equivalence checks below.
+    fn synth_llr(n: usize, seed: u32) -> Vec<f32> {
+        let mut state = seed.wrapping_mul(2654435761).wrapping_add(1);
+        (0..n)
+            .map(|_| {
+                state = state.wrapping_mul(1103515245).wrapping_add(12345);
+                // Map to roughly [-8.0, 8.0], a realistic LLR magnitude range.
+                ((state >> 8) as f32 / (1u32 << 24) as f32) * 16.0 - 8.0
+            })
+            .collect()
+    }
+
+    /// [`bp_decode_generic_kind_with_scratch`] must produce byte-
+    /// identical results to [`bp_decode_generic_kind`] — same inputs,
+    /// same `SumProduct`/NMS kernel — since the scratch version is a
+    /// mechanical transform of the same algorithm, not a new one.
+    #[test]
+    fn scratch_bp_matches_unpooled_sum_product() {
+        let mut scratch = BpScratch::<Ldpc174_91Params, f32>::new();
+        for seed in 0..8u32 {
+            let llr = synth_llr(174, seed);
+            let expected = bp_decode_generic_kind::<Ldpc174_91Params>(
+                &llr,
+                None,
+                30,
+                None,
+                BpKind::SumProduct,
+            );
+            let actual = bp_decode_generic_kind_with_scratch::<Ldpc174_91Params>(
+                &mut scratch,
+                &llr,
+                None,
+                30,
+                None,
+                BpKind::SumProduct,
+            );
+            match (expected, actual) {
+                (None, None) => {}
+                (Some(e), Some(a)) => {
+                    assert_eq!(e.info, a.info, "seed {seed}: info mismatch");
+                    assert_eq!(e.codeword, a.codeword, "seed {seed}: codeword mismatch");
+                    assert_eq!(
+                        e.hard_errors, a.hard_errors,
+                        "seed {seed}: hard_errors mismatch"
+                    );
+                    assert_eq!(
+                        e.iterations, a.iterations,
+                        "seed {seed}: iterations mismatch"
+                    );
+                }
+                (e, a) => panic!(
+                    "seed {seed}: convergence mismatch — unpooled={}, pooled={}",
+                    e.is_some(),
+                    a.is_some()
+                ),
+            }
+        }
+    }
+
+    /// Same equivalence check for the `NormalizedMinSum` kernel — the
+    /// scratch version's `tanhtoc` is only grown for `SumProduct`, so
+    /// this also confirms the NMS path stays correct with `tanhtoc`
+    /// left empty.
+    #[test]
+    fn scratch_bp_matches_unpooled_normalized_min_sum() {
+        let mut scratch = BpScratch::<Ldpc174_91Params, f32>::new();
+        let kind = BpKind::NormalizedMinSum { alpha: 0.75 };
+        for seed in 0..8u32 {
+            let llr = synth_llr(174, seed);
+            let expected = bp_decode_generic_kind::<Ldpc174_91Params>(&llr, None, 30, None, kind);
+            let actual = bp_decode_generic_kind_with_scratch::<Ldpc174_91Params>(
+                &mut scratch,
+                &llr,
+                None,
+                30,
+                None,
+                kind,
+            );
+            match (expected, actual) {
+                (None, None) => {}
+                (Some(e), Some(a)) => {
+                    assert_eq!(e.info, a.info, "seed {seed}: info mismatch");
+                    assert_eq!(
+                        e.hard_errors, a.hard_errors,
+                        "seed {seed}: hard_errors mismatch"
+                    );
+                }
+                (e, a) => panic!(
+                    "seed {seed}: convergence mismatch — unpooled={}, pooled={}",
+                    e.is_some(),
+                    a.is_some()
+                ),
+            }
+        }
+    }
+
+    /// [`bp_llr_zsum_with_scratch`] must return byte-identical values
+    /// to [`bp_llr_zsum`] across repeated calls on the same scratch
+    /// instance (checks `ensure_zsum`'s re-zero-on-reuse path, not just
+    /// first-use).
+    #[test]
+    fn scratch_zsum_matches_unpooled() {
+        let mut scratch = BpScratch::<Ldpc174_91Params, f32>::new();
+        for seed in 0..5u32 {
+            let llr = synth_llr(174, seed);
+            let expected = bp_llr_zsum::<Ldpc174_91Params>(&llr, 2);
+            let actual = bp_llr_zsum_with_scratch::<Ldpc174_91Params>(&mut scratch, &llr, 2);
+            assert_eq!(expected, actual, "seed {seed}: zsum mismatch");
+        }
     }
 }

--- a/mfsk-core/src/fec/ldpc/mod.rs
+++ b/mfsk-core/src/fec/ldpc/mod.rs
@@ -29,7 +29,9 @@ pub use bp::{BpResult, bp_decode, bp_decode_kind, check_crc14, crc14};
 pub use osd::{OsdResult, ldpc_encode, osd_decode, osd_decode_deep, osd_decode_deep4};
 pub use params::{Ldpc174_91Params, Ldpc240_101Params, LdpcParams};
 
+use crate::engine::protocol::BpPooledFec;
 use crate::engine::{FecCodec, FecOpts, FecResult};
+use bp::{BpScratch, bp_decode_generic_kind_with_scratch};
 
 /// Codeword length of the WSJT LDPC code.
 pub const LDPC_N: usize = 174;
@@ -60,36 +62,11 @@ impl FecCodec for Ldpc174_91 {
     }
 
     fn decode_soft(&self, llr: &[f32], opts: &FecOpts<'_>) -> Option<FecResult> {
-        assert_eq!(llr.len(), LDPC_N, "llr must be {} values", LDPC_N);
-        let mut llr_arr = [0f32; LDPC_N];
-        llr_arr.copy_from_slice(llr);
-
-        // Apply AP hint: for every `mask[i] == 1`, clamp LLR to ±apmag
-        // according to `values[i]` (1 → +apmag, 0 → −apmag).
-        // `apmag = max(|llr|) · 1.01` gives the AP bits a stronger vote than
-        // any channel observation, matching WSJT-X convention.
-        let ap_storage;
-        let ap_mask: Option<&[bool; LDPC_N]> = match opts.ap_mask {
-            Some((mask, values)) => {
-                assert_eq!(mask.len(), LDPC_N, "ap mask must be {} bits", LDPC_N);
-                assert_eq!(values.len(), LDPC_N, "ap values must be {} bits", LDPC_N);
-                let apmag = llr_arr.iter().map(|x| x.abs()).fold(0.0f32, f32::max) * 1.01;
-                let mut a = [false; LDPC_N];
-                for i in 0..LDPC_N {
-                    if mask[i] != 0 {
-                        a[i] = true;
-                        llr_arr[i] = if values[i] != 0 { apmag } else { -apmag };
-                    }
-                }
-                ap_storage = a;
-                Some(&ap_storage)
-            }
-            None => None,
-        };
+        let (llr_arr, ap_mask) = prepare_ap_llr(llr, opts);
 
         if let Some(r) = bp_decode_kind(
             &llr_arr,
-            ap_mask,
+            ap_mask.as_ref(),
             opts.bp_max_iter,
             opts.verify_info,
             opts.bp_kind,
@@ -118,4 +95,81 @@ impl FecCodec for Ldpc174_91 {
             iterations: 0,
         })
     }
+}
+
+impl BpPooledFec for Ldpc174_91 {
+    type Scratch = BpScratch<Ldpc174_91Params, f32>;
+
+    fn decode_soft_pooled(
+        &self,
+        llr: &[f32],
+        opts: &FecOpts<'_>,
+        scratch: &mut Self::Scratch,
+    ) -> Option<FecResult> {
+        let (llr_arr, ap_mask) = prepare_ap_llr(llr, opts);
+        let ap_mask_slice: Option<&[bool]> = ap_mask.as_ref().map(|a| a.as_slice());
+
+        if let Some(r) = bp_decode_generic_kind_with_scratch::<Ldpc174_91Params>(
+            scratch,
+            &llr_arr,
+            ap_mask_slice,
+            opts.bp_max_iter,
+            opts.verify_info,
+            opts.bp_kind,
+        ) {
+            return Some(FecResult {
+                info: r.info,
+                hard_errors: r.hard_errors,
+                iterations: r.iterations,
+            });
+        }
+
+        // OSD fallback stays unpooled — out of scope for this pass
+        // (identical to `decode_soft`'s tail above).
+        if opts.osd_depth == 0 {
+            return None;
+        }
+
+        let r = if opts.osd_depth >= 4 {
+            osd_decode_deep4(&llr_arr, 30, opts.verify_info)?
+        } else {
+            osd_decode_deep(&llr_arr, opts.osd_depth.min(3) as u8, opts.verify_info)?
+        };
+        Some(FecResult {
+            info: r.info,
+            hard_errors: r.hard_errors,
+            iterations: 0,
+        })
+    }
+}
+
+/// Shared AP-hint LLR preparation for [`Ldpc174_91`]'s pooled and
+/// unpooled `decode_soft`: for every `mask[i] == 1`, clamps LLR to
+/// ±apmag according to `values[i]` (1 → +apmag, 0 → −apmag);
+/// `apmag = max(|llr|) · 1.01` gives the AP bits a stronger vote than
+/// any channel observation, matching WSJT-X convention. Returns an
+/// owned array (not a borrow tied to `opts`) so both callers can build
+/// their own `Option<&[bool; N]>`/`Option<&[bool]>` view over it.
+fn prepare_ap_llr(llr: &[f32], opts: &FecOpts<'_>) -> ([f32; LDPC_N], Option<[bool; LDPC_N]>) {
+    assert_eq!(llr.len(), LDPC_N, "llr must be {} values", LDPC_N);
+    let mut llr_arr = [0f32; LDPC_N];
+    llr_arr.copy_from_slice(llr);
+
+    let ap_mask = match opts.ap_mask {
+        Some((mask, values)) => {
+            assert_eq!(mask.len(), LDPC_N, "ap mask must be {} bits", LDPC_N);
+            assert_eq!(values.len(), LDPC_N, "ap values must be {} bits", LDPC_N);
+            let apmag = llr_arr.iter().map(|x| x.abs()).fold(0.0f32, f32::max) * 1.01;
+            let mut a = [false; LDPC_N];
+            for i in 0..LDPC_N {
+                if mask[i] != 0 {
+                    a[i] = true;
+                    llr_arr[i] = if values[i] != 0 { apmag } else { -apmag };
+                }
+            }
+            Some(a)
+        }
+        None => None,
+    };
+    (llr_arr, ap_mask)
 }

--- a/mfsk-core/src/fec/ldpc240_101/mod.rs
+++ b/mfsk-core/src/fec/ldpc240_101/mod.rs
@@ -13,9 +13,14 @@
 pub mod tables;
 
 use alloc::vec;
+use alloc::vec::Vec;
 
+use crate::engine::protocol::BpPooledFec;
 use crate::engine::{FecCodec, FecOpts, FecResult};
-use crate::fec::ldpc::bp::bp_decode_generic_kind;
+use crate::fec::ldpc::bp::{
+    BpScratch, bp_decode_generic_kind, bp_decode_generic_kind_with_scratch, bp_llr_zsum,
+    bp_llr_zsum_with_scratch,
+};
 use crate::fec::ldpc::osd::{ldpc_encode_generic, osd_decode_generic};
 use crate::fec::ldpc::params::Ldpc240_101Params;
 
@@ -105,32 +110,8 @@ impl FecCodec for Ldpc240_101 {
     }
 
     fn decode_soft(&self, llr: &[f32], opts: &FecOpts<'_>) -> Option<FecResult> {
-        assert_eq!(llr.len(), LDPC_N, "llr must be {} values", LDPC_N);
-        let mut llr_arr = vec![0f32; LDPC_N];
-        llr_arr.copy_from_slice(llr);
-
-        // AP hint injection (same convention as Ldpc174_91): clamp the
-        // masked bits to ±apmag where apmag dominates any channel
-        // observation, then build a parallel bool mask the BP loop
-        // consults to skip variable-node updates on those bits.
-        let ap_storage_holder;
-        let ap_slice: Option<&[bool]> = match opts.ap_mask {
-            Some((mask, values)) => {
-                assert_eq!(mask.len(), LDPC_N, "ap mask must be {} bits", LDPC_N);
-                assert_eq!(values.len(), LDPC_N, "ap values must be {} bits", LDPC_N);
-                let apmag = llr_arr.iter().map(|x| x.abs()).fold(0.0f32, f32::max) * 1.01;
-                let mut a = vec![false; LDPC_N];
-                for i in 0..LDPC_N {
-                    if mask[i] != 0 {
-                        a[i] = true;
-                        llr_arr[i] = if values[i] != 0 { apmag } else { -apmag };
-                    }
-                }
-                ap_storage_holder = a;
-                Some(ap_storage_holder.as_slice())
-            }
-            None => None,
-        };
+        let (llr_arr, ap_storage) = prepare_ap_llr(llr, opts);
+        let ap_slice: Option<&[bool]> = ap_storage.as_deref();
 
         if let Some(r) = bp_decode_generic_kind::<Ldpc240_101Params>(
             &llr_arr,
@@ -182,7 +163,7 @@ impl FecCodec for Ldpc240_101 {
         // BP loop does, so running it under an AP mask would drift
         // those bits away from their hinted value.
         if ap_slice.is_none() {
-            let zsum = crate::fec::ldpc::bp::bp_llr_zsum::<Ldpc240_101Params>(&llr_arr, 2);
+            let zsum = bp_llr_zsum::<Ldpc240_101Params>(&llr_arr, 2);
             if let Some(r) = osd_decode_generic::<Ldpc240_101Params>(
                 &zsum,
                 opts.osd_depth.min(3) as u8,
@@ -199,6 +180,104 @@ impl FecCodec for Ldpc240_101 {
 
         None
     }
+}
+
+impl BpPooledFec for Ldpc240_101 {
+    type Scratch = BpScratch<Ldpc240_101Params, f32>;
+
+    fn decode_soft_pooled(
+        &self,
+        llr: &[f32],
+        opts: &FecOpts<'_>,
+        scratch: &mut Self::Scratch,
+    ) -> Option<FecResult> {
+        let (llr_arr, ap_storage) = prepare_ap_llr(llr, opts);
+        let ap_slice: Option<&[bool]> = ap_storage.as_deref();
+
+        if let Some(r) = bp_decode_generic_kind_with_scratch::<Ldpc240_101Params>(
+            scratch,
+            &llr_arr,
+            ap_slice,
+            opts.bp_max_iter,
+            opts.verify_info,
+            opts.bp_kind,
+        ) {
+            return Some(FecResult {
+                info: r.info,
+                hard_errors: r.hard_errors,
+                iterations: r.iterations,
+            });
+        }
+
+        // OSD fallback (raw-LLR attempt) stays unpooled — out of scope
+        // for this pass, identical to `decode_soft`'s tail above.
+        if opts.osd_depth == 0 {
+            return None;
+        }
+
+        if let Some(r) = osd_decode_generic::<Ldpc240_101Params>(
+            &llr_arr,
+            opts.osd_depth.min(3) as u8,
+            LDPC_K,
+            opts.verify_info,
+        ) {
+            return Some(FecResult {
+                info: r.info,
+                hard_errors: r.hard_errors,
+                iterations: 0,
+            });
+        }
+
+        // zsum-seeded OSD retry (issue #146 — see `decode_soft`'s doc
+        // comment for the full rationale) — pooled: `bp_llr_zsum_with_scratch`
+        // reuses the same `scratch` the BP staircase above already used,
+        // and returns a borrow instead of a fresh `Vec`.
+        if ap_slice.is_none() {
+            let zsum = bp_llr_zsum_with_scratch::<Ldpc240_101Params>(scratch, &llr_arr, 2);
+            if let Some(r) = osd_decode_generic::<Ldpc240_101Params>(
+                zsum,
+                opts.osd_depth.min(3) as u8,
+                LDPC_K,
+                opts.verify_info,
+            ) {
+                return Some(FecResult {
+                    info: r.info,
+                    hard_errors: r.hard_errors,
+                    iterations: 0,
+                });
+            }
+        }
+
+        None
+    }
+}
+
+/// Shared AP-hint LLR preparation for [`Ldpc240_101`]'s pooled and
+/// unpooled `decode_soft` — same convention as
+/// `crate::fec::ldpc::prepare_ap_llr` for [`crate::fec::ldpc::Ldpc174_91`],
+/// just `Vec`-backed (`LDPC_N` = 240 here) instead of array-backed.
+fn prepare_ap_llr(llr: &[f32], opts: &FecOpts<'_>) -> (Vec<f32>, Option<Vec<bool>>) {
+    assert_eq!(llr.len(), LDPC_N, "llr must be {} values", LDPC_N);
+    let mut llr_arr = vec![0f32; LDPC_N];
+    llr_arr.copy_from_slice(llr);
+
+    let ap_mask = match opts.ap_mask {
+        Some((mask, values)) => {
+            assert_eq!(mask.len(), LDPC_N, "ap mask must be {} bits", LDPC_N);
+            assert_eq!(values.len(), LDPC_N, "ap values must be {} bits", LDPC_N);
+            let apmag = llr_arr.iter().map(|x| x.abs()).fold(0.0f32, f32::max) * 1.01;
+            let mut a = vec![false; LDPC_N];
+            for i in 0..LDPC_N {
+                if mask[i] != 0 {
+                    a[i] = true;
+                    llr_arr[i] = if values[i] != 0 { apmag } else { -apmag };
+                }
+            }
+            Some(a)
+        }
+        None => None,
+    };
+    (llr_arr, ap_mask)
 }
 
 #[cfg(test)]

--- a/mfsk-core/src/ft8/decode_block/osd_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/osd_strategy.rs
@@ -46,7 +46,7 @@
 use super::super::decode::{DecodeDepth, DecodeStrictness};
 use crate::engine::scalar::Cmplx;
 use crate::fec::ldpc::LDPC_N;
-use crate::fec::ldpc::bp::{BpResult, bp_llr_zsum};
+use crate::fec::ldpc::bp::{BpResult, BpScratch, bp_llr_zsum_with_scratch};
 use crate::fec::ldpc::osd::{OsdResult, osd_decode_npre1, osd_decode_npre1_npre2};
 use crate::fec::ldpc::params::Ldpc174_91Params;
 
@@ -226,6 +226,20 @@ pub(super) fn try_fallback(
     // Pass-ID space (post-0.6.1): BP variants 0..3, AP iaptypes 5..12
     // (mirroring WSJT-X ipass 5..12), host OSD-Deep 13, embedded OSD
     // zsave(1) a/b/c/d 14..17, auto-AP 18, zsave(2) a/b/c/d 19..22.
+    //
+    // `zsum_scratch` is local to this call (not caller-threaded like
+    // `process_one_candidate_inner`'s `bp_scratch`): `try_fallback`
+    // runs once per candidate, and the loop below already calls
+    // `bp_llr_zsum_with_scratch` 8× (4 llr variants × 2 `n_iter`) per
+    // call, so one scratch here already captures the whole win —
+    // threading it in from the caller would only additionally pool
+    // across candidates, which a real-WAV before/after measurement
+    // (perf review, `MFSK_BP_KIND=nms` vs default on
+    // `bench_qso3_busy_timing.rs`) found made no measurable wall-clock
+    // difference for FT8's BP stage, so the extra plumbing through
+    // `process_one_candidate_inner` and its five callers isn't
+    // justified by anything measured.
+    let mut zsum_scratch = BpScratch::<Ldpc174_91Params, f32>::new();
     for (idx, llr) in [
         &llr_full_f32.llra,
         &llr_full_f32.llrb,
@@ -236,9 +250,10 @@ pub(super) fn try_fallback(
     .enumerate()
     {
         for (n_iter, base) in [(1u32, PASS_ID_OSD_ZSAVE1_A), (2u32, PASS_ID_OSD_ZSAVE2_A)] {
-            let zsum_vec = bp_llr_zsum::<Ldpc174_91Params>(llr, n_iter);
+            let zsum_slice =
+                bp_llr_zsum_with_scratch::<Ldpc174_91Params>(&mut zsum_scratch, llr, n_iter);
             let mut zsum = [0f32; LDPC_N];
-            zsum.copy_from_slice(&zsum_vec);
+            zsum.copy_from_slice(zsum_slice);
             if let Some(osd) = dispatch(&zsum) {
                 return Some((to_bp(osd), base + idx as u8));
             }

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1776,10 +1776,8 @@ pub(in crate::ft8) fn process_one_candidate_inner(
                 // three separate bounds-checked `[i]` indexes; run up
                 // to ~28x per Step-4 candidate (4 LLR variants × up to
                 // ~7 AP passes).
-                for ((dst, &locked), &val) in llr_ap
-                    .iter_mut()
-                    .zip(ap_mask.iter())
-                    .zip(ap_values.iter())
+                for ((dst, &locked), &val) in
+                    llr_ap.iter_mut().zip(ap_mask.iter()).zip(ap_values.iter())
                 {
                     if locked {
                         *dst = if val == 1 { apmag } else { -apmag };

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -667,8 +667,15 @@ pub(super) fn fine_refine_pass1<S: AudioSample>(
     cands
         .into_iter()
         .map(|c| {
-            let (cd0, _) =
-                crate::ft8::downsample::downsample(&audio_i16, c.freq_hz, Some(&fft_cache));
+            // Use `downsample_cached` directly so the FT8 wrapper's
+            // `cache.to_vec()` clone (~1.5 MB) on the `Some(_)` branch is
+            // bypassed — same pattern as `decode.rs::process_candidate_with_scratch`
+            // (that fix's scope never covered this sibling call site).
+            let cd0 = crate::engine::dsp::downsample::downsample_cached(
+                &fft_cache,
+                c.freq_hz,
+                &crate::ft8::downsample::FT8_CFG,
+            );
             let r = crate::ft8::refine_fine::fine_refine_3stage(&cd0, c.dt_sec);
             crate::engine::sync::SyncCandidate {
                 freq_hz: c.freq_hz + r.delf_hz,

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1771,9 +1771,18 @@ pub(in crate::ft8) fn process_one_candidate_inner(
 
             for &base_llr in &llr_variants {
                 let mut llr_ap = *base_llr;
-                for i in 0..LDPC_N {
-                    if ap_mask[i] {
-                        llr_ap[i] = if ap_values[i] == 1 { apmag } else { -apmag };
+                // Iterator form (issue #208-style — same shape as
+                // `fill_bmet_for_nsym`'s max-reduction fix) instead of
+                // three separate bounds-checked `[i]` indexes; run up
+                // to ~28x per Step-4 candidate (4 LLR variants × up to
+                // ~7 AP passes).
+                for ((dst, &locked), &val) in llr_ap
+                    .iter_mut()
+                    .zip(ap_mask.iter())
+                    .zip(ap_values.iter())
+                {
+                    if locked {
+                        *dst = if val == 1 { apmag } else { -apmag };
                     }
                 }
                 // Inline AP-result validator: hard-error gate, unpack,

--- a/mfsk-core/src/ft8/llr.rs
+++ b/mfsk-core/src/ft8/llr.rs
@@ -31,13 +31,15 @@ pub struct LlrSet<T: LlrScalar = f32> {
     pub llrd: [T; LDPC_N],
 }
 
+/// Zero-cost layout cast: `cs` is already contiguous with the flat
+/// `[Cmplx<f32>; 632]` layout `compute_llr_generic`/etc. consume — no
+/// allocation or copy needed, just a reinterpreted view. Replaces a
+/// former `flatten_cs` that allocated+copied a fresh `Vec` on every
+/// call (this function runs 3-5+ times per candidate, up to ~1200
+/// candidates/decode via `sync_quality` alone).
 #[inline]
-fn flatten_cs(cs: &[[Cmplx<f32>; 8]; 79]) -> Vec<Cmplx<f32>> {
-    let mut out: Vec<Cmplx<f32>> = Vec::with_capacity(79 * 8);
-    for sym in cs.iter() {
-        out.extend_from_slice(sym);
-    }
-    out
+fn flatten_cs(cs: &[[Cmplx<f32>; 8]; 79]) -> &[Cmplx<f32>] {
+    cs.as_slice().as_flattened()
 }
 
 #[inline]
@@ -55,7 +57,7 @@ fn inflate_llr<T: LlrScalar>(v: Vec<T>) -> [T; LDPC_N] {
 /// `&[Cmplx<f32>]` view via `flatten_cs`.
 pub fn compute_llr<T: LlrScalar>(cs: &[[Cmplx<f32>; 8]; 79]) -> LlrSet<T> {
     let flat = flatten_cs(cs);
-    let g = crate::engine::llr::compute_llr_generic::<Ft8, f32, T>(&flat, 3);
+    let g = crate::engine::llr::compute_llr_generic::<Ft8, f32, T>(flat, 3);
     // Sanity check scale consistency at build time.
     debug_assert!((crate::engine::llr::LLR_SCALE - LLR_SCALE).abs() < 1e-6);
     LlrSet {
@@ -71,7 +73,7 @@ pub fn compute_llr<T: LlrScalar>(cs: &[[Cmplx<f32>; 8]; 79]) -> LlrSet<T> {
 /// `llra` and `llrd` are valid.
 pub fn compute_llr_fast<T: LlrScalar>(cs: &[[Cmplx<f32>; 8]; 79]) -> LlrSet<T> {
     let flat = flatten_cs(cs);
-    let g = crate::engine::llr::compute_llr_generic::<Ft8, f32, T>(&flat, 1);
+    let g = crate::engine::llr::compute_llr_generic::<Ft8, f32, T>(flat, 1);
     LlrSet {
         llra: inflate_llr(g.llra),
         llrb: inflate_llr(g.llrb),
@@ -89,20 +91,20 @@ pub fn compute_llr_fast<T: LlrScalar>(cs: &[[Cmplx<f32>; 8]; 79]) -> LlrSet<T> {
 /// `nsym = 2` and `nsym = 3`.
 pub fn compute_llr_partial<T: LlrScalar>(cs: &[[Cmplx<f32>; 8]; 79], nsym: usize) -> [T; LDPC_N] {
     let flat = flatten_cs(cs);
-    let v = crate::engine::llr::compute_llr_partial::<Ft8, f32, T>(&flat, nsym);
+    let v = crate::engine::llr::compute_llr_partial::<Ft8, f32, T>(flat, nsym);
     inflate_llr(v)
 }
 
 /// WSJT-X compatible SNR from 8-tone spectra + decoded 79-tone sequence.
 pub fn compute_snr_db(cs: &[[Cmplx<f32>; 8]; 79], itone: &[u8; 79]) -> f32 {
     let flat = flatten_cs(cs);
-    crate::engine::llr::compute_snr_db_generic::<Ft8, f32>(&flat, itone)
+    crate::engine::llr::compute_snr_db_generic::<Ft8, f32>(flat, itone)
 }
 
 /// Hard-decision sync quality (0..21). FT8 threshold ≤ 6 → bail out.
 pub fn sync_quality(cs: &[[Cmplx<f32>; 8]; 79]) -> u32 {
     let flat = flatten_cs(cs);
-    crate::engine::llr::sync_quality_generic::<Ft8, f32>(&flat)
+    crate::engine::llr::sync_quality_generic::<Ft8, f32>(flat)
 }
 
 #[cfg(test)]

--- a/mfsk-core/tests/bench_qso3_busy_timing.rs
+++ b/mfsk-core/tests/bench_qso3_busy_timing.rs
@@ -3,9 +3,12 @@
 //! throughput across machines (e.g. Ryzen 9 vs Apple M5) — not a
 //! correctness regression, no assertions.
 //!
-//! Run:
+//! Run (needs `full` — `timing_fst4_300`/`timing_fst4_300_sanity_strong_signal`
+//! import `mfsk_core::fst4::Fst4s300`, which the default feature set
+//! doesn't enable; `--test bench_qso3_busy_timing` alone as documented
+//! here previously fails to compile with `E0432`):
 //! ```sh
-//! cargo test --release -p mfsk-core --test bench_qso3_busy_timing -- --nocapture
+//! cargo test --release -p mfsk-core --features full --test bench_qso3_busy_timing -- --nocapture
 //! ```
 
 use std::path::Path;

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -380,7 +380,9 @@ fn fst4_diag_weak_trials() {
         dir: &std::path::Path,
         file_prefix: &str,
         cfg: &mfsk_core::engine::dsp::downsample::DownsampleCfg,
-    ) {
+    ) where
+        P::Fec: mfsk_core::engine::protocol::BpPooledFec,
+    {
         for trial in 1..=5 {
             let path = dir.join(format!("{file_prefix}_{trial:02}.wav"));
             let Some(audio) = load_wav_i16_opt(&path) else {
@@ -484,7 +486,7 @@ fn fst4_diag_nsym4_ladder() {
         tally: &mut Tally,
     ) where
         P: mfsk_core::engine::pipeline::GenericPipelineProtocol,
-        P::Fec: FecCodec,
+        P::Fec: FecCodec + mfsk_core::engine::protocol::BpPooledFec,
         P::Msg: MessageCodec,
     {
         for trial in trials {
@@ -946,6 +948,118 @@ fn fst4_60_diag_candidate_cost_split() {
     let dt = t0.elapsed();
     eprintln!(
         "FST4-60A golden: decode_frame wall-clock = {:.1} ms, {} decode(s)",
+        dt.as_secs_f64() * 1000.0,
+        decodes.len()
+    );
+}
+
+/// Same cost-split methodology as [`fst4_60_diag_candidate_cost_split`],
+/// applied to FST4-300 (5-min slot, longest sub-mode) — issue
+/// mfsk-core#perf-review Phase 0: `fst4_60_diag_candidate_cost_split`'s
+/// original investigation (FST4_BENCHMARK.md §8) only ever profiled
+/// FST4-60A; no per-stage breakdown exists for the long sub-modes,
+/// which have no comparable prior perf-tuning pass either. Uses the
+/// first slot of the WSJT-X sample `201230_0300.wav`, same asset
+/// `bench_qso3_busy_timing.rs::timing_fst4_300` already depends on
+/// (sibling `../../WSJT-X` checkout — skips cleanly if absent).
+#[test]
+#[ignore = "manual diagnostic — FST4-300 coarse-sync cost split (perf-review Phase 0)"]
+fn fst4_300_diag_candidate_cost_split() {
+    use std::time::{Duration, Instant};
+
+    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::engine::equalize::EqMode;
+    use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
+    use mfsk_core::engine::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::engine::sync2d::fst4_sync_search;
+    use mfsk_core::fst4::Fst4s300;
+    use mfsk_core::fst4::decode::FST4_300_DOWNSAMPLE;
+
+    const SYNC_Q_MIN: u32 = 10;
+
+    fn freq_bucket_count(cands: &[SyncCandidate]) -> usize {
+        let mut buckets: Vec<i32> = cands
+            .iter()
+            .map(|c| (c.freq_hz / 4.0).round() as i32)
+            .collect();
+        buckets.sort_unstable();
+        buckets.dedup();
+        buckets.len()
+    }
+
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let golden_path = Path::new(&manifest).join("../../WSJT-X/samples/FST4+FST4W/201230_0300.wav");
+    let Ok(golden_path) = golden_path.canonicalize() else {
+        eprintln!("skipping: WSJT-X FST4 sample not found (sibling checkout)");
+        return;
+    };
+    let Some(full) = load_wav_i16_opt(&golden_path) else {
+        eprintln!("skipping: WAV not 12 kHz mono PCM-16");
+        return;
+    };
+    let audio: Vec<i16> = full.iter().take(300 * 12_000).copied().collect();
+
+    let t0 = Instant::now();
+    let cands = coarse_sync::<Fst4s300>(&audio, 100.0, 3000.0, 1.0, None, 50);
+    let coarse_dt = t0.elapsed();
+
+    eprintln!(
+        "FST4-300 golden (slot 0): {} candidates, {} distinct freq buckets (avg {:.1} cand/freq), coarse_sync={:.1}ms",
+        cands.len(),
+        freq_bucket_count(&cands),
+        cands.len() as f32 / freq_bucket_count(&cands).max(1) as f32,
+        coarse_dt.as_secs_f64() * 1000.0
+    );
+
+    let fft_cache = build_fft_cache(&audio, &FST4_300_DOWNSAMPLE);
+    let mut total_downsample = Duration::ZERO;
+    let mut total_sync_search = Duration::ZERO;
+    let mut total_process = Duration::ZERO;
+    let mut n_decoded = 0usize;
+    for c in &cands {
+        let t0 = Instant::now();
+        let cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_300_DOWNSAMPLE);
+        total_downsample += t0.elapsed();
+
+        let t0 = Instant::now();
+        let _ = fst4_sync_search::<Fst4s300>(&cd0, c);
+        total_sync_search += t0.elapsed();
+
+        let t0 = Instant::now();
+        let r = process_candidate_basic::<Fst4s300>(
+            c,
+            &fft_cache,
+            &FST4_300_DOWNSAMPLE,
+            DecodeDepth::FULL,
+            DecodeStrictness::Normal,
+            &[],
+            EqMode::Off,
+            SYNC_Q_MIN,
+        );
+        total_process += t0.elapsed();
+        if r.is_some() {
+            n_decoded += 1;
+        }
+    }
+    let llr_bp_osd = total_process
+        .saturating_sub(total_downsample)
+        .saturating_sub(total_sync_search);
+    eprintln!(
+        "  per-cand[downsample={:.1}ms sync_search={:.1}ms llr+bp+osd(inferred)={:.1}ms] decoded={n_decoded}",
+        total_downsample.as_secs_f64() * 1000.0,
+        total_sync_search.as_secs_f64() * 1000.0,
+        llr_bp_osd.as_secs_f64() * 1000.0
+    );
+
+    let t0 = Instant::now();
+    let decodes = mfsk_core::msg::decode_request::DecodeRequest::<mfsk_core::fst4::Fst4s300>::new(
+        &audio, 100.0, 3000.0, 1.0, 50,
+    )
+    .decode()
+    .results;
+    let dt = t0.elapsed();
+    eprintln!(
+        "FST4-300 golden: decode_frame wall-clock = {:.1} ms, {} decode(s)",
         dt.as_secs_f64() * 1000.0,
         decodes.len()
     );


### PR DESCRIPTION
## Summary

FT8/FST4 decode hot-path review requested by the user: allocation-timing fixes, caching, and iterator-friendly loops. Five independently-verified commits:

- `eb859cf` — pool BP scratch across the `SumProduct` kernel (the actual host default) + FST4/FT8's `bp_llr_zsum` OSD retry
- `c5d8031` — eliminate two provably-wasteful per-candidate allocations (dead `downsample` clone, `flatten_cs`'s allocating copy → zero-cost `as_flattened()`)
- `1b078ca` — cache `make_costas_ref`'s output across `fine_sync_power_per_block` calls (also fixes `refine_candidate`'s AP/sniper-path loop for free)
- `66888b3` — reuse `downsample_cached`'s thread_local FFT planner in `symbol_spectra`
- `2177768` — iterator-chain the Step-4 AP-mask LLR overwrite loop (issue #208 sibling)

## Correctness

Every commit is verified byte-identical against the full FT4/FST4/FT8 recall suite (`qso3_apoff/apon/full_parity/jtdx`, `ft4_wsjtx_samples`, `ft4_sic_rounds_recall`, `fst4_wsjtx_samples`), with and without `--features fixed-point`, and with and without `MFSK_BP_KIND=nms`. `cargo check`/`clippy --all-targets` clean under both `--features full` and `--features full,internal-testing`.

## Performance — corrected

An earlier report in this session claimed a ~51-55% aggregate wall-clock win, computed by comparing a Phase-0 baseline (measured before any of these commits existed) against a final-verification run taken hours later in the same long working session. **That number does not hold up.** A follow-up controlled same-session A/B (`git worktree`, pre-branch commit vs branch tip, measured back-to-back within minutes) found the real delta is within run-to-run noise (~1%) on `qso3_busy.wav` (EMBEDDED and FULL-parity configs), FST4-60A, and FST4-300. The original comparison was confounded by a machine power-state change (AC vs battery on the Apple M5 host) between the two measurement points, not by these code changes — see `2177768`'s commit message for the full writeup, and `1b078ca`/`66888b3` for the two commits whose messages originally (incorrectly) implied a measured win.

Each commit is still landed on its own merits as correctness-preserving waste/redundancy elimination — dead clones, rebuilt trig tables, rebuilt FFT plans, rebuilt BP scratch buffers — not as a measured performance improvement on this workload/machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
