### PR TITLE
feat(msg): add Decoded unified host-UI decode row + serde feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## 0.9.0 (unreleased) — streaming ergonomics for host UIs
+
+Theme for this cycle: make the streaming decode surface easier to
+build desktop/host UIs on. Redundant-processing cleanup from recent
+PRs rides along as internal hygiene (it shrinks the surface these
+additive APIs sit on); it is not the headline and has no behavioural
+effect on any decode path.
+
+### Added
+
+- **`msg::decoded::Decoded`** — a unified, owned, human-readable decode
+  row for host UIs, plus a `to_decoded(..)` conversion on every
+  protocol's native result type (`engine::pipeline::DecodeResult` for
+  FT8/FT4/FST4, `WsprResult`, `Q65Result`, `Jt65Result`, `Jt9Result`).
+  Each native result is structurally distinct with a different
+  message-text path (FT8-family `unpack77`, `Display` for WSPR/JT65/JT9,
+  an already-resolved `String` for Q65); `Decoded` resolves that once at
+  the conversion boundary into the columns a decode list binds to for
+  *every* mode — `text` / `freq_hz` / `dt_sec` / `snr_db` / `protocol`
+  (`ProtocolId`). Owned (`Clone` + `Send`), so it drops straight into a
+  channel from inside a streaming `.on_result` callback without the
+  hand-rolled per-mode extraction the Tokio example in
+  `docs/reference/STREAMING.md` previously spelled out.
+
+  Additive, not a replacement: the native result types stay and keep
+  their mode-specific diagnostics (`sync_score`, `hard_errors`,
+  `iterations`, …). `Decoded` deliberately carries only the cross-mode
+  intersection — those extras don't generalise into clean shared
+  columns. Conversion signatures differ where the modes genuinely do:
+  FT8/FT4/FST4 is fallible (`Option<Decoded>` — an unpack failure yields
+  no row) and takes the caller's `ProtocolId` + an optional
+  `CallsignHashTable`; WSPR is infallible; Q65/JT65/JT9 take
+  `(sample_rate, nominal_start_sample)` to derive `dt_sec` from their
+  sample-index `start_sample`. Design note: `docs/notes/DECODED_ROW.md`.
+
+- **`serde` feature** (off by default) — derives `Serialize`/
+  `Deserialize` on `Decoded` and `ProtocolId`, `no_std`-clean via
+  serde's `alloc` feature, so a UI can emit decode rows as JSON for
+  spotting / websocket / IPC. Folded into `full`. Purely additive.
+
 ## 0.8.1 — decode-side `snr_db` for WSPR/JT65/JT9/Q65 (#226)
 
 ### Added

--- a/docs/notes/DECODED_ROW.md
+++ b/docs/notes/DECODED_ROW.md
@@ -1,0 +1,99 @@
+# Design note — `Decoded`, the unified host-UI decode row (0.9)
+
+Status: **landed** (core type + all five per-protocol conversions +
+`serde` feature). This note records the decisions and the deferred
+follow-ups, as the tracking start-point for the 0.9 "streaming
+ergonomics for host UIs" cycle.
+
+## Problem
+
+Every protocol's native decode result is structurally distinct —
+different field names, and **four** different message-text paths:
+
+| Result type (native)                    | Modes         | Text path            |
+|-----------------------------------------|---------------|----------------------|
+| `engine::pipeline::DecodeResult`        | FT8/FT4/FST4  | `unpack77` (fallible)|
+| `wspr::WsprResult`                      | WSPR          | `WsprMessage: Display` |
+| `q65::Q65Result`                        | Q65           | already a `String`   |
+| `jt65::Jt65Result` / `jt9::Jt9Result`   | JT65 / JT9    | `Jt72Message: Display` |
+
+A host UI / spotting uploader / IPC bridge that shows more than one
+mode re-writes the same "pull out text + freq + dt + snr" glue per
+type, and — critically for the streaming path — the borrowed
+`&NativeResult` handed to `.on_result` can't cross a thread boundary,
+so the extraction has to happen right there anyway.
+
+## Decision
+
+A single owned row, resolved once at the conversion boundary:
+
+```rust
+// mfsk_core::msg::decoded
+pub struct Decoded {
+    pub text: String,
+    pub freq_hz: f32,
+    pub dt_sec: f32,
+    pub snr_db: f32,
+    pub protocol: ProtocolId,
+}
+```
+
+Locked choices (from the 0.9 planning thread):
+
+1. **Name: `Decoded`.**
+2. **Scope: minimal cross-mode intersection only** (option A of the
+   three considered — vs. flat `Option` extras, vs. an embedded native
+   handle). The mode-specific diagnostics (`sync_score`, `hard_errors`,
+   `iterations`, `start_sample`, …) don't generalise into clean shared
+   columns, so hoisting them would just reintroduce per-mode branching.
+   `Decoded` is **additive**: native results stay, keep their extras,
+   and remain `Clone`+`Send` for callers who need that detail across a
+   channel (they stream the native result instead).
+3. **unpack failure → `None`.** The FT8-family conversion is
+   `Option<Decoded>`; a payload that passed CRC but won't unpack (rare)
+   is not surfaced as a placeholder row.
+4. **`serde` feature, off by default**, folded into `full`. Derives on
+   `Decoded` + `ProtocolId`, `no_std`-clean via serde's `alloc`.
+
+## Conversion API
+
+Per-protocol `to_decoded(..)` methods (not one trait) — signatures
+differ because the modes genuinely differ, matching the crate's
+"free-function / per-protocol method over a forced trait" philosophy
+(LIBRARY §0.3):
+
+```rust
+impl DecodeResult { // FT8/FT4/FST4 (shared type)
+    fn to_decoded(&self, protocol: ProtocolId,
+                  hash: Option<&CallsignHashTable>) -> Option<Decoded>;
+}
+impl WsprResult { fn to_decoded(&self) -> Decoded; }               // infallible
+impl Q65Result  { fn to_decoded(&self, sample_rate: u32,
+                                nominal_start_sample: usize) -> Decoded; }
+impl Jt65Result { fn to_decoded(&self, sample_rate: u32,
+                                nominal_start_sample: usize) -> Decoded; }
+impl Jt9Result  { fn to_decoded(&self, sample_rate: u32,
+                                nominal_start_sample: usize) -> Decoded; }
+```
+
+- The FT8-family impl is authored in `msg::decoded` (not `engine`) so it
+  can call `unpack77` without `engine` depending on `msg` — the impl
+  block lives in `msg`, keeping the crate-wide dependency arrow intact.
+- `dt_sec` for Q65/JT65/JT9 is `(start_sample − nominal_start_sample) /
+  sample_rate`; `nominal_start_sample` is the anchor the caller already
+  passed to `decode_scan` / the decode builder. FT8/WSPR carry `dt_sec`
+  directly, so their conversions need no sample-rate argument.
+
+## Deferred follow-ups
+
+- **Streaming-doc example** — simplify the Tokio `.on_result` bridge in
+  `docs/reference/STREAMING.md` to stream `Decoded` via `to_decoded(..)`
+  instead of a hand-rolled struct (the concrete "UI is easier" payoff).
+- **FFI mapping** — `Decoded` is a flat, fixed struct precisely so it
+  can map to a C struct in `mfsk-ffi` later; not wired yet.
+- **Generic dispatch** — no unifying `trait ToDecoded` for now (a
+  GAT-based context type could unify the differing signatures). Add only
+  when a caller actually needs to convert generically over `P`.
+- **Session / slot-timing abstraction** — item (b) of the 0.9 UI work:
+  an object owning audio ingestion + slot alignment + decoder lifecycle,
+  so callers stop hand-managing 15 s slot buffers. Separate change.

--- a/docs/reference/STREAMING.ja.md
+++ b/docs/reference/STREAMING.ja.md
@@ -237,7 +237,9 @@ mfsk-core は*あなたが*供給するクロージャを通じて結果を配�
 
 ```toml
 [dependencies]
-mfsk-core = "0.8"
+# `Decoded` + `to_decoded` は 0.9 で導入。デコード行を JSON 化したいなら
+# `features = ["serde"]` を足す。
+mfsk-core = "0.9"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 # 任意、§5.3 の Stream アダプタ用のみ:
 tokio-stream = "0.1"
@@ -246,22 +248,13 @@ tokio-stream = "0.1"
 ### 5.1 橋渡し
 
 ```rust
+use mfsk_core::engine::protocol::ProtocolId;
 use mfsk_core::ft8::Ft8;
 use mfsk_core::ft8::decode::DecodeResult;
 use mfsk_core::msg::decode_request::DecodeRequest;
-use mfsk_core::msg::wsjt77::unpack77;
+use mfsk_core::msg::decoded::Decoded; // クレート提供の所有・Send な UI 行
 
 use tokio::sync::mpsc;
-
-/// デコードされた FT8 メッセージ 1 件。借用スコープに縛られ `Send` でない
-/// `DecodeResult` から、チャネル越しに move できる所有値へ持ち上げたもの。
-#[derive(Debug, Clone)]
-pub struct Decoded {
-    pub freq_hz: f32,
-    pub dt_sec: f32,
-    pub snr_db: f32,
-    pub text: String,
-}
 
 /// 1 つの 15 秒 FT8 スロット（12 kHz モノラル i16 PCM）をブロッキングワーカ
 /// 上でデコードし、受理されたメッセージを届き次第 async 呼び出し側へ流す。
@@ -282,20 +275,19 @@ pub fn decode_slot_stream(audio: Vec<i16>) -> mpsc::Receiver<Decoded> {
         // 広帯域戦略が候補を rayon ワーカスレッドへ分配し、これを並行に
         // 呼びうるため必須。
         let on_result = move |r: &DecodeResult| {
-            let text = unpack77(r.message77())
-                .unwrap_or_else(|| "<unpack-fail>".into());
-
-            // ここでの `blocking_send` は正しい: これは spawn_blocking スレッド
-            // （並列戦略では rayon ワーカでもありうる）上で走り、Tokio ランタイム
-            // ワーカでは決してない —— よって async コンテキスト内で `blocking_send`
-            // が起こすようなパニックはしない。送信エラーは受信側が drop された
-            // ことを意味し、それ以上することはない。
-            let _ = tx.blocking_send(Decoded {
-                freq_hz: r.freq_hz,
-                dt_sec: r.dt_sec,
-                snr_db: r.snr_db,
-                text,
-            });
+            // `DecodeResult::to_decoded` が 77 ビットペイロードを unpack し、
+            // 所有・Send な `Decoded` 行（text + freq + dt + snr + protocol）を返す
+            // —— まさにチャネル越しに move したいもの。`None` は unpack 不能を意味し、
+            // ゴミ行を送らずスキップする。（クレートが `Decoded` を出す前は、この
+            // クロージャは所有構造体を手組みし `unpack77` を自前で呼んでいた。今は1呼び出し。）
+            if let Some(d) = r.to_decoded(ProtocolId::Ft8, None) {
+                // ここでの `blocking_send` は正しい: これは spawn_blocking スレッド
+                // （並列戦略では rayon ワーカでもありうる）上で走り、Tokio ランタイム
+                // ワーカでは決してない —— よって async コンテキスト内で `blocking_send`
+                // が起こすようなパニックはしない。送信エラーは受信側が drop された
+                // ことを意味し、それ以上することはない。
+                let _ = tx.blocking_send(d);
+            }
         };
 
         // 広帯域探索 100–3000 Hz、sync_min 1.5、最大 100 候補。
@@ -311,6 +303,13 @@ pub fn decode_slot_stream(audio: Vec<i16>) -> mpsc::Receiver<Decoded> {
     rx
 }
 ```
+
+> `Decoded`（`mfsk_core::msg::decoded::Decoded`）はクレートの統一・所有
+> デコード行 —— `text` / `freq_hz` / `dt_sec` / `snr_db` / `protocol`、
+> `Clone` + `Send`、`--features serde` で `Serialize`/`Deserialize`。
+> 各プロトコルのネイティブ結果に `to_decoded(..)` 変換があり
+> （WSPR/Q65/JT65/JT9 も）、同じ橋渡し形が全モードで使える。
+> [LIBRARY.ja.md](LIBRARY.ja.md) と `docs/notes/DECODED_ROW.md` を参照。
 
 ### 5.2 ストリームを消費する
 

--- a/docs/reference/STREAMING.md
+++ b/docs/reference/STREAMING.md
@@ -248,7 +248,9 @@ Two facts drive the shape:
 
 ```toml
 [dependencies]
-mfsk-core = "0.8"
+# `Decoded` + `to_decoded` land in 0.9; add `features = ["serde"]` if you
+# want to serialize decode rows to JSON.
+mfsk-core = "0.9"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "sync"] }
 # Optional, only for the Stream adaptor in §5.3:
 tokio-stream = "0.1"
@@ -257,22 +259,13 @@ tokio-stream = "0.1"
 ### 5.1 The bridge
 
 ```rust
+use mfsk_core::engine::protocol::ProtocolId;
 use mfsk_core::ft8::Ft8;
 use mfsk_core::ft8::decode::DecodeResult;
 use mfsk_core::msg::decode_request::DecodeRequest;
-use mfsk_core::msg::wsjt77::unpack77;
+use mfsk_core::msg::decoded::Decoded; // the crate's owned, Send UI row
 
 use tokio::sync::mpsc;
-
-/// One decoded FT8 message, lifted out of the borrow-scoped, non-`Send`
-/// `DecodeResult` into an owned value we can move across the channel.
-#[derive(Debug, Clone)]
-pub struct Decoded {
-    pub freq_hz: f32,
-    pub dt_sec: f32,
-    pub snr_db: f32,
-    pub text: String,
-}
 
 /// Decode one 15 s FT8 slot (12 kHz mono i16 PCM) on a blocking worker,
 /// streaming each accepted message back to the async caller as it lands.
@@ -293,20 +286,20 @@ pub fn decode_slot_stream(audio: Vec<i16>) -> mpsc::Receiver<Decoded> {
         // default wide-band strategy dispatches candidates across rayon
         // worker threads and may call this concurrently.
         let on_result = move |r: &DecodeResult| {
-            let text = unpack77(r.message77())
-                .unwrap_or_else(|| "<unpack-fail>".into());
-
-            // `blocking_send` is correct here: this runs on a spawn_blocking
-            // thread (and, for the parallel strategy, possibly a rayon
-            // worker) — never a Tokio runtime worker — so it will not panic
-            // the way `blocking_send` does inside async context. A send
-            // error means the receiver was dropped; nothing more to do.
-            let _ = tx.blocking_send(Decoded {
-                freq_hz: r.freq_hz,
-                dt_sec: r.dt_sec,
-                snr_db: r.snr_db,
-                text,
-            });
+            // `DecodeResult::to_decoded` unpacks the 77-bit payload and returns
+            // an owned, `Send` `Decoded` row (text + freq + dt + snr + protocol)
+            // — exactly what we want to move across the channel. `None` means
+            // the payload didn't unpack; skip it rather than send a junk row.
+            // (Before this crate exposed `Decoded`, this closure hand-rolled an
+            // owned struct and called `unpack77` itself — one call now.)
+            if let Some(d) = r.to_decoded(ProtocolId::Ft8, None) {
+                // `blocking_send` is correct here: this runs on a spawn_blocking
+                // thread (and, for the parallel strategy, possibly a rayon
+                // worker) — never a Tokio runtime worker — so it will not panic
+                // the way `blocking_send` does inside async context. A send
+                // error means the receiver was dropped; nothing more to do.
+                let _ = tx.blocking_send(d);
+            }
         };
 
         // Wide-band search 100–3000 Hz, sync_min 1.5, up to 100 candidates.
@@ -322,6 +315,14 @@ pub fn decode_slot_stream(audio: Vec<i16>) -> mpsc::Receiver<Decoded> {
     rx
 }
 ```
+
+> `Decoded` (`mfsk_core::msg::decoded::Decoded`) is the crate's unified,
+> owned decode row — `text` / `freq_hz` / `dt_sec` / `snr_db` /
+> `protocol`, `Clone` + `Send`, and `Serialize`/`Deserialize` under
+> `--features serde`. Every protocol's native result has a
+> `to_decoded(..)` conversion into it (WSPR/Q65/JT65/JT9 too), so the
+> same bridge shape works for any mode. See
+> [LIBRARY.md](LIBRARY.md) and `docs/notes/DECODED_ROW.md`.
 
 ### 5.2 Consuming the stream
 

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -26,7 +26,14 @@ std          = ["alloc"]
 alloc        = []
 
 # Aggregate features.
-full         = ["std", "fft-rustfft", "ft8", "ft4", "fst4", "wspr", "jt9", "jt65", "q65", "msk144", "packet-bytes", "uvpacket", "parallel"]
+full         = ["std", "fft-rustfft", "ft8", "ft4", "fst4", "wspr", "jt9", "jt65", "q65", "msk144", "packet-bytes", "uvpacket", "parallel", "serde"]
+
+# Optional derive of `serde::{Serialize, Deserialize}` on the host-facing
+# `msg::decoded::Decoded` UI row and `engine::protocol::ProtocolId`. Off by
+# default; purely additive (no behavioural change to any decode path). Folded
+# into `full` so the published docs show the impls and CI exercises the
+# round-trip.
+serde        = ["dep:serde"]
 
 # FFT backend selection. `mfsk-core::core::fft::FftPlanner` is the
 # trait every decode-side caller talks to; one of these features must
@@ -147,6 +154,11 @@ num-traits  = { version = "0.2", default-features = false, features = ["libm"] }
 rustfft     = { version = "6", optional = true }
 crc         = { version = "3", default-features = false }
 rayon       = { version = "1", optional = true }
+# Optional `Serialize`/`Deserialize` for the host-facing `msg::decoded::Decoded`
+# UI row (and `ProtocolId`). `default-features = false` + `alloc` keeps it
+# no_std-clean (Decoded carries a `String`); host consumers wanting JSON for
+# spotting / websocket / IPC turn on `--features serde`.
+serde       = { version = "1", default-features = false, features = ["derive", "alloc"], optional = true }
 
 [dev-dependencies]
 # Only for tests/ft8_decode_block_streaming.rs, which exercises the

--- a/mfsk-core/src/engine/protocol.rs
+++ b/mfsk-core/src/engine/protocol.rs
@@ -22,6 +22,7 @@ use alloc::vec::Vec;
 /// the C ABI. Order is stable; append new variants at the end.
 #[repr(u8)]
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ProtocolId {
     /// FT8 — 15 s slot, 8-FSK, LDPC(174,91), 77-bit message.
     Ft8 = 0,

--- a/mfsk-core/src/msg/decoded.rs
+++ b/mfsk-core/src/msg/decoded.rs
@@ -1,0 +1,305 @@
+//! `Decoded` — a unified, owned, human-readable decode row for host UIs.
+//!
+//! Every protocol's native decode result (`engine::pipeline::DecodeResult`
+//! for FT8/FT4/FST4, [`WsprResult`](crate::wspr::WsprResult),
+//! [`Q65Result`](crate::q65::Q65Result), [`Jt65Result`](crate::jt65::Jt65Result),
+//! [`Jt9Result`](crate::jt9::Jt9Result)) is structurally distinct — different
+//! field names, and four different message-text paths (FT8-family unpack via
+//! [`unpack77`](crate::msg::wsjt77::unpack77), `Display` for WSPR/JT65/JT9, an
+//! already-resolved `String` for Q65). A host UI, a spotting uploader, or an
+//! IPC/websocket bridge that shows
+//! decodes from more than one mode ends up re-writing the same "pull out the
+//! text + frequency + dt + SNR" glue per result type.
+//!
+//! [`Decoded`] is that common row, resolved once at the conversion boundary:
+//! the exact columns a decode list binds to for *every* mode, as an owned
+//! (`Clone`, `Send`) value that crosses a thread/channel boundary cleanly —
+//! e.g. dropped into a `tokio::sync::mpsc::Sender` inside a streaming
+//! `.on_result` callback (see `docs/reference/STREAMING.md`).
+//!
+//! It is **additive, not a replacement**: the native result types stay, carry
+//! their mode-specific diagnostics (`sync_score`, `hard_errors`, `iterations`,
+//! …), and remain `Clone`/`Send` for callers that need that detail across a
+//! channel. `Decoded` deliberately holds only the cross-mode intersection —
+//! those extras don't generalise into clean shared columns, so hoisting them
+//! here would just reintroduce per-mode branching.
+//!
+//! ## Conversions
+//!
+//! Each protocol's result grows a `to_decoded(..)` method. The signatures
+//! differ because the modes genuinely differ — this is honest, not an
+//! oversight:
+//!
+//! - **FT8/FT4/FST4** (`DecodeResult::to_decoded`) is **fallible**
+//!   (`Option<Decoded>`): the 77-bit payload is unpacked here, and a payload
+//!   that survived the CRC but fails to unpack (rare) yields `None` rather
+//!   than a placeholder row. It also takes the caller's
+//!   [`ProtocolId`](crate::engine::protocol::ProtocolId) (the result type is
+//!   shared across the three) and an optional
+//!   [`CallsignHashTable`](crate::msg::hash_table::CallsignHashTable) to
+//!   resolve `<...>` hashed callsigns.
+//! - **WSPR** ([`WsprResult`](crate::wspr::WsprResult)`::to_decoded`) is
+//!   infallible — text via `Display`, `dt_sec` already present on the result.
+//! - **Q65 / JT65 / JT9** take `(sample_rate, nominal_start_sample)` to derive
+//!   `dt_sec` from the result's `start_sample` (those modes report a sample
+//!   index, not a pre-computed dt). `nominal_start_sample` is the same anchor
+//!   the caller passed to `decode_scan` / the decode builder.
+//!
+//! ## `serde`
+//!
+//! Under `--features serde`, [`Decoded`] and
+//! [`ProtocolId`](crate::engine::protocol::ProtocolId) derive
+//! `Serialize`/`Deserialize` (`no_std`-clean via serde's `alloc` feature), so
+//! a UI can emit decode rows straight to JSON for spotting, a websocket, or
+//! IPC. Off by default; purely additive.
+
+use alloc::string::String;
+// `ToString` is only used by the modes whose message text comes via `Display`
+// (WSPR / JT65 / JT9); gate the import so an FT8/FT4/FST4-only build (whose
+// text path is `unpack77`, returning `String` directly) doesn't warn on it.
+#[cfg(any(feature = "wspr", feature = "jt65", feature = "jt9"))]
+use alloc::string::ToString;
+
+use crate::engine::protocol::ProtocolId;
+
+/// One decoded message, resolved into the columns a host UI actually shows,
+/// as an owned value that moves across threads/channels cleanly.
+///
+/// See the [module docs](self) for the rationale (why this is the cross-mode
+/// intersection and not a superset) and the per-protocol `to_decoded`
+/// conversions that produce it.
+#[derive(Debug, Clone, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Decoded {
+    /// Human-readable message text, already resolved (unpacked / formatted).
+    pub text: String,
+    /// Tone-0 (base) frequency in the audio passband, Hz.
+    pub freq_hz: f32,
+    /// Signal-start offset in seconds, signed, relative to the mode's nominal
+    /// slot anchor (positive = late). `0.0` where the source mode has no
+    /// meaningful dt to report.
+    pub dt_sec: f32,
+    /// SNR estimate in dB. WSJT-X 2500 Hz reference-bandwidth convention for
+    /// every mode except JT9 (see [`Jt9Result::snr_db`](crate::jt9::Jt9Result),
+    /// whose estimate is comparable across JT9 decodes but not in absolute
+    /// terms to other modes).
+    pub snr_db: f32,
+    /// Which protocol produced this decode (UI mode column). Q65 sub-modes and
+    /// uvpacket sub-modes collapse onto their family tag here.
+    pub protocol: ProtocolId,
+}
+
+// ── FT8 / FT4 / FST4 ─────────────────────────────────────────────────────────
+//
+// These three share `engine::pipeline::DecodeResult`. The impl lives in `msg`
+// (not `engine`) because it calls `unpack77` — `engine` never depends on `msg`
+// (the crate-wide dependency direction), so authoring the conversion here keeps
+// that arrow pointing the right way while still giving `result.to_decoded(..)`
+// method syntax.
+#[cfg(any(feature = "ft8", feature = "ft4", feature = "fst4"))]
+impl crate::engine::pipeline::DecodeResult {
+    /// Resolve into a [`Decoded`] UI row, unpacking the 77-bit payload.
+    ///
+    /// `protocol` tags the row (the result type is shared across FT8/FT4/FST4,
+    /// so the caller says which). `hash`, when supplied, resolves `<...>`
+    /// hashed callsigns via [`unpack77_with_hash`](crate::msg::wsjt77::unpack77_with_hash);
+    /// pass `None` to unpack without a hash table.
+    ///
+    /// Returns `None` if the payload fails to unpack — a decode that passed
+    /// the CRC but can't be interpreted is not surfaced as a row (see the
+    /// module docs).
+    pub fn to_decoded(
+        &self,
+        protocol: ProtocolId,
+        hash: Option<&crate::msg::hash_table::CallsignHashTable>,
+    ) -> Option<Decoded> {
+        let text = match hash {
+            Some(ht) => crate::msg::wsjt77::unpack77_with_hash(self.message77(), ht)?,
+            None => crate::msg::wsjt77::unpack77(self.message77())?,
+        };
+        Some(Decoded {
+            text,
+            freq_hz: self.freq_hz,
+            dt_sec: self.dt_sec,
+            snr_db: self.snr_db,
+            protocol,
+        })
+    }
+}
+
+// ── WSPR ─────────────────────────────────────────────────────────────────────
+#[cfg(feature = "wspr")]
+impl crate::wspr::WsprResult {
+    /// Resolve into a [`Decoded`] UI row. Infallible: text via the message's
+    /// `Display`, `dt_sec` copied through from the result.
+    pub fn to_decoded(&self) -> Decoded {
+        Decoded {
+            text: self.message.to_string(),
+            freq_hz: self.freq_hz,
+            dt_sec: self.dt_sec,
+            snr_db: self.snr_db,
+            protocol: ProtocolId::Wspr,
+        }
+    }
+}
+
+// ── Q65 ──────────────────────────────────────────────────────────────────────
+#[cfg(feature = "q65")]
+impl crate::q65::Q65Result {
+    /// Resolve into a [`Decoded`] UI row.
+    ///
+    /// `dt_sec` is derived from the result's `start_sample`:
+    /// `(start_sample − nominal_start_sample) / sample_rate`, where
+    /// `nominal_start_sample` is the anchor the caller passed to the decode
+    /// builder.
+    pub fn to_decoded(&self, sample_rate: u32, nominal_start_sample: usize) -> Decoded {
+        Decoded {
+            text: self.message.clone(),
+            freq_hz: self.freq_hz,
+            dt_sec: dt_from_samples(self.start_sample, nominal_start_sample, sample_rate),
+            snr_db: self.snr_db,
+            protocol: ProtocolId::Q65,
+        }
+    }
+}
+
+// ── JT65 ─────────────────────────────────────────────────────────────────────
+#[cfg(feature = "jt65")]
+impl crate::jt65::Jt65Result {
+    /// Resolve into a [`Decoded`] UI row. Text via the message's `Display`;
+    /// `dt_sec` derived from `start_sample` the same way Q65's conversion does.
+    pub fn to_decoded(&self, sample_rate: u32, nominal_start_sample: usize) -> Decoded {
+        Decoded {
+            text: self.message.to_string(),
+            freq_hz: self.freq_hz,
+            dt_sec: dt_from_samples(self.start_sample, nominal_start_sample, sample_rate),
+            snr_db: self.snr_db,
+            protocol: ProtocolId::Jt65,
+        }
+    }
+}
+
+// ── JT9 ──────────────────────────────────────────────────────────────────────
+#[cfg(feature = "jt9")]
+impl crate::jt9::Jt9Result {
+    /// Resolve into a [`Decoded`] UI row. Text via the message's `Display`;
+    /// `dt_sec` derived from `start_sample` the same way Q65's conversion does.
+    ///
+    /// Note `snr_db` here is JT9's own per-symbol estimate, comparable across
+    /// JT9 decodes but not in absolute terms to other modes' `snr_db`.
+    pub fn to_decoded(&self, sample_rate: u32, nominal_start_sample: usize) -> Decoded {
+        Decoded {
+            text: self.message.to_string(),
+            freq_hz: self.freq_hz,
+            dt_sec: dt_from_samples(self.start_sample, nominal_start_sample, sample_rate),
+            snr_db: self.snr_db,
+            protocol: ProtocolId::Jt9,
+        }
+    }
+}
+
+/// `(start − nominal) / sample_rate`, the signed dt convention every mode's
+/// `Decoded` uses. Factored out so the three sample-index modes share one
+/// definition.
+#[cfg(any(feature = "q65", feature = "jt65", feature = "jt9"))]
+#[inline]
+fn dt_from_samples(start_sample: usize, nominal_start_sample: usize, sample_rate: u32) -> f32 {
+    (start_sample as f32 - nominal_start_sample as f32) / sample_rate as f32
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "serde")]
+    #[test]
+    fn decoded_and_protocol_id_are_serde() {
+        // Proving the derives are wired needs no serialization format — a
+        // trait-bound assertion is enough and keeps the test dependency-free.
+        fn assert_serde<T: serde::Serialize + serde::de::DeserializeOwned>() {}
+        assert_serde::<Decoded>();
+        assert_serde::<ProtocolId>();
+    }
+
+    #[cfg(any(feature = "ft8", feature = "ft4", feature = "fst4"))]
+    #[test]
+    fn ft8_family_to_decoded_carries_unpacked_text_and_fields() {
+        use crate::engine::pipeline::DecodeResult;
+        use crate::msg::wsjt77::{pack77_type1, unpack77};
+
+        let bits = pack77_type1("K1ABC", "W9XYZ", "FN42").expect("packs");
+        // `info` is the K-bit payload; the conversion only reads the leading
+        // 77 message bits (`message77()`), so a 77-length payload is enough.
+        let info = bits.to_vec().into_boxed_slice();
+        let expected = unpack77(&bits).expect("unpacks");
+
+        let r = DecodeResult {
+            info,
+            freq_hz: 1234.5,
+            dt_sec: 0.2,
+            hard_errors: 0,
+            sync_score: 3.0,
+            pass: 1,
+            sync_cv: 0.1,
+            snr_db: -5.0,
+        };
+
+        let d = r
+            .to_decoded(ProtocolId::Ft8, None)
+            .expect("valid payload unpacks");
+        assert_eq!(d.text, expected);
+        assert_eq!(d.freq_hz, 1234.5);
+        assert_eq!(d.dt_sec, 0.2);
+        assert_eq!(d.snr_db, -5.0);
+        assert_eq!(d.protocol, ProtocolId::Ft8);
+    }
+
+    #[cfg(feature = "wspr")]
+    #[test]
+    fn wspr_to_decoded_is_infallible_and_passes_dt_through() {
+        use crate::msg::wspr::WsprMessage;
+        use crate::wspr::WsprResult;
+
+        let msg = WsprMessage::Type1 {
+            callsign: "K1ABC".into(),
+            grid: "FN42".into(),
+            power_dbm: 37,
+        };
+        let expected = msg.to_string();
+
+        let r = WsprResult {
+            message: msg,
+            freq_hz: 1400.0,
+            start_sample: 0,
+            dt_sec: 1.0,
+            info_bits: [0u8; 50],
+            snr_db: -20.0,
+        };
+
+        let d = r.to_decoded();
+        assert_eq!(d.text, expected);
+        assert_eq!(d.freq_hz, 1400.0);
+        assert_eq!(d.dt_sec, 1.0);
+        assert_eq!(d.protocol, ProtocolId::Wspr);
+    }
+
+    #[cfg(feature = "q65")]
+    #[test]
+    fn q65_to_decoded_derives_dt_from_sample_rate() {
+        use crate::q65::Q65Result;
+
+        let r = Q65Result {
+            message: "K1ABC W9XYZ FN42".into(),
+            freq_hz: 1000.0,
+            start_sample: 12_000,
+            iterations: 3,
+            snr_db: -24.0,
+        };
+
+        // (12000 − 6000) / 12000 = 0.5 s late.
+        let d = r.to_decoded(12_000, 6_000);
+        assert_eq!(d.text, "K1ABC W9XYZ FN42");
+        assert_eq!(d.protocol, ProtocolId::Q65);
+        assert!((d.dt_sec - 0.5).abs() < 1e-6);
+    }
+}

--- a/mfsk-core/src/msg/decoded.rs
+++ b/mfsk-core/src/msg/decoded.rs
@@ -57,7 +57,10 @@ use alloc::string::String;
 // `ToString` is only used by the modes whose message text comes via `Display`
 // (WSPR / JT65 / JT9); gate the import so an FT8/FT4/FST4-only build (whose
 // text path is `unpack77`, returning `String` directly) doesn't warn on it.
-#[cfg(any(feature = "wspr", feature = "jt65", feature = "jt9"))]
+#[cfg(all(
+    any(feature = "wspr", feature = "jt65", feature = "jt9"),
+    any(feature = "fft-rustfft", feature = "fft-extern")
+))]
 use alloc::string::ToString;
 
 use crate::engine::protocol::ProtocolId;
@@ -96,7 +99,10 @@ pub struct Decoded {
 // (the crate-wide dependency direction), so authoring the conversion here keeps
 // that arrow pointing the right way while still giving `result.to_decoded(..)`
 // method syntax.
-#[cfg(any(feature = "ft8", feature = "ft4", feature = "fst4"))]
+#[cfg(all(
+    any(feature = "ft8", feature = "ft4", feature = "fst4"),
+    any(feature = "fft-rustfft", feature = "fft-extern")
+))]
 impl crate::engine::pipeline::DecodeResult {
     /// Resolve into a [`Decoded`] UI row, unpacking the 77-bit payload.
     ///
@@ -128,7 +134,7 @@ impl crate::engine::pipeline::DecodeResult {
 }
 
 // ── WSPR ─────────────────────────────────────────────────────────────────────
-#[cfg(feature = "wspr")]
+#[cfg(all(feature = "wspr", any(feature = "fft-rustfft", feature = "fft-extern")))]
 impl crate::wspr::WsprResult {
     /// Resolve into a [`Decoded`] UI row. Infallible: text via the message's
     /// `Display`, `dt_sec` copied through from the result.
@@ -144,7 +150,7 @@ impl crate::wspr::WsprResult {
 }
 
 // ── Q65 ──────────────────────────────────────────────────────────────────────
-#[cfg(feature = "q65")]
+#[cfg(all(feature = "q65", any(feature = "fft-rustfft", feature = "fft-extern")))]
 impl crate::q65::Q65Result {
     /// Resolve into a [`Decoded`] UI row.
     ///
@@ -164,7 +170,7 @@ impl crate::q65::Q65Result {
 }
 
 // ── JT65 ─────────────────────────────────────────────────────────────────────
-#[cfg(feature = "jt65")]
+#[cfg(all(feature = "jt65", any(feature = "fft-rustfft", feature = "fft-extern")))]
 impl crate::jt65::Jt65Result {
     /// Resolve into a [`Decoded`] UI row. Text via the message's `Display`;
     /// `dt_sec` derived from `start_sample` the same way Q65's conversion does.
@@ -180,7 +186,7 @@ impl crate::jt65::Jt65Result {
 }
 
 // ── JT9 ──────────────────────────────────────────────────────────────────────
-#[cfg(feature = "jt9")]
+#[cfg(all(feature = "jt9", any(feature = "fft-rustfft", feature = "fft-extern")))]
 impl crate::jt9::Jt9Result {
     /// Resolve into a [`Decoded`] UI row. Text via the message's `Display`;
     /// `dt_sec` derived from `start_sample` the same way Q65's conversion does.
@@ -221,7 +227,10 @@ mod tests {
         assert_serde::<ProtocolId>();
     }
 
-    #[cfg(any(feature = "ft8", feature = "ft4", feature = "fst4"))]
+    #[cfg(all(
+        any(feature = "ft8", feature = "ft4", feature = "fst4"),
+        any(feature = "fft-rustfft", feature = "fft-extern")
+    ))]
     #[test]
     fn ft8_family_to_decoded_carries_unpacked_text_and_fields() {
         use crate::engine::pipeline::DecodeResult;
@@ -254,7 +263,7 @@ mod tests {
         assert_eq!(d.protocol, ProtocolId::Ft8);
     }
 
-    #[cfg(feature = "wspr")]
+    #[cfg(all(feature = "wspr", any(feature = "fft-rustfft", feature = "fft-extern")))]
     #[test]
     fn wspr_to_decoded_is_infallible_and_passes_dt_through() {
         use crate::msg::wspr::WsprMessage;
@@ -283,7 +292,7 @@ mod tests {
         assert_eq!(d.protocol, ProtocolId::Wspr);
     }
 
-    #[cfg(feature = "q65")]
+    #[cfg(all(feature = "q65", any(feature = "fft-rustfft", feature = "fft-extern")))]
     #[test]
     fn q65_to_decoded_derives_dt_from_sample_rate() {
         use crate::q65::Q65Result;

--- a/mfsk-core/src/msg/mod.rs
+++ b/mfsk-core/src/msg/mod.rs
@@ -13,6 +13,8 @@
 //! is shared by every message unpack invocation.
 
 pub mod ap;
+/// Unified owned decode row for host UIs — see [`decoded::Decoded`].
+pub mod decoded;
 // `DecodeRequest`/`SniperRequest` builder (issue #191); depends on
 // `pipeline_ap`'s generic AP engine, so declared after it. Also needs
 // at least one `FrameDecodable` implementor (`ft8`/`ft4`/`fst4`) or its
@@ -39,6 +41,7 @@ pub mod wsjt77;
 pub mod wspr;
 
 pub use ap::ApHint;
+pub use decoded::Decoded;
 pub use hash_table::CallsignHashTable;
 pub use jt72::{Jt72Codec, Jt72Message};
 #[cfg(feature = "packet-bytes")]


### PR DESCRIPTION
## Summary

First landing of the **0.9 "streaming ergonomics for host UIs"** cycle:
a unified, owned decode row that makes building desktop/host UIs on the
streaming decode surface materially easier.

Introduces `mfsk_core::msg::decoded::Decoded` plus a `to_decoded(..)`
conversion on every protocol's native result type.

## Motivation

Each protocol's native result is structurally distinct with a different
message-text path — FT8-family `unpack77` (fallible), `Display` for
WSPR/JT65/JT9, an already-resolved `String` for Q65. A UI/spotting/IPC
consumer that shows more than one mode re-writes the same "pull out text
+ freq + dt + snr" glue per type, and for the streaming path the
borrowed `&NativeResult` can't cross a thread boundary, so the
extraction has to happen right there anyway. `Decoded` resolves that
once at the conversion boundary.

## What's added

- **`Decoded`** — `text` / `freq_hz` / `dt_sec` / `snr_db` / `protocol`
  (`ProtocolId`), owned (`Clone` + `Send`), so it drops straight into a
  channel from a streaming `.on_result` callback. Re-exported as
  `msg::Decoded`.
- **`to_decoded(..)`** on `DecodeResult` (FT8/FT4/FST4), `WsprResult`,
  `Q65Result`, `Jt65Result`, `Jt9Result`. Signatures differ where the
  modes genuinely do:
  - FT8-family is fallible (`Option<Decoded>`, `None` on unpack failure)
    and takes the caller's `ProtocolId` + an optional `CallsignHashTable`.
  - WSPR is infallible.
  - Q65/JT65/JT9 take `(sample_rate, nominal_start_sample)` to derive
    `dt_sec` from their sample-index `start_sample`.
  - The FT8-family impl is authored in `msg::decoded` (not `engine`) so
    it can call `unpack77` without inverting the crate-wide dependency
    direction (`engine` never depends on `msg`).
- **`serde` feature** (off by default, folded into `full`) — derives
  `Serialize`/`Deserialize` on `Decoded` and `ProtocolId`, `no_std`-clean
  via serde's `alloc` feature.

Additive, not a replacement: native result types stay and keep their
mode-specific diagnostics (`sync_score`, `hard_errors`, `iterations`,
…). `Decoded` deliberately carries only the cross-mode intersection —
those extras don't generalise into clean shared columns.

## Docs

- Design note `docs/notes/DECODED_ROW.md` (decisions + deferred
  follow-ups, as the 0.9 tracking start-point).
- `CHANGELOG.md` `0.9.0 (unreleased)` section. Workspace version stays
  `0.8.1` — bumped at release-PR time per the repo's cadence policy.
- `STREAMING.md` / `.ja.md` Tokio example simplified to stream `Decoded`
  via `to_decoded` instead of a hand-rolled struct.

## Verification

All under `--features full`: `cargo test` (lib) 4/4, `clippy`, `fmt`,
and `rustdoc` (`-D warnings`) clean. Builds clean across default /
no-serde / `no_std` (`alloc,ft8,fft-extern`) / `ft8`-only + `serde`
feature combos.

Not touched: any decode path's behaviour — this is purely additive
surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011ufmo6vyTtTJ3qFKDmGoi6)_