### PR TITLE
ci: name the test matrix by tier, delete the misnamed "catchall recall" suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,10 @@ jobs:
               - 'mfsk-core/src/uvpacket/**'
               - 'mfsk-core/tests/uvpacket_*'
               - 'mfsk-core/tests/common/**'
+            # Gates the tier-C characterization suite only. Tier A+B
+            # is gated by `src` above, which already covers every
+            # protocol's sources — so a change to any protocol here
+            # always runs the merge gate regardless of this filter.
             catchall:
               - '.github/workflows/**'
               - 'mfsk-core/Cargo.toml'
@@ -279,7 +283,12 @@ jobs:
           # protocol's non-ignored tests, but is skipped entirely on
           # docs-only PRs (README / CHANGELOG / docs/** / rustdoc) since
           # the inputs to the compiler/test binaries did not move.
-          - name: default
+          # Tiers A + B (see CONTRIBUTING.md "Testing philosophy"):
+          # every non-ignored test, i.e. all invariants (unit,
+          # roundtrip, bit-exact parity, TX waveform) plus all golden
+          # fidelity (recall + precision + SNR accuracy). This is the
+          # merge gate; everything else in this matrix is tier C.
+          - name: tier A+B — invariants + golden
             kind: default
             changes_key: src
             push_only: false
@@ -314,7 +323,7 @@ jobs:
           # fast_fading, snr_sweep). Recall protection sits in the
           # non-ignored `q65_roundtrip` / `q65_eme_submodes` /
           # `q65_wsjtx_samples` which already run in default.
-          - name: q65 sweeps
+          - name: tier C — q65 sweeps
             kind: ignored-integration
             globs: "q65_*"
             changes_key: q65
@@ -323,17 +332,19 @@ jobs:
           # pi4_dqpsk_eq, ssb_channel, fm_channel, ldpc_direct,
           # snr_calibration). Recall in `uvpacket_multichannel` is
           # non-ignored and covered by default.
-          - name: uvpacket sweeps
+          - name: tier C — uvpacket sweeps
             kind: ignored-integration
             globs: "uvpacket_*"
             changes_key: uvpacket
             push_only: true
-          # catchall recall — FST4 WSJT-X reference WAV recall.
-          - name: catchall recall
-            kind: ignored-integration
-            globs: "fst4_wsjtx_samples"
-            changes_key: catchall
-            push_only: false
+          # The former "catchall recall" tier is gone. It claimed to be
+          # FST4 golden recall protection but ran `--ignored` tests in
+          # `fst4_wsjtx_samples`, of which there is exactly one:
+          # `fst4_60_diagnose_golden`, whose own ignore reason reads
+          # "diagnostic probe, not a recall gate — run manually". So it
+          # executed a print-only probe on every PR under a name that
+          # misrepresented it. FST4's actual recall/precision/SNR
+          # assertions are not `#[ignore]`d and run in tier A+B above.
           # catchall characterization — tier C sensitivity sweeps plus
           # the lib-level #[ignore] tests. `ft4_coherent_wide_search_diag`
           # and the FT8 `qso3_*` probes used to sit adjacent to these;
@@ -344,7 +355,7 @@ jobs:
           # measurements. They are kept because a release wants the
           # numbers (see `scripts/` sweep generators and
           # `docs/notes/*BENCHMARK.md`), not because they gate a merge.
-          - name: catchall characterization
+          - name: tier C — characterization
             kind: catchall
             globs: "ft4_diag_low_snr ft4_snr_sweep ft4_timing_budget msk144_snr_sweep ldpc_min_sum bench_qso3_busy_timing"
             changes_key: catchall

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,12 @@ jobs:
               return;
             }
 
-            const wanted = 'Test (default)';
+            // Must track ci.yml's matrix entry name exactly — the job
+            // renders as `Test (<suite.name>)`. Renaming the suite
+            // without updating this string would silently disable the
+            // gate, so the check below fails closed when the job is
+            // absent rather than assuming it passed.
+            const wanted = 'Test (tier A+B — invariants + golden)';
             let found = null;
             for (const run of ciRuns) {
               const jobs = await github.paginate(


### PR DESCRIPTION
## Why

`ci.yml`'s matrix named suites by history rather than by what they guarantee, and one name was actively wrong.

## `catchall recall` deleted

It claimed to be **FST4 golden recall protection** and ran on every PR.

What it actually ran was the `--ignored` tests in `fst4_wsjtx_samples` — of which there is exactly **one**:

```
fst4_60_diagnose_golden
#[ignore = "diagnostic probe, not a recall gate — run manually"]
```

So a print-only probe executed on every PR under a name asserting it was a gate. FST4's real recall/precision/SNR assertions are not `#[ignore]`d and run in the merge gate.

## Renamed for what they guarantee

| before | after |
|---|---|
| `default` | **`tier A+B — invariants + golden`** |
| `q65 sweeps` | `tier C — q65 sweeps` |
| `uvpacket sweeps` | `tier C — uvpacket sweeps` |
| `catchall characterization` | `tier C — characterization` |

Leaving **one PR-blocking suite and three push-only tier-C ones**, which is what `CONTRIBUTING.md`'s taxonomy says should exist.

## Cross-file coupling — handled deliberately

`release.yml`'s publish gate (#270) looks the job up **by name**, so renaming the suite here would have silently disabled it.

The rename is applied to both files in this commit, verified by asserting `'Test (' + suite[0].name + ')'` equals the string `release.yml` searches for:

```
ci suites:        ['tier A+B — invariants + golden', ...]
release expects:  Test (tier A+B — invariants + golden)
MATCH: True
```

The gate **fails closed** when the job is absent, so a future divergence blocks a publish rather than waving one through — but the comment now says to keep them in sync.

## Also

Documents that the `catchall` paths filter gates **tier C only**. Tier A+B is gated by `src`, which already covers every protocol's sources, so no protocol change can miss the merge gate.

## Verification

Both workflows parse; `scripts/pre-push-check.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ade9sQ4376UaMFHw7Ccd6N