### PR TITLE
fix(ft8): restore WSJT-X's fixed-window primary sync channel

### DIFF
--- a/mfsk-core/src/ft8/decode_block/coarse_sync.rs
+++ b/mfsk-core/src/ft8/decode_block/coarse_sync.rs
@@ -484,28 +484,83 @@ fn coarse_sync_inner(
 
     const MLAG: i32 = 10;
 
-    // Per-bin peak + 40-percentile noise floor.
-    let mut red = vec![0.0f32; n_freq];
+    // Two independent noise-floor channels, matching WSJT-X `sync8.f90`
+    // exactly (issue #280). Collapsing these into a single
+    // `±jz`-dependent channel — the pre-#280 shape of this function —
+    // let the noise floor `base` scale with the requested lag window:
+    // widening `MFSK_SYNC_LAG_S` toward WSJT-X's own `±2.5s` inflated
+    // the *only* floor available here (per-bin max over a wider window
+    // has a higher expected value under basic extreme-value
+    // statistics), silently pushing weak real decodes below `sync_min`
+    // even though WSJT-X's actual primary channel — anchored to a
+    // fixed `mlag=10` regardless of `JZ` — would still have caught
+    // them. `red_primary`/`base_primary` restores that JZ-independent
+    // anchor; `red_secondary`/`base_secondary` (the old sole channel)
+    // now plays its correct WSJT-X role: a supplementary second
+    // candidate per bin, contributed only when its peak lag disagrees
+    // with the primary's.
+    let primary_half = MLAG.min(jz);
+    let mut red_primary = vec![0.0f32; n_freq];
+    let mut jpeak_primary = vec![0i32; n_freq];
+    let mut red_secondary = vec![0.0f32; n_freq];
+    let mut jpeak_secondary = vec![0i32; n_freq];
     for fi in 0..n_freq {
-        red[fi] = (-jz..=jz)
-            .map(|lag| sync2d[idx(fi, lag)])
-            .fold(0.0f32, f32::max);
+        let mut best_p = f32::NEG_INFINITY;
+        let mut lag_p = -primary_half;
+        let mut best_s = f32::NEG_INFINITY;
+        let mut lag_s = -jz;
+        for lag in -jz..=jz {
+            let v = sync2d[idx(fi, lag)];
+            if v > best_s {
+                best_s = v;
+                lag_s = lag;
+            }
+            if (-primary_half..=primary_half).contains(&lag) && v > best_p {
+                best_p = v;
+                lag_p = lag;
+            }
+        }
+        red_primary[fi] = best_p;
+        jpeak_primary[fi] = lag_p;
+        red_secondary[fi] = best_s;
+        jpeak_secondary[fi] = lag_s;
     }
-    let base = {
-        // 40th-percentile noise floor: `select_nth_unstable_by` is O(N)
-        // average vs the previous full-sort's O(N log N). Pivot
-        // ordering inside the percentile isn't load-bearing
-        // (downstream only uses `red[pct_idx]` as a normaliser), so
-        // unstable selection is fine. `unwrap_or(Ordering::Equal)`
-        // for NaN safety — matches the same pattern at
-        // `process_candidates.rs` xsnr2_db_simple median.
-        // Gemini PR #79 + #101 review.
-        let mut sorted = red.clone();
+
+    // 40th-percentile noise floor: `select_nth_unstable_by` is O(N)
+    // average vs a full sort's O(N log N). Pivot ordering inside the
+    // percentile isn't load-bearing (downstream only uses the selected
+    // element as a normaliser), so unstable selection is fine.
+    // `unwrap_or(Ordering::Equal)` for NaN safety — matches the same
+    // pattern at `process_candidates.rs` xsnr2_db_simple median.
+    // Gemini PR #79 + #101 review.
+    let percentile_floor = |red: &[f32]| -> f32 {
+        let mut sorted = red.to_vec();
         let pct_idx = ((0.40 * n_freq as f32) as usize).min(n_freq - 1);
         sorted.select_nth_unstable_by(pct_idx, |a, b| {
             a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal)
         });
         sorted[pct_idx].max(f32::EPSILON)
+    };
+    let base_primary = percentile_floor(&red_primary);
+    let base_secondary = percentile_floor(&red_secondary);
+
+    // Parabolic sub-quantum interpolation around a chosen peak lag —
+    // shared by both channels. Only valid strictly inside the searched
+    // window (needs both neighbours); falls back to 0 at the edge.
+    let dt_quanta_at = |fi: usize, lag: i32| -> f32 {
+        if lag > -jz && lag < jz {
+            let y_lo = sync2d[idx(fi, lag - 1)];
+            let y_mi = sync2d[idx(fi, lag)];
+            let y_hi = sync2d[idx(fi, lag + 1)];
+            let denom = y_lo - 2.0 * y_mi + y_hi;
+            if denom.abs() > f32::EPSILON {
+                (0.5 * (y_lo - y_hi) / denom).clamp(-1.0, 1.0)
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        }
     };
 
     let mut cands: Vec<SyncCandidate> = Vec::new();
@@ -513,56 +568,30 @@ fn coarse_sync_inner(
         let i_carrier = ia + fi;
         let freq_hz = i_carrier as f32 * df;
 
-        let mut peaks: Vec<(i32, f32)> = (-jz..=jz)
-            .filter_map(|lag| {
-                let raw = sync2d[idx(fi, lag)];
-                let norm = raw / base;
-                if norm.is_finite() && norm >= sync_min {
-                    Some((lag, norm))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        peaks.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
-
-        let mut picked: Vec<i32> = Vec::new();
-        for (lag, score) in peaks {
-            if picked.iter().any(|&pl| (lag - pl).abs() <= MLAG) {
-                continue;
-            }
-            picked.push(lag);
-            let dt_quanta = if lag > -jz && lag < jz {
-                let y_lo = sync2d[idx(fi, lag - 1)];
-                let y_mi = sync2d[idx(fi, lag)];
-                let y_hi = sync2d[idx(fi, lag + 1)];
-                let denom = y_lo - 2.0 * y_mi + y_hi;
-                if denom.abs() > f32::EPSILON {
-                    let off = 0.5 * (y_lo - y_hi) / denom;
-                    off.clamp(-1.0, 1.0)
-                } else {
-                    0.0
-                }
-            } else {
-                0.0
-            };
-            let dt_lag = lag as f32 + dt_quanta;
+        let lag_p = jpeak_primary[fi];
+        let norm_p = red_primary[fi] / base_primary;
+        if norm_p.is_finite() && norm_p >= sync_min {
+            let dt_lag = lag_p as f32 + dt_quanta_at(fi, lag_p);
             cands.push(SyncCandidate {
                 freq_hz,
                 dt_sec: (dt_lag - 0.5) * tstep,
-                score,
+                score: norm_p,
             });
-            // WSJT-X sync8.f90 emits at most 2 candidates per freq:
-            // one from `red` (narrow ±MLAG window) and one from `red2`
-            // (full ±jz window) when the peak lags differ. We don't
-            // run two windows separately; the `picked` greedy NMS with
-            // cap 2 produces equivalent recall on `qso3_busy.wav` —
-            // empirically verified during the v0.6.2 plan (a
-            // dual-window prototype produced identical 16/18 JTDX
-            // hit, so the additional separate normalization wasn't
-            // worth the code volume). Dropped from 0.6.2 scope.
-            if picked.len() >= 2 {
-                break;
+        }
+
+        // Secondary candidate only when the full-window peak actually
+        // disagrees with the fixed-window one — matches `sync8.f90`'s
+        // `if (jpeak2(n)==jpeak(n)) cycle`.
+        let lag_s = jpeak_secondary[fi];
+        if lag_s != lag_p {
+            let norm_s = red_secondary[fi] / base_secondary;
+            if norm_s.is_finite() && norm_s >= sync_min {
+                let dt_lag = lag_s as f32 + dt_quanta_at(fi, lag_s);
+                cands.push(SyncCandidate {
+                    freq_hz,
+                    dt_sec: (dt_lag - 0.5) * tstep,
+                    score: norm_s,
+                });
             }
         }
     }


### PR DESCRIPTION
Closes part of #280 (restores WSJT-X's fixed-window primary channel;
does **not** claim full 2.5s parity — see the "Known remaining gap"
section below and the issue comment for the open follow-up).

## The bug

`coarse_sync_inner`'s noise-floor normalization and per-bin candidate
picking were built entirely from the requested `±jz` (lag) window.
WSJT-X's `sync8.f90` instead runs two independent channels: a primary
one anchored to a **fixed `±mlag=10`** window (never moves regardless
of the search range), and a secondary one over the full `±JZ` window
that only supplements the primary when its peak lag disagrees. This
port only implemented something resembling the secondary channel and
used it as the sole channel.

At the shipped default (`SYNC_LAG_S_DEFAULT = 1.0`, `jz≈25`) this
happened to stay close enough to WSJT-X's fixed `±10` that golden
recall looked fine. Widening the window toward WSJT-X's own `±2.5s`
(`jz≈62`, e.g. via `MFSK_SYNC_LAG_S=2.5`) exposed it: the noise floor
(`base`, a 40th-percentile normalizer) scales with the window width
under basic extreme-value statistics, so real, previously-decoding
stations silently dropped out of `qso3_busy.wav` recall. Full
investigation and measurements are in #280.

## The fix

Restores WSJT-X's two-channel design:

- `red_primary`/`base_primary`: built from a **fixed `±MLAG` (10)**
  window regardless of the requested `jz`. This is now the primary
  candidate source per frequency bin.
- `red_secondary`/`base_secondary`: the previous full-`±jz` computation,
  demoted to a secondary channel that only contributes a candidate when
  its peak lag disagrees with the primary's — mirroring `sync8.f90`'s
  `if (jpeak2(n)==jpeak(n)) cycle`.

`const MLAG: i32 = 10;` already existed in this file (previously only
used for post-hoc NMS dedup) and is reused here as the primary
window's half-width.

## Verification

**No regression at the shipped 1.0s default** — confirmed byte-identical
results vs pre-fix `main` across:
- `ft8_decode_block_real_qso` (qso1/qso2/qso3_busy embedded-config floors)
- `ft8_qso3_apoff_recall`, `ft8_qso3_apon_recall` (both subtests)
- `ft8_qso3_full_parity_recall`
- `ft8_sic_rounds_recall`
- Full `cargo test -p mfsk-core --lib --features full,internal-testing`
  (409 passed, 0 failed)
- Broader FT8 integration coverage: `ft8_qso3_jtdx_recall`,
  `ft8_qso3_staged_sic_check`, `ft8_streaming_decode`,
  `ft8_decode_block_streaming`, `ft8_resample`, `ft8_protocol_trait`,
  `ft8_decode_frame_with_ap`, `ft8_no_nsym3_sweep`
- `cargo fmt --all -- --check` and
  `cargo clippy -p mfsk-core --features full,internal-testing --all-targets -- -D warnings`
  both clean

**Real, measured improvement at `MFSK_SYNC_LAG_S=2.5`** (not the
shipped default): the AP+SIC multipass path
(`qso3_apon_subtract_jtdx_extras_diag`) went from 5/6 to **6/6**,
matching the 1.0s reference exactly — `K1JT HA5WA 73` is now recovered
at WSJT-X's own window width.

## Known remaining gap (tracked in #280, not blocking this PR)

`K1BZM DK8NE -10` is still not recovered at 2.5s through any path that
doesn't add AP+SIC, so `ft8_qso3_full_parity_recall` (floor 8/8) and
`ft8_qso3_jtdx_high_sensitivity_recall` (floor 19/20) still fail at
`MFSK_SYNC_LAG_S=2.5`. Its back-computed lag sits outside the fixed
`±10` primary window, so it can only be reached via the secondary
channel, which still scales with `jz` (by design — it mirrors WSJT-X's
own `red2`/`base2`, also built from the full `±JZ` window). Whether
real WSJT-X recovers this specific decode via a single `sync8` pass or
only through its own downstream multi-pass refinement is still an open
question — see the latest comment on #280 for the plan to compare
against actual WSJT-X output.

**`SYNC_LAG_S_DEFAULT` is intentionally left at `1.0` in this PR.** It
should only move toward `2.5` once the remaining gap above is
understood, not as a side effect of this fix.
