### PR TITLE
test+fix: guard SIC strategies, cover the cross-slot flow, and repair WSPR's subtraction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,29 @@ Tier C is **not** run by CI — the corpora need WSJT-X's Fortran
 simulators built and are far too large. Run it locally before cutting
 a release, or when you have changed something that moves sensitivity.
 
+### Decode strategies must each be guarded
+
+A protocol's `DecodeRequest` exposes more than one decode strategy,
+and **the phantom-prone code lives in the non-default ones**. Both
+false-decode bugs this suite has actually shipped were in a
+subtraction path, not the plain one: issue #243's was in
+`__staged_sic`'s post-hoc `retain`, and #253's in `.sic_early()`.
+Guarding only `decode()` therefore tests the path least likely to
+break.
+
+Current coverage — every cell must stay filled:
+
+| protocol | default | `.sic_rounds(n)` | `.sic_early()` |
+|---|---|---|---|
+| FT8 | total-decode ceiling | exact-set golden | ceiling + named `7Y8CIH` guard |
+| FT4 | precision budget 0 | precision budget 0 | *not implemented* |
+
+FST4/Q65/WSPR/JT9/JT65/MSK144 have no SIC strategy to guard —
+`SupportsSicRounds`/`SupportsSicEarly` are implemented for FT8/FT4
+only, mirroring an upstream WSJT-X absence.
+
+When adding a strategy, add its precision guard in the same PR.
+
 ### Which tests to run for a given change
 
 | You changed | Run |

--- a/mfsk-core/src/msg/decode_request.rs
+++ b/mfsk-core/src/msg/decode_request.rs
@@ -323,6 +323,25 @@ impl<'a, P: SupportsSicRounds> DecodeRequest<'a, P> {
     /// Implemented for `Ft8`/`Ft4` only — not any FST4 sub-mode; see
     /// [`SupportsSicRounds`]'s doc comment for why (an upstream WSJT-X
     /// absence, not an mfsk-core gap).
+    ///
+    /// # You probably want this if you are comparing against WSJT-X
+    ///
+    /// The default strategy is single-pass, so a plain
+    /// `DecodeRequest::new(…).decode()` does **no** subtraction —
+    /// while real `jt9`/`wsjtx` run their multi-pass subtraction by
+    /// default. Comparing the two without calling this is not
+    /// like-for-like, and the difference is not small: on
+    /// `WSJT-X/samples/FT4/000000_000002.wav` the default reaches
+    /// 11 of the 14 decodes `jt9` reports, and `.sic_rounds(2)`
+    /// reaches all 14 with no false decodes.
+    ///
+    /// The three it recovers are the ones subtraction exists for —
+    /// weak signals inside a stronger neighbour's 83 Hz occupied
+    /// bandwidth (`-15 dB` at 2300 Hz masked by `-1 dB` at 2310 Hz,
+    /// and so on). Cost on that file: 5.0 ms → 71.3 ms against a
+    /// 7.5 s slot. Two rounds suffice; three find nothing more.
+    /// Pinned by `tests/ft4_wsjtx_samples.rs::
+    /// ft4_wsjtx_sample_reaches_jt9_parity_with_sic`.
     pub fn sic_rounds(mut self, n: usize) -> Self {
         self.strategy = P::__flat_sic;
         self.sic_rounds = n.clamp(1, 3);

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -767,10 +767,9 @@ const WSPR_SUBTRACT: crate::engine::dsp::subtract::SubtractCfg =
         gfsk: None,
     };
 
-/// LPF kernel half-width for the channel-aware subtract (currently
-/// unused — see comment in [`decode_scan_subtract`] for why we use
-/// the constant-amplitude path instead).
-#[allow(dead_code)]
+/// LPF kernel half-width for the channel-aware subtract, in audio
+/// samples. Chosen by measuring residual suppression on the WSJT-X
+/// golden — see the call site in `decode_scan_subtract_inner`.
 const WSPR_SUBTRACT_LPF_HALF: usize = 600;
 
 /// Multi-pass WSPR decode with successive interference cancellation.
@@ -830,7 +829,7 @@ fn decode_scan_subtract_inner(
     params: &SearchParams,
     on_result: Option<&(dyn Fn(&WsprResult) + Sync)>,
 ) -> Vec<WsprResult> {
-    use crate::engine::dsp::subtract::subtract_tones;
+    use crate::engine::dsp::subtract::subtract_tones_lpf;
 
     // The subtract helper takes `&mut [i16]`; convert once, mutate
     // across passes, work on `f32` for `decode_scan` per pass.
@@ -872,19 +871,52 @@ fn decode_scan_subtract_inner(
             // residual at the decoded (freq, dt). Mirrors wsprd.c:1432-
             // 1437 `subtract_signal2(idat, qdat, …, channel_symbols)`.
             let symbols = super::encode_channel_symbols(&d.info_bits);
-            // Constant-amplitude LS subtract; ignores QSB / drift but
-            // is O(N) and avoids the multi-second convolution that
-            // `subtract_tones_lpf` (direct conv, kernel ~600 samples)
-            // would cost on a 1.4 M-sample WSPR slot. WSJT-X uses the
-            // LPF version on a decimated signal — we'll match once we
-            // have FFT-conv or a decimate-process-interpolate path.
-            subtract_tones(
+            // Channel-aware LPF subtract, matching wsprd's
+            // `subtract_signal2` (`wsprd.c:549-602`): it estimates a
+            // *time-varying* amplitude by low-pass filtering the
+            // product of residual and reference, so it tracks QSB and
+            // drift across the 110.6 s transmission.
+            //
+            // This replaces a constant-amplitude least-squares
+            // subtract that was measurably not doing its job. On the
+            // WSJT-X golden, subtracting W5BIT and measuring the
+            // residual at its own four tone frequencies:
+            //
+            //   const-amplitude   +9.0  -7.7  -5.8  -4.2  dB
+            //   LPF (this)       -25.4 -28.6 -30.0 -19.7  dB
+            //
+            // — the old path *amplified* the first tone by 9 dB and
+            // removed only a few dB from the rest, leaving most of
+            // the interferer in the residual it was supposed to
+            // clean.
+            //
+            // The comment this replaces said the LPF path was avoided
+            // because it "would cost a multi-second convolution on a
+            // 1.4 M-sample WSPR slot". That stopped being true when
+            // `subtract_tones_lpf` gained its FFT fast path for
+            // FT8/FT4 (one forward + inverse FFT per call, O(N log N));
+            // WSPR was simply never migrated. Measured cost of the
+            // whole `decode_scan_subtract` on that slot is unchanged
+            // at ~0.3-0.4 s.
+            //
+            // `lpf_half = 600` was chosen by measurement, not
+            // inherited: 5760 (wsprd's `nfilt=360` scaled from its
+            // 375 Hz baseband to 12 kHz) removes 10-15 dB less,
+            // because our reference is built at audio rate where a
+            // proportionally longer kernel over-smooths the amplitude
+            // estimate.
+            //
+            // `endcorrection = false`: measured identical either way
+            // here, and WSPR's transmission is long enough that edge
+            // handling is negligible.
+            subtract_tones_lpf(
                 &mut residual_i16,
                 &symbols,
                 d.freq_hz,
                 d.dt_sec,
-                1.0,
                 &WSPR_SUBTRACT,
+                WSPR_SUBTRACT_LPF_HALF,
+                false,
             );
             if let Some(cb) = on_result {
                 cb(&d);

--- a/mfsk-core/tests/ft4_wsjtx_samples.rs
+++ b/mfsk-core/tests/ft4_wsjtx_samples.rs
@@ -310,3 +310,80 @@ fn ft4_wsjtx_sample_snr_matches_real_jt9() {
         bad.len()
     );
 }
+
+/// With SIC enabled, FT4 reaches **full parity with real `jt9`** on
+/// this recording — 14/14, zero phantoms.
+///
+/// `ft4_wsjtx_sample_precision_vs_reference_decoder` above asserts
+/// 11/14, which is what the *default* single-pass strategy reaches.
+/// That is not a decoder deficiency: all three it misses are weak
+/// signals sitting inside a stronger neighbour's 83 Hz occupied
+/// bandwidth, which is exactly what successive interference
+/// cancellation exists to recover:
+///
+/// | missed | SNR | masked by | Δf |
+/// |---|---:|---|---:|
+/// | `W9JA PY2APK RRR` @ 520 Hz | -9 | `CQ RU AB5XS EM12` @ 560, -7 | 40 Hz |
+/// | `AC6BW KR9A R 559 WI` @ 2300 Hz | -15 | `WD9IGY KX1X 73` @ 2310, -1 | 10 Hz |
+/// | `CQ RU W0FRC DM79` @ 2560 Hz | -15 | `NI6G W7DRW 569 AZ` @ 2567, -7 | 7 Hz |
+///
+/// The comparison against `jt9` was therefore not like-for-like:
+/// real `jt9` runs its own multi-pass subtraction by default, and
+/// `DecodeRequest`'s default strategy is `__single_pass` (for FT8
+/// too — `sic_rounds` is a field default that only takes effect once
+/// `.sic_rounds()` switches the strategy). A caller wanting
+/// WSJT-X-equivalent recall must ask for it.
+///
+/// Two rounds suffice; three costs more and finds nothing extra.
+/// Measured on this file: 5.0 ms default → 71.3 ms with
+/// `.sic_rounds(2)`, against a 7.5 s slot — about 1 % of the slot for
+/// a 27 % recall gain.
+#[test]
+fn ft4_wsjtx_sample_reaches_jt9_parity_with_sic() {
+    use common::golden::{DecodeView, GoldenEntry, GoldenSet, Tolerances, assert_golden};
+
+    static REFERENCE: &[GoldenEntry] = &[
+        GoldenEntry::msg("AC6BW KR9A R 559 WI"),
+        GoldenEntry::msg("CQ RU AB5XS EM12"),
+        GoldenEntry::msg("CQ RU N9OY EN43"),
+        GoldenEntry::msg("CQ RU W0FRC DM79"),
+        GoldenEntry::msg("K1JT WB4HXE 559 GA"),
+        GoldenEntry::msg("KB0VHA KA1YQC R 539 MA"),
+        GoldenEntry::msg("N1TRK KB7RUQ RR73"),
+        GoldenEntry::msg("N1TRK N4FKH 569 VA"),
+        GoldenEntry::msg("NI6G W7DRW 569 AZ"),
+        GoldenEntry::msg("NZ7P WA7JAY 589 CA"),
+        GoldenEntry::msg("VE3LON K7RL R 549 WA"),
+        GoldenEntry::msg("W7BOB KJ7G RR73"),
+        GoldenEntry::msg("W9JA PY2APK RRR"),
+        GoldenEntry::msg("WD9IGY KX1X 73"),
+    ];
+
+    let Some(path) = sample_path() else {
+        eprintln!("skipping: FT4 golden recording not found");
+        return;
+    };
+    let audio = read_wsjtx_wav_i16(&path).expect("WAV must be 12 kHz mono PCM-16");
+    let out = DecodeRequest::<Ft4>::new(&audio, 300.0, 2700.0, 1.2, 50)
+        .sic_rounds(2)
+        .decode();
+
+    assert_golden(
+        &out.results,
+        &GoldenSet {
+            name: "FT4 000000_000002.wav + sic_rounds(2)",
+            expected: REFERENCE,
+            // Full parity with real jt9. This is a hard floor: SIC is
+            // the whole point of this test, so 13 is a regression.
+            min_hits: 14,
+            max_extra: 0,
+        },
+        Tolerances::default(),
+        |d| DecodeView {
+            msg: unpack77(d.message77()).unwrap_or_default(),
+            freq_hz: d.freq_hz,
+            dt_sec: d.dt_sec,
+            snr_db: None,
+        },
+    );
+}

--- a/mfsk-core/tests/wspr_wsjtx_samples.rs
+++ b/mfsk-core/tests/wspr_wsjtx_samples.rs
@@ -726,3 +726,81 @@ fn wspr_diag_pass_ablation() {
             .collect::<Vec<_>>()
     );
 }
+
+/// Carrying a callsign table **across slots** must not manufacture
+/// decodes.
+///
+/// This is the flow `decode_scan_with_table` exists for — a WSPR
+/// receiver hears the same beacons every 2 minutes, so a station
+/// confirmed by Fano in one slot stays OSD-recoverable in later ones.
+/// The existing `wspr_carried_table_recovers_osd_only_decode` seeds
+/// the table by hand and so tests the *gate*; this tests the *flow*,
+/// where the table is built by decoding and then fed forward.
+///
+/// The hazard being guarded is specific and real: OSD synthesises a
+/// valid codeword for any input, and the gate lets a result through
+/// whenever its callsign is already in the table. Every slot that
+/// carries the table forward therefore widens the set of callsigns
+/// OSD is permitted to emit, so a bug here would show up as phantoms
+/// that *accumulate with slot count* — invisible to any single-slot
+/// test.
+///
+/// Repeating one recording is a fair model of that: the same
+/// callsigns recur, which is exactly the real condition, and it holds
+/// the signal content constant so any growth in the output is
+/// attributable to the table rather than to new audio.
+///
+/// (A synthetic two-slot version — strong slot populates the table,
+/// weak slot is recovered from it — was tried and abandoned: across
+/// -25…-27 dB and six noise seeds, a clean single-signal slot never
+/// produced a case where the table added a decode. OSD's advantage on
+/// the real recording comes from the pass-2 environment after eight
+/// stronger signals have been subtracted, which a lone synthetic tone
+/// cannot reproduce. Recording that here so the absence is not
+/// mistaken for an untried idea.)
+#[test]
+fn wspr_carried_table_across_slots_adds_no_phantoms() {
+    use mfsk_core::wspr::decode::{WsprCallsignTable, decode_scan_with_table};
+
+    let Some((audio, params)) = sample_and_params() else {
+        return;
+    };
+
+    let mut table = WsprCallsignTable::new();
+    let mut per_slot: Vec<(usize, Vec<String>)> = Vec::new();
+
+    // Five slots of the same beacons, table fed forward each time.
+    for slot in 0..5 {
+        let d = decode_scan_with_table(&audio, 12_000, 0, &params, &mut table);
+        let msgs: Vec<String> = d.iter().map(|r| r.message.to_string()).collect();
+        let phantoms: Vec<&String> = msgs
+            .iter()
+            .filter(|m| !GOLDEN.iter().any(|g| g.msg == m.as_str()))
+            .collect();
+        eprintln!(
+            "  slot {slot}: {} decode(s), {} phantom(s)",
+            msgs.len(),
+            phantoms.len()
+        );
+        assert!(
+            phantoms.is_empty(),
+            "slot {slot} of a carried-table run emitted phantom(s): {phantoms:?}. \
+             The table grows every slot, so this is the direction the OSD gate \
+             fails in — a single-slot test cannot see it."
+        );
+        per_slot.push((msgs.len(), msgs));
+    }
+
+    // Decode count must not grow with slot count. Growth would mean
+    // the table is admitting results it did not admit before, which
+    // on identical audio can only be table-driven.
+    let first = per_slot[0].0;
+    for (i, (n, _)) in per_slot.iter().enumerate() {
+        assert_eq!(
+            *n, first,
+            "slot {i} returned {n} decodes vs slot 0's {first} on identical audio — \
+             the carried table is changing the outcome, which it must only ever do \
+             by recovering a *known* callsign, not by finding new ones"
+        );
+    }
+}


### PR DESCRIPTION
Three related changes that came out of asking "is recall at parity?" and measuring rather than assuming.

## 1. Guard the SIC strategies, not just `decode()`

**Guarding only the default path tests the path least likely to break.** Both false-decode bugs this suite has actually shipped were in a *subtraction* path — #243's in `__staged_sic`'s post-hoc `retain`, #253's in `.sic_early()`.

FT4's precision guard covered `decode()` only, so `.sic_rounds()` had **no phantom bound at all**. It does now, at budget 0.

`CONTRIBUTING.md` gains the coverage matrix and the rule that a new strategy ships with its guard in the same PR:

| protocol | default | `.sic_rounds(n)` | `.sic_early()` |
|---|---|---|---|
| FT8 | total-decode ceiling | exact-set golden | ceiling + named guard |
| FT4 | budget 0 | **budget 0 (new)** | *not implemented* |

## 2. FT4 reaches full jt9 parity — 14/14, zero phantoms

The default reaches 11/14, and the three it misses are exactly what subtraction exists for — weak signals inside a stronger neighbour's 83 Hz occupied bandwidth (−15 dB at 2300 Hz masked by −1 dB at 2310 Hz, etc.).

So "11/14 vs jt9" was **not a decoder deficiency but an unfair comparison**: real `jt9` runs multi-pass subtraction by default; `DecodeRequest`'s default strategy is `__single_pass`. Cost of parity: 5.0 ms → 71.3 ms against a 7.5 s slot.

The default is deliberately unchanged (FT8 behaves the same way; diverging would be the inconsistency). Instead `sic_rounds`' doc now says plainly that a WSJT-X comparison without it is not like-for-like.

## 3. WSPR: cross-slot flow test, and a genuinely broken subtraction

**The carried-table test only tested the gate.** It seeded the table by hand; nothing exercised the flow where the table is built by decoding and fed forward. That hazard is invisible to single-slot tests: every carried slot **widens the set of callsigns OSD may emit**, so a bug shows up as phantoms accumulating with slot count. New test runs 5 slots and asserts 0 phantoms and no decode-count growth.

**WSPR's subtraction was defective.** It used a constant-amplitude fit where `wsprd`'s `subtract_signal2` tracks a time-varying amplitude. Measured against `W5BIT`'s own four tones:

```
const-amplitude   +9.0  -7.7  -5.8  -4.2  dB
LPF (now)        -25.4 -28.6 -30.0 -19.7  dB
```

It **amplified the first tone by 9 dB**. The code's own comment justified this as avoiding a "multi-second convolution… we'll match once we have FFT-conv" — that FFT path arrived with the FT8/FT4 work and WSPR was never migrated. Cost unchanged at ~0.35 s.

This does **not** close WSPR's recall gap and the commit says so. Follow-up tracked in #275 with the full `wsprd` probe results.

## Verification

Full suite under `MFSK_REQUIRE_CORPUS=1` green (79 binaries); `scripts/pre-push-check.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ade9sQ4376UaMFHw7Ccd6N