### PR TITLE
test: decouple the shared test scaffolding from the uvpacket example

### DIFF
--- a/mfsk-core/tests/common/channel.rs
+++ b/mfsk-core/tests/common/channel.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-//! Channel models for the uvpacket characterisation harness.
+//! Protocol-agnostic channel models (AWGN, flat Rayleigh) and
+//! signal-power measurement, shared by every protocol's tests.
+//!
+//! uvpacket's Eb/N0 helpers used to live here and moved to
+//! `common/uvpacket_channel.rs` — see that module for why.
 //!
 //! - [`AwgnChannel`] — additive white Gaussian noise (Phase 2a).
 //! - [`RayleighFlatChannel`] — flat Rayleigh fading (frequency-non-
@@ -8,25 +12,11 @@
 //!   real and imaginary parts of the fading envelope; the audio
 //!   signal is multiplied by the resulting complex magnitude.
 //!   Followed by AWGN. Phase 2b.
-//!
-//! Eb/N0 sign convention: **Eb is per information bit** (not per
-//! channel bit). This is the cross-mode-fair convention used in the
-//! WSJT family — at the same Eb/N0 the noise variance per audio
-//! sample varies by mode because higher rates spend less channel
-//! energy per info bit.
 
 use std::f32::consts::PI;
 
-use mfsk_core::uvpacket::Mode;
-
-/// `Ldpc240_101` info-bit count — used to compute the per-mode
-/// info rate (`K / ch_bits_per_block`).
-const K_INFO: f32 = 101.0;
-
-/// uvpacket modulation parameters (for the AWGN-σ derivation).
-const SAMPLE_RATE_HZ: f32 = 12_000.0;
-const SYMBOL_RATE_HZ: f32 = 1_200.0;
-const BITS_PER_SYMBOL: f32 = 2.0;
+/// Audio sample rate the channel models operate at.
+pub(crate) const SAMPLE_RATE_HZ: f32 = 12_000.0;
 
 /// Box-Muller AWGN channel with a deterministic LCG seed. Apply
 /// to a buffer of f32 audio samples in-place.
@@ -67,48 +57,15 @@ impl AwgnChannel {
     }
 }
 
-/// Per-mode info-rate (information bits per channel bit).
-fn info_rate(mode: Mode) -> f32 {
-    K_INFO / mode.ch_bits_per_block() as f32
-}
-
-/// Mean-square (= average power) of an audio buffer. Used to feed
-/// [`awgn_sigma_for_eb_n0_info`] from the actual transmitted burst.
+/// Mean-square (= average power) of an audio buffer. Feeds the
+/// per-protocol Eb/N0 helpers (e.g.
+/// `uvpacket_channel::awgn_sigma_for_eb_n0_info`) from the actual
+/// transmitted burst.
 pub fn signal_power(audio: &[f32]) -> f32 {
     if audio.is_empty() {
         return 0.0;
     }
     audio.iter().map(|s| s * s).sum::<f32>() / audio.len() as f32
-}
-
-/// Compute the per-sample AWGN standard deviation that yields a
-/// target `Eb/N0` *per information bit*, given the **measured**
-/// signal power of the burst about to be noised.
-///
-/// Phase 2'a recalibration: the previous formula assumed a unit-
-/// envelope sinusoid (`P = 0.5`), which was approximately right for
-/// the old 4-FSK design but is ~10 dB off for the QPSK + RRC modem
-/// (peak-normalised burst has RMS ≈ 0.2 → P ≈ 0.04). To make
-/// stated Eb/N0 numbers comparable across modulations, callers now
-/// pass `signal_power = mean(audio²)` of the as-transmitted burst
-/// and the formula derives σ from that.
-///
-/// Derivation:
-///
-/// - Average signal power      `P = signal_power`         (caller-supplied)
-/// - Energy per channel bit    `Eb_ch = P / (R_s · b/sym)`
-/// - Energy per info bit       `Eb_info = Eb_ch / r_info` where
-///   `r_info = K / ch_bits_per_block`
-/// - Target ratio              `linear = 10^(eb_n0_db / 10)`
-/// - One-sided AWGN PSD        `N0 = Eb_info / linear`
-/// - Per-sample variance       `σ² = N0 · fs / 2`
-pub fn awgn_sigma_for_eb_n0_info(mode: Mode, eb_n0_db: f32, signal_power: f32) -> f32 {
-    let e_b_ch = signal_power / (SYMBOL_RATE_HZ * BITS_PER_SYMBOL);
-    let e_b_info = e_b_ch / info_rate(mode);
-    let target_linear = 10f32.powf(eb_n0_db / 10.0);
-    let n0 = e_b_info / target_linear;
-    let sigma_sq = n0 * SAMPLE_RATE_HZ / 2.0;
-    sigma_sq.sqrt()
 }
 
 /// Flat (non-frequency-selective) Rayleigh fading channel.

--- a/mfsk-core/tests/common/mod.rs
+++ b/mfsk-core/tests/common/mod.rs
@@ -5,7 +5,12 @@
 pub mod air_channel;
 pub mod channel;
 pub mod corpus;
+// uvpacket is an experimental example, not a feature of this crate —
+// its Eb/N0 helpers are gated so the shared scaffolding stays usable
+// without it.
 pub mod golden;
+#[cfg(feature = "uvpacket")]
+pub mod uvpacket_channel;
 
 /// Minimal RIFF/WAVE loader — parses the standard `fmt ` + `data`
 /// chunks (plus any `JUNK` / `LIST` / `bext` chunks ahead of `data`)

--- a/mfsk-core/tests/common/uvpacket_channel.rs
+++ b/mfsk-core/tests/common/uvpacket_channel.rs
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Eb/N0 helpers for the **uvpacket** tests.
+//!
+//! These moved out of `common/channel.rs` because they are not
+//! protocol-agnostic in any sense: `SYMBOL_RATE_HZ = 1200` and
+//! `BITS_PER_SYMBOL = 2` are uvpacket's own π/4-DQPSK PHY, `K_INFO`
+//! is its block size, and `info_rate` takes a `uvpacket::Mode`.
+//!
+//! Keeping them in the shared module made `common/channel.rs` import
+//! `mfsk_core::uvpacket::Mode` at file scope, which in turn made
+//! **every one of the 43 test binaries that write `mod common;`**
+//! require the `uvpacket` feature to compile — including the FT8,
+//! FT4 and FST4 tests, which have nothing to do with it. uvpacket is
+//! an experimental example built on this crate, not a feature of it,
+//! so the shared test scaffolding must not depend on it.
+
+use mfsk_core::uvpacket::Mode;
+
+use super::channel::SAMPLE_RATE_HZ;
+
+/// - Average signal power      `P = signal_power`         (caller-supplied)
+/// - Energy per channel bit    `Eb_ch = P / (R_s · b/sym)`
+/// - Energy per info bit       `Eb_info = Eb_ch / r_info` where
+///   `r_info = K / ch_bits_per_block`
+/// - Target ratio              `linear = 10^(eb_n0_db / 10)`
+/// - One-sided AWGN PSD        `N0 = Eb_info / linear`
+/// - Per-sample variance       `σ² = N0 · fs / 2`
+pub fn awgn_sigma_for_eb_n0_info(mode: Mode, eb_n0_db: f32, signal_power: f32) -> f32 {
+    let e_b_ch = signal_power / (SYMBOL_RATE_HZ * BITS_PER_SYMBOL);
+    let e_b_info = e_b_ch / info_rate(mode);
+    let target_linear = 10f32.powf(eb_n0_db / 10.0);
+    let n0 = e_b_info / target_linear;
+    let sigma_sq = n0 * SAMPLE_RATE_HZ / 2.0;
+    sigma_sq.sqrt()
+}
+/// Per-mode info-rate (information bits per channel bit).
+fn info_rate(mode: Mode) -> f32 {
+    K_INFO / mode.ch_bits_per_block() as f32
+}
+/// `Ldpc240_101` info-bit count — used to compute the per-mode
+/// info rate (`K / ch_bits_per_block`).
+const K_INFO: f32 = 101.0;
+const SYMBOL_RATE_HZ: f32 = 1_200.0;
+const BITS_PER_SYMBOL: f32 = 2.0;

--- a/mfsk-core/tests/common_selftest.rs
+++ b/mfsk-core/tests/common_selftest.rs
@@ -21,7 +21,23 @@
 //! were widened to `pub` — `common` is test-only scaffolding, so that
 //! costs nothing.
 
-#![cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
+// Deliberately **no** `#![cfg(...)]` gate on this binary.
+//
+// A crate-level `#![cfg(any(feature = "fft-rustfft", feature =
+// "fft-extern"))]` was tried and removed: under
+// `cargo test -p mfsk-core --no-default-features --test
+// common_selftest` it silently reduced this file to "0 passed; ok" —
+// the exact green-lie this suite's restructure exists to eliminate,
+// reintroduced by the very commit meant to make the pass count
+// honest.
+//
+// Ungated, an unsupported feature set fails to *compile* instead,
+// which is loud. That is not a regression: `common/channel.rs`
+// imports `mfsk_core::uvpacket::Mode` at file scope, so every one of
+// the 43 binaries that write `mod common;` already requires the
+// `uvpacket` feature — verified on an untouched one
+// (`ft8_streaming_decode` fails the same way without it). This binary
+// simply shares its siblings' constraint rather than hiding from it.
 
 #[allow(dead_code)]
 mod common;
@@ -29,7 +45,6 @@ mod common;
 mod channel_selftest {
     #[allow(unused_imports)]
     use crate::common::channel::*;
-    use mfsk_core::uvpacket::Mode;
 
     /// AWGN channel with σ = 0 must be a no-op (modulo the f32
     /// representation of `0.0 × x = 0.0`).
@@ -61,60 +76,10 @@ mod channel_selftest {
     /// At a high Eb/N0 (= 100 dB) the σ for every mode should be
     /// vanishingly small; at 0 dB it should be a meaningful fraction
     /// of the signal envelope.
-    #[test]
-    fn sigma_decreases_with_eb_n0() {
-        // Use a representative 4-FSK-era signal power (P = 0.5) so
-        // the test bounds are absolute rather than measurement-tied.
-        let p = 0.5;
-        for mode in [
-            Mode::Robust,
-            Mode::Standard,
-            Mode::UltraRobust,
-            Mode::Express,
-        ] {
-            let sigma_clean = awgn_sigma_for_eb_n0_info(mode, 100.0, p);
-            let sigma_zero = awgn_sigma_for_eb_n0_info(mode, 0.0, p);
-            assert!(sigma_clean < 1e-3, "{mode:?}: clean σ {sigma_clean}");
-            assert!(sigma_zero > 0.5, "{mode:?}: 0-dB σ {sigma_zero}");
-            assert!(
-                sigma_clean < sigma_zero,
-                "{mode:?}: σ should decrease as Eb/N0 grows",
-            );
-        }
-    }
-
     /// Higher-rate modes spend less channel energy per info bit, so
     /// at a fixed Eb/N0_info the channel-domain noise must be lower
     /// for them — i.e. σ decreases with rate.
-    #[test]
-    fn sigma_decreases_with_rate() {
-        // UltraRobust shares Robust's FEC rate (only the symbol
-        // rate differs), so σ at fixed Eb/N0 is identical between
-        // them — exclude UltraRobust from this strict-monotonic
-        // test and check only the FEC-rate-distinct modes.
-        let eb_n0 = 0.0;
-        let p = 0.5;
-        let sigmas: Vec<f32> = [Mode::Robust, Mode::Standard, Mode::Express]
-            .iter()
-            .map(|&m| awgn_sigma_for_eb_n0_info(m, eb_n0, p))
-            .collect();
-        for w in sigmas.windows(2) {
-            assert!(
-                w[0] > w[1],
-                "expected σ to decrease across rates: {sigmas:?}",
-            );
-        }
-    }
-
     /// σ scales as `√P` (since variance scales as P at fixed Eb/N0).
-    #[test]
-    fn sigma_scales_with_signal_power() {
-        let s1 = awgn_sigma_for_eb_n0_info(Mode::Robust, 0.0, 1.0);
-        let s4 = awgn_sigma_for_eb_n0_info(Mode::Robust, 0.0, 4.0);
-        // 4× power → 2× σ (within float epsilon).
-        assert!((s4 / s1 - 2.0).abs() < 1e-3, "s1={s1}, s4={s4}");
-    }
-
     /// Rayleigh envelope statistics: over a long buffer, the
     /// magnitude has E[|h|²] ≈ 1 by construction.
     #[test]
@@ -448,5 +413,66 @@ mod golden_selftest {
             v("SOMETHING ELSE", 1600.0, None),
         ];
         assert_golden(&d, &set(1, 1), Tolerances::default(), |x| x.clone());
+    }
+}
+
+/// uvpacket's Eb/N0 helper lives in its own gated module (it is built
+/// on uvpacket's π/4-DQPSK PHY constants, not on anything shared), so
+/// its self-tests are gated the same way.
+#[cfg(feature = "uvpacket")]
+mod uvpacket_channel_selftest {
+    #[allow(unused_imports)]
+    use crate::common::channel::*;
+    use crate::common::uvpacket_channel::*;
+    use mfsk_core::uvpacket::Mode;
+
+    #[test]
+    fn sigma_decreases_with_eb_n0() {
+        // Use a representative 4-FSK-era signal power (P = 0.5) so
+        // the test bounds are absolute rather than measurement-tied.
+        let p = 0.5;
+        for mode in [
+            Mode::Robust,
+            Mode::Standard,
+            Mode::UltraRobust,
+            Mode::Express,
+        ] {
+            let sigma_clean = awgn_sigma_for_eb_n0_info(mode, 100.0, p);
+            let sigma_zero = awgn_sigma_for_eb_n0_info(mode, 0.0, p);
+            assert!(sigma_clean < 1e-3, "{mode:?}: clean σ {sigma_clean}");
+            assert!(sigma_zero > 0.5, "{mode:?}: 0-dB σ {sigma_zero}");
+            assert!(
+                sigma_clean < sigma_zero,
+                "{mode:?}: σ should decrease as Eb/N0 grows",
+            );
+        }
+    }
+
+    #[test]
+    fn sigma_decreases_with_rate() {
+        // UltraRobust shares Robust's FEC rate (only the symbol
+        // rate differs), so σ at fixed Eb/N0 is identical between
+        // them — exclude UltraRobust from this strict-monotonic
+        // test and check only the FEC-rate-distinct modes.
+        let eb_n0 = 0.0;
+        let p = 0.5;
+        let sigmas: Vec<f32> = [Mode::Robust, Mode::Standard, Mode::Express]
+            .iter()
+            .map(|&m| awgn_sigma_for_eb_n0_info(m, eb_n0, p))
+            .collect();
+        for w in sigmas.windows(2) {
+            assert!(
+                w[0] > w[1],
+                "expected σ to decrease across rates: {sigmas:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn sigma_scales_with_signal_power() {
+        let s1 = awgn_sigma_for_eb_n0_info(Mode::Robust, 0.0, 1.0);
+        let s4 = awgn_sigma_for_eb_n0_info(Mode::Robust, 0.0, 4.0);
+        // 4× power → 2× σ (within float epsilon).
+        assert!((s4 / s1 - 2.0).abs() < 1e-3, "s1={s1}, s4={s4}");
     }
 }

--- a/mfsk-core/tests/uvpacket_fm_channel.rs
+++ b/mfsk-core/tests/uvpacket_fm_channel.rs
@@ -26,7 +26,8 @@ use mfsk_core::uvpacket::{AUDIO_CENTRE_HZ, Mode, rx, tx};
 #[allow(dead_code)]
 mod common;
 use common::air_channel::{FmChannel, PhaseFadingModel};
-use common::channel::{awgn_sigma_for_eb_n0_info, signal_power};
+use common::channel::signal_power;
+use common::uvpacket_channel::awgn_sigma_for_eb_n0_info;
 
 const N_BLOCKS: u8 = 4;
 

--- a/mfsk-core/tests/uvpacket_multichannel.rs
+++ b/mfsk-core/tests/uvpacket_multichannel.rs
@@ -17,7 +17,8 @@ use mfsk_core::uvpacket::{Mode, tx};
 // `tests/common_selftest.rs`.
 #[allow(dead_code)]
 mod common;
-use common::channel::{AwgnChannel, awgn_sigma_for_eb_n0_info, signal_power};
+use common::channel::{AwgnChannel, signal_power};
+use common::uvpacket_channel::awgn_sigma_for_eb_n0_info;
 
 fn default_fec_opts() -> FecOpts<'static> {
     FecOpts {

--- a/mfsk-core/tests/uvpacket_per_modes_sweep.rs
+++ b/mfsk-core/tests/uvpacket_per_modes_sweep.rs
@@ -28,7 +28,8 @@ use mfsk_core::uvpacket::{AUDIO_CENTRE_HZ, Mode, rx, tx};
 #[allow(dead_code)]
 mod common;
 use common::air_channel::{FmChannel, PhaseFadingModel, SsbChannel};
-use common::channel::{AwgnChannel, RayleighFlatChannel, awgn_sigma_for_eb_n0_info, signal_power};
+use common::channel::{AwgnChannel, RayleighFlatChannel, signal_power};
+use common::uvpacket_channel::awgn_sigma_for_eb_n0_info;
 
 const N_BLOCKS: u8 = 4;
 const N_TRIALS: usize = 30;

--- a/mfsk-core/tests/uvpacket_pi4_dqpsk_eq.rs
+++ b/mfsk-core/tests/uvpacket_pi4_dqpsk_eq.rs
@@ -31,7 +31,8 @@ use mfsk_core::uvpacket::{AUDIO_CENTRE_HZ, Mode, rx, tx};
 #[allow(dead_code)]
 mod common;
 use common::air_channel::{FmChannel, PhaseFadingModel, SsbChannel};
-use common::channel::{AwgnChannel, awgn_sigma_for_eb_n0_info, signal_power};
+use common::channel::{AwgnChannel, signal_power};
+use common::uvpacket_channel::awgn_sigma_for_eb_n0_info;
 
 const N_BLOCKS: u8 = 4;
 

--- a/mfsk-core/tests/uvpacket_snr_calibration.rs
+++ b/mfsk-core/tests/uvpacket_snr_calibration.rs
@@ -25,7 +25,8 @@ use mfsk_core::uvpacket::{AUDIO_CENTRE_HZ, Mode, rx, tx};
 // `tests/common_selftest.rs`.
 #[allow(dead_code)]
 mod common;
-use common::channel::{AwgnChannel, awgn_sigma_for_eb_n0_info, signal_power};
+use common::channel::{AwgnChannel, signal_power};
+use common::uvpacket_channel::awgn_sigma_for_eb_n0_info;
 
 const N_BLOCKS: u8 = 4;
 const N_TRIALS: usize = 20;

--- a/mfsk-core/tests/uvpacket_ssb_channel.rs
+++ b/mfsk-core/tests/uvpacket_ssb_channel.rs
@@ -32,7 +32,8 @@ use mfsk_core::uvpacket::{AUDIO_CENTRE_HZ, Mode, rx, tx};
 #[allow(dead_code)]
 mod common;
 use common::air_channel::{PhaseFadingModel, SsbChannel};
-use common::channel::{awgn_sigma_for_eb_n0_info, signal_power};
+use common::channel::signal_power;
+use common::uvpacket_channel::awgn_sigma_for_eb_n0_info;
 
 const N_BLOCKS: u8 = 4;
 


### PR DESCRIPTION
## Why

**uvpacket is an experimental example built on this crate, not a feature of it.** `tests/common/channel.rs` nonetheless imported `mfsk_core::uvpacket::Mode` at file scope, which made **every one of the 43 test binaries that write `mod common;`** require the `uvpacket` feature to compile — FT8, FT4 and FST4 tests included.

Verified on an untouched file. Before this change:

```
$ cargo test -p mfsk-core --no-default-features \
    --features std,ft8,fft-rustfft --test ft8_streaming_decode
error[E0432]: unresolved import `mfsk_core::uvpacket`
```

An FT8 test could not build without an experimental packet mode.

## It was not just the `Mode` parameter

`K_INFO = 101`, `SYMBOL_RATE_HZ = 1200` and `BITS_PER_SYMBOL = 2` are uvpacket's own π/4-DQPSK PHY numbers, and **all five callers** of `awgn_sigma_for_eb_n0_info` are uvpacket tests. The helper was never shared in any meaningful sense — only shared-by-location.

Moved wholesale to `common/uvpacket_channel.rs`, gated `#[cfg(feature = "uvpacket")]`.

What stays in `common/channel.rs` is genuinely protocol-agnostic: `AwgnChannel`, `RayleighFlatChannel`, `signal_power`, `SAMPLE_RATE_HZ`.

## Also fixes a defect #272 introduced

That commit put `#![cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]` on `common_selftest.rs`. Under `cargo test -p mfsk-core --no-default-features --test common_selftest` it silently reduced the binary to **"0 passed; ok"** — the exact green-lie this restructure exists to eliminate, reintroduced by the commit meant to make the pass count honest. Found while reviewing #272; it had already merged.

The gate is gone. An unsupported feature set now fails to **compile**, which is loud. The gating that remains is per-module and truthful:

| | self-tests |
|---|---:|
| without `uvpacket` | 20 |
| with `uvpacket` | 23 |

## Verification

- `ft8_streaming_decode` now builds without `uvpacket` (previously impossible)
- `common_selftest` reports 20 / 23 by feature set, never a silent 0
- Full suite under `MFSK_REQUIRE_CORPUS=1` green (79 binaries); `scripts/pre-push-check.sh` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ade9sQ4376UaMFHw7Ccd6N