### PR TITLE
docs: replace unmeasured "80% shared" claim with measured figures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,24 @@
   Costs nothing measurable: the tier-A+B suite is 91-94 s across
   before/after runs.
 
+- **The "roughly 80% of code is shared across protocols" claim
+  (`README.md`, `lib.rs` crate doc) was never measured** — introduced
+  as scene-setting prose in commit `929114c` and never revisited, not
+  even when Q65 (one of the least-shared protocols) was added and the
+  protocol count changed from six to seven with the percentage left
+  untouched. Measured (`wc -l`, excluding the experimental uvpacket
+  example): about a third of `src/` (18.7k / 58.9k lines) is generic
+  over `P: Protocol`; only FT4 and FST4 actually route through the
+  shared `engine::pipeline` decode driver. Both doc sites now cite the
+  measured figure and point at `docs/reference/LIBRARY.md` §0.5's
+  per-protocol table, which was already accurate and is now the
+  source of truth for future edits. Also fixed a flatly incorrect
+  claim in `wspr/mod.rs`'s module doc (dating to the initial commit,
+  never revised) that WSPR's FEC and message codecs are "shared with
+  the other modes" — they are not; WSPR has its own `ConvFano` and
+  `Wspr50Message`, as the same module doc's own preceding paragraph
+  already said.
+
 ### Added
 
 - **`Q65Result::dt_sec` / `Jt65Result::dt_sec`** — frame start in

--- a/README.md
+++ b/README.md
@@ -270,11 +270,18 @@ want to run the decoders *somewhere else*:
 
 ### Why a `Protocol` trait
 
-The seven protocols share roughly 80 % of their signal path: 8-GFSK /
-FSK demodulation, soft-decision LDPC / convolutional / Reed-Solomon /
-QRA decoding, 77- / 72- / 50-bit WSJT message packing, spectrogram-based
-sync search. In the Fortran codebase that commonality is expressed by
-copy-and-paste between per-mode source files; here it is expressed by
+Measured (`wc -l`, excluding the experimental uvpacket example, 2026-08-14):
+about a third of `src/` (18.7k / 58.9k lines) is generic over `P:
+Protocol` — the LDPC BP/OSD kernel, the `wsjt77`/`jt72` message codecs,
+FFT/resample/GFSK DSP. The rest is protocol-specific by necessity
+(different FEC math — LDPC / convolutional Fano / Reed-Solomon / QRA
+over GF(64) — and different message widths, 77- / 72- / 50-bit) or by
+how far each protocol has migrated onto the shared decode pipeline so
+far — currently FT4 and FST4; see
+[`docs/reference/LIBRARY.md` §0.5](https://github.com/jl1nie/mfsk-core/blob/main/docs/reference/LIBRARY.md#05-generic-vs-bespoke-per-protocol)
+for the per-protocol breakdown, which this paragraph is kept in sync
+with. In the Fortran codebase the *possible* commonality is expressed
+by copy-and-paste between per-mode source files; here it is expressed by
 traits, split by what actually varies per protocol:
 
 - **Shared** (lives in `engine`, generic over any `P: Protocol`): coarse

--- a/mfsk-core/src/lib.rs
+++ b/mfsk-core/src/lib.rs
@@ -1,8 +1,8 @@
 //! # mfsk-core
 //!
 //! Pure-Rust library for **WSJT-family digital amateur-radio modes**:
-//! FT8, FT4, FST4, WSPR, JT9, JT65 and Q65-30A. Decode, encode, and
-//! synthesis in a single crate.
+//! FT8, FT4, FST4, WSPR, JT9, JT65, Q65-30A and MSK144. Decode, encode,
+//! and synthesis in a single crate.
 //!
 //! ## Why this exists
 //!
@@ -34,13 +34,19 @@
 //!   LDPC and sync machinery for a different modulation / FEC /
 //!   message recipe.
 //!
-//! Each of the seven protocols here shares roughly 80 % of its signal
-//! path with at least one sibling: 8-GFSK / FSK demodulation, soft-
-//! decision LDPC / convolutional / Reed-Solomon / QRA decoding,
-//! 77- / 72- / 50-bit WSJT message packing, spectrogram-based sync
-//! search. In the Fortran codebase that commonality is expressed by
-//! copy-and-paste between per-mode source files; here it is expressed
-//! by a small set of traits.
+//! Measured (`wc -l`, excluding the experimental uvpacket example,
+//! 2026-08-14): about a third of `src/` (18.7k / 58.9k lines) is
+//! generic over `P: Protocol` — the LDPC BP/OSD kernel, the
+//! `wsjt77`/`jt72` message codecs, FFT/resample/GFSK DSP. The rest is
+//! protocol-specific by necessity (different FEC math — LDPC /
+//! convolutional Fano / Reed-Solomon / QRA over GF(64) — and different
+//! message widths, 77- / 72- / 50-bit) or by how far each protocol has
+//! migrated onto the shared decode pipeline so far — currently FT4
+//! and FST4; see `docs/reference/LIBRARY.md` §0.5 for the per-protocol
+//! breakdown this paragraph is kept in sync with. In the Fortran
+//! codebase the *possible* commonality is expressed by copy-and-paste
+//! between per-mode source files; here it is expressed by a small set
+//! of traits.
 //!
 //! ## The abstraction
 //!

--- a/mfsk-core/src/wspr/mod.rs
+++ b/mfsk-core/src/wspr/mod.rs
@@ -11,10 +11,15 @@
 //!   sync is not a block Costas array — the decoder recovers timing by
 //!   correlating every symbol's LSB against the known vector.
 //!
-//! All protocol-invariant pieces (FFT/downsample DSP, generic pipeline
-//! scaffolding, FEC codec, message codec) are shared with the other modes.
-//! This module provides the [`Wspr`] ZST plus WSPR-specific TX/RX helpers
-//! that handle the interleaver and sync-bit embedding.
+//! FFT is shared with the other modes; the FEC codec (`ConvFano`, above)
+//! and message codec (50-bit, above) are WSPR's own — they don't match
+//! any other protocol here closely enough to plug into the shared
+//! `fec`/`msg` machinery, and WSPR's decode path (`decode.rs`) doesn't
+//! route through `engine::pipeline` either (see
+//! `docs/reference/LIBRARY.md` §0.5 for the per-protocol shared-vs-
+//! bespoke breakdown this crate keeps). This module provides the
+//! [`Wspr`] ZST plus WSPR-specific TX/RX helpers that handle the
+//! interleaver and sync-bit embedding.
 //!
 //! ## Quick example
 //!


### PR DESCRIPTION
Step 1 of the code-sharing audit (plan: `mighty-chasing-castle`), triggered by a user question about whether faithful WSJT-X porting has caused excessive per-protocol divergence, and whether README's "80% shared" claim holds up.

It doesn't — but not for the reason suspected. Full write-up in the CHANGELOG entry; short version:

- The "roughly 80%" claim traces to commit `929114c` (2026-04-19), introduced as scene-setting prose with no measurement anywhere in the commit. Never revisited — when Q65 was added (one of the least-shared protocols: own FEC, own message codec) the protocol count went "six"→"seven" but the percentage was left untouched.
- Measured (`wc -l`, excluding the experimental uvpacket example): about **a third** of `src/` (18.7k / 58.9k lines) is generic over `P: Protocol`. Only FT4 and FST4 route through the shared `engine::pipeline` decode driver; the other six protocols have bespoke decode engines — much of that divergence is inherent (QRA/Fano/Reed-Solomon are mathematically different codes; upstream WSJT-X's own Fortran is itself per-protocol duplicated).
- `docs/reference/LIBRARY.md` §0.5 already has the accurate, hedged per-protocol table — this PR reconciles README/lib.rs against it rather than writing new analysis.
- Also fixes a flatly incorrect claim in `wspr/mod.rs`'s module doc ("FEC codec, message codec... shared with the other modes") that contradicts its own preceding paragraph and dates to the initial commit, unrevised since WSPR grew its own bespoke `ConvFano`/`Wspr50Message`.

No code changes. This is Stage/step 1 of a larger plan to close the real gap the audit found: dedup logic reimplemented 7+ times with inconsistent tolerances (one instance of which was issue #287, fixed in #289), and a scalloping-loss fix independently reinvented three times (WSPR → JT65 #169 → JT9) because those protocols don't share `engine::sync`'s coarse-search path. Later steps will land as separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)