### PR TITLE
perf(q65,ft4): extend the FT8/FST4 efficiency campaign — no measured wall-clock win, landed for correctness

### DIFF
--- a/mfsk-core/src/engine/ft4_coarse.rs
+++ b/mfsk-core/src/engine/ft4_coarse.rs
@@ -67,7 +67,7 @@ use num_complex::Complex;
 use num_traits::Float;
 
 use super::baseline::fit_baseline;
-use super::fft::default_planner;
+use super::dsp::downsample::with_default_planner;
 use super::sync::{SyncCandidate, nuttall_window, parabolic_peak};
 
 /// `NSPS` (samples/symbol at 12 kHz) — `ft4_params.f90:9`.
@@ -98,8 +98,7 @@ const FREQ_HARD_MAX_HZ: f32 = 4910.0;
 fn symbol_spectra_avg(audio: &[i16]) -> Vec<f32> {
     let window = nuttall_window(NFFT1);
     let fac = 1.0f32 / 300.0;
-    let mut planner = default_planner();
-    let fft = planner.plan_forward(NFFT1);
+    let fft = with_default_planner(|planner| planner.plan_forward(NFFT1));
 
     let nhsym = if audio.len() > NFFT1 {
         (audio.len() - NFFT1) / NSTEP

--- a/mfsk-core/src/engine/sync2d.rs
+++ b/mfsk-core/src/engine/sync2d.rs
@@ -84,6 +84,49 @@ fn make_costas_ref_continuous(pattern: &[u8], ds_spb: usize) -> Vec<Complex<f32>
     out
 }
 
+// `ft4_sync_search_window` calls `make_costas_ref_continuous` once per
+// call (not per grid cell — that per-cell cost was already eliminated,
+// see the module comments inside that function) to build `blocks_ref`,
+// but the function itself is called once per *candidate* (~31/decode
+// on the real FT4 golden WAV), and `(pattern, ds_spb)` never varies
+// within one decode call — every candidate for a given protocol `P`
+// rebuilds an identical reference from scratch. Mirrors
+// `engine::sync::cached_costas_ref`'s exact rationale and shape
+// (2-slot thread_local, content-keyed, std-gated with an uncached
+// no_std fallback) for this module's own phase-continuous variant.
+#[cfg(feature = "std")]
+type CostasRefContinuousCacheEntry = (&'static [u8], usize, Vec<Complex<f32>>);
+
+#[cfg(feature = "std")]
+std::thread_local! {
+    static COSTAS_REF_CONTINUOUS_CACHE: core::cell::RefCell<Vec<CostasRefContinuousCacheEntry>> =
+        const { core::cell::RefCell::new(Vec::new()) };
+}
+
+#[cfg(feature = "std")]
+fn cached_costas_ref_continuous(pattern: &'static [u8], ds_spb: usize) -> Vec<Complex<f32>> {
+    COSTAS_REF_CONTINUOUS_CACHE.with_borrow_mut(|cache| {
+        if let Some((_, _, flat)) = cache.iter().find(|(p, d, _)| *p == pattern && *d == ds_spb) {
+            return flat.clone();
+        }
+        let flat = make_costas_ref_continuous(pattern, ds_spb);
+        if cache.len() >= 2 {
+            cache.remove(0);
+        }
+        cache.push((pattern, ds_spb, flat.clone()));
+        flat
+    })
+}
+
+/// `no_std` (embedded) fallback — `thread_local!` needs `std`. FT4's
+/// generic pipeline doesn't reach embedded builds today (same
+/// reasoning as `cached_costas_ref`'s own no_std fallback), so a plain
+/// uncached rebuild is fine here.
+#[cfg(not(feature = "std"))]
+fn cached_costas_ref_continuous(pattern: &[u8], ds_spb: usize) -> Vec<Complex<f32>> {
+    make_costas_ref_continuous(pattern, ds_spb)
+}
+
 /// Apply a carrier twiddle to a flat continuous reference.
 /// Returns a new Vec; if `df_hz ≈ 0` returns the input unchanged.
 fn twiddle_flat_ref(flat_ref: &[Complex<f32>], df_hz: f32, ds_rate: f32) -> Vec<Complex<f32>> {
@@ -307,7 +350,7 @@ pub fn ft4_sync_search_window<P: Protocol>(
         .iter()
         .map(|b| {
             let off = b.start_symbol as i32 * ds_spb as i32;
-            (off, make_costas_ref_continuous(b.pattern, ds_spb))
+            (off, cached_costas_ref_continuous(b.pattern, ds_spb))
         })
         .collect();
 

--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -103,9 +103,9 @@ fn extract_data_energies<P: ModulationParams>(
         // The 6-bit symbol value `s` is on bin
         // `base_bin + (s + 1) * bins_per_tone`.
         let row = &mut energies[64 * k..64 * (k + 1)];
-        for tone in 0..64 {
+        for (tone, slot) in row.iter_mut().enumerate() {
             let bin = base_bin + (tone + 1) * bins_per_tone;
-            row[tone] = buf[bin].norm_sqr();
+            *slot = buf[bin].norm_sqr();
         }
         k += 1;
     }
@@ -298,12 +298,11 @@ fn snr_db_wide<P: ModulationParams>(energies: &[f32], sample_rate: u32, codeword
         let row = &energies[bins_per_symbol * k..bins_per_symbol * (k + 1)];
         let mut sig = 0.0f32;
         let mut total = 0.0f32;
-        for tone in 0..64usize {
-            let idx = 64 + tone * bins_per_tone;
-            if idx >= row.len() {
-                continue;
-            }
-            let v = row[idx];
+        // `bins_per_tone >= 1` (clamped above), so `step_by` is safe;
+        // the slice naturally runs out at `row.len()`, matching the
+        // original manually-indexed loop's `idx >= row.len()` skip.
+        let tail = row.get(64..).unwrap_or(&[]);
+        for (tone, &v) in tail.iter().step_by(bins_per_tone).take(64).enumerate() {
             total += v;
             if tone == t {
                 sig = v;
@@ -972,9 +971,16 @@ fn averaged_data_energies_wide<P: ModulationParams>(
 }
 
 /// Run the AP-list decoder against averaged narrow energies.
+///
+/// `energies` is the caller's already-extracted
+/// [`averaged_data_energies`] output — see [`decode_multi_period_for`]'s
+/// candidate loop, which extracts it once per candidate and passes the
+/// same slice into this function and [`decode_averaged_plain_for`]
+/// (Stage B and Stage C-plain used to each call `averaged_data_energies`
+/// independently with identical arguments, extracting the same FFT
+/// energies twice per candidate that reaches Stage C-plain).
 fn decode_averaged_ap_list_for<P: ModulationParams>(
-    audio_slots: &[&[f32]],
-    sample_rate: u32,
+    energies: &[f32],
     start_sample: usize,
     base_freq_hz: f32,
     candidates: &[[i32; 63]],
@@ -985,11 +991,9 @@ fn decode_averaged_ap_list_for<P: ModulationParams>(
     if candidates.is_empty() {
         return None;
     }
-    let energies =
-        averaged_data_energies::<P>(audio_slots, sample_rate, start_sample, base_freq_hz)?;
 
     let mut intrinsics = vec![0.0_f32; 64 * 63];
-    QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, &energies, 63, default_es_no_metric());
+    QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, energies, 63, default_es_no_metric());
 
     let codec = Q65Codec::new(&QRA15_65_64_IRR_E23);
     let (idx, info_syms) = codec.decode_with_codeword_list(&intrinsics, candidates)?;
@@ -997,7 +1001,7 @@ fn decode_averaged_ap_list_for<P: ModulationParams>(
     let bits77 = unpack_symbols_to_bits77(&info_syms);
     let text = Q65Message.unpack(&bits77, &DecodeContext::default())?;
 
-    let snr_db = snr_db_narrow::<P>(&energies, &candidates[idx]);
+    let snr_db = snr_db_narrow::<P>(energies, &candidates[idx]);
 
     Some(Q65Result {
         message: text,
@@ -1020,6 +1024,23 @@ fn decode_averaged_ap_list_for<P: ModulationParams>(
 /// `(audio_slots, start_sample, base_freq_hz)`, never on `b90_ts`/
 /// `model`, so those 6 calls were doing bit-identical extraction work
 /// 6 times over.
+///
+/// `codec`/`intrinsics` are allocated fresh per call — **deliberately
+/// not** hoisted/reused across the `b90 × model` sweep the way
+/// [`decode_at_grid_for`]'s own `(Δf,Δt,ibw)` sweep hoists its codec.
+/// That hoist was tried (perf-review follow-up to the FT8/FST4 pass)
+/// and measured a real, reproducible ~8% regression on the Q65-30A
+/// golden test (`q65_multi_period_speed_diag`) despite `Q65Codec::
+/// decode`/`intrinsics_fast_fading` both fully overwriting their
+/// output buffers every call — reusing the same codec across 6 calls
+/// with similar-but-different intrinsics apparently perturbs
+/// `Q65Codec`'s internal BP scratch/extrinsic-message state enough to
+/// change the *convergence path* (not the final answer — recall tests
+/// stayed byte-identical) in a way that costs more than the ~32KB
+/// allocation it was meant to save. Not investigated further: BP
+/// iteration cost dominating over allocation cost is the same
+/// conclusion yesterday's FT8/FST4 pass reached for its own BP-scratch
+/// item, just here the reuse made things *worse* instead of neutral.
 fn decode_fading_with_energies<P: ModulationParams>(
     energies: &[f32],
     sample_rate: u32,
@@ -1063,20 +1084,19 @@ fn decode_fading_with_energies<P: ModulationParams>(
 }
 
 /// Run plain Bessel-metric BP against averaged narrow energies.
+///
+/// `energies` — see [`decode_averaged_ap_list_for`]'s doc comment;
+/// same already-extracted-by-the-caller convention.
 fn decode_averaged_plain_for<P: ModulationParams>(
-    audio_slots: &[&[f32]],
-    sample_rate: u32,
-    start_sample: usize,
+    energies: &[f32],
     base_freq_hz: f32,
+    start_sample: usize,
 ) -> Option<Q65Result> {
     use crate::engine::{DecodeContext, MessageCodec};
     use crate::msg::Q65Message;
 
-    let energies =
-        averaged_data_energies::<P>(audio_slots, sample_rate, start_sample, base_freq_hz)?;
-
     let mut intrinsics = vec![0.0_f32; 64 * 63];
-    QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, &energies, 63, default_es_no_metric());
+    QRA15_65_64_IRR_E23.mfsk_bessel_metric(&mut intrinsics, energies, 63, default_es_no_metric());
 
     let mut codec = Q65Codec::new(&QRA15_65_64_IRR_E23);
     let mut info_syms = [0_i32; 13];
@@ -1087,7 +1107,7 @@ fn decode_averaged_plain_for<P: ModulationParams>(
 
     let mut codeword = [0_i32; 63];
     codec.encode(&info_syms, &mut codeword);
-    let snr_db = snr_db_narrow::<P>(&energies, &codeword);
+    let snr_db = snr_db_narrow::<P>(energies, &codeword);
 
     Some(Q65Result {
         message: text,
@@ -1180,11 +1200,43 @@ pub(crate) fn decode_multi_period_for<P: ModulationParams>(
         let mut slot_decode: Option<Q65Result> = None;
 
         'candidate_loop: for cand in candidates {
+            // Narrow energies feed both Stage B and Stage C-plain below
+            // — extraction depends only on `(history, cand.start_sample,
+            // cand.freq_hz)`, never on `ap_codewords`/the BP metric used,
+            // so it's shared instead of each stage extracting
+            // independently (was 2 redundant extractions per candidate
+            // that reached Stage C-plain, mirroring the wide/fading-path
+            // fix directly below). Lazy (`Option<Option<Vec<f32>>>` via
+            // `get_or_insert_with`), not eager: Stage B is skipped
+            // entirely when `ap_codewords` is `None`, and Stage C-plain
+            // is never reached when Stage B or Stage C-fading already
+            // succeeded — an eager extraction here would pay for work
+            // neither stage ends up needing in either of those common
+            // cases (caught by a same-session A/B measurement showing a
+            // small but consistent regression vs. computing it eagerly).
+            // Outer `Option` tracks "extracted yet?", inner tracks
+            // "did extraction succeed?" — plain lazy-init, no closure
+            // (a closure returning a borrow of its own captured state,
+            // called from two different points in this loop body, runs
+            // into exactly the streaming-iterator borrow-checker
+            // friction Rust is known for; inlining the two call sites
+            // is simpler than working around it).
+            let mut energies_narrow: Option<Option<Vec<f32>>> = None;
+
             // Stage B — AP-list decode on averaged narrow energies.
             if let Some(codewords) = ap_codewords
+                && let Some(energies) = energies_narrow
+                    .get_or_insert_with(|| {
+                        averaged_data_energies::<P>(
+                            history,
+                            sample_rate,
+                            cand.start_sample,
+                            cand.freq_hz,
+                        )
+                    })
+                    .as_deref()
                 && let Some(d) = decode_averaged_ap_list_for::<P>(
-                    history,
-                    sample_rate,
+                    energies,
                     cand.start_sample,
                     cand.freq_hz,
                     codewords,
@@ -1199,6 +1251,10 @@ pub(crate) fn decode_multi_period_for<P: ModulationParams>(
             // `(history, cand.start_sample, cand.freq_hz)`, not on
             // `b90`/`model` — computed once here and reused across all
             // 6 sweep combinations (was 6 redundant extractions).
+            // `codec`/`intrinsics` are allocated fresh inside
+            // `decode_fading_with_energies` on every one of the 6 sweep
+            // calls below — see that function's doc comment for why
+            // this is deliberate, not an oversight.
             if let Some(energies) = averaged_data_energies_wide::<P>(
                 history,
                 sample_rate,
@@ -1222,13 +1278,24 @@ pub(crate) fn decode_multi_period_for<P: ModulationParams>(
                 }
             }
 
-            // Stage C-plain — Bessel-metric BP fallback.
-            if let Some(d) = decode_averaged_plain_for::<P>(
-                history,
-                sample_rate,
-                cand.start_sample,
-                cand.freq_hz,
-            ) {
+            // Stage C-plain — Bessel-metric BP fallback. Reuses Stage
+            // B's extraction if it already ran (`ap_codewords: Some`),
+            // or computes it fresh here on first use otherwise (never
+            // computed at all if Stage B or Stage C-fading already
+            // succeeded above, since this line is then unreached).
+            if let Some(energies) = energies_narrow
+                .get_or_insert_with(|| {
+                    averaged_data_energies::<P>(
+                        history,
+                        sample_rate,
+                        cand.start_sample,
+                        cand.freq_hz,
+                    )
+                })
+                .as_deref()
+                && let Some(d) =
+                    decode_averaged_plain_for::<P>(energies, cand.freq_hz, cand.start_sample)
+            {
                 slot_decode = Some(d);
                 break 'candidate_loop;
             }

--- a/scripts/pre-push-check.sh
+++ b/scripts/pre-push-check.sh
@@ -1,6 +1,17 @@
 #!/usr/bin/env bash
-# Pre-push quality gate — mirrors what CI's rustfmt+clippy job checks.
+# Pre-push quality gate — mirrors what CI's rustfmt+clippy, rustdoc, and
+# feature-matrix jobs check.
 # Install once with:  scripts/install-hooks.sh
+#
+# The feature-matrix and rustdoc steps were added after PR #233 (2026-08)
+# shipped code that only compiled clean under `--features full` and
+# `--features full,internal-testing` — CI's per-protocol build matrix
+# (`--no-default-features` plus each single protocol feature) caught a
+# `dead_code` error and rustdoc caught broken intra-doc links that
+# neither `cargo fmt` nor `cargo clippy --features full,internal-testing`
+# ever exercised. `dead_code` in particular depends on which cfg'd items
+# are reachable for a *given* feature set — passing under one or two
+# combos says nothing about the rest of this crate's feature matrix.
 set -euo pipefail
 
 echo "► cargo fmt --check"
@@ -9,5 +20,33 @@ cargo fmt --check
 echo "► cargo clippy (full features, tests)"
 cargo clippy --workspace --all-targets --features full,internal-testing --no-deps -- \
   -D warnings -D clippy::perf
+
+echo "► cargo doc (full features)"
+RUSTDOCFLAGS="-D warnings" cargo doc -p mfsk-core --no-deps --features full
+
+echo "► feature matrix (mirrors ci.yml's feature-matrix job)"
+FEATURE_MATRIX=(
+  ""
+  "ft8"
+  "ft4"
+  "fst4"
+  "wspr"
+  "jt9"
+  "jt65"
+  "q65"
+  "uvpacket"
+  "alloc ft8"
+  "alloc ft8 fft-extern"
+  "alloc ft8 fft-extern fixed-point"
+  "full"
+)
+for features in "${FEATURE_MATRIX[@]}"; do
+  echo "  · [${features:-<none>}]"
+  if [ -z "$features" ]; then
+    RUSTFLAGS="-D warnings" cargo build -p mfsk-core --no-default-features --release
+  else
+    RUSTFLAGS="-D warnings" cargo build -p mfsk-core --no-default-features --features "$features" --release
+  fi
+done
 
 echo "✓ pre-push checks passed"


### PR DESCRIPTION
## Summary

Extends the FT8/FST4 hot-path efficiency campaign (PR #233) to Q65 and
FT4, per request. Both protocols turned out to be far from a blank
slate:

- **FT4** shares `engine::pipeline::GenericPipelineProtocol` with
  FST4, so PR #233's three engine-level fixes (BP scratch pooling,
  Costas-ref caching, `symbol_spectra`'s FFT-planner cache) already
  applied to FT4 automatically — zero code needed there.
- **Q65** has its own bespoke pipeline and already went through a
  separate, dedicated perf investigation 2026-07-20/25
  (`docs/notes/Q65_BENCHMARK.md`) — most FT8/FST4-style fixes were
  already done (codec/intrinsics hoisting for the grid sweep,
  FFT-planner caching explicitly measured and rejected).

Four commits for what was actually left:

1. `1e16a1a` — extend `scripts/pre-push-check.sh` with `cargo doc` +
   the full 13-combo feature-matrix build (follow-up to PR #233
   shipping a `dead_code` bug + broken rustdoc links that only CI's
   fuller matrix caught).
2. `85f57f8` — Q65: dedupe redundant narrow-energy extraction between
   Stage B (AP-list) and Stage C-plain (was up to ~160 redundant FFT
   extractions per multi-slot decode), plus 2 iterator-loop
   conversions. **Also**: hoisting `Q65Codec`/`intrinsics` out of the
   6-iteration fading sweep was tried, measured a real ~8% regression
   on Q65-30A, and was reverted — see commit message for the
   same-session A/B numbers and root-cause discussion.
3. `556f97a` — FT4: reuse the cached FFT planner in
   `ft4_coarse.rs`'s `symbol_spectra_avg` (same anti-pattern #233
   fixed elsewhere, missed here).
4. `d3769ca` — FT4: cache `ft4_sync_search_window`'s phase-continuous
   Costas reference across candidates (not the per-cell scoring logic,
   which already went through 3 prior optimization passes — just the
   once-per-call reference construction).

## Performance

Every item was measured via the same-session `git worktree` A/B
methodology established after PR #233's own false-positive lesson
(machine power-state drift produced a misleading 51-55% "win" there
that didn't hold up to a controlled re-measurement). Applying that
discipline from the start here:

- Q65 finding 1 (dedup): no measurable delta on `q65_multi_period_speed_diag`
  (Q65-60B/30A both within noise before/after).
- Q65 finding 2 (codec hoist): **measured regression** (~8% slower on
  Q65-30A), reverted.
- FT4 item 2 (planner swap): no measurable delta on
  `ft4_diag_candidate_cost_split` (called ≤3×/decode, small by design).
- FT4 item 1 (Costas-ref cache): no measurable delta (the per-cell
  scoring work 3 prior optimization passes already targeted dominates
  far more than the once-per-call reference construction this caches).

No item in this PR shows a measured wall-clock win on this
workload/machine. All are landed as correctness-preserving waste
elimination (real eliminated redundant computation, zero downside),
same standard PR #233 was corrected to after its own review — not
claimed as performance wins without a same-session A/B backing them.

## Correctness

Every commit verified byte-identical against the full recall suite:
`ft4_wsjtx_samples`, `ft4_sic_rounds_recall`, `ft4_roundtrip`,
`ft4_decode_with_options`, `ft4_subtract_pipeline`,
`q65_wsjtx_samples` (all 7 WSJT-X golden WAVs), `fst4_wsjtx_samples`,
`fst4_sim_roundtrip`, `ft8_qso3_apoff/apon/full_parity/jtdx_recall`
(confirming the untouched FT8/FST4 paths are unaffected). Full lib
test suite: 378 passed, 0 failed. Full build matrix
(`scripts/pre-push-check.sh`: fmt, clippy on `full`+`full,internal-testing`,
rustdoc, 13-combo feature matrix) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
