### PR TITLE
docs: add streaming decode interface reference (EN/JA)

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,13 @@ reference:
      layout: docs/ lives at the repo root, not under the crate). -->
 - **English:** [`docs/reference/LIBRARY.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/reference/LIBRARY.md)
 - **日本語:** [`docs/reference/LIBRARY.ja.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/reference/LIBRARY.ja.md)
+- **Streaming decode interface (`.on_result` + async bridge):**
+  [English `docs/reference/STREAMING.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/reference/STREAMING.md)
+  / [日本語 `docs/reference/STREAMING.ja.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/reference/STREAMING.ja.md)
+  — per-protocol streaming entry points, the delivery contract
+  (sequential exact-match vs. parallel completion-order), why it's a
+  synchronous callback rather than `async`/Tokio/a channel, and a
+  complete worked example of driving it from a Tokio async client.
 - **Benchmarks vs. WSJT-X, full per-protocol detail:**
   [`docs/notes/BENCHMARKS.md`](https://github.com/jl1nie/mfsk-core/blob/main/docs/notes/BENCHMARKS.md)
   — golden-WAV recall + AWGN sensitivity sweep results for every

--- a/docs/reference/LIBRARY.md
+++ b/docs/reference/LIBRARY.md
@@ -857,6 +857,13 @@ application layer (`std::thread::spawn` + call `.decode()`/
 `decode_block_streaming` there) without any core-library support for
 it.
 
+> **Dedicated guide:** [STREAMING.md](STREAMING.md)
+> ([日本語](STREAMING.ja.md)) collects the per-protocol streaming
+> entry points, both delivery contracts, the full "why a synchronous
+> callback, not `async`/Tokio/a channel" rationale, and a complete
+> worked example of bridging `.on_result` into a Tokio async client
+> (`spawn_blocking` + `mpsc` + optional `Stream` adaptor).
+
 `DecodeDepth` (`llr_effort`/`osd`) itself is still a real type — it's
 what `decode_block`/`decode_block_into` (the embedded/host-shared
 plain-function FT8 API, §10) take positionally — but `DecodeRequest`/

--- a/docs/reference/STREAMING.ja.md
+++ b/docs/reference/STREAMING.ja.md
@@ -1,0 +1,399 @@
+# mfsk-core — ストリーミングデコードインターフェイス
+
+> **English:** [STREAMING.md](STREAMING.md)
+
+本ドキュメントは mfsk-core の**ストリーミング配信**インターフェイス
+を解説する: `DecodeRequest` / `SniperRequest` ファミリの
+`.on_result(cb)` コールバックとプロトコルごとの兄弟関数、その配信契約
+が保証するもの、**なぜ `async fn` / `Future` / チャネルベースの API で
+はなく素の同期コールバックなのか**、そして Tokio 非同期クライアントへ
+橋渡しする完全な実例。
+
+ライブラリ全体（トレイト階層、DSP プリミティブ、C ABI）については
+[LIBRARY.ja.md](LIBRARY.ja.md) を参照。本ドキュメントはそのうち §4 の
+「ストリーミング配信」を深掘りし、非同期橋渡しの実例を追加したもの。
+
+---
+
+## 1. ここでの「ストリーミング」とは
+
+デコードは**すでに手元にある 1 スロット分の音声**を対象とする —
+FT8 なら 15 秒、WSPR なら 110.6 秒、といった単位である。開きっぱなし
+のソケット読み込みではない。したがって「ストリーミング」は*サンプルを
+逐次流し込む*という意味ではない（スロット全体を参照で渡す）。逆方向、
+つまり**結果が逐次流れ出す**ことを指す。スロット全体のデコードが完了
+してから単一の `Vec` として返すのではなく、デコーダがメッセージを見つ
+けるたびに、受理された 1 件ごとにコールバックが 1 回発火する。
+
+バッチ API とストリーミング API は**同じ呼び出し**である。ストリーミ
+ングは純粋に加算的:
+
+```rust
+use mfsk_core::ft8::Ft8;
+use mfsk_core::msg::decode_request::DecodeRequest;
+
+// バッチ: 最後にまとめて受け取る。
+let outcome = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 1.5, 100)
+    .decode();
+for r in &outcome.results { /* ... */ }
+
+// ストリーミング: 同じデコードに、途中で結果ごとに発火するコールバック
+// を足すだけ。終了後も `outcome.results` はバッチ全体を保持している。
+let on_result = |r: &mfsk_core::ft8::decode::DecodeResult| {
+    // 候補が受理されるたびに発火
+};
+let outcome = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 1.5, 100)
+    .on_result(&on_result)
+    .decode();
+```
+
+`.on_result()` を呼ばない呼び出し側にとっては、この機能が存在しなかっ
+た頃と挙動上の差はまったくない。
+
+### なぜストリーミングするのか
+
+1 スロットのデコードは瞬時ではない。混雑した FT8 バンドでは OSD エスカ
+レーションを伴うフルデプスの広帯域探索がホストでも体感できる程度に時間
+を要し、組込みターゲットではさらに長い。ストリーミングにより、最初の
+（通常は最も強い）デコードが得られた瞬間に UI に描画でき、最も高価な最
+後の候補が深い OSD を抜けきるまでスピナーを眺めずに済む。ログ記録、QSO
+状態機械、スポットのアップロードといった下流段も、後続の結果を計算中で
+あっても早い結果に対して処理を開始できる。
+
+---
+
+## 2. プロトコルごとのエントリポイント
+
+プロトコル横断の**共有コールバック型は存在しない** —
+`DecodeResult`（FT8/FT4/FST4）、`Q65Result`、`WsprResult`、
+`Jt65Result`、`Jt9Result` は構造的に別物である。よってこれは 1 つのトレ
+イトで抽象化するものではなく、各プロトコル自身の API ファミリ内で同じ
+名前・同じ意味論に従う一貫した*パターン*である。
+
+| プロトコル           | エントリポイント                                                        | コールバック型                          |
+|----------------------|------------------------------------------------------------------------|-----------------------------------------|
+| FT8 / FT4 / FST4     | `DecodeRequest<P>` / `SniperRequest<P>` — `.on_result(cb)`             | `&(dyn Fn(&DecodeResult) + Sync)`       |
+| Q65                  | `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` — `.on_result(cb)` | `&(dyn Fn(&Q65Result) + Sync)`          |
+| WSPR                 | `decode_scan_streaming` / `decode_scan_subtract_streaming`             | `&(dyn Fn(&WsprResult) + Sync)`         |
+| JT65                 | `decode_scan_streaming`                                                | `&(dyn Fn(&Jt65Result) + Sync)`         |
+| JT9                  | `decode_scan_streaming`                                                | `&(dyn Fn(&Jt9Result) + Sync)`          |
+| FT8（組込み no_std） | `ft8::decode_block::decode_block_streaming`                            | `&mut dyn FnMut(&DecodeResult)`         |
+
+補足:
+
+- **ビルダ（FT8/FT4/FST4/Q65）**は `.on_result(cb)` をもう 1 つの連鎖可
+  能なメソッドとして持つ。返される `DecodeOutcome` は引き続きバッチ全体
+  を保持する。
+- **WSPR/JT65/JT9 にはビルダがない**ため、既存の `decode_scan` に対する
+  `decode_scan_streaming` *兄弟関数*が追加された（WSPR には
+  `decode_scan_subtract` に対する `decode_scan_subtract_streaming` もあ
+  る）。兄弟関数は同じ引数に末尾の `on_result` 参照を足したもので、非ス
+  トリーミング版と同じ `Vec` を返す。
+- **組込み FT8 パス**（`decode_block_streaming`、`fft-rustfft` が*オフ*
+  のときだけコンパイルされる）は `&dyn Fn + Sync` ではなく
+  `&mut dyn FnMut` を取る。このパスは厳密に逐次（no_std では rayon なし）
+  なので、捕捉した状態を変更する `FnMut` クロージャで安全であり、`Sync`
+  境界は不要。`fft-rustfft` 下では利用不可 — ホストのマルチパス/減算ド
+  ライバは事後の SNR 再ゲートを持ち、結果が*すでにストリームされた後*に
+  それを破棄・変更しうる。このコールバックには修正/撤回イベントがないた
+  め。
+
+---
+
+## 3. 配信契約
+
+契約はちょうど**2 種類**あり、戦略が逐次で走るか `rayon`
+（`feature = "parallel"`）下で走るかで決まる。正典は
+`DecodeRequest::on_result` の doc コメントで、ここではその要約を示す。
+
+### 3a. 逐次 — 完全一致
+
+`cb` は**返される `Vec` に最終的に載る結果ごとに、同じ順序でちょうど
+1 回**発火する。ストリームした内容とバッチ返り値の間に乖離はゼロ。
+
+対象: `.sic_rounds(n)` と `.sic_early()`（FT8/FT4 の SIC 戦略）、組込み
+の `decode_block_streaming`、JT65 と JT9 の `decode_scan_streaming`、
+Q65 の全ビルダ、WSPR の `decode_scan_subtract_streaming`（自身の外側
+SIC パスの受理点でのみ発火）。Q65 の `MultiPeriodRequest` は逐次形の一
+変種で、候補ごとではなく受理デコードを生む**スロットごと**に 1 回発火
+する（複数周期 EME / 電離層散乱の平均化における自然なストリーミング単
+位）。
+
+### 3b. 並列 — 完了順、一時的な重複がありうる
+
+`cb` は**その候補をデコードしたスレッドから、完了順**（候補探索順では
+ない）に、そして最終的なクロス候補デデュープパスの**前**に発火する。
+2 つの同期候補が同じメッセージに収束する稀なケースでは、`Vec` に残るの
+は 1 件だけでも `cb` は両方に対して発火しうる。バッチと厳密に一致させた
+い呼び出し側は自分の側で `.message77()` によるデデュープを行うこと —
+クレート自身のデデュープが使うのと同じキーである。
+
+対象: デフォルトの単一パス戦略と `SniperRequest`（FT8/FT4）、WSPR の
+`decode_scan_streaming`（両方の粗探索パスが `rayon::par_iter()` 下で走
+る）。
+
+**これが並列パスのコールバックに `Sync` が必要な理由である** — 複数の
+rayon ワーカスレッドから並行して呼ばれうる。
+
+### 配信順は強い信号を優先するか
+
+両ファミリで、そうなる傾向はある: `coarse_sync` は候補を Costas 同期ス
+コアの降順で返し、逐次ループも並列スイープもそのリストを順に処理するた
+め、スコアの高い（同期スコアは SNR と相関するので通常はより強い）候補
+が先に現れやすい。ただし**相関であって保証ではない** — 同期スコアはデ
+モジュレーション前の相関電力の測定値であり、デモジュレーション後の
+BP/OSD コストの予測子ではない。よってスコアの高い候補がフル OSD エスカ
+レーションを要する一方、スコアの低い候補が 1 回の BP パスで収束すること
+もある。逐次戦略に限っては、深い OSD を要するリスト前方の候補が後続すべ
+ての候補をブロックする（単一スレッド）; 並列戦略にこのヘッドオブライン
+ブロッキングはない。
+
+---
+
+## 4. なぜ同期コールバックで、`async` / Tokio / チャネルではないのか
+
+これは未完成ではなく意図的な設計判断である。要約すると: **mfsk-core は
+ランタイム非依存を保ち、各コンシューマ（ランタイムをまったく持てないも
+のを含む）が自身の並行モデルを選べるようにする。そして端で Tokio に橋
+渡しするのは自明（§5）なので、コアから async を排しても失うものはな
+い。**
+
+理由を重み順に:
+
+### 4a. 移植性 — コアは `std`・エグゼキュータ非依存でなければならない
+
+mfsk-core が掲げる目標は「複数のランタイム（ネイティブ Rust、
+WebAssembly、Android JNI、C ABI）から同一に消費される」単一クレートで
+ある。`engine` とプロトコル層が `no_std` クリーンなのは、ESP32 組込み
+ターゲット（`embedded-poc/m5stack-*-app`）が**まさにこのデコードパスの
+一級コンシューマ**だからだ — 同じ `decode_block` ストリーミングコール
+バックが、アロケータ付きエグゼキュータも `std` も持たない Xtensa LX7 上
+で走る。
+
+`async fn` / `Future` を返す API — あるいは既定でチャネルやエグゼキュー
+タを要求する何か — は、`std` とランタイムをコールグラフ*全体*に引き込
+み、それらの `no_std` ターゲット、`wasm32-unknown-unknown` ビルド、
+C ABI（`libmfsk.so`）、JNI スキャフォールドを壊す。同期 `Fn` コールバッ
+クはそのすべてで無変更でコンパイルされる。
+
+### 4b. `await` するものがない
+
+async は**I/O バウンド**で中断点の多い処理 — ソケット・タイマ・ディス
+ク待ち — に適した道具である。デコードはその正反対で、**固定のインメモ
+リバッファに対する CPU バウンドな計算**を最初から最後まで行い、譲るべ
+き外部イベントを持たない。これを `async` にしても、ランタイム機構と関数
+色の伝播を増やすだけで、レイテンシもスループットも**まったく**得られな
+い — リアクタが代わりに有用な仕事をできる await 点が存在しないからだ。
+
+### 4c. ランタイム選択を強制しない（関数の色付けがない）
+
+`async` なデコード API はその上のコールスタック全体を色付けする: すべて
+の呼び出し側も `async` になり、*何らかの*エグゼキュータを走らせねばな
+らない。同期コールバックはそれを一切強制しない。呼び出し側がモデルを選
+ぶ — Tokio、`async-std`、素の `std::thread`、GUI イベントループ、素の
+組込みスーパーループ、あるいは何も無し — そして mfsk-core はどれかを知
+る必要がない。`tokio::sync::mpsc`（や任意のチャネル型）を焼き込めば、ラ
+ンタイムを使えないコンシューマに特定のランタイムを強制し、呼び出し側が
+1 行でできる仕事のためにクレートが重いオプション依存を背負うことにな
+る。
+
+### 4d. コードベース内の前例
+
+素のコールバックのイディオムはすでにここにある:
+`process_candidates_with_ap` は充填クロージャ
+（`F: FnMut(&mut [[Cmplx<f32>;8];79], &SyncCandidate, SymMask)`）を取
+る。`.on_result()` は 2 つ目の async 風パターンを隣に導入するのではな
+く、同じ形に従う。
+
+### 帰結
+
+mfsk-core は*あなたが*供給するクロージャを通じて結果を配信するので、そ
+れがどうスレッドやランタイムを越えるかはあなたが握る。Tokio チャネルに
+乗せたい? クロージャに `Sender` を入れる。GUI スレッドに乗せたい? クロー
+ジャからイベントループへポストする。スロット跨ぎのバックグラウンド継続
+（WSJT-X「Fast」モード型 — 次スロットのキャプチャ開始後もデコードを続け
+る）が欲しい? `std::thread::spawn` してそこで `.decode()` を呼ぶ。どれ
+もコアライブラリの支援を要さず、すべてアプリケーションの端で組み上が
+る。
+
+---
+
+## 5. 実例: Tokio 非同期クライアントから呼ぶ
+
+目標: 1 つの 15 秒 FT8 スロットを**非同期ランタイムをブロックせず**にデ
+コードし、各メッセージを最後にまとめてではなく**デコードされた瞬間に**
+`async` ループで受け取る。
+
+形を決めるのは 2 つの事実:
+
+1. **デコードはブロッキングな CPU バウンド処理である。** Tokio のワーカ
+   スレッド上で走らせてはならない（リアクタを止めてしまう）。
+   `tokio::task::spawn_blocking` で走らせる。
+2. **コールバックが橋渡しである。** `tokio::sync::mpsc::Sender` を捕捉
+   し、借用された各 `DecodeResult` を所有権を持つ `Send` な値に変換して
+   送る。mfsk-core はチャネルもランタイムも `async` も一切見ない。
+
+### `Cargo.toml`
+
+```toml
+[dependencies]
+mfsk-core = "0.8"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+# 任意、§5.3 の Stream アダプタ用のみ:
+tokio-stream = "0.1"
+```
+
+### 5.1 橋渡し
+
+```rust
+use mfsk_core::ft8::Ft8;
+use mfsk_core::ft8::decode::DecodeResult;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+use tokio::sync::mpsc;
+
+/// デコードされた FT8 メッセージ 1 件。借用スコープに縛られ `Send` でない
+/// `DecodeResult` から、チャネル越しに move できる所有値へ持ち上げたもの。
+#[derive(Debug, Clone)]
+pub struct Decoded {
+    pub freq_hz: f32,
+    pub dt_sec: f32,
+    pub snr_db: f32,
+    pub text: String,
+}
+
+/// 1 つの 15 秒 FT8 スロット（12 kHz モノラル i16 PCM）をブロッキングワーカ
+/// 上でデコードし、受理されたメッセージを届き次第 async 呼び出し側へ流す。
+///
+/// チャネルの受信側を即座に返し、デコードは spawn_blocking 上で走る。
+/// デコード終了時にチャネルが閉じる。
+pub fn decode_slot_stream(audio: Vec<i16>) -> mpsc::Receiver<Decoded> {
+    // 有界にして、遅いコンシューマに対しメモリを無限に伸ばす代わりに
+    // バックプレッシャをかける。1 スロットが 64 件に届くことはまずないので、
+    // ここで生産側がブロックすることは実際上ほぼない。
+    let (tx, rx) = mpsc::channel::<Decoded>(64);
+
+    tokio::task::spawn_blocking(move || {
+        // このクロージャが mfsk-core の同期世界と Tokio の async 世界を
+        // つなぐ橋渡しのすべて。`Fn`（`&self` メソッドの
+        // `Sender::blocking_send` のみ）かつ `Sync` で、`.on_result` の
+        // `&(dyn Fn(&DecodeResult) + Sync)` 境界を満たす —— FT8 の既定の
+        // 広帯域戦略が候補を rayon ワーカスレッドへ分配し、これを並行に
+        // 呼びうるため必須。
+        let on_result = move |r: &DecodeResult| {
+            let text = unpack77(r.message77())
+                .unwrap_or_else(|| "<unpack-fail>".into());
+
+            // ここでの `blocking_send` は正しい: これは spawn_blocking スレッド
+            // （並列戦略では rayon ワーカでもありうる）上で走り、Tokio ランタイム
+            // ワーカでは決してない —— よって async コンテキスト内で `blocking_send`
+            // が起こすようなパニックはしない。送信エラーは受信側が drop された
+            // ことを意味し、それ以上することはない。
+            let _ = tx.blocking_send(Decoded {
+                freq_hz: r.freq_hz,
+                dt_sec: r.dt_sec,
+                snr_db: r.snr_db,
+                text,
+            });
+        };
+
+        // 広帯域探索 100–3000 Hz、sync_min 1.5、最大 100 候補。
+        // `.on_result` は加算的 —— 返る DecodeOutcome は引き続きバッチ全体を
+        // 保持するが、ここでは全件ストリームしたので破棄する。
+        let _outcome = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 1.5, 100)
+            .on_result(&on_result)
+            .decode();
+        // タスク復帰時にここで `on_result`（と捕捉した `tx`）が drop され、
+        // チャネルが閉じてコンシューマのループが終わる。
+    });
+
+    rx
+}
+```
+
+### 5.2 ストリームを消費する
+
+```rust
+#[tokio::main]
+async fn main() {
+    // あなたのキャプチャパイプラインが供給する: スロット境界に整列した
+    // 12 kHz モノラル i16 PCM の 15 秒スロット 1 つ（約 180,000 サンプル）。
+    let audio: Vec<i16> = load_one_ft8_slot();
+
+    let mut rx = decode_slot_stream(audio);
+
+    // 各メッセージは、末尾でまとめてではなくデコーダが受理した瞬間にここへ
+    // 届く。デコードタスクが終わって Sender を drop するとループが抜ける。
+    while let Some(msg) = rx.recv().await {
+        println!(
+            "{:+5.1} dB  {:7.1} Hz  dt={:+.2}s  {}",
+            msg.snr_db, msg.freq_hz, msg.dt_sec, msg.text,
+        );
+        // ...あるいは `msg` を QSO 状態機械、スポットアップローダ、
+        // websocket、DB 書き込みへ転送 —— すべてここから `.await` 可能。
+    }
+
+    println!("スロットのデコード完了");
+}
+
+# fn load_one_ft8_slot() -> Vec<i16> { Vec::new() }
+```
+
+### 5.3 任意: `Stream` として公開する
+
+コンビネータベースのコンシューマ
+（`while let Some(x) = stream.next().await`、`.map()`、`.filter()`）へ
+渡したい場合は、受信側をラップする:
+
+```rust
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
+
+let stream = ReceiverStream::new(decode_slot_stream(audio));
+tokio::pin!(stream);
+while let Some(msg) = stream.next().await {
+    // §5.2 と同じ。ただし StreamExt のコンビネータと合成可能
+}
+```
+
+### 5.4 よくあるバリエーション
+
+- **ブロックしない生産側。** 遅いコンシューマでデコードスレッドを決して
+  ブロックさせず、むしろ結果を落としたい場合は、`blocking_send` を
+  `try_send` に替えて `Err(TrySendError::Full)` を処理する（例: 落とし
+  た件数を数える）。有界チャネルと `blocking_send` の組み合わせでは、詰
+  まったコンシューマは代わりにバックプレッシャをかけてデコードを遅らせ
+  る —— 正しさが重要な UI では通常こちらが望ましい。
+- **逐次・完全一致配信。** §3a のより強い契約（コールバック順 == バッチ
+  順、一時的重複なし）が欲しければ、既定の広帯域パスではなく逐次戦略 ——
+  例えば FT8 の `.sic_rounds(3)` や `.sic_early()` —— を使う。橋渡しコー
+  ドは同一で、変わるのはビルダのメソッドだけ。
+- **他プロトコル。** WSPR/JT65/JT9 では、同じ `spawn_blocking` の殻の中
+  でフリー関数 `decode_scan_streaming(&audio, sample_rate,
+  nominal_start_sample, &params, &on_result)` を呼ぶ。クロージャは同じ
+  `Sender` を捕捉する。Q65 では上の FT8 とまったく同様に
+  `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` ビルダを使う。
+- **キャンセル。** `Receiver` を drop すると、クロージャ内の次の
+  `blocking_send` が `Err` を返すので早期に止められる —— ただしデコード
+  自体に内部キャンセル点はないため、`spawn_blocking` タスクは何であれ完
+  了まで走る。ハードなキャンセルには、より短い単位（候補ごとの
+  `SniperRequest` 呼び出し）でデコードし、その間でフラグを確認する。
+
+---
+
+## 6. 関連
+
+- [LIBRARY.ja.md](LIBRARY.ja.md) §4 —— ライブラリ API リファレンス内の
+  ストリーミング節、およびそれが属する `DecodeRequest` /
+  `SniperRequest` ビルダ面。
+- `DecodeRequest::on_result` の doc コメント
+  （`mfsk-core/src/msg/decode_request.rs`）—— 正典であり常に最新の配信
+  契約。
+- `mfsk-core/tests/ft8_decode_block_streaming.rs` —— 組込み
+  `decode_block_streaming` の完全一致テスト。
+- `mfsk-core/tests/wspr_wsjtx_samples.rs` —— 実信号に対する WSPR
+  `decode_scan_streaming` / `decode_scan_subtract_streaming`。
+- [EMBEDDED.ja.md](EMBEDDED.ja.md) —— `mfsk-ffi-ft8` FFI 成果物向けの
+  C ABI ストリーミングチュートリアル（同じ移植性の理由で、C 境界越しに
+  も同じストリーミングの考え方をコールバックベースで実現）。

--- a/docs/reference/STREAMING.md
+++ b/docs/reference/STREAMING.md
@@ -1,0 +1,416 @@
+# mfsk-core — Streaming Decode Interface
+
+> **日本語版:** [STREAMING.ja.md](STREAMING.ja.md)
+
+This document covers the **streaming delivery** surface of mfsk-core:
+the `.on_result(cb)` callback on the `DecodeRequest` / `SniperRequest`
+family and its per-protocol siblings, what its delivery contract
+guarantees, **why it is a plain synchronous callback rather than an
+`async fn` / `Future` / channel-based API**, and a complete worked
+example of bridging it into a Tokio async client.
+
+For the wider library surface (trait hierarchy, DSP primitives, the C
+ABI) see [LIBRARY.md](LIBRARY.md) — this doc drills into one section
+of it (§4's "Streaming delivery") and adds the async-bridge example.
+
+---
+
+## 1. What "streaming" means here
+
+A decode operates on **one complete audio slot already in hand** — a
+15 s FT8 buffer, a 110.6 s WSPR buffer, and so on. It is not an
+open-ended socket read. "Streaming" therefore does not mean *feeding
+samples in incrementally*; the whole slot is passed by reference. It
+means the opposite direction: **results flow out incrementally**, one
+callback per accepted message, *as the decoder finds them*, instead of
+being handed back only as a single `Vec` when the entire slot has
+finished decoding.
+
+The batch API and the streaming API are the **same call**. Streaming
+is purely additive:
+
+```rust
+use mfsk_core::ft8::Ft8;
+use mfsk_core::msg::decode_request::DecodeRequest;
+
+// Batch: get everything at the end.
+let outcome = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 1.5, 100)
+    .decode();
+for r in &outcome.results { /* ... */ }
+
+// Streaming: same decode, plus a callback fired per result along the
+// way. `outcome.results` still holds the full batch afterwards.
+let on_result = |r: &mfsk_core::ft8::decode::DecodeResult| {
+    // fired as each candidate is accepted
+};
+let outcome = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 1.5, 100)
+    .on_result(&on_result)
+    .decode();
+```
+
+A caller that never calls `.on_result()` sees zero behavioural
+difference from before the feature existed.
+
+### Why stream at all?
+
+A single slot's decode is not instantaneous — on a busy FT8 band a
+full-depth wide-band search with OSD escalation can take a meaningful
+fraction of a second on a host, and much longer on an embedded target.
+Streaming lets a UI paint the first (typically strongest) decode the
+moment it lands rather than staring at a spinner until the last, most
+expensive candidate has been chased through deep OSD. It also lets a
+downstream stage (logging, QSO-state machine, spotting upload) start
+work on early results while later ones are still being computed.
+
+---
+
+## 2. Per-protocol entry points
+
+There is **no single shared callback type** across protocols —
+`DecodeResult` (FT8/FT4/FST4), `Q65Result`, `WsprResult`,
+`Jt65Result`, `Jt9Result` are structurally distinct. So this is a
+consistent *pattern* to code against (same name and semantics inside
+each protocol's own API family), not one trait to abstract over.
+
+| Protocol(s)          | Entry point                                                            | Callback type                          |
+|----------------------|------------------------------------------------------------------------|----------------------------------------|
+| FT8 / FT4 / FST4     | `DecodeRequest<P>` / `SniperRequest<P>` — `.on_result(cb)`             | `&(dyn Fn(&DecodeResult) + Sync)`      |
+| Q65                  | `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` — `.on_result(cb)` | `&(dyn Fn(&Q65Result) + Sync)`         |
+| WSPR                 | `decode_scan_streaming` / `decode_scan_subtract_streaming`             | `&(dyn Fn(&WsprResult) + Sync)`        |
+| JT65                 | `decode_scan_streaming`                                                | `&(dyn Fn(&Jt65Result) + Sync)`        |
+| JT9                  | `decode_scan_streaming`                                                | `&(dyn Fn(&Jt9Result) + Sync)`         |
+| FT8 (embedded no_std)| `ft8::decode_block::decode_block_streaming`                            | `&mut dyn FnMut(&DecodeResult)`        |
+
+Notes:
+
+- **Builders (FT8/FT4/FST4/Q65)** carry `.on_result(cb)` as one more
+  chainable method; the returned `DecodeOutcome` still holds the full
+  batch.
+- **WSPR/JT65/JT9 have no builder**, so each gained a
+  `decode_scan_streaming` *sibling* alongside its existing
+  `decode_scan` (WSPR also has `decode_scan_subtract_streaming` next to
+  `decode_scan_subtract`). The sibling takes the same arguments plus a
+  trailing `on_result` reference and returns the same `Vec` the
+  non-streaming version does.
+- **The embedded FT8 path** (`decode_block_streaming`, only compiled
+  when `fft-rustfft` is *off*) takes `&mut dyn FnMut` rather than
+  `&dyn Fn + Sync`: that path is strictly sequential (no rayon on
+  no_std), so a `FnMut` closure that mutates captured state is safe and
+  the `Sync` bound is unnecessary. Not available under `fft-rustfft` —
+  the host multipass/subtract driver has a post-hoc SNR re-gate that
+  can drop or mutate a result *after* it would already have streamed,
+  which this callback has no revise/retract event for.
+
+---
+
+## 3. Delivery contract
+
+There are exactly **two** contracts, decided by whether the strategy
+runs sequentially or under `rayon` (`feature = "parallel"`). The
+authoritative version is the doc comment on
+`DecodeRequest::on_result`; summarised here:
+
+### 3a. Sequential — exact match
+
+`cb` fires **exactly once per result that ends up in the returned
+`Vec`, in the same order**. Zero divergence between what you stream and
+what the batch return holds.
+
+Covers: `.sic_rounds(n)` and `.sic_early()` (FT8/FT4 SIC strategies);
+the embedded `decode_block_streaming`; JT65 and JT9
+`decode_scan_streaming`; every Q65 builder; WSPR's
+`decode_scan_subtract_streaming` (fires only at its own outer SIC-pass
+accept point). Q65's `MultiPeriodRequest` is a variant of the
+sequential shape: it fires once **per slot** that yields an accepted
+decode (its natural streaming unit for multi-period EME / ionoscatter
+averaging), not once per candidate.
+
+### 3b. Parallel — completion order, possible transient duplicate
+
+`cb` fires from **whichever thread decoded that candidate, in
+completion order** (not candidate-exploration order), and **before**
+the final cross-candidate dedup pass. On the rare occasion two sync
+candidates converge on the same message, `cb` may fire for both even
+though only one survives into the returned `Vec`. Callers wanting exact
+parity should dedup by `.message77()` on their side — the same key the
+crate's own dedup uses.
+
+Covers: the default single-pass strategy and `SniperRequest`
+(FT8/FT4); WSPR's `decode_scan_streaming` (both coarse-search passes
+run under `rayon::par_iter()`).
+
+**This is why the parallel-path callback must be `Sync`** — it may be
+called concurrently from multiple rayon worker threads.
+
+### Does delivery order favour strong signals?
+
+Tends to, on both families: `coarse_sync` returns candidates sorted by
+Costas sync score descending, and both the sequential loop and the
+parallel sweep process that list in-order, so higher-scored (typically
+stronger, since sync score correlates with SNR) candidates tend to
+surface first. But it is a **correlation, not a guarantee** — sync
+score is a pre-demod correlation-power measurement, not a predictor of
+post-demod BP/OSD cost, so a highly-scored candidate can still need
+full OSD escalation while a lower-scored one converges in one BP pass.
+On the sequential strategies specifically, a candidate ahead in the
+list that needs deep OSD blocks every candidate behind it (single
+thread); the parallel strategies have no such head-of-line blocking.
+
+---
+
+## 4. Why a synchronous callback, and not `async` / Tokio / a channel
+
+This is a deliberate design decision, not an unfinished one. The short
+version: **mfsk-core stays runtime-agnostic so that every consumer can
+choose its own concurrency model — including the ones that cannot have
+a runtime at all — and bridging to Tokio at the edge is trivial (§5),
+so nothing is lost by keeping async out of the core.**
+
+The reasons, in order of weight:
+
+### 4a. Portability — the core must stay `std`- and executor-free
+
+mfsk-core's stated goal is a single crate "consumed identically from
+several runtimes (native Rust, WebAssembly, Android JNI, C ABI)." The
+`engine` and protocol layers are `no_std`-clean because the ESP32
+embedded targets (`embedded-poc/m5stack-*-app`) are **first-class
+consumers of this exact decode path** — the same `decode_block`
+streaming callback runs on an Xtensa LX7 with no allocator-backed
+executor and no `std`.
+
+An `async fn` / `Future`-returning API — or anything that requires a
+channel or executor by default — would pull `std` and a runtime into
+the call graph *everywhere*, which breaks those `no_std` targets, the
+`wasm32-unknown-unknown` build, the C ABI (`libmfsk.so`), and the JNI
+scaffold. A synchronous `Fn` callback compiles unchanged on all of
+them.
+
+### 4b. There is nothing to `await`
+
+Async is the right tool for **I/O-bound** work with many suspension
+points — waiting on sockets, timers, disk. A decode is the opposite:
+**CPU-bound compute over a fixed in-memory buffer**, start to finish,
+with no external event to yield to. Making it `async` would add runtime
+machinery and function-colour churn for **zero** latency or throughput
+benefit — there is no await point where a reactor could do useful work
+instead.
+
+### 4c. No forced runtime choice (no function colouring)
+
+An `async` decode API colours the whole call stack above it: every
+caller must also become `async`, and must run *some* executor. A
+synchronous callback forces none of that. The caller picks its model —
+Tokio, `async-std`, a raw `std::thread`, a GUI event loop, a bare
+embedded superloop, or nothing at all — and mfsk-core never needs to
+know which. Baking in `tokio::sync::mpsc` (or any channel type) would
+force a specific runtime on consumers that can't use one, and would
+make the crate carry a heavy optional dependency for a job the caller
+can do in one line.
+
+### 4d. Precedent in the codebase
+
+The plain-callback idiom already exists here:
+`process_candidates_with_ap` takes a fill-closure
+(`F: FnMut(&mut [[Cmplx<f32>;8];79], &SyncCandidate, SymMask)`).
+`.on_result()` follows the same shape rather than introducing a second,
+async-flavoured pattern next to it.
+
+### The upshot
+
+Because mfsk-core delivers results through a closure *you* supply, you
+own how they cross a thread or into a runtime. Want them on a Tokio
+channel? Put a `Sender` in the closure. Want them on a GUI thread?
+Post to your event loop from the closure. Want cross-slot background
+continuation (the WSJT-X "Fast"-mode shape — keep decoding after the
+next slot's capture has started)? `std::thread::spawn` and call
+`.decode()` there. None of that requires core-library support, and all
+of it composes at the application edge.
+
+---
+
+## 5. Worked example: calling from a Tokio async client
+
+The goal: decode one 15 s FT8 slot **without blocking the async
+runtime**, and receive each message in an `async` loop **as it is
+decoded** rather than all at once at the end.
+
+Two facts drive the shape:
+
+1. **The decode is blocking, CPU-bound work.** It must not run on a
+   Tokio worker thread (it would stall the reactor). Run it on
+   `tokio::task::spawn_blocking`.
+2. **The callback is the bridge.** It captures a
+   `tokio::sync::mpsc::Sender`, converts each borrowed `DecodeResult`
+   into an owned `Send` value, and pushes it. mfsk-core never sees the
+   channel, the runtime, or `async`.
+
+### `Cargo.toml`
+
+```toml
+[dependencies]
+mfsk-core = "0.8"
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
+# Optional, only for the Stream adaptor in §5.3:
+tokio-stream = "0.1"
+```
+
+### 5.1 The bridge
+
+```rust
+use mfsk_core::ft8::Ft8;
+use mfsk_core::ft8::decode::DecodeResult;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+use tokio::sync::mpsc;
+
+/// One decoded FT8 message, lifted out of the borrow-scoped, non-`Send`
+/// `DecodeResult` into an owned value we can move across the channel.
+#[derive(Debug, Clone)]
+pub struct Decoded {
+    pub freq_hz: f32,
+    pub dt_sec: f32,
+    pub snr_db: f32,
+    pub text: String,
+}
+
+/// Decode one 15 s FT8 slot (12 kHz mono i16 PCM) on a blocking worker,
+/// streaming each accepted message back to the async caller as it lands.
+///
+/// Returns immediately with the receiving half of a channel; the decode
+/// runs on `spawn_blocking`. The channel closes when the decode finishes.
+pub fn decode_slot_stream(audio: Vec<i16>) -> mpsc::Receiver<Decoded> {
+    // Bounded, so a slow consumer applies backpressure instead of letting
+    // memory grow without limit. A single slot never yields anywhere near
+    // 64 messages, so this practically never blocks the producer here.
+    let (tx, rx) = mpsc::channel::<Decoded>(64);
+
+    tokio::task::spawn_blocking(move || {
+        // The closure is the entire bridge between mfsk-core's synchronous
+        // world and Tokio's async world. It is `Fn` (only `&self` methods:
+        // `Sender::blocking_send`) and `Sync`, satisfying `.on_result`'s
+        // `&(dyn Fn(&DecodeResult) + Sync)` bound — required because FT8's
+        // default wide-band strategy dispatches candidates across rayon
+        // worker threads and may call this concurrently.
+        let on_result = move |r: &DecodeResult| {
+            let text = unpack77(r.message77())
+                .unwrap_or_else(|| "<unpack-fail>".into());
+
+            // `blocking_send` is correct here: this runs on a spawn_blocking
+            // thread (and, for the parallel strategy, possibly a rayon
+            // worker) — never a Tokio runtime worker — so it will not panic
+            // the way `blocking_send` does inside async context. A send
+            // error means the receiver was dropped; nothing more to do.
+            let _ = tx.blocking_send(Decoded {
+                freq_hz: r.freq_hz,
+                dt_sec: r.dt_sec,
+                snr_db: r.snr_db,
+                text,
+            });
+        };
+
+        // Wide-band search 100–3000 Hz, sync_min 1.5, up to 100 candidates.
+        // `.on_result` is additive — the returned DecodeOutcome still holds
+        // the full batch, which we drop here since we streamed everything.
+        let _outcome = DecodeRequest::<Ft8>::new(&audio, 100.0, 3000.0, 1.5, 100)
+            .on_result(&on_result)
+            .decode();
+        // `on_result` (and its captured `tx`) is dropped here as the task
+        // returns, closing the channel and ending the consumer's loop.
+    });
+
+    rx
+}
+```
+
+### 5.2 Consuming the stream
+
+```rust
+#[tokio::main]
+async fn main() {
+    // Your capture pipeline supplies this: one 15 s slot of 12 kHz mono
+    // i16 PCM, aligned to the slot boundary (~180 000 samples).
+    let audio: Vec<i16> = load_one_ft8_slot();
+
+    let mut rx = decode_slot_stream(audio);
+
+    // Each message arrives here the moment the decoder accepts it, not
+    // batched at the end. The loop exits when the decode task finishes
+    // and drops its Sender.
+    while let Some(msg) = rx.recv().await {
+        println!(
+            "{:+5.1} dB  {:7.1} Hz  dt={:+.2}s  {}",
+            msg.snr_db, msg.freq_hz, msg.dt_sec, msg.text,
+        );
+        // ...or forward `msg` to a QSO state machine, a spot uploader,
+        // a websocket, a database write — all `.await`-able from here.
+    }
+
+    println!("slot decode complete");
+}
+
+# fn load_one_ft8_slot() -> Vec<i16> { Vec::new() }
+```
+
+### 5.3 Optional: expose it as a `Stream`
+
+If you prefer to hand the results to combinator-based consumers
+(`while let Some(x) = stream.next().await`, `.map()`, `.filter()`),
+wrap the receiver:
+
+```rust
+use tokio_stream::wrappers::ReceiverStream;
+use tokio_stream::StreamExt;
+
+let stream = ReceiverStream::new(decode_slot_stream(audio));
+tokio::pin!(stream);
+while let Some(msg) = stream.next().await {
+    // same as §5.2, now composable with the StreamExt combinators
+}
+```
+
+### 5.4 Common variations
+
+- **Non-blocking producer.** If you would rather drop results than ever
+  block the decode thread on a slow consumer, swap `blocking_send` for
+  `try_send` and handle `Err(TrySendError::Full)` (e.g. count drops).
+  With a bounded channel and `blocking_send`, a stalled consumer instead
+  applies backpressure and slows the decode — usually what you want for
+  a correctness-critical UI.
+- **Sequential, exact-match delivery.** If you want the stronger
+  contract from §3a (callback order == batch order, no transient
+  duplicates), use a sequential strategy — e.g.
+  `.sic_rounds(3)` or `.sic_early()` on FT8 — instead of the default
+  wide-band pass. The bridge code is identical; only the builder method
+  changes.
+- **Other protocols.** For WSPR/JT65/JT9, call the free function
+  `decode_scan_streaming(&audio, sample_rate, nominal_start_sample,
+  &params, &on_result)` inside the same `spawn_blocking` shell; the
+  closure captures the same `Sender`. For Q65, use its
+  `DecodeRequest`/`SniperRequest`/`MultiPeriodRequest` builder exactly
+  as FT8 above.
+- **Cancellation.** Dropping the `Receiver` makes the next
+  `blocking_send` in the closure return `Err`, which you can use to stop
+  early — but note the decode itself has no interior cancellation point,
+  so a `spawn_blocking` task runs to completion regardless. For hard
+  cancellation, decode in shorter units (per-candidate `SniperRequest`
+  calls) and check a flag between them.
+
+---
+
+## 6. See also
+
+- [LIBRARY.md](LIBRARY.md) §4 — the streaming section in the wider API
+  reference, and the `DecodeRequest` / `SniperRequest` builder surface
+  it sits in.
+- `DecodeRequest::on_result` doc comment
+  (`mfsk-core/src/msg/decode_request.rs`) — the authoritative,
+  always-current delivery contract.
+- `mfsk-core/tests/ft8_decode_block_streaming.rs` — the embedded
+  `decode_block_streaming` exact-match test.
+- `mfsk-core/tests/wspr_wsjtx_samples.rs` — WSPR
+  `decode_scan_streaming` / `decode_scan_subtract_streaming` against
+  real signals.
+- [EMBEDDED.md](EMBEDDED.md) — the C ABI streaming tutorial for the
+  `mfsk-ffi-ft8` FFI artifact (the same streaming idea across the C
+  boundary, callback-based for the same portability reasons).


### PR DESCRIPTION
## Summary

Adds a dedicated reference for the streaming decode interface
(`.on_result(cb)` and its per-protocol siblings) under
`docs/reference/STREAMING.md` + `docs/reference/STREAMING.ja.md`,
following the repo's paired EN/JA convention.

This surfaces material that previously lived only inside LIBRARY.md §4
and the `DecodeRequest::on_result` doc comment, and adds the two things
the docs didn't yet cover: an explicit rationale for **not** using
`async`/Tokio, and a full worked async-client example.

## Contents

- **Per-protocol entry points** — FT8/FT4/FST4 + Q65 builders
  (`.on_result`), WSPR/JT65/JT9 `decode_scan_streaming` siblings, and
  the embedded no_std `decode_block_streaming` (`&mut FnMut`), each with
  its callback type.
- **Delivery contract** — the two contracts (sequential exact-match vs.
  parallel completion-order with a possible transient duplicate), and
  why the parallel path's callback must be `Sync`.
- **Why a synchronous callback, not `async`/Tokio/a channel** —
  portability (the `engine`/protocol layers stay `no_std`- and
  executor-free so ESP32/wasm/C ABI/JNI consumers keep working), nothing
  to `await` in a CPU-bound decode, no forced runtime choice / function
  colouring, and the in-crate plain-callback precedent.
- **Worked Tokio async-client example** — `spawn_blocking` so the decode
  never stalls the reactor, an `mpsc` bridge in the `on_result` closure
  (with the `blocking_send` safety rationale), an optional
  `ReceiverStream` adaptor, and common variations (non-blocking producer,
  sequential exact-match delivery, other protocols, cancellation).

## Cross-links

- README's reference-doc list gains a STREAMING entry.
- LIBRARY.md's streaming section (§4) now points at the dedicated guide.

## Notes

Docs-only change; no code touched. All API paths used in the examples
(`ft8::Ft8`, `ft8::decode::DecodeResult`,
`msg::wsjt77::unpack77 -> Option<String>`,
`msg::decode_request::DecodeRequest`) were verified against the current
source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ufmo6vyTtTJ3qFKDmGoi6)_