### PR TITLE
ci(release): require Test (default) to have actually run before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,65 @@ jobs:
             }
             core.setFailed(`Timed out (30 min) waiting for CI on ${ref}`);
 
+      # The poll above only looks at *workflow-run* conclusions, and it
+      # deliberately treats `skipped` as acceptable — a docs-only push
+      # legitimately skips the build matrix. That tolerance is too wide
+      # for the one job that carries the golden (tier-B) assertions:
+      # a `Test (default)` that never ran would sail through, and this
+      # crate has already shipped with those tests passing vacuously
+      # (before the recordings were vendored they resolved from a
+      # sibling WSJT-X checkout CI does not have, so five protocols'
+      # golden tests skipped and reported success).
+      #
+      # So require, at job granularity, that `Test (default)` actually
+      # ran and succeeded. Combined with `MFSK_REQUIRE_CORPUS=1` in
+      # ci.yml — which turns a missing corpus into a failure rather
+      # than a skip — a green `Test (default)` is a positive statement
+      # that the tier-B assertions executed against real recordings.
+      - name: Require Test (default) to have actually run
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const ref = context.sha;
+            const { data } = await github.rest.actions.listWorkflowRunsForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              head_sha: ref,
+              event: 'push',
+              per_page: 100,
+            });
+            const ciRuns = data.workflow_runs.filter(r => r.name === 'CI');
+            if (ciRuns.length === 0) {
+              core.setFailed(`No CI run for ${ref} to inspect`);
+              return;
+            }
+
+            const wanted = 'Test (default)';
+            let found = null;
+            for (const run of ciRuns) {
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                { owner: context.repo.owner, repo: context.repo.repo, run_id: run.id, per_page: 100 },
+              );
+              const job = jobs.find(j => j.name === wanted);
+              if (job) { found = job; break; }
+            }
+
+            if (!found) {
+              core.setFailed(
+                `CI on ${ref} has no '${wanted}' job. The tier-B golden ` +
+                `assertions therefore did not run; refusing to publish.`);
+              return;
+            }
+            if (found.conclusion !== 'success') {
+              core.setFailed(
+                `'${wanted}' concluded '${found.conclusion}' (not success) on ` +
+                `${ref}: ${found.html_url}. Tier-B golden assertions did not ` +
+                `pass; refusing to publish.`);
+              return;
+            }
+            core.info(`'${wanted}' succeeded on ${ref}: ${found.html_url}`);
+
   # ── Gate 2 ─────────────────────────────────────────────────────────
   # Tag must be reachable from main and the version embedded in the
   # tag must match `mfsk-core/Cargo.toml`. Cheap; runs in parallel

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,16 @@ runs `cargo publish -p mfsk-core --features full` + builds the
 `mfsk-ffi-ft8` FFI artifacts + creates the GitHub release with
 attached tarballs.
 
+`wait-for-ci` checks two things, not one. The workflow-run poll
+tolerates `skipped` (a docs-only push legitimately skips the build
+matrix), which is too wide for the job carrying the golden tier-B
+assertions — so a second step requires `Test (default)` to have
+concluded `success` at *job* granularity. Together with
+`MFSK_REQUIRE_CORPUS=1` in `ci.yml`, a green `Test (default)` is a
+positive statement that the golden tests ran against real recordings
+rather than skipping. Before the recordings were vendored they did
+skip, silently, for five protocols.
+
 **Do not `cargo publish` from a local clone.** crates.io publishes
 are irreversible — once a version is up, you cannot unpublish
 (yank exists but blocks new dependents while existing dependents


### PR DESCRIPTION
## Why

`release.yml` ran **no tests** and inspected only *workflow-run* conclusions, deliberately treating `skipped` as acceptable — correct for a docs-only push that legitimately skips the build matrix, far too wide for the one job carrying the golden (tier-B) assertions.

**A `Test (default)` that never ran would sail straight through to `cargo publish`.**

That is not hypothetical for this crate. Before the recordings were vendored (#261), the golden tests resolved from a sibling WSJT-X checkout CI does not have, so **five protocols' tests skipped and reported success**. A release cut in that window would have published against assertions that never executed — and a crates.io publish is irreversible.

## What this adds

A second step in `wait-for-ci` that inspects the CI run at **job granularity** and requires `Test (default)` to exist and to have concluded `success`.

Combined with `MFSK_REQUIRE_CORPUS=1` in `ci.yml` — which turns a missing corpus into a failure rather than a skip — a green `Test (default)` becomes a **positive statement that the tier-B assertions ran against real recordings**, not merely that nothing failed.

Failure modes it now catches:

| situation | before | after |
|---|---|---|
| `Test (default)` skipped by paths filter | publishes | **refuses** |
| No `Test (default)` job at all | publishes | **refuses** |
| Golden corpus missing in CI | publishes (tests skip green) | **refuses** (via `MFSK_REQUIRE_CORPUS`) |

`CLAUDE.md`'s release section documents both halves of the gate.

## Verification

`release.yml` parses (`yaml.safe_load`, `wait-for-ci` now has 2 steps); `scripts/pre-push-check.sh` clean.

Note this workflow only runs on a `v*` tag push, so it cannot be exercised end-to-end until the next release — the change is deliberately additive and fail-closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ade9sQ4376UaMFHw7Ccd6N