### PR TITLE
test: precision (phantom) guards for FT4, FST4, JT9 and MSK144

### DIFF
--- a/mfsk-core/tests/fst4_wsjtx_samples.rs
+++ b/mfsk-core/tests/fst4_wsjtx_samples.rs
@@ -346,3 +346,43 @@ fn fst4_60_diagnose_golden() {
         );
     }
 }
+
+/// Precision: nothing beyond the two real signals may be emitted.
+///
+/// FST4 had no false-decode guard. Real `jt9 -7 -p 60` reports exactly
+/// the two decodes below on this recording, and so does this crate —
+/// so the budget is 0 with full recall, and any future candidate-
+/// selection change that starts inventing signals fails here.
+#[test]
+fn fst4_wsjtx_sample_precision_vs_reference_decoder() {
+    use common::golden::{DecodeView, GoldenEntry, GoldenSet, Tolerances, assert_golden};
+
+    static REFERENCE: &[GoldenEntry] = &[
+        GoldenEntry::msg("CQ N5TM EL29"),
+        GoldenEntry::msg("CQ K9KFR EN71"),
+    ];
+
+    let Some(path) = sample_path() else {
+        eprintln!("skipping: FST4 golden recording not found");
+        return;
+    };
+    let audio = read_wsjtx_wav_i16(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let out = DecodeRequest::<Fst4s60>::new(&audio, 100.0, 3000.0, 1.2, 50).decode();
+
+    assert_golden(
+        &out.results,
+        &GoldenSet {
+            name: "FST4-60 210115_0058.wav",
+            expected: REFERENCE,
+            min_hits: 2,
+            max_extra: 0,
+        },
+        Tolerances::default(),
+        |d| DecodeView {
+            msg: unpack77(d.message77()).unwrap_or_default(),
+            freq_hz: d.freq_hz,
+            dt_sec: d.dt_sec,
+            snr_db: None,
+        },
+    );
+}

--- a/mfsk-core/tests/ft4_wsjtx_samples.rs
+++ b/mfsk-core/tests/ft4_wsjtx_samples.rs
@@ -159,3 +159,66 @@ fn ft4_wsjtx_sample_recall_vs_golden() {
         GOLDEN.len()
     );
 }
+
+/// Precision: the decoder must emit **nothing** the reference decoder
+/// doesn't.
+///
+/// FT4 had no false-decode guard of any kind. This file's `GOLDEN`
+/// list holds only 6 of the recording's signals, so "extra" had to be
+/// measured against something authoritative: a real local
+/// `jt9 -5 -p 15 -L 300 -H 2700 -d 3` run over the same WAV finds the
+/// 14 below. Against that set this crate emits **11 decodes, all
+/// real, zero phantom** — so the budget is 0, and the recall floor
+/// states the 3 it does not reach rather than hiding them.
+///
+/// Written through `common::golden::assert_golden`, which asserts
+/// recall and precision together — see its module doc for why that is
+/// one call and not two.
+#[test]
+fn ft4_wsjtx_sample_precision_vs_reference_decoder() {
+    use common::golden::{DecodeView, GoldenEntry, GoldenSet, Tolerances, assert_golden};
+
+    /// Every decode real `jt9` reports on this recording.
+    static REFERENCE: &[GoldenEntry] = &[
+        GoldenEntry::msg("AC6BW KR9A R 559 WI"),
+        GoldenEntry::msg("CQ RU AB5XS EM12"),
+        GoldenEntry::msg("CQ RU N9OY EN43"),
+        GoldenEntry::msg("CQ RU W0FRC DM79"),
+        GoldenEntry::msg("K1JT WB4HXE 559 GA"),
+        GoldenEntry::msg("KB0VHA KA1YQC R 539 MA"),
+        GoldenEntry::msg("N1TRK KB7RUQ RR73"),
+        GoldenEntry::msg("N1TRK N4FKH 569 VA"),
+        GoldenEntry::msg("NI6G W7DRW 569 AZ"),
+        GoldenEntry::msg("NZ7P WA7JAY 589 CA"),
+        GoldenEntry::msg("VE3LON K7RL R 549 WA"),
+        GoldenEntry::msg("W7BOB KJ7G RR73"),
+        GoldenEntry::msg("W9JA PY2APK RRR"),
+        GoldenEntry::msg("WD9IGY KX1X 73"),
+    ];
+
+    let Some(path) = sample_path() else {
+        eprintln!("skipping: FT4 golden recording not found");
+        return;
+    };
+    let audio = read_wsjtx_wav_i16(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let out = DecodeRequest::<Ft4>::new(&audio, 300.0, 2700.0, 1.2, 50).decode();
+
+    assert_golden(
+        &out.results,
+        &GoldenSet {
+            name: "FT4 000000_000002.wav",
+            expected: REFERENCE,
+            // 11 of jt9's 14. Raising this is a sensitivity win;
+            // lowering it is a regression.
+            min_hits: 11,
+            max_extra: 0,
+        },
+        Tolerances::default(),
+        |d| DecodeView {
+            msg: unpack77(d.message77()).unwrap_or_default(),
+            freq_hz: d.freq_hz,
+            dt_sec: d.dt_sec,
+            snr_db: None,
+        },
+    );
+}

--- a/mfsk-core/tests/jt9_wsjtx_samples.rs
+++ b/mfsk-core/tests/jt9_wsjtx_samples.rs
@@ -263,3 +263,51 @@ fn jt9_wsjtx_sample_snr_matches_real_jt9() {
          — recall regressed, so this test could not measure what it exists to measure"
     );
 }
+
+/// Precision: nothing beyond the seven real signals may be emitted.
+///
+/// JT9 had no false-decode guard. This crate emits exactly the seven
+/// golden messages on this recording and nothing else, so the budget
+/// is 0 at full recall — the state a protocol should be in, now
+/// actually asserted rather than assumed.
+#[test]
+fn jt9_wsjtx_sample_precision() {
+    use common::golden::{DecodeView, GoldenEntry, GoldenSet, Tolerances, assert_golden};
+
+    static REFERENCE: &[GoldenEntry] = &[
+        GoldenEntry::msg("CQ GM7GAX IO75"),
+        GoldenEntry::msg("TF3G N7MQ CN84"),
+        GoldenEntry::msg("K1JT KF4RWA 73"),
+        GoldenEntry::msg("CQ M0WAY IO82"),
+        GoldenEntry::msg("K1JT N5KDV EM41"),
+        GoldenEntry::msg("G7CNF N4HFA EL89"),
+        GoldenEntry::msg("JA1KAU PD0JAC -23"),
+    ];
+
+    let audio = read_wsjtx_wav_f32(Path::new(SAMPLE_PATH));
+    let params = SearchParams {
+        freq_min_hz: 1050.0,
+        freq_max_hz: 1550.0,
+        time_tolerance_symbols: 3,
+        score_threshold: 0.05,
+        max_candidates: 200,
+    };
+    let decodes = decode_scan(&audio, 12_000, 0, &params);
+
+    assert_golden(
+        &decodes,
+        &GoldenSet {
+            name: "JT9 130418_1742.wav",
+            expected: REFERENCE,
+            min_hits: 7,
+            max_extra: 0,
+        },
+        Tolerances::default(),
+        |d| DecodeView {
+            msg: d.message.to_string(),
+            freq_hz: d.freq_hz,
+            dt_sec: d.start_sample as f32 / 12_000.0,
+            snr_db: Some(d.snr_db),
+        },
+    );
+}

--- a/mfsk-core/tests/msk144_wsjtx_samples.rs
+++ b/mfsk-core/tests/msk144_wsjtx_samples.rs
@@ -156,3 +156,58 @@ fn msk144_181211_120800_wsjtx_sample() {
         ],
     );
 }
+
+/// Precision: nothing beyond the known signals may be emitted, on
+/// both recordings.
+///
+/// MSK144 had no false-decode guard. Its own `check()` above asserts
+/// recall only — and MSK144 is the protocol most exposed to this
+/// class of bug, because `msk144sync.f90`-faithful search attempts
+/// OSD on the order of a thousand times per file (measured under
+/// issue #246: 1044-1116 attempts, 0 successes on these very
+/// recordings). Every one of those is an opportunity to synthesise a
+/// codeword out of noise, exactly as WSPR's OSD path did.
+#[test]
+fn msk144_wsjtx_samples_precision() {
+    use common::golden::{DecodeView, GoldenEntry, GoldenSet, Tolerances, assert_golden};
+
+    for (file, expected, floor) in [
+        (
+            "181211_120500.wav",
+            &[GoldenEntry::msg("K1JT WA4CQG EM72")][..],
+            1usize,
+        ),
+        (
+            "181211_120800.wav",
+            &[
+                GoldenEntry::msg("CQ W4IMD EM84"),
+                GoldenEntry::msg("CQ KD9VV EN71"),
+            ][..],
+            2,
+        ),
+    ] {
+        let Some(path) = sample_path(file) else {
+            eprintln!("skipping: MSK144 golden {file} not found");
+            continue;
+        };
+        let audio = read_wsjtx_wav_i16(&path).expect("WAV must be 12 kHz mono PCM-16");
+        let decodes = decode_slot(&audio, 1477.0, 60.0, Depth::Deep);
+
+        assert_golden(
+            &decodes,
+            &GoldenSet {
+                name: "MSK144",
+                expected: Box::leak(expected.to_vec().into_boxed_slice()),
+                min_hits: floor,
+                max_extra: 0,
+            },
+            Tolerances::default(),
+            |d| DecodeView {
+                msg: d.message.clone(),
+                freq_hz: d.freq_hz,
+                dt_sec: d.tsec,
+                snr_db: None,
+            },
+        );
+    }
+}


### PR DESCRIPTION
> Re-opened from #263, auto-closed when its stacked base branch was deleted on merge of #264. Content unchanged, rebased onto `main`.

## Why

**5 of 9 protocols had no false-decode guard at all** — ft4, fst4, jt65, jt9, msk144. Their golden tests asserted recall and never bounded what else came out.

That is precisely the shape of the WSPR defect this restructure started from: its recall test reported 8/8 while the decoder simultaneously emitted 8 phantoms, green throughout.

## The expected set is the *reference decoder's*, not the existing `GOLDEN` array

This mattered. FT4's `GOLDEN` list holds only 6 of the recording's signals, so a naive "anything not in `GOLDEN` is a phantom" check reported **6 phantoms** — all of which turned out to be real contest exchanges that a real `jt9 -5 -p 15 -L 300 -H 2700 -d 3` also finds.

Running the reference decoder over the vendored WAV gives **14**; against that set this crate emits 11 decodes, **all real**.

## Result — every protocol is already clean, and now says so

| protocol | recall | phantoms | budget |
|---|---|---:|---:|
| FT4 | 11/14 (vs `jt9`) | **0** | 0 |
| FST4-60 | 2/2 | **0** | 0 |
| JT9 | 7/7 | **0** | 0 |
| MSK144 | 1/1, 2/2 | **0** | 0 |

These are **not bug fixes** — they are the assertions that would have caught the WSPR bug had they existed, now in place before the next one.

FT4's recall floor of 11 states the 3 decodes it does not reach rather than hiding them behind a shorter golden list. Raising it is a sensitivity win; lowering it is a regression.

## Why MSK144 especially

It is the protocol most exposed to this class of bug: its `msk144sync.f90`-faithful search attempts OSD on the order of a thousand times per file — measured under #246 as 1044–1116 attempts with 0 successes on these very recordings. Every one is an opportunity to synthesise a codeword out of noise, exactly as WSPR's OSD path did.

## Not covered

**JT65** — it has no golden-WAV recall test at all to extend. Separate PR.

## Verification

Full suite 87 binaries green; `scripts/pre-push-check.sh` clean; each guard's output checked (`recall N/M (floor F)  extra 0 (budget 0)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ade9sQ4376UaMFHw7Ccd6N