### PR TITLE
docs(ft8): correct on_result's delivery-order claim — coarse_sync IS score-sorted

### DIFF
--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -782,6 +782,23 @@ final cross-candidate dedup pass — on the rare occasion two different
 sync candidates converge on the same message, `cb` may fire for both
 even though only one survives into the returned `Vec`.
 
+**Does delivery order favour strong signals?** Tends to, on *both*
+strategy families — `ft8::decode_block::coarse_sync` returns
+candidates sorted by Costas sync score descending, and both the
+sequential SIC loop and the parallel sweep process/dispatch that list
+in-order, so higher-scored (typically stronger) candidates tend to
+surface first either way (sync score correlates with SNR). But it's a
+correlation, not a guarantee: sync score is a pre-demod
+correlation-power measurement, not a direct predictor of post-demod
+BP/OSD cost, so a highly-scored candidate can still need the full OSD
+escalation while a lower-scored one converges in one BP pass. On the
+**sequential** strategies specifically this has a real consequence the
+parallel ones don't share — a candidate ahead in the list that needs
+deep OSD blocks every candidate behind it (including ones that would
+individually decode in microseconds), since there's only one thread;
+the parallel strategies have no such blocking, each candidate's cost
+is independent of every other's.
+
 **Design decision: a synchronous callback, not `async`/a channel —
 portability first.** §0.2's stated goal is a single crate "consumed
 identically from several runtimes (native Rust, WebAssembly, Android

--- a/mfsk-core/src/msg/decode_request.rs
+++ b/mfsk-core/src/msg/decode_request.rs
@@ -250,6 +250,31 @@ impl<'a, P: FrameDecodable> DecodeRequest<'a, P> {
     ///   dedup by `.message77()` on their side, the same key the
     ///   crate's own dedup already uses.
     ///
+    /// **Does "delivery order" mean strong signals report first?**
+    /// Tends to, on both strategies, but it's a correlation, not a
+    /// guarantee, for two independent reasons:
+    /// - `coarse_sync` (`ft8::decode_block::coarse_sync`) returns
+    ///   candidates sorted by Costas sync score *descending* — both
+    ///   the sequential SIC loop and the parallel `par_iter()` sweep
+    ///   process/dispatch that list in-order, and sync score does
+    ///   correlate with SNR, so higher-scoring (typically stronger)
+    ///   candidates tend to appear earlier either way.
+    /// - Sync score is a pre-demod correlation-power measurement, not
+    ///   a direct predictor of post-demod BP/OSD cost — fading,
+    ///   interference, and frequency drift can decouple the two for
+    ///   any individual signal, so a highly-scored candidate can still
+    ///   need the full OSD escalation while a slightly-lower-scored
+    ///   one converges in one BP pass.
+    /// - On the **sequential** strategies specifically, this residual
+    ///   mismatch has a real consequence the parallel strategies don't
+    ///   share: a candidate ahead in the (mostly-but-not-perfectly)
+    ///   strength-ordered list that needs deep OSD blocks every
+    ///   candidate behind it — including ones that would individually
+    ///   decode in microseconds — since there's only one thread. The
+    ///   parallel strategies don't have this blocking problem; each
+    ///   candidate's processing is independent of every other
+    ///   candidate's cost.
+    ///
     /// `cb` must be `Sync` for this reason — it may be called
     /// concurrently from multiple `rayon` worker threads.
     pub fn on_result(mut self, cb: OnResultCallback<'a, P>) -> Self {


### PR DESCRIPTION
Follow-up correction to #237: verified against the actual `coarse_sync` code that candidates are returned Costas-sync-score descending, not scan-order — so both the sequential SIC strategies *and* the parallel single-pass/sniper strategies tend to surface strong signals first (score correlates with SNR), not just the parallel one as previously documented. Corrects `DecodeRequest::on_result`'s doc comment and `LIBRARY.md`'s streaming-delivery section with the accurate picture, including the residual caveats (sync score isn't a perfect BP/OSD-cost predictor; sequential strategies still have head-of-line blocking that parallel ones don't).

Docs only, no code changes. Full build matrix (`scripts/pre-push-check.sh`) clean; `ft8_streaming_decode`/`ft8_decode_block_streaming` tests re-verified passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)