### PR TITLE
fix(q65): scale cross-candidate dedup window to tone spacing

### DIFF
--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -537,7 +537,7 @@ pub(crate) fn decode_scan_fading_for<P: ModulationParams>(
         };
         let dup = seen.iter().any(|prev| {
             prev.message == decode.message
-                && (prev.freq_hz - decode.freq_hz).abs() <= 4.0
+                && (prev.freq_hz - decode.freq_hz).abs() <= dedup_freq_tol_hz::<P>()
                 && (prev.start_sample as i64 - decode.start_sample as i64).abs() <= nsps as i64
         });
         if !dup {
@@ -645,7 +645,7 @@ pub(crate) fn decode_scan_with_ap_list_for<P: ModulationParams>(
         };
         let dup = seen.iter().any(|prev| {
             prev.message == decode.message
-                && (prev.freq_hz - decode.freq_hz).abs() <= 4.0
+                && (prev.freq_hz - decode.freq_hz).abs() <= dedup_freq_tol_hz::<P>()
                 && (prev.start_sample as i64 - decode.start_sample as i64).abs() <= nsps as i64
         });
         if !dup {
@@ -658,11 +658,43 @@ pub(crate) fn decode_scan_with_ap_list_for<P: ModulationParams>(
     seen
 }
 
+/// Post-decode dedup frequency window (issue #287): two candidates
+/// decoding the *same* message within this window are treated as one
+/// real signal, not two.
+///
+/// [`super::search::coarse_search_on_spec_for`]'s own frequency-domain
+/// local-max suppression only rules out a second peak within
+/// `±bins_per_tone` (= `±P::TONE_SPACING_HZ`) of a higher one — a
+/// direct port of WSJT-X's own `q65_ccf_22` admission rule
+/// (`i3=i-mode_q65, i4=i+mode_q65`). On wide sub-modes under real
+/// fading (Q65-120D 10 GHz rainscatter, `q65_wsjtx_samples.rs`'s
+/// `rainscatter_10ghz_120d_decodes_with_fading_metric`), that leaves
+/// room for two lobes of one Doppler-spread signal to each be a local
+/// maximum in its own ±1-tone-spacing neighbourhood while still being
+/// separated by *more* than one tone spacing overall (measured: 993.8
+/// Hz and 1001.2 Hz on `210117_0920.wav`, TONE_SPACING_HZ = 6.0 Hz,
+/// 7.4 Hz apart) — both survive coarse search and both decode the
+/// identical message.
+///
+/// The old fixed `4.0 Hz` window (this function's predecessor) was too
+/// narrow to catch that on wide sub-modes; scaling to
+/// `2 × TONE_SPACING_HZ` covers it with margin. `max(_, 4.0)` keeps
+/// the previously-tested radius as a floor for narrow sub-modes
+/// (Q65-15A..Q65-300A's `A`) rather than *shrinking* it — this dedup's
+/// real safety net is exact message-text equality (a 77-bit
+/// CRC-protected Wsjt77 message colliding between two different real
+/// transmissions is not a realistic concern), so widening the
+/// frequency window carries negligible risk of merging genuinely
+/// distinct signals.
+fn dedup_freq_tol_hz<P: ModulationParams>() -> f32 {
+    (2.0 * P::TONE_SPACING_HZ).max(4.0)
+}
+
 /// Scan an audio buffer for Q65 frames in sub-mode `P` within the
 /// search window: runs [`super::search::coarse_search_for`] and tries
 /// [`decode_at_for`] on each candidate in score order, collapsing
-/// duplicate decodes (same message, frequency within ±4 Hz, start
-/// sample within ±1 symbol).
+/// duplicate decodes (same message, frequency within
+/// [`dedup_freq_tol_hz`], start sample within ±1 symbol).
 pub(crate) fn decode_scan_for<P: ModulationParams>(
     audio: &[f32],
     sample_rate: u32,
@@ -735,7 +767,7 @@ fn decode_scan_inner<P: ModulationParams>(
         };
         let dup = seen.iter().any(|prev| {
             prev.message == decode.message
-                && (prev.freq_hz - decode.freq_hz).abs() <= 4.0
+                && (prev.freq_hz - decode.freq_hz).abs() <= dedup_freq_tol_hz::<P>()
                 && (prev.start_sample as i64 - decode.start_sample as i64).abs() <= nsps as i64
         });
         if !dup {

--- a/mfsk-core/tests/q65_wsjtx_samples.rs
+++ b/mfsk-core/tests/q65_wsjtx_samples.rs
@@ -557,18 +557,17 @@ fn rainscatter_10ghz_120d_decodes_with_fading_metric() {
 
     // Golden "VK3WE VK7MO QE37" @ 995 Hz, jt9 SNR -16 dB.
     //
-    // `max_extra: 1`, not the usual 0 — **tracked debt, not accepted
-    // design.** A real local `jt9 -3 -p 120 -b D -d 3` run on this file
-    // (2026-08-14) reports exactly *one* decode at 995 Hz; this crate
-    // reports the identical message twice, at two nearby frequencies
-    // (~994 Hz and ~1001 Hz, ~7 Hz apart). Root cause: `q65` has no
-    // cross-candidate dedup at all (unlike FT8/FT4/FST4, which collapse
-    // re-derivations of the same message via SIC-subtraction or a
-    // `known`-list filter) — two coarse candidates a few Hz apart both
-    // independently lock onto and decode the same real signal, and
-    // nothing downstream notices they agree. Filed as issue #287
-    // rather than fixed here or silently accepted: this test's job is
-    // to make the gap visible, not to design the fix.
+    // Was max_extra: 1 (tracked debt, issue #287): this crate used to
+    // report the identical message twice, at two nearby frequencies
+    // (~994 Hz and ~1001 Hz, ~7.4 Hz apart — more than one
+    // TONE_SPACING_HZ=6.0 Hz tone away). Root cause: two coarse
+    // candidates each independently local-maximal in their own
+    // ±1-tone-spacing neighbourhood (WSJT-X's own `q65_ccf_22`
+    // admission radius) can still be more than one tone spacing apart
+    // overall, and the post-decode dedup's fixed ±4 Hz window didn't
+    // reach that far. Fixed by scaling the dedup window to
+    // `dedup_freq_tol_hz` (`q65::rx`, `2 × TONE_SPACING_HZ` floored at
+    // the old 4 Hz) — back to the normal max_extra: 0.
     assert_golden(
         &fading,
         &GoldenSet {
@@ -580,7 +579,7 @@ fn rainscatter_10ghz_120d_decodes_with_fading_metric() {
                 snr_db: Some(-16.0),
             }],
             min_hits: 1,
-            max_extra: 1,
+            max_extra: 0,
         },
         Tolerances {
             freq_hz: 15.0,


### PR DESCRIPTION
Closes #287.

## Root cause

Q65's post-decode dedup (collapse candidates that agree on message text, frequency, and start time) used a fixed `±4 Hz` frequency window regardless of sub-mode. `q65::search::coarse_search_on_spec_for`'s own frequency-domain local-max suppression only rules out a second peak within `±TONE_SPACING_HZ` of a higher one (a direct port of WSJT-X's `q65_ccf_22` admission rule). On wide sub-modes (the `...D`/`...E` letters) under real fading, that leaves room for two lobes of one Doppler-spread signal to each be a local maximum in its own `±1×TONE_SPACING_HZ` neighbourhood while still being separated by *more* than one tone spacing overall — both survive coarse search, both decode, and the dedup pass (narrower than a tone spacing on these sub-modes) doesn't catch it.

Measured on Q65-120D 10 GHz rainscatter (`210117_0920.wav`, `TONE_SPACING_HZ = 6.0`): two candidates at 993.8 Hz and 1001.2 Hz (7.4 Hz apart) both decoded `VK3WE VK7MO QE37`.

## Fix

Scale the dedup window to `(2 × TONE_SPACING_HZ).max(4.0)` — covers the observed 7.4 Hz gap with margin, and never shrinks below the previously-tested 4 Hz floor for narrow sub-modes. Message-text equality (exact 77-bit CRC-protected Wsjt77 match) is dedup's real safety net against merging genuinely distinct signals, so widening the frequency window carries negligible risk of a false merge. Applied via a shared `dedup_freq_tol_hz<P>()` helper at all three dedup call sites (`decode_scan_inner`, `decode_scan_with_ap_list_for`, `decode_scan_fading_for`).

## Verification

- `rainscatter_10ghz_120d_decodes_with_fading_metric`: 2 decodes → 1, golden test's `max_extra` back to the normal `0` (was `1`, tracked debt).
- Full Q65 suite (golden + `q65_ap_list` + `q65_fast_fading`), host f32 and `fixed-point`: 0 failures.
- Crate-wide merge gate (`MFSK_REQUIRE_CORPUS=1 cargo test --features full,internal-testing --release`): 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)