### PR TITLE
feat(ft8): streaming decode via DecodeRequest::on_result / decode_block_streaming

### DIFF
--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -741,21 +741,73 @@ points, §6.3/§6.5):
   `.sic_rounds(n)` / `.sic_early()` to pick a
   successive-interference-cancellation strategy where the protocol
   supports it (`SupportsSicRounds`: FT8+FT4, `n` clamped 1..=3;
-  `SupportsSicEarly`: FT8 only, fixed 3-checkpoint structure). Call
+  `SupportsSicEarly`: FT8 only, fixed 3-checkpoint structure), and
+  `.on_result(cb)` (FT8 only today — see below) for streaming
+  delivery. Call
   `.decode()` to get a
   `DecodeOutcome<P>` (`.results: Vec<P::DecodeResult>`, plus
   `.fft_cache` for a follow-up call).
 * **`SniperRequest<P>`** — narrow-band, single-target search.
   `DecodeRequest::<P>::sniper(audio, target_freq_hz, max_cand)` or
   `SniperRequest::<P>::new(...)` directly; `.osd(bool)`,
-  `.strictness(...)`, `.eq_mode(...)`, and `.ap_hint(...)` where the
+  `.strictness(...)`, `.eq_mode(...)`, `.ap_hint(...)` where the
   protocol's message codec implements `WsjtApCompatible` (no SIC
-  variant — sniper mode is inherently single-candidate). `.decode()`
+  variant — sniper mode is inherently single-candidate), and
+  `.on_result(cb)` (same as above). `.decode()`
   returns the same `DecodeOutcome<P>` shape.
 
 This replaced FT8's `decode_frame*`/`decode_frame_subtract*`/
 `decode_sniper*` family (15 public functions) and FT4/FST4's own
 suffix-exploded equivalents — see §6.2/§6.4 for worked examples.
+
+#### Streaming delivery: `.on_result(cb)`
+
+FT8 only (`DecodeRequest<Ft8>`/`SniperRequest<Ft8>`, plus the embedded
+`ft8::decode_block::decode_block_streaming` sibling to `decode_block`)
+— `cb: &(dyn Fn(&P::DecodeResult) + Sync)` fires once per candidate as
+it's accepted, *alongside* (not instead of) `decode()`'s own returned
+`DecodeOutcome`. Purely additive: the batch API is unchanged, callers
+who don't call `.on_result()` see zero behavioural difference.
+
+**Delivery order and dedup contract differs by strategy** — see
+`DecodeRequest::on_result`'s own doc comment for the authoritative
+version, summarised here: on the sequential SIC strategies
+(`.sic_rounds()`/`.sic_early()`) and the embedded
+`decode_block_streaming`, `cb` fires exactly once per result that ends
+up in the returned `Vec`, in the same order — zero divergence. On the
+default single-pass strategy and `SniperRequest` (both parallelized
+via `rayon` under `feature = "parallel"`), `cb` fires from whichever
+thread decoded that candidate, in completion order, and *before* the
+final cross-candidate dedup pass — on the rare occasion two different
+sync candidates converge on the same message, `cb` may fire for both
+even though only one survives into the returned `Vec`.
+
+**Design decision: a synchronous callback, not `async`/a channel —
+portability first.** §0.2's stated goal is a single crate "consumed
+identically from several runtimes (native Rust, WebAssembly, Android
+JNI, C ABI)," broadening the set of platforms that can host it — an
+`async fn`/`Future`-based API (or anything requiring a channel/executor
+by default) would need `std` and a runtime everywhere in the call
+graph, which breaks the no_std embedded targets
+(`embedded-poc/m5stack-*-app`) that are first-class consumers of this
+exact decode path. `process_candidates_with_ap`'s existing fill-closure
+parameter already established the plain-callback idiom for this
+codebase (`F: FnMut(&mut [[Cmplx<f32>;8];79], &SyncCandidate,
+SymMask)`) — `.on_result()` follows the same shape rather than
+introducing a second, async-flavoured pattern next to it.
+
+This also means `mfsk-core` never needs to know *how* a caller wants
+results delivered across a thread — a host application wanting to feed
+a GUI wraps the callback itself (e.g. `Sender::send` inside the
+closure body) rather than the crate baking in a channel type. This
+mirrors §0.3's "generic core + per-protocol plug-ins" framing: `engine`
+and the protocol modules stay ignorant of their caller's runtime
+environment, and cross-slot-boundary background continuation (the
+WSJT-X "Fast"-mode shape — decoding keeps running after the next
+slot's capture has already started) is achievable today purely at the
+application layer (`std::thread::spawn` + call `.decode()`/
+`decode_block_streaming` there) without any core-library support for
+it.
 
 `DecodeDepth` (`llr_effort`/`osd`) itself is still a real type — it's
 what `decode_block`/`decode_block_into` (the embedded/host-shared

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -148,6 +148,18 @@ rustfft     = { version = "6", optional = true }
 crc         = { version = "3", default-features = false }
 rayon       = { version = "1", optional = true }
 
+[dev-dependencies]
+# Only for tests/ft8_decode_block_streaming.rs, which exercises the
+# true no_std decode_block_multipass arm (needs `fft-extern`, not the
+# host-default `fft-rustfft`) — that arm still needs *some* FftPlanner,
+# and `fft-extern`'s contract is that the final binary supplies
+# `mfsk_core_make_default_fft_planner` itself (see
+# `engine::fft::default_planner`'s doc comment: "tests / unusual
+# targets can return any Box<dyn FftPlanner> impl"). This dev-only
+# rustfft lets that one test provide it without touching the main
+# `fft-rustfft` feature/dependency.
+rustfft = "6"
+
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = [
     'cfg(feature, values("std","alloc","ft8","ft4","fst4","wspr","jt9","jt65","q65","msk144","packet-bytes","uvpacket","parallel","full","fft-rustfft","fft-extern","fixed-point","profile-coarse","nstep-half"))',

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -323,6 +323,7 @@ fn process_candidate_with_scratch(
 ///
 /// Returns `(decoded_results, fft_cache)`.  Callers that don't need the cache
 /// can simply ignore the second element.
+#[allow(clippy::too_many_arguments)]
 fn decode_frame_inner(
     audio: &[i16],
     freq_min: f32,
@@ -336,6 +337,7 @@ fn decode_frame_inner(
     eq_mode: EqMode,
     precomputed_fft: Option<&[num_complex::Complex<f32>]>,
     ap_hint: Option<&ApHint>,
+    on_result: Option<&(dyn Fn(&DecodeResult) + Sync)>,
 ) -> (Vec<DecodeResult>, Vec<num_complex::Complex<f32>>) {
     // `freq_hint` is intentionally not forwarded — the WSJT-X-faithful
     // decode_block::coarse_sync (the only FT8 coarse-sync after the v0.6
@@ -358,22 +360,34 @@ fn decode_frame_inner(
         return (Vec::new(), fft_cache);
     }
 
+    // `on_result` fires here, inside the per-candidate closure, *before*
+    // the cross-candidate dedup pass below — see `DecodeRequest::
+    // on_result`'s doc comment for why that ordering means a result can
+    // fire via callback but not survive into the returned `Vec`.
     #[cfg(feature = "parallel")]
     let raw: Vec<DecodeResult> = candidates
         .par_iter()
         .filter_map(|cand| {
-            process_candidate(
+            let r = process_candidate(
                 cand, audio, &fft_cache, depth, strictness, known, eq_mode, ap_hint,
-            )
+            )?;
+            if let Some(cb) = on_result {
+                cb(&r);
+            }
+            Some(r)
         })
         .collect();
     #[cfg(not(feature = "parallel"))]
     let raw: Vec<DecodeResult> = candidates
         .iter()
         .filter_map(|cand| {
-            process_candidate(
+            let r = process_candidate(
                 cand, audio, &fft_cache, depth, strictness, known, eq_mode, ap_hint,
-            )
+            )?;
+            if let Some(cb) = on_result {
+                cb(&r);
+            }
+            Some(r)
         })
         .collect();
 
@@ -431,6 +445,7 @@ fn flat_sic_inner(
     ap_hint: Option<&ApHint>,
     precomputed_fft: Option<&[num_complex::Complex<f32>]>,
     n_rounds: usize,
+    on_result: Option<&(dyn Fn(&DecodeResult) + Sync)>,
 ) -> (Vec<DecodeResult>, FftCache) {
     let mut residual = audio.to_vec();
     sic_inner_passes_with_cache(
@@ -446,6 +461,7 @@ fn flat_sic_inner(
         ap_hint,
         precomputed_fft,
         n_rounds,
+        on_result,
     )
 }
 
@@ -477,10 +493,11 @@ fn sic_inner_passes(
     eq_mode: EqMode,
     ap_hint: Option<&ApHint>,
     n_rounds: usize,
+    on_result: Option<&(dyn Fn(&DecodeResult) + Sync)>,
 ) -> Vec<DecodeResult> {
     sic_inner_passes_with_cache(
         residual, freq_min, freq_max, sync_min, depth, max_cand, strictness, known, eq_mode,
-        ap_hint, None, n_rounds,
+        ap_hint, None, n_rounds, on_result,
     )
     .0
 }
@@ -514,6 +531,7 @@ fn sic_inner_passes_with_cache(
     ap_hint: Option<&ApHint>,
     precomputed_fft: Option<&[num_complex::Complex<f32>]>,
     n_rounds: usize,
+    on_result: Option<&(dyn Fn(&DecodeResult) + Sync)>,
 ) -> (Vec<DecodeResult>, FftCache) {
     let mut all_results: Vec<DecodeResult> = Vec::new();
     let mut pass0_cache: Option<FftCache> = None;
@@ -609,6 +627,9 @@ fn sic_inner_passes_with_cache(
             // the FT4 busy-band-fading synthetic 10/10) passes
             // identically or better with the single-shot call.
             subtract_signal_lpf(residual, &r);
+            if let Some(cb) = on_result {
+                cb(&r);
+            }
             all_results.push(r);
         }
     }
@@ -707,6 +728,7 @@ pub(crate) fn decode_frame_subtract_staged_with_ap_debug_residual(
         strictness,
         EqMode::Off,
         ap_hint,
+        None,
     )
 }
 
@@ -728,6 +750,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
     strictness: DecodeStrictness,
     eq_mode: EqMode,
     ap_hint: Option<&ApHint>,
+    on_result: Option<&(dyn Fn(&DecodeResult) + Sync)>,
 ) -> (Vec<DecodeResult>, Vec<i16>) {
     use staged_checkpoint::{A_SAMPLES, B_SAMPLES, C_SAMPLES};
 
@@ -752,6 +775,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
             ap_hint,
             None,
             CHECKPOINT_SIC_ROUNDS,
+            on_result,
         );
         return (r, audio.to_vec());
     }
@@ -787,6 +811,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
         eq_mode,
         ap_hint,
         CHECKPOINT_SIC_ROUNDS,
+        on_result,
     );
     // Checkpoint A's own residual is not carried forward — only its
     // decoded results are (ft8_decode.f90 reloads `dd=iwave` fresh at
@@ -816,6 +841,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
             ap_hint,
             None,
             CHECKPOINT_SIC_ROUNDS,
+            on_result,
         );
         return (r, audio.to_vec());
     }
@@ -879,6 +905,7 @@ fn decode_frame_subtract_staged_with_ap_inner(
         eq_mode,
         ap_hint,
         CHECKPOINT_SIC_ROUNDS,
+        on_result,
     );
 
     let mut all_results = early_results;
@@ -902,6 +929,7 @@ fn decode_sniper_inner(
     eq_mode: EqMode,
     ap_hint: Option<&ApHint>,
     sync_min: f32,
+    on_result: Option<&(dyn Fn(&DecodeResult) + Sync)>,
 ) -> (Vec<DecodeResult>, FftCache) {
     let freq_min = (target_freq - 250.0).max(100.0);
     let freq_max = (target_freq + 250.0).min(5900.0);
@@ -919,11 +947,13 @@ fn decode_sniper_inner(
         return (Vec::new(), fft_cache);
     }
 
+    // Same on_result-fires-before-dedup ordering as decode_frame_inner —
+    // see its comment above the analogous par_iter block.
     #[cfg(feature = "parallel")]
     let raw: Vec<DecodeResult> = candidates
         .par_iter()
         .filter_map(|cand| {
-            process_candidate(
+            let r = process_candidate(
                 cand,
                 audio,
                 fft_cache.as_slice(),
@@ -932,14 +962,18 @@ fn decode_sniper_inner(
                 &[],
                 eq_mode,
                 ap_hint,
-            )
+            )?;
+            if let Some(cb) = on_result {
+                cb(&r);
+            }
+            Some(r)
         })
         .collect();
     #[cfg(not(feature = "parallel"))]
     let raw: Vec<DecodeResult> = candidates
         .iter()
         .filter_map(|cand| {
-            process_candidate(
+            let r = process_candidate(
                 cand,
                 audio,
                 fft_cache.as_slice(),
@@ -948,7 +982,11 @@ fn decode_sniper_inner(
                 &[],
                 eq_mode,
                 ap_hint,
-            )
+            )?;
+            if let Some(cb) = on_result {
+                cb(&r);
+            }
+            Some(r)
         })
         .collect();
 
@@ -981,6 +1019,7 @@ impl FrameDecodable for Ft8 {
             req.eq_mode,
             req.fft_cache.as_ref().map(FftCache::as_slice),
             req.ap_hint,
+            req.on_result,
         );
         DecodeOutcome {
             results,
@@ -998,6 +1037,7 @@ impl FrameDecodable for Ft8 {
             req.eq_mode,
             req.ap_hint,
             req.sync_min,
+            req.on_result,
         );
         DecodeOutcome { results, fft_cache }
     }
@@ -1028,6 +1068,7 @@ impl SupportsSicRounds for Ft8 {
                 req.ap_hint,
                 req.fft_cache.as_ref().map(FftCache::as_slice),
                 req.sic_rounds,
+                req.on_result,
             );
             DecodeOutcome { results, fft_cache }
         } else {
@@ -1048,6 +1089,7 @@ impl SupportsSicRounds for Ft8 {
                 req.ap_hint,
                 None,
                 req.sic_rounds,
+                req.on_result,
             );
             DecodeOutcome { results, fft_cache }
         }
@@ -1095,6 +1137,7 @@ impl SupportsSicEarly for Ft8 {
             req.strictness,
             req.eq_mode,
             req.ap_hint,
+            req.on_result,
         );
         // Belt-and-braces dedup: subtraction above should already
         // prevent `known` signals from re-decoding, but an imperfect

--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -49,6 +49,8 @@ pub use fill_symbol_spectra::{
     SymMask, fill_symbol_spectra, fill_symbol_spectra_generic, fill_symbol_spectra_goertzel,
     goertzel_window_end_sample, symbol_spectra_direct,
 };
+#[cfg(not(feature = "fft-rustfft"))]
+pub use process_candidates::decode_block_streaming;
 /// Phase 1.7.7-Stick: fill-closure variant for host research /
 /// regression tests (spec-lookup vs BASIS dot product comparison).
 pub use process_candidates::process_candidates_into_with_cs_scratch_tuned_with_fill;

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -91,6 +91,48 @@ pub fn decode_block<S: AudioSample>(
     )
 }
 
+/// [`decode_block`] with a per-candidate streaming callback — fires
+/// `on_result` once per accepted candidate, in candidate-processing
+/// order, immediately before that candidate's result is pushed into
+/// the returned `Vec` (this path is always sequential — no
+/// `parallel`/rayon on embedded — so every callback delivery is
+/// guaranteed to also appear in the returned `Vec`, unlike the host
+/// `DecodeRequest::on_result`'s single-pass/sniper strategies, which
+/// are parallelized and can fire on a same-slot duplicate that's later
+/// excluded — see that method's doc comment for the full contrast).
+///
+/// Not available under `fft-rustfft` (the host-shaped multipass/
+/// subtract driver, `decode_block_with_ap`'s engine) — that variant
+/// has a post-hoc `retain_mut` SNR re-gate after all subtract passes
+/// finish, which can drop or mutate a result *after* it would have
+/// already been streamed. Streaming that surface would need a
+/// revise/retract event this callback doesn't provide; use the
+/// non-streaming `decode_block`/`decode_block_with_ap` there instead.
+#[cfg(not(feature = "fft-rustfft"))]
+pub fn decode_block_streaming<S: AudioSample>(
+    audio: &[S],
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    depth: DecodeDepth,
+    max_cand: usize,
+    on_result: &mut dyn FnMut(&DecodeResult),
+) -> Vec<DecodeResult> {
+    let spec = compute_spectrogram(audio, freq_max);
+    let pass1 = coarse_sync(&spec, freq_min, freq_max, sync_min, pass1_limit());
+    drop(spec);
+    let pass1 = fine_refine_pass1(audio, pass1);
+    let pass2 = refine_candidates(audio, pass1, max_cand, None);
+    process_candidates_tuned_streaming(
+        audio,
+        pass2,
+        depth,
+        DEFAULT_Q_THRESH,
+        DEFAULT_BP_MAX_ITER,
+        on_result,
+    )
+}
+
 /// Variant of [`decode_block`] that accepts a runtime `bp_max_iter`
 /// (= per-LLR-variant BP iteration cap, default
 /// [`DEFAULT_BP_MAX_ITER`]). Useful on time-budgeted targets.
@@ -279,6 +321,7 @@ fn decode_block_multipass<S: AudioSample>(
                 strictness,
                 fft_cache.as_deref(),
                 &mut bp_scratch,
+                None,
             );
             for r in single_results {
                 if all.iter().any(|x| x.message77() == r.message77()) {
@@ -1078,6 +1121,41 @@ pub fn process_candidates_tuned<S: AudioSample>(
         None,
         DecodeStrictness::Normal,
         None,
+        None,
+    )
+}
+
+/// [`process_candidates_tuned`] with a per-candidate streaming
+/// callback — fires `on_result` once per accepted candidate, in
+/// candidate-processing order (this loop is always sequential, no
+/// `parallel`/rayon involved on the embedded path), immediately after
+/// the existing `results.push(r)` site inside
+/// [`process_candidates_with_ap`] — so, unlike the host's parallel
+/// `par_iter()` sites, every callback delivery here is guaranteed to
+/// also appear in the returned `Vec`, in the same order.
+///
+/// `#[cfg(not(feature = "fft-rustfft"))]`: this exists solely to back
+/// [`decode_block_streaming`], which is gated the same way — see that
+/// function's doc comment for why.
+#[cfg(not(feature = "fft-rustfft"))]
+pub(crate) fn process_candidates_tuned_streaming<S: AudioSample>(
+    audio: &[S],
+    cands: Vec<RefinedCandidate>,
+    depth: DecodeDepth,
+    q_thresh: u32,
+    bp_max_iter: u32,
+    on_result: &mut dyn FnMut(&DecodeResult),
+) -> Vec<DecodeResult> {
+    process_candidates_tuned_with_ap(
+        audio,
+        cands,
+        depth,
+        q_thresh,
+        bp_max_iter,
+        None,
+        DecodeStrictness::Normal,
+        None,
+        Some(on_result),
     )
 }
 
@@ -1102,6 +1180,7 @@ pub(super) fn process_candidates_tuned_with_ap<S: AudioSample>(
     ap_hint: Option<&ApHint>,
     strictness: DecodeStrictness,
     fft_cache: Option<&[Complex<f32>]>,
+    on_result: Option<&mut dyn FnMut(&DecodeResult)>,
 ) -> Vec<DecodeResult> {
     let mut bp_scratch =
         crate::fec::ldpc::bp::BpScratch::<crate::fec::ldpc::params::Ldpc174_91Params, LlrT>::new();
@@ -1115,6 +1194,7 @@ pub(super) fn process_candidates_tuned_with_ap<S: AudioSample>(
         strictness,
         fft_cache,
         &mut bp_scratch,
+        on_result,
     )
 }
 
@@ -1137,6 +1217,7 @@ pub(super) fn process_candidates_tuned_with_ap_scratch<S: AudioSample>(
         crate::fec::ldpc::params::Ldpc174_91Params,
         LlrT,
     >,
+    on_result: Option<&mut dyn FnMut(&DecodeResult)>,
 ) -> Vec<DecodeResult> {
     let mut cs_scratch: alloc::boxed::Box<[[Cmplx<f32>; 8]; 79]> =
         alloc::vec![[Cmplx::<f32>::default(); 8]; 79]
@@ -1155,6 +1236,7 @@ pub(super) fn process_candidates_tuned_with_ap_scratch<S: AudioSample>(
         },
         ap_hint,
         strictness,
+        on_result,
     )
 }
 
@@ -1284,6 +1366,7 @@ pub fn process_candidates_into_with_cs_scratch_tuned<S: AudioSample>(
         },
         None,
         DecodeStrictness::Normal,
+        None,
     )
 }
 
@@ -1328,6 +1411,7 @@ where
         fill,
         None,
         DecodeStrictness::Normal,
+        None,
     )
 }
 
@@ -1356,6 +1440,7 @@ fn process_candidates_with_ap<S: AudioSample, F>(
     mut fill: F,
     ap_hint: Option<&ApHint>,
     strictness: DecodeStrictness,
+    mut on_result: Option<&mut dyn FnMut(&DecodeResult)>,
 ) -> Vec<DecodeResult>
 where
     F: FnMut(&mut [[Cmplx<f32>; 8]; 79], &SyncCandidate, SymMask),
@@ -1409,6 +1494,9 @@ where
             strictness,
             0.0,
         ) {
+            if let Some(cb) = on_result.as_mut() {
+                cb(&r);
+            }
             results.push(r);
         }
     }

--- a/mfsk-core/src/msg/decode_request.rs
+++ b/mfsk-core/src/msg/decode_request.rs
@@ -100,6 +100,12 @@ pub trait SupportsSicEarly: FrameDecodable {
 /// is already validated for all three protocols.
 pub trait SupportsWideBandAp: FrameDecodable {}
 
+/// Callback type for [`DecodeRequest::on_result`]/[`SniperRequest::on_result`]
+/// — factored into a named alias purely to keep `clippy::type_complexity`
+/// quiet at the two struct-field sites; see `on_result`'s own doc comment
+/// for the actual delivery contract.
+type OnResultCallback<'a, P> = &'a (dyn Fn(&<P as FrameDecodable>::DecodeResult) + Sync);
+
 /// Decoded messages plus the FFT cache built along the way, reusable by a
 /// follow-up pipelined [`DecodeRequest::fft_cache`] call. The cache is
 /// always returned (it's already computed internally regardless of
@@ -138,6 +144,9 @@ pub struct DecodeRequest<'a, P: FrameDecodable> {
     /// structure is fixed. Not independently settable — see
     /// `sic_rounds`'s doc comment for why.
     pub(crate) sic_rounds: usize,
+    /// Set via [`DecodeRequest::on_result`] — see that method's doc
+    /// comment for the delivery-order/dedup contract.
+    pub(crate) on_result: Option<OnResultCallback<'a, P>>,
     strategy: fn(&DecodeRequest<'a, P>) -> DecodeOutcome<P>,
 }
 
@@ -165,6 +174,7 @@ impl<'a, P: FrameDecodable> DecodeRequest<'a, P> {
             known: &[],
             fft_cache: None,
             sic_rounds: 3,
+            on_result: None,
             strategy: P::__single_pass,
         }
     }
@@ -210,6 +220,40 @@ impl<'a, P: FrameDecodable> DecodeRequest<'a, P> {
     /// [`DecodeOutcome::fft_cache`]) instead of rebuilding it from `audio`.
     pub fn fft_cache(mut self, c: FftCache) -> Self {
         self.fft_cache = Some(c);
+        self
+    }
+    /// Fire `cb` once per candidate as it's accepted, *in addition to*
+    /// (not instead of) `decode()`'s own returned `DecodeOutcome` —
+    /// this is purely additive, streaming delivery alongside the
+    /// existing batch result, not a replacement for it.
+    ///
+    /// A plain synchronous callback, not an async/channel primitive —
+    /// see `docs/reference/LIBRARY.md`'s "public decode entry point"
+    /// section for why (portability: `mfsk-core`'s `engine`/protocol
+    /// layers stay `std`-and-executor-free so embedded targets keep
+    /// working; a host caller wanting cross-thread delivery to e.g. a
+    /// GUI wraps `cb` itself, such as a `Sender::send` inside the
+    /// closure — `mfsk-core` doesn't need to know about that).
+    ///
+    /// **Delivery order and dedup contract differs by strategy:**
+    /// - `.sic_rounds(_)`/`.sic_early()` (sequential SIC): `cb` fires
+    ///   exactly once per result that ends up in the returned `Vec`,
+    ///   in the same order — zero divergence from the batch result.
+    /// - the default single-pass strategy and [`SniperRequest`]
+    ///   (parallelized via `rayon` under `feature = "parallel"`): `cb`
+    ///   fires from whichever thread decoded that candidate, in
+    ///   completion order (not candidate-exploration order), and
+    ///   *before* the final cross-candidate dedup pass — on the rare
+    ///   occasion two different sync candidates converge on the same
+    ///   message, `cb` may fire for both even though only one survives
+    ///   into the returned `Vec`. Callers wanting exact parity should
+    ///   dedup by `.message77()` on their side, the same key the
+    ///   crate's own dedup already uses.
+    ///
+    /// `cb` must be `Sync` for this reason — it may be called
+    /// concurrently from multiple `rayon` worker threads.
+    pub fn on_result(mut self, cb: OnResultCallback<'a, P>) -> Self {
+        self.on_result = Some(cb);
         self
     }
 
@@ -304,6 +348,10 @@ pub struct SniperRequest<'a, P: FrameDecodable> {
     pub(crate) strictness: DecodeStrictness,
     pub(crate) eq_mode: EqMode,
     pub(crate) ap_hint: Option<&'a ApHint>,
+    /// Set via [`SniperRequest::on_result`] — see
+    /// [`DecodeRequest::on_result`]'s doc comment for the delivery-
+    /// order/dedup contract (same rules apply here).
+    pub(crate) on_result: Option<OnResultCallback<'a, P>>,
     _protocol: core::marker::PhantomData<P>,
 }
 
@@ -318,6 +366,7 @@ impl<'a, P: FrameDecodable> SniperRequest<'a, P> {
             strictness: DecodeStrictness::Normal,
             eq_mode: EqMode::Off,
             ap_hint: None,
+            on_result: None,
             _protocol: core::marker::PhantomData,
         }
     }
@@ -341,6 +390,13 @@ impl<'a, P: FrameDecodable> SniperRequest<'a, P> {
     }
     pub fn eq_mode(mut self, e: EqMode) -> Self {
         self.eq_mode = e;
+        self
+    }
+    /// See [`DecodeRequest::on_result`] — same contract (this request
+    /// type is always parallel-strategy-shaped, so the "may fire for a
+    /// duplicate that's later excluded" caveat always applies here).
+    pub fn on_result(mut self, cb: OnResultCallback<'a, P>) -> Self {
+        self.on_result = Some(cb);
         self
     }
 

--- a/mfsk-core/tests/ft8_decode_block_streaming.rs
+++ b/mfsk-core/tests/ft8_decode_block_streaming.rs
@@ -1,0 +1,172 @@
+//! `ft8::decode_block::decode_block_streaming` — the true no_std
+//! embedded-path streaming callback (`#[cfg(not(feature =
+//! "fft-rustfft"))]`, mirrors host's `DecodeRequest::on_result`).
+//!
+//! `decode_block_streaming` only exists when `fft-rustfft` is *off*,
+//! so this file (unlike this crate's other host recall tests) must be
+//! run against a feature combo that excludes it — the test binary
+//! itself is still linked against the host's real `std` regardless
+//! (only the *library*'s `std`/`fft-rustfft` features are toggled),
+//! so ordinary `std::fs` WAV loading still works here.
+//!
+//! Deliberately does **not** `mod common;` — that shared test module
+//! unconditionally pulls in `common::channel`/`common::air_channel`,
+//! which need `rustfft`/`uvpacket` (via `fft-rustfft`/`uvpacket`),
+//! defeating the entire point of this file (running with
+//! `fft-rustfft` off). Inlines a minimal WAV loader instead —
+//! source-faithful copy of `tests/common/mod.rs::load_wav_i16_opt`'s
+//! core parse loop, trimmed to just what this file needs.
+//!
+//! Run:
+//! ```sh
+//! cargo test --release -p mfsk-core --no-default-features \
+//!     --features std,ft8,fft-extern \
+//!     --test ft8_decode_block_streaming -- --nocapture
+//! ```
+#![cfg(not(feature = "fft-rustfft"))]
+
+use std::path::Path;
+
+use mfsk_core::ft8::decode::DecodeDepth;
+use mfsk_core::ft8::decode_block::{decode_block, decode_block_streaming};
+
+// Local, not `tests/common/mod.rs`'s — see the module doc above for why.
+macro_rules! asset_path {
+    ($asset:literal) => {
+        concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../embedded-poc/assets/",
+            $asset
+        )
+    };
+}
+
+const QSO3_PATH: &str = asset_path!("qso3_busy.wav");
+
+// `fft-extern`'s contract (`engine::fft::default_planner`'s doc
+// comment): the final binary supplies this symbol. A real embedded
+// target bridges to a chip-native FFT here; this test binary — like
+// the doc comment's own "tests / unusual targets can return any
+// Box<dyn FftPlanner> impl" — just wraps the dev-dependency `rustfft`
+// directly (not through this crate's own `fft-rustfft`-gated
+// wrapper, which is deliberately off in this file).
+mod fft_extern_impl {
+    use std::sync::Arc;
+
+    use mfsk_core::engine::fft::{Fft, FftPlanner};
+    use num_complex::Complex32;
+
+    struct TestFftPlanner {
+        inner: rustfft::FftPlanner<f32>,
+    }
+
+    struct TestFftAdapter {
+        inner: Arc<dyn rustfft::Fft<f32>>,
+    }
+
+    impl Fft for TestFftAdapter {
+        fn process(&self, buf: &mut [Complex32]) {
+            self.inner.process(buf);
+        }
+        fn len(&self) -> usize {
+            self.inner.len()
+        }
+    }
+
+    impl FftPlanner for TestFftPlanner {
+        fn plan_forward(&mut self, len: usize) -> Box<dyn Fft> {
+            Box::new(TestFftAdapter {
+                inner: self.inner.plan_fft_forward(len),
+            })
+        }
+        fn plan_inverse(&mut self, len: usize) -> Box<dyn Fft> {
+            Box::new(TestFftAdapter {
+                inner: self.inner.plan_fft_inverse(len),
+            })
+        }
+    }
+
+    #[unsafe(no_mangle)]
+    pub extern "Rust" fn mfsk_core_make_default_fft_planner() -> Box<dyn FftPlanner> {
+        Box::new(TestFftPlanner {
+            inner: rustfft::FftPlanner::new(),
+        })
+    }
+}
+
+/// Minimal RIFF/WAVE → mono i16 loader — see this file's module doc
+/// for why this doesn't just `mod common;`.
+fn load_wav_i16(path: impl AsRef<Path>) -> Vec<i16> {
+    let p = path.as_ref();
+    let bytes = std::fs::read(p).unwrap_or_else(|e| panic!("read {}: {e}", p.display()));
+    assert!(
+        bytes.len() >= 12 && &bytes[0..4] == b"RIFF" && &bytes[8..12] == b"WAVE",
+        "{} is not a RIFF/WAVE file",
+        p.display()
+    );
+    let mut i = 12usize;
+    let (mut sample_rate, mut bits, mut channels) = (0u32, 0u16, 0u16);
+    let (mut data_off, mut data_len) = (0usize, 0usize);
+    while i + 8 <= bytes.len() {
+        let id = &bytes[i..i + 4];
+        let len = u32::from_le_bytes(bytes[i + 4..i + 8].try_into().unwrap()) as usize;
+        i += 8;
+        if id == b"fmt " && i + 16 <= bytes.len() {
+            channels = u16::from_le_bytes(bytes[i + 2..i + 4].try_into().unwrap());
+            sample_rate = u32::from_le_bytes(bytes[i + 4..i + 8].try_into().unwrap());
+            bits = u16::from_le_bytes(bytes[i + 14..i + 16].try_into().unwrap());
+        } else if id == b"data" {
+            data_off = i;
+            data_len = len.min(bytes.len() - i);
+        }
+        i += len + (len % 2);
+    }
+    assert!(
+        channels == 1 && sample_rate == 12_000 && bits == 16 && data_off != 0,
+        "{} must be 12 kHz / mono / 16-bit PCM",
+        p.display()
+    );
+    bytes[data_off..data_off + data_len]
+        .chunks_exact(2)
+        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+        .collect()
+}
+
+#[test]
+fn decode_block_streaming_matches_decode_block_exactly() {
+    let slot = load_wav_i16(Path::new(QSO3_PATH));
+
+    let batch = decode_block(&slot, 100.0, 3000.0, 1.3, DecodeDepth::EMBEDDED, 15);
+
+    let mut streamed = Vec::new();
+    let streamed_count = decode_block_streaming(
+        &slot,
+        100.0,
+        3000.0,
+        1.3,
+        DecodeDepth::EMBEDDED,
+        15,
+        &mut |r| streamed.push(r.message77().to_vec()),
+    )
+    .len();
+
+    println!(
+        "batch: {} decode(s), streaming return: {} decode(s), callback firings: {}",
+        batch.len(),
+        streamed_count,
+        streamed.len()
+    );
+
+    // Embedded path is always sequential (no rayon on this cfg arm) —
+    // callback firings must exactly match the returned Vec, in the
+    // same order, and that Vec must exactly match plain decode_block's
+    // (same coarse_sync/refine/process_candidates_tuned pipeline,
+    // just with a callback threaded through — no behavior change).
+    let batch_msgs: Vec<Vec<u8>> = batch.iter().map(|r| r.message77().to_vec()).collect();
+    assert_eq!(
+        streamed, batch_msgs,
+        "streamed callback order/content must exactly match decode_block's own output"
+    );
+    assert_eq!(streamed_count, batch.len());
+    assert!(!batch.is_empty(), "expected real decodes on qso3_busy.wav");
+}

--- a/mfsk-core/tests/ft8_streaming_decode.rs
+++ b/mfsk-core/tests/ft8_streaming_decode.rs
@@ -1,0 +1,133 @@
+//! `DecodeRequest::on_result`/`SniperRequest::on_result` — streaming
+//! decode-callback verification against the real WSJT-X golden WAV
+//! (`qso3_busy.wav`), per `docs/reference/LIBRARY.md`'s "public decode
+//! entry point" section and the design doc comment on
+//! `DecodeRequest::on_result` itself.
+//!
+//! Two contracts to check, matching the two different delivery
+//! guarantees `on_result`'s own doc comment documents:
+//!
+//! 1. **Sequential SIC path** (`.sic_rounds(n)`): callback-delivered
+//!    messages must be *exactly* the batch result, same set, no more
+//!    no less — the push point inside `sic_inner_passes_with_cache`
+//!    *is* the final-acceptance point, so there's no divergence
+//!    mechanism at all.
+//! 2. **Parallel single-pass path** (`DecodeRequest::new(...)` with no
+//!    `.sic_rounds()`/`.sic_early()`): callback-delivered messages must
+//!    be a *superset* of the batch result — the callback fires inside
+//!    each candidate's `par_iter()` closure, before the later
+//!    cross-candidate dedup pass, so a same-message duplicate found by
+//!    two different sync candidates could in principle fire twice via
+//!    callback while only one survives into the final `Vec`. On the
+//!    real golden WAV this test doesn't actually hit that duplicate
+//!    case (verified equal, not just superset, below) — the assertion
+//!    is a superset check because that's the documented contract, not
+//!    because equality is expected to fail here.
+//!
+//! Run:
+//! ```sh
+//! cargo test --release -p mfsk-core --features fft-rustfft,ft8 \
+//!     --test ft8_streaming_decode -- --nocapture
+//! ```
+#![cfg(feature = "fft-rustfft")]
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::sync::Mutex;
+
+use mfsk_core::ft8::Ft8;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16;
+
+const QSO3_PATH: &str = asset_path!("qso3_busy.wav");
+
+#[test]
+fn ft8_streaming_sic_rounds_matches_batch_exactly() {
+    let slot = load_wav_i16(Path::new(QSO3_PATH));
+
+    let streamed: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let on_result = |r: &mfsk_core::ft8::decode::DecodeResult| {
+        if let Some(text) = unpack77(r.message77()) {
+            streamed.lock().unwrap().push(text);
+        }
+    };
+
+    let outcome = DecodeRequest::<Ft8>::new(&slot, 100.0, 3000.0, 1.3, 50)
+        .sic_rounds(3)
+        .on_result(&on_result)
+        .decode();
+
+    let batch: BTreeSet<String> = outcome
+        .results
+        .iter()
+        .filter_map(|r| unpack77(r.message77()))
+        .collect();
+    let streamed: BTreeSet<String> = streamed.into_inner().unwrap().into_iter().collect();
+
+    println!(
+        "batch: {} decode(s), streamed: {} callback(s)",
+        batch.len(),
+        streamed.len()
+    );
+
+    assert_eq!(
+        streamed, batch,
+        "sequential SIC path: streamed callback deliveries must exactly \
+         match the batch result (no divergence mechanism exists on this path)"
+    );
+    // Sanity: this is a real decode, not a vacuously-true empty-set match.
+    assert!(!batch.is_empty(), "expected real decodes on qso3_busy.wav");
+}
+
+#[test]
+fn ft8_streaming_single_pass_superset_of_batch() {
+    let slot = load_wav_i16(Path::new(QSO3_PATH));
+
+    let streamed: Mutex<Vec<String>> = Mutex::new(Vec::new());
+    let on_result = |r: &mfsk_core::ft8::decode::DecodeResult| {
+        if let Some(text) = unpack77(r.message77()) {
+            streamed.lock().unwrap().push(text);
+        }
+    };
+
+    // No .sic_rounds()/.sic_early() — default single-pass strategy,
+    // parallelized via par_iter() under feature = "parallel".
+    let outcome = DecodeRequest::<Ft8>::new(&slot, 100.0, 3000.0, 1.3, 50)
+        .on_result(&on_result)
+        .decode();
+
+    let batch: BTreeSet<String> = outcome
+        .results
+        .iter()
+        .filter_map(|r| unpack77(r.message77()))
+        .collect();
+    let streamed: BTreeSet<String> = streamed.into_inner().unwrap().into_iter().collect();
+
+    println!(
+        "batch: {} decode(s), streamed: {} callback(s)",
+        batch.len(),
+        streamed.len()
+    );
+
+    let missing_from_stream: Vec<&String> = batch.difference(&streamed).collect();
+    assert!(
+        missing_from_stream.is_empty(),
+        "every batch result must have fired via callback at least once: missing {:?}",
+        missing_from_stream
+    );
+    assert!(!batch.is_empty(), "expected real decodes on qso3_busy.wav");
+    // On this golden WAV the parallel path happens not to hit the
+    // documented same-message-two-candidates duplicate case — verify
+    // that explicitly rather than silently allowing the weaker
+    // superset check to mask a real regression elsewhere.
+    assert_eq!(
+        streamed, batch,
+        "no duplicate-delivery case expected on this golden WAV \
+         (if this starts failing, the superset contract is what's \
+         guaranteed, not this equality — see this test's doc comment)"
+    );
+}


### PR DESCRIPTION
## Summary

Adds streaming per-candidate result delivery to FT8's decode API, per
request: WSJT-X's newer decoders return results progressively as
candidates resolve (BP/OSD/SIC cost varies a lot per candidate) rather
than blocking until the whole slot finishes. This adds the same shape
here, scoped to FT8.

- `DecodeRequest<Ft8>`/`SniperRequest<Ft8>` gain `.on_result(cb)` —
  `cb: &(dyn Fn(&DecodeResult) + Sync)` fires once per accepted
  candidate, purely additive alongside the existing batch
  `DecodeOutcome`/`Vec<DecodeResult>`.
- Embedded (`#[cfg(not(feature = "fft-rustfft"))]`, true no_std): new
  `ft8::decode_block::decode_block_streaming` alongside `decode_block`.
- **Design decision, not just an API addition**: a synchronous
  callback, not `async`/a channel — documented in
  `docs/reference/LIBRARY.md`'s "public decode entry point" section
  and `DecodeRequest::on_result`'s own doc comment. `mfsk-core`'s
  stated goal (running identically across native/WebAssembly/Android
  JNI/C ABI) rules out anything requiring `std` + an executor in
  `engine`/protocol code — that would break the no_std embedded
  targets that are first-class consumers of this exact path. A host
  wanting cross-thread delivery (e.g. to a GUI) wraps the callback
  itself; true cross-slot-boundary background continuation (WSJT-X's
  "Fast" mode) is achievable today at the application layer without
  any core-library change.

## Delivery contract

- **Sequential paths** (`.sic_rounds()`/`.sic_early()` on host,
  `decode_block_streaming` on embedded — always single-threaded):
  callback fires exactly once per result in the returned `Vec`, same
  order. Zero divergence.
- **Parallel paths** (default single-pass, `SniperRequest` — `rayon`
  `par_iter()` under `feature = "parallel"`): callback fires from
  whichever thread decoded that candidate, in completion order, before
  the cross-candidate dedup pass. On the rare case two sync candidates
  converge on the same message, the callback may fire for both even
  though only one survives into the returned `Vec` — documented, not
  silently different.

## Correctness

- New `tests/ft8_streaming_decode.rs` (real `qso3_busy.wav`): SIC path
  — callback set exactly equals batch (20/20). Single-pass path —
  callback set is a superset of (verified exactly equal, on this
  golden) batch (14/14).
- New `tests/ft8_decode_block_streaming.rs` (true no_std, `--features
  std,ft8,fft-extern` — the test binary supplies its own
  `rustfft`-backed `FftPlanner` per `fft-extern`'s own contract, see
  the new dev-only `rustfft` dependency): streaming callback firings
  exactly match `decode_block`'s own output (4/4).
- Existing recall suites (`ft8_qso3_apoff/apon/full_parity/jtdx_recall`)
  byte-identical.
- Full lib test suite: 378 passed, 0 failed.
- No perf claim — this is an API-shape change. Spot-checked
  `bench_qso3_busy_timing.rs` once: no red flags.
- Full build matrix (`scripts/pre-push-check.sh`) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
