### PR TITLE
perf(wspr): extend the efficiency campaign — parallelization is the real win (~2.4x)

### DIFF
--- a/docs/notes/WSPR_BENCHMARK.md
+++ b/docs/notes/WSPR_BENCHMARK.md
@@ -17,11 +17,16 @@ all 4 items) found only **~1-2% overall wall-clock improvement**
 other 3 items barely moved the needle: none of them touched the
 dominant cost.
 
-**This is a proposal document, not a completed fix** — the options
-below are analyzed and ranked but none are implemented yet. Treat this
-the way `Q65_BENCHMARK.md`'s "Q65-60A: deferred" section treats its own
-unimplemented follow-up: real diagnostic data backing each option, but
-a decision on which to pursue (and in what order) is still open.
+**Update (2026-08-06, same day)**: Option A (candidate-loop
+parallelization) is now implemented and merged into
+`perf/wspr-jt9-hotpath-pass` — measured ~2.4x speedup, by far the
+largest single win of the whole FT8/FST4/FT4/Q65/WSPR campaign.
+Option C's calibration diagnostic is also done, with a clean result
+recommending implementation (see that section below). The rest of this
+document's "proposal, not completed fix" framing still applies to
+Options B and D and to Option C's *implementation* (only its
+calibration is done) — see "Recommended sequencing" at the bottom for
+current status of each.
 
 ## Methodology: a real cost-split diagnostic
 
@@ -169,24 +174,59 @@ claim about the *inner* pass 2 doing most of the work, not evidence
 that the *outer* pass 2 (a second full `decode_scan` call, i.e. up to
 2 more full inner passes) earns its ~2x cost.
 
-**Confidence**: low-to-medium on the *direction* (there's likely real
-redundancy here), very low on knowing the *right* fix without
-measuring — this needs its own dedicated investigation (which recall
-gains, if any, does dropping/merging a layer cost — the W3BI-class
-signal specifically motivated the *inner* pass 2 per the code
-comments, but the *outer* pass 2's marginal contribution isn't
-documented anywhere and should be measured directly: run
-`decode_scan_subtract` with `NPASSES=1` against the golden WAV and see
-which of the 8 golden messages, if any, only the outer pass 2 finds).
+**Calibration run** (`wspr_diag_pass_ablation`,
+`tests/wspr_wsjtx_samples.rs`, added 2026-08-06): 3 conditions on the
+golden WAV, all via `pub` building blocks (`decode_scan` itself already
+*is* "inner=1+2, outer=1" — no new helper needed for that half):
 
-**Risk**: highest of the four — this is an architectural question
-about the decode strategy, not a mechanical optimization, and getting
-it wrong costs real recall on weak/crowded-band signals, which is
-WSPR's whole reason for existing as a mode. Do not attempt without a
-dedicated calibration pass first (same spirit as Option B, but at a
-coarser granularity), and treat a "no measurable recall loss" result
-on one golden WAV as necessary, not sufficient, given only 8
-transmitters are in it.
+```
+A inner=1only outer=1            83.7 ms  7/8 golden  [...all but W3BI...]
+B inner=1+2   outer=1           130.2 ms  8/8 golden  [...+ W3BI...]
+D inner=1+2   outer=2 (prod)    330.9 ms  8/8 golden  [same set as B]
+
+inner pass-2 contributes (B \ A): ["W3BI FN20 30"]
+outer pass-2 contributes (D \ B): []
+```
+
+Reproduced 3x, deterministic (no run-to-run variation in which golden
+messages hit, only timing). **The inner pass 2 earns its cost exactly
+as the code comments claim — it's the only thing that recovers W3BI
+(-27 dB SNR).** The outer pass 2, on this golden WAV, recovers
+**nothing** beyond what a single `decode_scan` call already finds,
+while costing an extra ~201ms — roughly **2.5x** condition B's own
+cost, for zero measured benefit here.
+
+**Caveat, unchanged from before the calibration run**: this is one
+golden WAV with 8 transmitters (the only real WSPR sample in this
+repo's `WSJT-X/samples/WSPR/` — no second sample exists to
+cross-check against). A "0 marginal recall" result on 8 signals is
+suggestive, not proof, that the outer pass never helps on a busier or
+differently-conditioned band — WSPR slots can carry many more
+concurrent transmitters than this one does, and the outer pass's
+whole justification is recovering signals masked by *other* signals'
+subtraction residue, which a sparser slot exercises less. Treat this
+as strong evidence to act on with an appropriate fallback (see below),
+not as license to delete the outer pass outright without further
+safety margin.
+
+**Recommendation**: this now has enough evidence to implement, but
+conservatively — not by deleting `NPASSES=2` outright. A reasonable
+shape: keep the outer loop but make its second iteration
+*conditional* (e.g. skip it when pass-1's own inner-pass-2 already
+found signals covering a configurable fraction of the coarse
+candidates, or simply expose `NPASSES` as tunable and default it to 1
+while keeping 2 available for callers who want maximum recall on busy
+bands at 2.5x the cost) rather than a blanket removal — this keeps the
+"more real evidence might change this" caveat above from becoming a
+silent regression for someone else's use case. Still needs the full
+recall suite (`wspr_wsjtx_sample_recall_vs_golden`, 8/8) as a hard
+gate regardless of which shape is chosen.
+
+**Risk**: was rated highest of the four before this calibration run;
+now downgraded to medium given the clean, reproduced 0-contribution
+result — but the single-sample caveat above keeps it above Option A's
+risk floor. Do not skip the recall-suite gate even though the
+diagnostic already ran it once.
 
 ### Option D — OSD fallback cost
 
@@ -213,28 +253,32 @@ trade-off like Option B, needing the same calibration discipline).
 
 ## Recommended sequencing
 
-1. **Option A first** — parallelize the candidate loops. Highest
-   confidence, lowest risk, no recall-invariance question at all (it's
-   not an algorithm change), and the plumbing already exists in this
-   crate (FT8's exact pattern to copy). This alone, on a multi-core
-   host, could meaningfully cut into the ~918ms pass-2-across-both-outer-passes
-   component without touching anything that needs new measurement
-   discipline beyond "still 8/8 golden, still same messages."
-2. **Then split Option D's OSD-vs-Fano cost** inside pass 2's sweep —
+1. ~~**Option A first**~~ — **done** (`perf/wspr-jt9-hotpath-pass`,
+   commit `71fc382`). Parallelized the candidate loops via
+   `par_iter()`, mirroring FT8's existing pattern. Measured ~2.4x
+   speedup (git worktree A/B, alternating, same session), no algorithm
+   change, 8/8 golden held.
+2. ~~**Option C's calibration**~~ — **done** (`wspr_diag_pass_ablation`,
+   see the updated Option C section above). Clean, reproduced result:
+   the outer `NPASSES=2` pass contributes 0 marginal golden recall on
+   the one real WSPR sample available, at ~2.5x the cost of stopping
+   after one `decode_scan` call. **Now the top implementation
+   candidate** given both its measured impact (bigger than Option A's,
+   on paper — cutting straight to ~130ms vs today's ~330ms on this
+   golden) and now-downgraded risk, but still needs the conditional/
+   tunable-rather-than-deleted shape discussed in that section, plus
+   the full recall gate, before landing.
+3. **Then split Option D's OSD-vs-Fano cost** inside pass 2's sweep —
    cheap to add (a few more `Instant` timers in
    `wspr_diag_candidate_cost_split` or a dedicated variant), and tells
-   us whether Option D is worth a dedicated pass or can be folded into
-   whatever Option B/C work follows.
-3. **Option B and C are architectural/algorithmic and need their own
-   calibration diagnostics before any code changes** — do not
-   implement either from the reasoning in this document alone. Build
-   the calibration diagnostics described in each section first (hard-
-   error-count distribution across `nblock` values for B; an
-   `NPASSES=1` vs `NPASSES=2` golden-recall diff for C), review what
-   they show, *then* decide whether either is worth pursuing — matching
-   this campaign's own established discipline (measure before
-   implementing, not after).
+   us whether Option D is worth a dedicated pass.
+4. **Option B still needs its own calibration diagnostic before any
+   code changes** — hard-error-count distribution across `nblock`
+   values, not yet built. Do not implement from the reasoning in that
+   section alone.
 
-None of this is scheduled — this document exists so the next session
-picking up WSPR speed work starts from real profiled data instead of
+Only Option A is actually landed — the rest (including Option C, whose
+calibration is now done but whose implementation is not) exists here
+so the next session picking up WSPR speed work starts from real
+profiled data instead of
 re-deriving it.

--- a/docs/notes/WSPR_BENCHMARK.md
+++ b/docs/notes/WSPR_BENCHMARK.md
@@ -1,0 +1,240 @@
+# WSPR decode-speed investigation
+
+New investigation (2026-08-06), same "diagnose against real WSJT-X
+audio, profile, propose, verify against recall before implementing"
+methodology as `FT4_BENCHMARK.md`/`FST4_BENCHMARK.md`/`Q65_BENCHMARK.md`'s
+speed sections — first such document for WSPR. Prompted by a
+follow-up question after the FT8/FST4 → FT4/Q65 → WSPR efficiency
+campaign (PR #233/#235/`perf/wspr-jt9-hotpath-pass`): that pass landed
+4 WSPR items (FFT-planner caching, a dead clone, `fano_decode` scratch
+pooling, an LPF-loop iterator conversion), all verified byte-identical
+against `wspr_wsjtx_sample_recall_vs_golden`, but a true apples-to-apples
+same-session measurement (`git worktree`, before any WSPR work vs after
+all 4 items) found only **~1-2% overall wall-clock improvement**
+(~1615ms → ~1602ms on the WSJT-X `150426_0918.wav` golden, via
+`wspr_speed_diag`) — small, and almost entirely attributable to item 1
+(the FFT-planner cache) alone. This document investigates *why* the
+other 3 items barely moved the needle: none of them touched the
+dominant cost.
+
+**This is a proposal document, not a completed fix** — the options
+below are analyzed and ranked but none are implemented yet. Treat this
+the way `Q65_BENCHMARK.md`'s "Q65-60A: deferred" section treats its own
+unimplemented follow-up: real diagnostic data backing each option, but
+a decision on which to pursue (and in what order) is still open.
+
+## Methodology: a real cost-split diagnostic
+
+No per-stage breakdown existed for WSPR before this — `wspr_speed_diag`
+(added alongside the perf-review's Phase 0) only times the whole
+`decode_scan_subtract` call end-to-end. Added
+`wspr_diag_candidate_cost_split` (`tests/wspr_wsjtx_samples.rs`,
+`#[ignore]`d) to fix that: it replicates `decode_scan`'s exact
+call sequence using its own `pub` building blocks
+(`decimate_to_baseband`, `coarse_baseband`, `decode_at_baseband`,
+`decode_at_baseband_nblocks`, `subtract_signal_baseband`), with
+`Instant` timers around each stage, on the real WSJT-X golden WAV
+(`150426_0918.wav`).
+
+## Finding 1: `decode_scan_subtract` is a nested 2-pass-inside-2-pass structure
+
+This wasn't obvious from reading `wspr_speed_diag`'s single end-to-end
+number, but became clear once `wspr_diag_candidate_cost_split` was
+built: `decode_scan_subtract` (`decode.rs:501`) is an **outer**
+`NPASSES = 2` SIC loop (12 kHz audio, `subtract_tones`), and each outer
+iteration calls `decode_scan` (`decode.rs:278`), which is *itself* an
+**inner** 2-pass structure (375 Hz baseband, `subtract_signal_baseband`):
+coarse search → pass-1 candidates (single-`nblock` Fano) → subtract →
+re-coarse on the residual → pass-2 candidates (3-`nblock` Fano/OSD
+sweep). So a full `decode_scan_subtract` call pays the coarse+refine+
+Fano pipeline **up to 4 times** in the worst case (2 outer × 2 inner),
+not 2.
+
+`wspr_diag_candidate_cost_split`'s output for one `decode_scan` call
+(i.e. one outer-pass iteration) on the golden WAV:
+
+```
+decimate_to_baseband      =     35.1 ms
+coarse_baseband (pass 1)  =     16.0 ms  (13 candidates)
+pass-1 refine+Fano total  =    115.4 ms  (8878.0 µs/cand, 8 decoded, nblocks=[1])
+subtract_signal_baseband  =    102.0 ms  (8 decodes subtracted)
+coarse_baseband (pass 2)  =     15.8 ms  (13 candidates)
+pass-2 refine+Fano total  =    459.2 ms  (35326.2 µs/cand, 9 decoded, nblocks=[1,2,3])
+------------------------------------------------
+sum of stages above       =    743.6 ms
+```
+
+Doubling for the outer `NPASSES = 2` loop (`decode_scan_subtract` runs
+this whole sequence twice, second time on the 12 kHz-level residual)
+lands very close to `wspr_speed_diag`'s independently-measured
+~1600ms end-to-end total — confirming the nesting model, not just
+theorizing about it.
+
+## Finding 2: pass-2's 3-`nblock` sweep is the dominant single cost
+
+Within one `decode_scan` call, pass-2's refine+Fano total (459.2ms) is
+**~62% of the summed stages**, and per-candidate it costs **~4x**
+pass-1's (35.3 ms/cand vs 8.9 ms/cand; both passes
+share the same candidate count, 13, so the delta is entirely the
+`nblocks=[1,2,3]` sweep vs `nblocks=[1]`). Mode-0/mode-1 (lag/freq
+refine — 9 `tone_amplitudes` evals, shared once per candidate
+regardless of `nblocks`) is paid identically by both passes; the ~4x
+delta is 2 *extra* `(nblock_bit_metrics + Fano + OSD-fallback-on-failure)`
+cycles, at roughly 13ms each.
+
+**Combined**: pass-2's sweep, run inside *each* of the outer SIC's 2
+passes, is roughly `459ms × 2 ≈ 918ms` of the ~1600ms total — the
+single biggest lever in this whole decode path, well ahead of
+anything item 1-4 touched.
+
+## Options considered
+
+Ranked by confidence × expected impact × implementation risk, not
+implementation order — see "Recommended sequencing" below.
+
+### Option A — parallelize the per-candidate loops (rayon)
+
+**What**: WSPR's pass-1 and pass-2 candidate loops
+(`for c in &cands { decode_at_baseband(...) }` /
+`decode_at_baseband_nblocks(...)`) are fully sequential today. Each
+candidate's decode is a pure function of `(idat, qdat, sample_rate,
+candidate)` — no shared mutable state during the loop body, results
+only get pushed to a local `Vec` afterward. FT8 already established
+the exact idiom for this crate
+(`src/ft8/decode.rs:361-368`): `#[cfg(feature = "parallel")]`
+`candidates.par_iter().filter_map(...).collect()`, falling back to
+plain `.iter()` when the feature is off. `par_iter()` + `.collect()`
+is order-preserving, so downstream dedup logic (which relies on
+first-occurrence-wins) stays correct unchanged.
+
+**Confidence**: highest of the four options. This doesn't change the
+algorithm or its output at all — same computation, same results, just
+concurrent — so it doesn't carry the recall-risk the other options do.
+Real speedup depends on core count and `max_candidates` (13 real
+candidates on the golden WAV; more on a busy band), but pass-2's
+459ms/call component alone has enough independent per-candidate work
+(13 candidates × ~35ms each) to be worth parallelizing even on a
+modest core count.
+
+**Risk**: low. Main things to verify: `WsprResult` and the closures'
+captured types need to be `Send`/`Sync` (should be — no interior
+mutability, no `Rc`/`RefCell` in the call chain); confirm the
+`parallel` feature's existing cfg-gate pattern compiles clean on the
+no_std/embedded combos the way FT8's own gate already does (WSPR is
+`std`-only-realistic today per the existing FFT-planner-cache work,
+but should still respect the feature boundary for consistency).
+
+### Option B — adaptive/early-exit `nblock` sweep
+
+**What**: pass-2 unconditionally tries all of `nblocks=[1,2,3]` per
+candidate, even when `nblock=1` already converges (its Fano succeeds
+— `best_type1`/`best_other` get set, but the loop keeps trying `2`/`3`
+anyway looking for a *lower-hard-error* result, not just any
+converging one). A cheaper gate — stop the sweep once a candidate hits
+some `hard_errors` threshold low enough that further `nblock` values
+are very unlikely to improve it — could skip a meaningful fraction of
+the 2 extra cycles per candidate.
+
+**Confidence**: medium. The 13ms/extra-cycle cost is real and this
+would cut some of it, but *how much* depends on how often `nblock=1`
+already converges cleanly vs how often the coherent-block gain from
+`nblock=2/3` is actually needed to convert a near-miss into a decode
+(this is explicitly the scenario the code comment at `decode.rs:171-175`
+describes W3BI needing) — an aggressive early-exit could cost real
+recall on exactly the weak signals pass 2 exists for. **Needs a
+calibration diagnostic** (mirroring Q65's
+`q65_candidate_score_calibration_diag` — profile real hard-error-count
+distributions across `nblock` values on the golden WAV, and ideally a
+larger off-air corpus) before choosing a threshold, not a guessed
+cutoff.
+
+**Risk**: medium-high — this is an algorithmic change to the decode
+ladder, not a pure refactor; needs the full recall-invariance bar
+(8/8 golden) *and* probably a wider sensitivity check than the single
+golden WAV gives, since the failure mode (losing weak-signal recall)
+wouldn't necessarily show up on one 8-transmitter slot.
+
+### Option C — question the outer/inner 2-pass nesting itself
+
+**What**: `decode_scan_subtract`'s outer `NPASSES=2` SIC (12 kHz,
+`subtract_tones`) and `decode_scan`'s own inner 2-pass SIC (375 Hz
+baseband, `subtract_signal_baseband`) are two *different*
+implementations of essentially the same idea (remove decoded signals,
+re-search the residual for weaker ones) operating at two different
+sample rates. It's not obvious both layers are pulling their weight —
+`decode_scan_subtract`'s own doc comment already notes it caps at 2
+outer passes specifically because "the bulk of the SIC benefit lands
+on pass 2 once the strong ... signals have been removed," which is a
+claim about the *inner* pass 2 doing most of the work, not evidence
+that the *outer* pass 2 (a second full `decode_scan` call, i.e. up to
+2 more full inner passes) earns its ~2x cost.
+
+**Confidence**: low-to-medium on the *direction* (there's likely real
+redundancy here), very low on knowing the *right* fix without
+measuring — this needs its own dedicated investigation (which recall
+gains, if any, does dropping/merging a layer cost — the W3BI-class
+signal specifically motivated the *inner* pass 2 per the code
+comments, but the *outer* pass 2's marginal contribution isn't
+documented anywhere and should be measured directly: run
+`decode_scan_subtract` with `NPASSES=1` against the golden WAV and see
+which of the 8 golden messages, if any, only the outer pass 2 finds).
+
+**Risk**: highest of the four — this is an architectural question
+about the decode strategy, not a mechanical optimization, and getting
+it wrong costs real recall on weak/crowded-band signals, which is
+WSPR's whole reason for existing as a mode. Do not attempt without a
+dedicated calibration pass first (same spirit as Option B, but at a
+coarser granularity), and treat a "no measurable recall loss" result
+on one golden WAV as necessary, not sufficient, given only 8
+transmitters are in it.
+
+### Option D — OSD fallback cost
+
+**What**: the per-audit finding that `osd::osd_decode`'s order-2
+search (`osd.rs:180-192`) is `C(50,2) = 1225` trials × O(N) work,
+run as a fallback whenever Fano fails to converge — which, given pass
+2's `nblocks=[1,2,3]` sweep, can happen up to 3x per candidate. Not
+separately broken out by `wspr_diag_candidate_cost_split` (it's
+folded into the pass-1/pass-2 refine+Fano totals above), so its actual
+share of the ~35ms/candidate pass-2 cost isn't known yet — would need
+a further diagnostic split (time `codec.decode_soft_pooled` vs
+`osd::osd_decode` separately inside the sweep) before this is
+actionable.
+
+**Confidence**: unknown pending the above split — this is explicitly
+the least-investigated of the four options. Likely a smaller
+contributor than A-C (OSD is a fallback path, not the common case),
+but worth a follow-up measurement rather than dismissing it outright.
+
+**Risk**: low if pursued as pure allocation/loop-count reduction
+inside OSD (same shape as this session's other neutral items); medium
+if pursued as reducing the *trial count* (that would be a sensitivity
+trade-off like Option B, needing the same calibration discipline).
+
+## Recommended sequencing
+
+1. **Option A first** — parallelize the candidate loops. Highest
+   confidence, lowest risk, no recall-invariance question at all (it's
+   not an algorithm change), and the plumbing already exists in this
+   crate (FT8's exact pattern to copy). This alone, on a multi-core
+   host, could meaningfully cut into the ~918ms pass-2-across-both-outer-passes
+   component without touching anything that needs new measurement
+   discipline beyond "still 8/8 golden, still same messages."
+2. **Then split Option D's OSD-vs-Fano cost** inside pass 2's sweep —
+   cheap to add (a few more `Instant` timers in
+   `wspr_diag_candidate_cost_split` or a dedicated variant), and tells
+   us whether Option D is worth a dedicated pass or can be folded into
+   whatever Option B/C work follows.
+3. **Option B and C are architectural/algorithmic and need their own
+   calibration diagnostics before any code changes** — do not
+   implement either from the reasoning in this document alone. Build
+   the calibration diagnostics described in each section first (hard-
+   error-count distribution across `nblock` values for B; an
+   `NPASSES=1` vs `NPASSES=2` golden-recall diff for C), review what
+   they show, *then* decide whether either is worth pursuing — matching
+   this campaign's own established discipline (measure before
+   implementing, not after).
+
+None of this is scheduled — this document exists so the next session
+picking up WSPR speed work starts from real profiled data instead of
+re-deriving it.

--- a/mfsk-core/src/fec/conv/fano.rs
+++ b/mfsk-core/src/fec/conv/fano.rs
@@ -114,7 +114,63 @@ pub struct FanoDecodeResult {
 /// i-th coded-bit position (`branch_metrics.len() == 2 * nbits`). The last
 /// `K_CONSTRAINT - 1` input bits (the "tail") are assumed to be zero — the
 /// decoder exploits that to prune the 1-branch.
+///
+/// Allocates a fresh [`FanoScratch`] every call — for a hot loop that
+/// calls this repeatedly with the same `nbits` (WSPR: once per
+/// `nblock` value per candidate, up to ~100 calls/decode), use
+/// [`fano_decode_with_scratch`] with a caller-pooled scratch instead.
 pub fn fano_decode(
+    branch_metrics: &[[i32; 2]],
+    nbits: usize,
+    delta: i32,
+    max_cycles_per_bit: u64,
+) -> FanoDecodeResult {
+    let mut scratch = FanoScratch::new();
+    fano_decode_with_scratch(
+        &mut scratch,
+        branch_metrics,
+        nbits,
+        delta,
+        max_cycles_per_bit,
+    )
+}
+
+/// Reusable working memory for [`fano_decode_with_scratch`] — the
+/// `Vec<Node>` search-tree buffer, pooled across calls that share the
+/// same `nbits` instead of reallocated (~`nbits+1` `Node`s, ~32B each)
+/// every time.
+#[derive(Default)]
+pub struct FanoScratch {
+    nodes: Vec<Node>,
+}
+
+impl FanoScratch {
+    pub fn new() -> Self {
+        Self { nodes: Vec::new() }
+    }
+}
+
+/// [`fano_decode`] with caller-provided scratch, reused across calls
+/// that share `nbits` (constant for a given code — 81 for WSPR,
+/// [`crate::fec::ConvFano::NBITS`]) instead of reallocating
+/// `Vec<Node>` every call.
+///
+/// Safe to pool: the precompute loop below unconditionally rewrites
+/// `.metrics` for every node index `0..nbits`, and every node's
+/// `.gamma`/`.encstate`/`.tm`/`.i` are set on first visit *before* any
+/// read, both going forward (the `while cycles < max_cycles` loop's
+/// "look forward" branch) and on backtrack (which only revisits nodes
+/// already touched earlier *in the same call*) — no field is ever read
+/// before this call has written it, so nothing leaks from a prior
+/// call's leftover values as long as `nbits` (hence `nodes.len()`)
+/// stays constant. `nodes[nbits]` itself is the one exception: its
+/// `.metrics` is never rewritten by the precompute loop (which only
+/// touches `0..nbits`) *and* never read either (the forward loop
+/// breaks with `converged = true` the instant `np` reaches `nbits`,
+/// before ever reaching the "look forward" read at the top of the
+/// next iteration) — so its stale contents are inert either way.
+pub fn fano_decode_with_scratch(
+    scratch: &mut FanoScratch,
     branch_metrics: &[[i32; 2]],
     nbits: usize,
     delta: i32,
@@ -126,7 +182,10 @@ pub fn fano_decode(
         "branch_metrics length mismatch"
     );
 
-    let mut nodes: Vec<Node> = (0..=nbits).map(|_| Node::default()).collect();
+    if scratch.nodes.len() != nbits + 1 {
+        scratch.nodes = (0..=nbits).map(|_| Node::default()).collect();
+    }
+    let nodes = &mut scratch.nodes;
 
     // Precompute all 4 branch-metric sums per node position.
     for (k, node) in nodes.iter_mut().take(nbits).enumerate() {

--- a/mfsk-core/src/fec/conv/mod.rs
+++ b/mfsk-core/src/fec/conv/mod.rs
@@ -85,6 +85,38 @@ impl FecCodec for ConvFano {
             Self::DEFAULT_DELTA,
             Self::DEFAULT_MAX_CYCLES,
         );
+        self.finish_decode(llr, res)
+    }
+}
+
+impl ConvFano {
+    /// [`FecCodec::decode_soft`] with caller-provided [`fano::FanoScratch`],
+    /// reused across every call for one candidate's `nblock` sweep
+    /// instead of reallocated per call — see
+    /// [`fano::fano_decode_with_scratch`]'s doc comment for why this is
+    /// safe to pool.
+    pub fn decode_soft_pooled(
+        &self,
+        llr: &[f32],
+        _opts: &FecOpts,
+        scratch: &mut fano::FanoScratch,
+    ) -> Option<FecResult> {
+        assert_eq!(llr.len(), Self::N);
+        let bm = fano::build_branch_metrics(llr, Self::METRIC_BIAS, Self::METRIC_SCALE);
+        let res = fano::fano_decode_with_scratch(
+            scratch,
+            &bm,
+            Self::NBITS,
+            Self::DEFAULT_DELTA,
+            Self::DEFAULT_MAX_CYCLES,
+        );
+        self.finish_decode(llr, res)
+    }
+
+    /// Shared post-processing for [`FecCodec::decode_soft`] /
+    /// [`Self::decode_soft_pooled`]: recover the info vector, re-encode
+    /// to count hard errors, and reject on non-convergence.
+    fn finish_decode(&self, llr: &[f32], res: fano::FanoDecodeResult) -> Option<FecResult> {
         if !res.converged {
             return None;
         }

--- a/mfsk-core/src/wspr/baseband.rs
+++ b/mfsk-core/src/wspr/baseband.rs
@@ -18,7 +18,7 @@ use alloc::vec::Vec;
 
 use num_complex::Complex;
 
-use crate::engine::fft::default_planner;
+use crate::engine::dsp::downsample::with_default_planner;
 
 /// Baseband sample rate. Matches wsprd `dt = 1.0/375.0` throughout.
 pub const BASEBAND_RATE: f32 = 375.0;
@@ -57,9 +57,7 @@ pub fn decimate_to_baseband(audio: &[f32]) -> (Vec<f32>, Vec<f32>) {
     }
     buf.resize(NFFT1, Complex::new(0.0, 0.0));
 
-    let mut planner = default_planner();
-    let fft = planner.plan_forward(NFFT1);
-    fft.process(&mut buf);
+    with_default_planner(|planner| planner.plan_forward(NFFT1)).process(&mut buf);
 
     let df = 12_000.0 / NFFT1 as f32;
     let i0 = (CENTER_HZ / df).round() as usize;
@@ -82,8 +80,7 @@ pub fn decimate_to_baseband(audio: &[f32]) -> (Vec<f32>, Vec<f32>) {
         }
     }
 
-    let ifft = planner.plan_inverse(NFFT2);
-    ifft.process(&mut fftin);
+    with_default_planner(|planner| planner.plan_inverse(NFFT2)).process(&mut fftin);
 
     const NORM: f32 = 1.0 / 1000.0;
     let mut idat = vec![0.0f32; NFFT2];

--- a/mfsk-core/src/wspr/coarse_baseband.rs
+++ b/mfsk-core/src/wspr/coarse_baseband.rs
@@ -40,7 +40,7 @@ use num_complex::Complex;
 #[cfg(not(feature = "std"))]
 use num_traits::Float;
 
-use crate::engine::fft::default_planner;
+use crate::engine::dsp::downsample::with_default_planner;
 
 use super::WSPR_SYNC_VECTOR;
 use super::baseband::{BASEBAND_RATE, CENTER_HZ};
@@ -129,8 +129,7 @@ fn build_spectro(idat: &[f32], qdat: &[f32]) -> Spectro {
         *w = (PI * j as f32 / NFFT as f32).sin();
     }
 
-    let mut planner = default_planner();
-    let fft = planner.plan_forward(NFFT);
+    let fft = with_default_planner(|planner| planner.plan_forward(NFFT));
     let mut buf: Vec<Complex<f32>> = vec![Complex::new(0.0, 0.0); NFFT];
     let mut ps = vec![0.0f32; n_time * NFFT];
 

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -109,7 +109,7 @@ pub fn decode_at_baseband_nblocks(
     drift_hz: f32,
     nblocks: &[usize],
 ) -> Option<WsprResult> {
-    use crate::engine::{FecCodec, FecOpts, MessageCodec};
+    use crate::engine::{FecOpts, MessageCodec};
     // `freq_hz` follows our tone-0 convention (matches `synthesize_audio`
     // and `coarse_search.freq_hz`); wsprd's `noncoherent_sequence_detection`
     // takes the signal CENTER, so we add 1.5·tone_spacing here and sweep
@@ -126,6 +126,11 @@ pub fn decode_at_baseband_nblocks(
     let f0_baseband_init = f0_center_init - super::baseband::CENTER_HZ;
     let lag_baseband_init = start_sample as i32 / 32;
     let codec = crate::fec::ConvFano;
+    // Pooled across the whole `nblocks` sweep below (up to 3 values in
+    // pass 2) instead of `fano_decode` allocating a fresh `Vec<Node>`
+    // scratch per call — see `fano::fano_decode_with_scratch`'s doc
+    // comment for why reuse is safe here.
+    let mut fano_scratch = crate::fec::conv::fano::FanoScratch::new();
 
     // Mode 0: lag refine. wsprd uses lagstep=64 baseband-samples,
     // ±128 around shift1 → 5 lags. Per cell: tone_amplitudes
@@ -177,39 +182,40 @@ pub fn decode_at_baseband_nblocks(
         // (Ordered-Statistics Decoding, port of `osdwspr.f90`). OSD
         // can recover signals at -27 dB SNR (e.g. W3BI on the WSJT-X
         // golden) where Fano alone hits the convergence threshold.
-        let (info_bits, hard_errors) =
-            if let Some(fec_res) = codec.decode_soft(&llrs, &FecOpts::default()) {
-                let mut info = [0u8; 50];
-                info.copy_from_slice(&fec_res.info);
-                (info, fec_res.hard_errors)
-            } else if let Some((info, nhardmin)) = super::osd::osd_decode(&llrs) {
-                // OSD-2 will synthesise a valid codeword for *any* input;
-                // gate by:
-                //   1. `nhardmin ≤ 44` — at -27 dB the real signal lands
-                //      around 35-40 hard errors after pass-2 subtract;
-                //      pure noise produces ≥ 50.
-                //   2. Reject Type-3 (hashed-callsign) messages — they're
-                //      the dominant phantom class because the 13-bit hash
-                //      space produces a nominally valid message for ~15 %
-                //      of all 50-bit info vectors. We have no hash table
-                //      so any Type-3 that pops out of OSD is overwhelmingly
-                //      likely to be garbage.
-                const OSD_HARD_ERR_MAX: u32 = 44;
-                if nhardmin > OSD_HARD_ERR_MAX {
-                    continue;
-                }
-                let Some(msg) = crate::msg::Wspr50Message
-                    .unpack(&info, &crate::engine::DecodeContext::default())
-                else {
-                    continue;
-                };
-                if matches!(msg, crate::msg::WsprMessage::Type3 { .. }) {
-                    continue;
-                }
-                (info, nhardmin)
-            } else {
+        let (info_bits, hard_errors) = if let Some(fec_res) =
+            codec.decode_soft_pooled(&llrs, &FecOpts::default(), &mut fano_scratch)
+        {
+            let mut info = [0u8; 50];
+            info.copy_from_slice(&fec_res.info);
+            (info, fec_res.hard_errors)
+        } else if let Some((info, nhardmin)) = super::osd::osd_decode(&llrs) {
+            // OSD-2 will synthesise a valid codeword for *any* input;
+            // gate by:
+            //   1. `nhardmin ≤ 44` — at -27 dB the real signal lands
+            //      around 35-40 hard errors after pass-2 subtract;
+            //      pure noise produces ≥ 50.
+            //   2. Reject Type-3 (hashed-callsign) messages — they're
+            //      the dominant phantom class because the 13-bit hash
+            //      space produces a nominally valid message for ~15 %
+            //      of all 50-bit info vectors. We have no hash table
+            //      so any Type-3 that pops out of OSD is overwhelmingly
+            //      likely to be garbage.
+            const OSD_HARD_ERR_MAX: u32 = 44;
+            if nhardmin > OSD_HARD_ERR_MAX {
+                continue;
+            }
+            let Some(msg) =
+                crate::msg::Wspr50Message.unpack(&info, &crate::engine::DecodeContext::default())
+            else {
                 continue;
             };
+            if matches!(msg, crate::msg::WsprMessage::Type3 { .. }) {
+                continue;
+            }
+            (info, nhardmin)
+        } else {
+            continue;
+        };
         let Some(message) =
             crate::msg::Wspr50Message.unpack(&info_bits, &crate::engine::DecodeContext::default())
         else {

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -286,7 +286,7 @@ pub fn decode_scan(
     // Decimate ONCE up-front; the wsprd-equivalent coarse and the
     // demod both consume the same baseband buffer, so we save 32×
     // FFT work vs running each separately.
-    let (idat, qdat) = super::baseband::decimate_to_baseband(&padded);
+    let (mut idat, mut qdat) = super::baseband::decimate_to_baseband(&padded);
     // wsprd-equivalent coarse: 512-pt windowed FFT on the 375 Hz
     // baseband, time-averaged spectrum + 30 th-percentile noise
     // floor, peak detection on smspec, 3-D (freq, time, drift)
@@ -388,15 +388,19 @@ pub fn decode_scan(
     // neighbours' noise floor — the only path that recovers W3BI on
     // the WSJT-X golden (-27 dB SNR, hidden by ND6P / KI7CI / etc.).
     if !pass1.is_empty() {
-        let mut idat2 = idat.clone();
-        let mut qdat2 = qdat.clone();
+        // `idat`/`qdat` are locally owned (from `decimate_to_baseband`
+        // above) and never read again after pass 1's loop — subtract
+        // the pass-1 decodes in place instead of cloning both ~180KB
+        // buffers first. (Pass 1's own borrows of `&idat`/`&qdat` are
+        // all scoped to that loop's iterations, so they've ended by
+        // the time we get here.)
         for (d, start_refined) in &pass1 {
             let symbols = super::encode_channel_symbols(&d.info_bits);
             let f0_audio = d.freq_hz + 1.5 * super::demod::TONE_SPACING_HZ;
             let shift_baseband = (*start_refined as i32) / 32;
             super::subtract::subtract_signal_baseband(
-                &mut idat2,
-                &mut qdat2,
+                &mut idat,
+                &mut qdat,
                 f0_audio,
                 shift_baseband,
                 0.0,
@@ -408,8 +412,8 @@ pub fn decode_scan(
         // residual buffer, and reconstructing 12 kHz from baseband is
         // pointless for the same coarse_search call.
         let bb_cands2 = super::coarse_baseband::coarse_baseband(
-            &idat2,
-            &qdat2,
+            &idat,
+            &qdat,
             pad,
             params.max_candidates,
             max_drift,
@@ -421,8 +425,8 @@ pub fn decode_scan(
             // exposed them in the spectrum, but they still need the
             // coherent gain to clear the Fano convergence threshold.
             let Some(mut d) = decode_at_baseband_nblocks(
-                &idat2,
-                &qdat2,
+                &idat,
+                &qdat,
                 sample_rate,
                 c.start_sample,
                 c.freq_hz,

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -6,6 +6,9 @@
 
 use alloc::vec::Vec;
 
+#[cfg(feature = "parallel")]
+use rayon::prelude::*;
+
 use crate::msg::WsprMessage;
 
 use super::search::SearchParams;
@@ -275,6 +278,50 @@ pub fn decode_at_with_drift(
 /// for the same reason.
 const NEGATIVE_DT_PAD_SEC: f32 = 3.0;
 
+/// Per-candidate pass-1 decode step, factored out of [`decode_scan`]'s
+/// pass-1 loop so it can run under `par_iter()` (feature `parallel`)
+/// or plain `.iter()` identically — pure function of its arguments, no
+/// shared mutable state, so parallelizing this doesn't change behavior.
+fn decode_pass1_candidate(
+    idat: &[f32],
+    qdat: &[f32],
+    sample_rate: u32,
+    pad: usize,
+    c: &super::coarse_baseband::BasebandCandidate,
+) -> Option<(WsprResult, usize)> {
+    let mut d = decode_at_baseband(idat, qdat, sample_rate, c.start_sample, c.freq_hz, 0.0)?;
+    let start_refined = d.start_sample;
+    d.dt_sec = (start_refined as i64 - pad as i64) as f32 / sample_rate as f32 - 1.0;
+    d.start_sample = start_refined.saturating_sub(pad);
+    d.snr_db = c.snr_db;
+    Some((d, start_refined))
+}
+
+/// Per-candidate pass-2 decode step — same parallelization rationale
+/// as [`decode_pass1_candidate`], for [`decode_scan`]'s pass-2 loop.
+fn decode_pass2_candidate(
+    idat: &[f32],
+    qdat: &[f32],
+    sample_rate: u32,
+    pad: usize,
+    c: &super::coarse_baseband::BasebandCandidate,
+) -> Option<WsprResult> {
+    let mut d = decode_at_baseband_nblocks(
+        idat,
+        qdat,
+        sample_rate,
+        c.start_sample,
+        c.freq_hz,
+        c.drift_hz,
+        &[1, 2, 3],
+    )?;
+    let start_refined = d.start_sample;
+    d.dt_sec = (start_refined as i64 - pad as i64) as f32 / sample_rate as f32 - 1.0;
+    d.start_sample = start_refined.saturating_sub(pad);
+    d.snr_db = c.snr_db;
+    Some(d)
+}
+
 pub fn decode_scan(
     audio: &[f32],
     sample_rate: u32,
@@ -365,17 +412,29 @@ pub fn decode_scan(
     );
     // pass-1 decodes carry their padded-buffer alignment so we can
     // subtract them from the baseband for pass 2.
+    //
+    // Each candidate's decode_at_baseband call is a pure function of
+    // (idat, qdat, sample_rate, candidate) — no shared mutable state
+    // during the loop body, so the decode step runs in parallel
+    // (mirroring ft8::decode's own par_iter()/filter_map()/collect()
+    // pattern, src/ft8/decode.rs:361-368). The dedup pass below stays
+    // strictly sequential afterward, over `raw1` in its original
+    // (order-preserving) candidate order, so "first occurrence wins"
+    // semantics are unchanged — this doesn't alter behavior, only
+    // parallelizes independent work.
+    #[cfg(feature = "parallel")]
+    let raw1: Vec<(WsprResult, usize)> = cands
+        .par_iter()
+        .filter_map(|c| decode_pass1_candidate(&idat, &qdat, sample_rate, pad, c))
+        .collect();
+    #[cfg(not(feature = "parallel"))]
+    let raw1: Vec<(WsprResult, usize)> = cands
+        .iter()
+        .filter_map(|c| decode_pass1_candidate(&idat, &qdat, sample_rate, pad, c))
+        .collect();
+
     let mut pass1: Vec<(WsprResult, usize)> = Vec::new();
-    for c in &cands {
-        let Some(mut d) =
-            decode_at_baseband(&idat, &qdat, sample_rate, c.start_sample, c.freq_hz, 0.0)
-        else {
-            continue;
-        };
-        let start_refined = d.start_sample;
-        d.dt_sec = (start_refined as i64 - pad as i64) as f32 / sample_rate as f32 - 1.0;
-        d.start_sample = start_refined.saturating_sub(pad);
-        d.snr_db = c.snr_db;
+    for (d, start_refined) in raw1 {
         let dup = seen.iter().any(|prev| {
             prev.message == d.message
                 && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ
@@ -424,27 +483,27 @@ pub fn decode_scan(
             params.max_candidates,
             max_drift,
         );
-        for c in bb_cands2 {
-            // Pass 2 uses nblock = 1, 2, 3 (coherent block detection)
-            // for the +3..+4.8 dB margin needed to decode signals like
-            // W3BI at -27 dB SNR. The strong-signal subtract above has
-            // exposed them in the spectrum, but they still need the
-            // coherent gain to clear the Fano convergence threshold.
-            let Some(mut d) = decode_at_baseband_nblocks(
-                &idat,
-                &qdat,
-                sample_rate,
-                c.start_sample,
-                c.freq_hz,
-                c.drift_hz,
-                &[1, 2, 3],
-            ) else {
-                continue;
-            };
-            let start_refined = d.start_sample;
-            d.dt_sec = (start_refined as i64 - pad as i64) as f32 / sample_rate as f32 - 1.0;
-            d.start_sample = start_refined.saturating_sub(pad);
-            d.snr_db = c.snr_db;
+        // Pass 2 uses nblock = 1, 2, 3 (coherent block detection) for
+        // the +3..+4.8 dB margin needed to decode signals like W3BI at
+        // -27 dB SNR. The strong-signal subtract above has exposed
+        // them in the spectrum, but they still need the coherent gain
+        // to clear the Fano convergence threshold. Same parallelize-
+        // the-decode-step / dedup-sequentially-after shape as pass 1
+        // above — this is pass 2's own per-candidate cost that's ~4x
+        // pass 1's (3 nblock values vs 1), the dominant single cost in
+        // `decode_scan` per `docs/notes/WSPR_BENCHMARK.md`'s Finding 2.
+        #[cfg(feature = "parallel")]
+        let raw2: Vec<WsprResult> = bb_cands2
+            .par_iter()
+            .filter_map(|c| decode_pass2_candidate(&idat, &qdat, sample_rate, pad, c))
+            .collect();
+        #[cfg(not(feature = "parallel"))]
+        let raw2: Vec<WsprResult> = bb_cands2
+            .iter()
+            .filter_map(|c| decode_pass2_candidate(&idat, &qdat, sample_rate, pad, c))
+            .collect();
+
+        for d in raw2 {
             let dup = seen.iter().any(|prev| {
                 prev.message == d.message
                     && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ

--- a/mfsk-core/src/wspr/subtract.rs
+++ b/mfsk-core/src/wspr/subtract.rs
@@ -122,12 +122,25 @@ pub fn subtract_signal_baseband(
     let mut cfq = vec![0.0f32; nc2];
     let half = NFILT / 2;
     for i in half..(nc2 - half) {
-        let mut acc_i = 0.0f32;
-        let mut acc_q = 0.0f32;
-        for j in 0..NFILT {
-            acc_i += window[j] * ci[i - half + j];
-            acc_q += window[j] * cq[i - half + j];
-        }
+        // `i - half + j` for `j in 0..NFILT` spans exactly
+        // `[i-half, i-half+NFILT)`, which the outer loop's
+        // `half..(nc2-half)` bound keeps within `ci`/`cq` — a plain
+        // slice zip instead of `NFILT` manually-indexed accesses per
+        // sample. Fused into one `fold` (not two separate `.sum()`
+        // chains) so `window[j]` is read once per `j` and reused for
+        // both products, matching the original single-pass loop —
+        // two separate chains measured a real ~5-6% regression
+        // (doubles the loop's iteration count, breaks whatever
+        // fused vectorization the original got).
+        let ci_win = &ci[i - half..i - half + NFILT];
+        let cq_win = &cq[i - half..i - half + NFILT];
+        let (acc_i, acc_q) = window
+            .iter()
+            .zip(ci_win)
+            .zip(cq_win)
+            .fold((0.0f32, 0.0f32), |(ai, aq), ((&w, &c_i), &c_q)| {
+                (ai + w * c_i, aq + w * c_q)
+            });
         cfi[i] = acc_i;
         cfq[i] = acc_q;
     }

--- a/mfsk-core/tests/wspr_wsjtx_samples.rs
+++ b/mfsk-core/tests/wspr_wsjtx_samples.rs
@@ -199,3 +199,143 @@ fn wspr_speed_diag() {
         times.len()
     );
 }
+
+/// Cost-split diagnostic — where does `decode_scan_subtract`'s
+/// wall-clock actually go? Follow-up to `wspr_speed_diag`: that probe
+/// found only the FFT-planner-cache item (of 4 tried) showed a real
+/// measured win, all ~1-2% of total — implying the dominant cost lives
+/// somewhere `wspr_speed_diag` doesn't break out. Replicates
+/// `decode_scan`'s exact 2-pass sequence (`decode.rs`) using its own
+/// `pub` building blocks, with `Instant` timers around each stage
+/// instead of just the end-to-end call.
+///
+/// Run: `cargo test --release --features full --test wspr_wsjtx_samples
+/// wspr_diag_candidate_cost_split -- --ignored --nocapture`
+#[test]
+#[ignore = "manual diagnostic — WSPR decode cost-split (perf-review follow-up)"]
+fn wspr_diag_candidate_cost_split() {
+    use std::time::Instant;
+
+    use mfsk_core::wspr::baseband::decimate_to_baseband;
+    use mfsk_core::wspr::coarse_baseband::coarse_baseband;
+    use mfsk_core::wspr::decode::{decode_at_baseband, decode_at_baseband_nblocks};
+    use mfsk_core::wspr::encode_channel_symbols;
+    use mfsk_core::wspr::subtract::subtract_signal_baseband;
+
+    let Some(path) = sample_path() else {
+        eprintln!(
+            "skipping: WSJT-X WSPR sample not found at ../../WSJT-X/samples/WSPR/150426_0918.wav"
+        );
+        return;
+    };
+    let audio = read_wsjtx_wav_f32(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let params = SearchParams {
+        freq_min_hz: 1400.0,
+        freq_max_hz: 1620.0,
+        max_candidates: 100,
+        score_threshold: 0.05,
+        ..SearchParams::default()
+    };
+    let sample_rate = 12_000u32;
+    let max_drift = 4i32;
+
+    // Mirror decode_scan's own NEGATIVE_DT_PAD_SEC padding exactly so
+    // candidate counts/alignment match the production path.
+    let pad = (3.0 * sample_rate as f32) as usize;
+    let mut padded = vec![0.0f32; pad + audio.len()];
+    padded[pad..].copy_from_slice(&audio);
+
+    let t0 = Instant::now();
+    let (mut idat, mut qdat) = decimate_to_baseband(&padded);
+    let t_decimate = t0.elapsed();
+
+    let t0 = Instant::now();
+    let mut cands1 = coarse_baseband(&idat, &qdat, pad, params.max_candidates, max_drift);
+    cands1.truncate(params.max_candidates);
+    let t_coarse1 = t0.elapsed();
+    let n_cand1 = cands1.len();
+
+    let t0 = Instant::now();
+    let mut pass1: Vec<(mfsk_core::wspr::WsprResult, usize)> = Vec::new();
+    for c in &cands1 {
+        if let Some(mut d) =
+            decode_at_baseband(&idat, &qdat, sample_rate, c.start_sample, c.freq_hz, 0.0)
+        {
+            let start_refined = d.start_sample;
+            d.start_sample = start_refined.saturating_sub(pad);
+            pass1.push((d, start_refined));
+        }
+    }
+    let t_pass1 = t0.elapsed();
+    let n_pass1_decoded = pass1.len();
+
+    let t0 = Instant::now();
+    for (d, start_refined) in &pass1 {
+        let symbols = encode_channel_symbols(&d.info_bits);
+        let f0_audio = d.freq_hz + 1.5 * mfsk_core::wspr::demod::TONE_SPACING_HZ;
+        let shift_baseband = (*start_refined as i32) / 32;
+        subtract_signal_baseband(
+            &mut idat,
+            &mut qdat,
+            f0_audio,
+            shift_baseband,
+            0.0,
+            &symbols,
+        );
+    }
+    let t_subtract = t0.elapsed();
+
+    let t0 = Instant::now();
+    let cands2 = coarse_baseband(&idat, &qdat, pad, params.max_candidates, max_drift);
+    let t_coarse2 = t0.elapsed();
+    let n_cand2 = cands2.len();
+
+    let t0 = Instant::now();
+    let mut n_pass2_decoded = 0;
+    for c in &cands2 {
+        if decode_at_baseband_nblocks(
+            &idat,
+            &qdat,
+            sample_rate,
+            c.start_sample,
+            c.freq_hz,
+            c.drift_hz,
+            &[1, 2, 3],
+        )
+        .is_some()
+        {
+            n_pass2_decoded += 1;
+        }
+    }
+    let t_pass2 = t0.elapsed();
+
+    let per_cand1_us = t_pass1.as_secs_f64() * 1e6 / n_cand1.max(1) as f64;
+    let per_cand2_us = t_pass2.as_secs_f64() * 1e6 / n_cand2.max(1) as f64;
+
+    eprintln!(
+        "\n=== WSPR 150426_0918.wav decode_scan_subtract cost split ===\n\
+         decimate_to_baseband      = {:8.1} ms\n\
+         coarse_baseband (pass 1)  = {:8.1} ms  ({} candidates)\n\
+         pass-1 refine+Fano total  = {:8.1} ms  ({:.1} µs/cand, {} decoded, nblocks=[1])\n\
+         subtract_signal_baseband  = {:8.1} ms  ({} decodes subtracted)\n\
+         coarse_baseband (pass 2)  = {:8.1} ms  ({} candidates)\n\
+         pass-2 refine+Fano total  = {:8.1} ms  ({:.1} µs/cand, {} decoded, nblocks=[1,2,3])\n\
+         ------------------------------------------------\n\
+         sum of stages above       = {:8.1} ms",
+        t_decimate.as_secs_f64() * 1000.0,
+        t_coarse1.as_secs_f64() * 1000.0,
+        n_cand1,
+        t_pass1.as_secs_f64() * 1000.0,
+        per_cand1_us,
+        n_pass1_decoded,
+        t_subtract.as_secs_f64() * 1000.0,
+        pass1.len(),
+        t_coarse2.as_secs_f64() * 1000.0,
+        n_cand2,
+        t_pass2.as_secs_f64() * 1000.0,
+        per_cand2_us,
+        n_pass2_decoded,
+        (t_decimate + t_coarse1 + t_pass1 + t_subtract + t_coarse2 + t_pass2).as_secs_f64()
+            * 1000.0,
+    );
+}

--- a/mfsk-core/tests/wspr_wsjtx_samples.rs
+++ b/mfsk-core/tests/wspr_wsjtx_samples.rs
@@ -142,3 +142,60 @@ fn wspr_wsjtx_sample_recall_vs_golden() {
         GOLDEN.len()
     );
 }
+
+/// Ad-hoc wall-clock timing probe for `decode_scan_subtract` on the
+/// real WSJT-X golden WAV — same params as
+/// `wspr_wsjtx_sample_recall_vs_golden`. Modeled on
+/// `bench_qso3_busy_timing.rs`'s warm-up-then-N-iteration structure
+/// (perf-review Phase 0, WSPR round — no prior WSPR timing harness
+/// existed before this).
+///
+/// Run: `cargo test --release --features full --test
+/// wspr_wsjtx_samples wspr_speed_diag -- --ignored --nocapture`
+#[test]
+#[ignore = "manual diagnostic — WSPR decode_scan_subtract timing (perf-review Phase 0)"]
+fn wspr_speed_diag() {
+    use std::time::Instant;
+
+    let Some(path) = sample_path() else {
+        eprintln!(
+            "skipping: WSJT-X WSPR sample not found at ../../WSJT-X/samples/WSPR/150426_0918.wav"
+        );
+        return;
+    };
+    let audio = read_wsjtx_wav_f32(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let params = SearchParams {
+        freq_min_hz: 1400.0,
+        freq_max_hz: 1620.0,
+        max_candidates: 100,
+        score_threshold: 0.05,
+        ..SearchParams::default()
+    };
+
+    // Warm-up (page faults, allocator, etc.) — excluded from timing.
+    let n = decode_scan_subtract(&audio, 12_000, 0, &params).len();
+    eprintln!("warm-up: {n} decodes");
+
+    const N_ITERS: usize = 5;
+    let mut times = Vec::with_capacity(N_ITERS);
+    for i in 0..N_ITERS {
+        let t0 = Instant::now();
+        let r = decode_scan_subtract(&audio, 12_000, 0, &params);
+        let dt = t0.elapsed();
+        eprintln!(
+            "iter {i:2}: {:8.3} ms  ({} decodes)",
+            dt.as_secs_f64() * 1000.0,
+            r.len()
+        );
+        times.push(dt.as_secs_f64() * 1000.0);
+    }
+
+    let total: f64 = times.iter().sum();
+    let avg = total / times.len() as f64;
+    let min = times.iter().cloned().fold(f64::INFINITY, f64::min);
+    let max = times.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+    eprintln!(
+        "\n=== WSPR 150426_0918.wav decode_scan_subtract timing (n={}) ===\navg={avg:.3} ms  min={min:.3} ms  max={max:.3} ms",
+        times.len()
+    );
+}

--- a/mfsk-core/tests/wspr_wsjtx_samples.rs
+++ b/mfsk-core/tests/wspr_wsjtx_samples.rs
@@ -339,3 +339,154 @@ fn wspr_diag_candidate_cost_split() {
             * 1000.0,
     );
 }
+
+/// Pass-nesting ablation — `WSPR_BENCHMARK.md`'s Option C question:
+/// does the *outer* `NPASSES=2` SIC (`decode_scan_subtract`, 12 kHz)
+/// earn its ~2x cost over the *inner* 2-pass SIC (`decode_scan` itself,
+/// 375 Hz baseband) it wraps, or is one layer doing all the real work?
+///
+/// Three conditions on the real WSJT-X golden WAV, all using `pub`
+/// building blocks (no source changes needed — `decode_scan`
+/// *is* "inner=1+2, outer=1" already; the outer ablation needs no
+/// separate helper since a single `decode_scan` call already skips
+/// the outer loop entirely):
+/// - **A**: inner pass-1 only, outer=1 — cheapest possible baseline.
+/// - **B**: inner pass-1+2, outer=1 (`decode_scan` called directly).
+/// - **D**: inner pass-1+2, outer=2 (`decode_scan_subtract`, the
+///   current production default).
+///
+/// `B \ A` isolates what the *inner* pass 2 contributes; `D \ B`
+/// isolates what the *outer* pass 2 contributes. (Condition C — inner=1
+/// only, outer=2 — is skipped: it needs the private `WSPR_SUBTRACT`
+/// LPF config to replicate the outer loop without `decode_scan`'s own
+/// inner pass 2, and A vs B / B vs D already answer the question this
+/// document needs answered without it.)
+///
+/// Run: `cargo test --release --features full --test wspr_wsjtx_samples
+/// wspr_diag_pass_ablation -- --ignored --nocapture`
+#[test]
+#[ignore = "manual diagnostic — WSPR outer/inner 2-pass ablation (WSPR_BENCHMARK.md Option C)"]
+fn wspr_diag_pass_ablation() {
+    use std::time::Instant;
+
+    use mfsk_core::wspr::WsprResult;
+    use mfsk_core::wspr::baseband::decimate_to_baseband;
+    use mfsk_core::wspr::coarse_baseband::coarse_baseband;
+    use mfsk_core::wspr::decode::{decode_at_baseband, decode_scan, decode_scan_subtract};
+
+    let Some(path) = sample_path() else {
+        eprintln!(
+            "skipping: WSJT-X WSPR sample not found at ../../WSJT-X/samples/WSPR/150426_0918.wav"
+        );
+        return;
+    };
+    let audio = read_wsjtx_wav_f32(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let params = SearchParams {
+        freq_min_hz: 1400.0,
+        freq_max_hz: 1620.0,
+        max_candidates: 100,
+        score_threshold: 0.05,
+        ..SearchParams::default()
+    };
+    let sample_rate = 12_000u32;
+    let max_drift = 4i32;
+    const FREQ_DEDUP_HZ: f32 = 5.0;
+    const TIME_DEDUP_SAMPLES: i64 = 8192;
+
+    // Condition A: inner pass-1 only, outer=1. Mirrors
+    // wspr_diag_candidate_cost_split's first half (decimate + coarse
+    // + pass-1 loop), stopping before subtract/re-coarse/pass-2.
+    let pad = (3.0 * sample_rate as f32) as usize;
+    let mut padded = vec![0.0f32; pad + audio.len()];
+    padded[pad..].copy_from_slice(&audio);
+
+    let t0 = Instant::now();
+    let (idat, qdat) = decimate_to_baseband(&padded);
+    let mut cands = coarse_baseband(&idat, &qdat, pad, params.max_candidates, max_drift);
+    cands.truncate(params.max_candidates);
+    let mut a_results: Vec<WsprResult> = Vec::new();
+    for c in &cands {
+        let Some(mut d) =
+            decode_at_baseband(&idat, &qdat, sample_rate, c.start_sample, c.freq_hz, 0.0)
+        else {
+            continue;
+        };
+        let start_refined = d.start_sample;
+        d.dt_sec = (start_refined as i64 - pad as i64) as f32 / sample_rate as f32 - 1.0;
+        d.start_sample = start_refined.saturating_sub(pad);
+        d.snr_db = c.snr_db;
+        let dup = a_results.iter().any(|prev| {
+            prev.message == d.message
+                && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ
+                && (prev.start_sample as i64 - d.start_sample as i64).abs() <= TIME_DEDUP_SAMPLES
+        });
+        if !dup {
+            a_results.push(d);
+        }
+    }
+    let t_a = t0.elapsed();
+
+    // Condition B: inner pass-1+2, outer=1.
+    let t0 = Instant::now();
+    let b_results = decode_scan(&audio, sample_rate, 0, &params);
+    let t_b = t0.elapsed();
+
+    // Condition D: inner pass-1+2, outer=2 (production default).
+    let t0 = Instant::now();
+    let d_results = decode_scan_subtract(&audio, sample_rate, 0, &params);
+    let t_d = t0.elapsed();
+
+    let hits = |results: &[WsprResult]| -> Vec<&'static str> {
+        GOLDEN
+            .iter()
+            .filter(|g| {
+                results.iter().any(|r| {
+                    r.message.to_string() == g.msg
+                        && (r.freq_hz - g.freq_hz).abs() <= FREQ_TOL_HZ
+                        && (r.dt_sec - g.dt_sec).abs() <= DT_TOL_SEC
+                })
+            })
+            .map(|g| g.msg)
+            .collect()
+    };
+    let a_hits = hits(&a_results);
+    let b_hits = hits(&b_results);
+    let d_hits = hits(&d_results);
+
+    eprintln!("\n=== WSPR 150426_0918.wav pass-nesting ablation ===");
+    eprintln!(
+        "A inner=1only outer=1        {:8.1} ms  {}/{} golden  {:?}",
+        t_a.as_secs_f64() * 1000.0,
+        a_hits.len(),
+        GOLDEN.len(),
+        a_hits
+    );
+    eprintln!(
+        "B inner=1+2   outer=1        {:8.1} ms  {}/{} golden  {:?}",
+        t_b.as_secs_f64() * 1000.0,
+        b_hits.len(),
+        GOLDEN.len(),
+        b_hits
+    );
+    eprintln!(
+        "D inner=1+2   outer=2 (prod) {:8.1} ms  {}/{} golden  {:?}",
+        t_d.as_secs_f64() * 1000.0,
+        d_hits.len(),
+        GOLDEN.len(),
+        d_hits
+    );
+    eprintln!(
+        "\ninner pass-2 contributes (B \\ A): {:?}",
+        b_hits
+            .iter()
+            .filter(|m| !a_hits.contains(m))
+            .collect::<Vec<_>>()
+    );
+    eprintln!(
+        "outer pass-2 contributes (D \\ B): {:?}",
+        d_hits
+            .iter()
+            .filter(|m| !b_hits.contains(m))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Extends the FT8/FST4 (#233) → FT4/Q65 (#235) efficiency campaign to
WSPR, per request. JT9 was scoped into the same branch initially but
descoped — both WSPR and JT9 are legacy/non-interactive modes (no QSO
real-time requirement), and WSPR alone already produced the largest
single win of the whole campaign, so this PR closes out WSPR-only.

8 commits:

1. `02781f3` — Phase-0 `wspr_speed_diag` timing test (none existed
   before this).
2. `f7efb13` — FFT-planner caching in `decimate_to_baseband`/
   `build_spectro` (same fix shape as #233's `downsample_cached`).
3. `8e2feb7` — dead `idat`/`qdat` clone removal before pass-2 subtract.
4. `362b769` — `fano_decode`'s `Vec<Node>` scratch pooling, traced safe
   against the exact Q65-codec-reuse regression shape from #235.
5. `42e3f57` — LPF convolution iterator-zip in `subtract_signal_baseband`
   — caught and fixed a real ~5-6% regression in the naive two-pass
   version before landing the fused single-pass fix.
6. `e7c2f2d` — `docs/notes/WSPR_BENCHMARK.md` (new) + a cost-split
   diagnostic, investigating why items 2-5 barely moved the needle:
   found `decode_scan_subtract` is a nested 2-pass-inside-2-pass
   structure, with pass-2's 3-`nblock` Fano/OSD sweep as the dominant
   cost (~62% of one `decode_scan` call).
7. `71fc382` — **the big one**: parallelized the pass-1/pass-2
   candidate loops via `rayon`, mirroring FT8's existing `par_iter()`
   pattern exactly. Pure parallelization of independent work, not an
   algorithm change (dedup stays sequential, order-preserving) — no
   recall risk.
8. `2a60b7e` — Option C calibration diagnostic (`wspr_diag_pass_ablation`):
   found the outer `NPASSES=2` SIC pass contributes 0 marginal golden
   recall on the one real WSPR sample available, at ~2.5x the cost of
   stopping after one inner `decode_scan` call. Documented with an
   explicit single-sample caveat and a conservative
   (conditional/tunable, not blanket-deleted) implementation
   recommendation for a future session — not implemented in this PR.

## Performance

Same-session `git worktree` A/B throughout (never comparing across
sessions, per #233's own corrected methodology):

- Items 2-5: mostly noise-level individually (~1-2% combined, almost
  entirely from item 2's FFT-planner cache) — landed for correctness/
  waste-elimination, not measured wins, matching this campaign's
  established honest-reporting standard.
- **Item 7 (parallelization): ~2.4x measured speedup** (alternating
  3x, 10-core host) — by far the largest single win across the whole
  FT8/FST4/FT4/Q65/WSPR campaign.
- Item 8 is a calibration diagnostic only, not a perf change.

## Correctness

Every commit verified byte-identical against
`wspr_wsjtx_sample_recall_vs_golden` (8/8 real WSJT-X golden messages,
same frequencies/dt). Full lib test suite: 378 passed, 0 failed. Full
build matrix (`scripts/pre-push-check.sh`: fmt, clippy on
`full`+`full,internal-testing`, rustdoc, 13-combo feature matrix,
including the bare `--features wspr` combo exercising item 7's
non-parallel fallback branch) clean throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
