### PR TITLE
refactor: Stage 0 — extract refine_freq_hz and dedup_known (byte-identical dupes)

### DIFF
--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -1125,6 +1125,27 @@ pub(crate) fn known_filtered_on_result<'a>(
     })
 }
 
+/// Dedup `raw` against caller-supplied `known` (by `info` equality) —
+/// the generic engine has no `known`/AP-hint parameter at all, so this
+/// is a best-effort post-filter rather than an in-loop skip. Always
+/// correct (never mis-reports a known signal as new), just cannot save
+/// the work of re-decoding it the way FT8's engine-level `known`
+/// handling can. [`known_filtered_on_result`] above is this same idea
+/// applied to the streaming `on_result` callback instead of the
+/// returned `Vec`.
+///
+/// Extracted (2026-08-14, code-sharing audit) from two byte-identical
+/// copies in `ft4::decode` and `fst4::decode`, both operating on this
+/// same concrete `DecodeResult` type (not just structurally similar —
+/// literally the same function body, `use`-imported from here in both
+/// modules).
+#[cfg(any(feature = "ft4", feature = "fst4"))]
+pub(crate) fn dedup_known(raw: Vec<DecodeResult>, known: &[DecodeResult]) -> Vec<DecodeResult> {
+    raw.into_iter()
+        .filter(|r| !known.iter().any(|k| k.info == r.info))
+        .collect()
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Frame-level entry points
 // ──────────────────────────────────────────────────────────────────────────

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -886,6 +886,61 @@ pub fn parabolic_peak(y_neg: f32, y_0: f32, y_pos: f32) -> (f32, f32) {
     (offset.clamp(-0.5, 0.5), peak)
 }
 
+/// Refine a coarse-search frequency bin to sub-bin precision via
+/// 3-point log-power parabolic ("Jacobsen") interpolation of power
+/// around `base_bin`. `power_at(bin)` supplies the (linear-domain,
+/// un-normalised) power at a neighbouring bin — callers pass a closure
+/// over their own already-computed spectrogram rather than this
+/// function owning any spectrogram type, since that type (and how
+/// "power at a bin" is defined — which sync positions get summed) is
+/// protocol-specific.
+///
+/// Extracted (2026-08-14, code-sharing audit) from two byte-identical
+/// copies that had independently accreted in `jt65::search` and
+/// `jt9::search` — the second copy was deliberately written to match
+/// the first (see the historical `jt9::search::refine_freq_hz` doc:
+/// "reused here with the same technique... and the same non-peak-shaped
+/// fallback"), so unifying them changes nothing behaviourally, only
+/// where the one copy lives.
+///
+/// **Not the same estimator as [`parabolic_peak`]**, despite solving a
+/// superficially similar problem: `parabolic_peak` fits a parabola in
+/// the *linear* power domain and always returns an interpolated offset
+/// (the near-zero-denominator guard exists only to avoid a division by
+/// zero); this fits in the *log*-power domain and explicitly declines
+/// to extrapolate — falling back to the untouched bin center — when
+/// the 3-point curve isn't concave-down (`denom >= -1e-9`), i.e. isn't
+/// actually peak-shaped. That fallback matters here specifically:
+/// coarse-search candidates can be noise-dominated or off the true
+/// local max, and extrapolating a non-peak-shaped curve would invent
+/// a frequency offset from noise rather than declining to guess.
+/// Collapsing the two into one function would be an algorithm change,
+/// not a refactor — they stay separate on purpose.
+pub fn refine_freq_hz_log_power(
+    base_bin: usize,
+    bin_count: usize,
+    df: f32,
+    power_at: impl Fn(usize) -> f32,
+) -> f32 {
+    if base_bin == 0 || base_bin + 1 >= bin_count {
+        return base_bin as f32 * df;
+    }
+    let y_lo = power_at(base_bin - 1).max(1e-12).ln();
+    let y_mid = power_at(base_bin).max(1e-12).ln();
+    let y_hi = power_at(base_bin + 1).max(1e-12).ln();
+    let denom = y_lo - 2.0 * y_mid + y_hi;
+    // `denom < 0` at a genuine local peak (concave-down parabola); a
+    // non-negative denom means the 3-point fit isn't peak-shaped
+    // (noise-dominated or `base_bin` isn't actually the local max) —
+    // don't extrapolate, just keep the coarse bin-center frequency.
+    let delta = if denom < -1e-9 {
+        (0.5 * (y_lo - y_hi) / denom).clamp(-0.5, 0.5)
+    } else {
+        0.0
+    };
+    (base_bin as f32 + delta) * df
+}
+
 /// Refine timing by scanning ±`search_steps` downsampled samples, then
 /// applying parabolic sub-sample interpolation around the peak for a
 /// fractional-sample refinement. The sub-sample shift is used to report a

--- a/mfsk-core/src/fst4/decode.rs
+++ b/mfsk-core/src/fst4/decode.rs
@@ -129,16 +129,6 @@ const SYNC_Q_MIN: u32 = 16;
 /// search window across all of them — no per-sub-mode retuning needed.
 const REFINE_STEPS: i32 = 40;
 
-/// Dedup `raw` against caller-supplied `known` (by `info` equality) — the
-/// generic engine has no `known` parameter at all, so this is a
-/// best-effort post-filter rather than an in-loop skip (same rationale as
-/// `ft4::decode`'s copy of this helper).
-fn dedup_known(raw: Vec<DecodeResult>, known: &[DecodeResult]) -> Vec<DecodeResult> {
-    raw.into_iter()
-        .filter(|r| !known.iter().any(|k| k.info == r.info))
-        .collect()
-}
-
 /// Implements [`FrameDecodable`] for one FST4 sub-mode ZST, wiring in its
 /// `DownsampleCfg`. Every sub-mode shares the same generic engine
 /// (`engine::pipeline`/`msg::pipeline_ap`), `REFINE_STEPS`, and
@@ -172,7 +162,7 @@ macro_rules! impl_frame_decodable {
                 // See `pipeline::known_filtered_on_result`'s doc comment
                 // (same rationale as `ft4::decode`'s copy of this fix):
                 // without this, `on_result` could fire for a candidate
-                // `dedup_known` below then silently drops from the
+                // `pipeline::dedup_known` below then silently drops from the
                 // returned `Vec`.
                 let filtered_cb = pipeline::known_filtered_on_result(req.known, req.on_result);
                 let on_result: Option<&(dyn Fn(&DecodeResult) + Sync)> = filtered_cb
@@ -194,7 +184,7 @@ macro_rules! impl_frame_decodable {
                     on_result,
                 );
                 DecodeOutcome {
-                    results: dedup_known(raw, req.known),
+                    results: pipeline::dedup_known(raw, req.known),
                     fft_cache,
                 }
             }

--- a/mfsk-core/src/ft4/decode.rs
+++ b/mfsk-core/src/ft4/decode.rs
@@ -5,8 +5,6 @@
 //! via the shared [`crate::msg::decode_request::DecodeRequest`] /
 //! [`crate::msg::decode_request::SniperRequest`] builders (issue #191).
 
-use alloc::vec::Vec;
-
 use super::Ft4;
 use crate::engine::dsp::downsample::DownsampleCfg;
 use crate::engine::dsp::subtract::SubtractCfg;
@@ -57,17 +55,6 @@ const REFINE_STEPS: i32 = 32;
 /// FT4 has 16 sync symbols (4 × 4); require at least half correct.
 const SYNC_Q_MIN: u32 = 8;
 
-/// Dedup `raw` against caller-supplied `known` (by `info` equality) — the
-/// generic engine has no `known`/AP-hint parameter at all, so this is a
-/// best-effort post-filter rather than an in-loop skip. Always correct
-/// (never mis-reports a known signal as new), just cannot save the work
-/// of re-decoding it the way FT8's engine-level `known` handling can.
-fn dedup_known(raw: Vec<DecodeResult>, known: &[DecodeResult]) -> Vec<DecodeResult> {
-    raw.into_iter()
-        .filter(|r| !known.iter().any(|k| k.info == r.info))
-        .collect()
-}
-
 impl pipeline::GenericPipelineProtocol for Ft4 {
     /// `ft4_decode.f90:226,452-457` — see [`pipeline::ft4_snr_db`]'s doc
     /// comment for the formula and its verification against a real
@@ -82,7 +69,7 @@ impl FrameDecodable for Ft4 {
 
     fn __single_pass(req: &DecodeRequest<'_, Self>) -> DecodeOutcome<Self> {
         // See `pipeline::known_filtered_on_result`'s doc comment: without
-        // this, `on_result` could fire for a candidate `dedup_known`
+        // this, `on_result` could fire for a candidate `pipeline::dedup_known`
         // below then silently drops from the returned `Vec`.
         let filtered_cb = pipeline::known_filtered_on_result(req.known, req.on_result);
         let on_result: Option<&(dyn Fn(&DecodeResult) + Sync)> = filtered_cb
@@ -104,7 +91,7 @@ impl FrameDecodable for Ft4 {
             on_result,
         );
         DecodeOutcome {
-            results: dedup_known(raw, req.known),
+            results: pipeline::dedup_known(raw, req.known),
             fft_cache,
         }
     }
@@ -205,7 +192,7 @@ impl SupportsSicRounds for Ft4 {
             &FT4_DOWNSAMPLE,
         ));
         DecodeOutcome {
-            results: dedup_known(raw, req.known),
+            results: pipeline::dedup_known(raw, req.known),
             fft_cache,
         }
     }

--- a/mfsk-core/src/jt65/search.rs
+++ b/mfsk-core/src/jt65/search.rs
@@ -10,6 +10,7 @@
 //! are the sync-positions list and the per-frame symbol count.
 
 use crate::engine::ModulationParams;
+use crate::engine::sync::refine_freq_hz_log_power;
 use num_complex::Complex;
 use rustfft::FftPlanner;
 
@@ -224,9 +225,9 @@ pub fn score_candidate(spec: &Spectrogram, start_row: usize, base_bin: usize) ->
     sync_pwr / (sync_pwr + noise_floor)
 }
 
-/// Refine a candidate's frequency to sub-bin precision via 3-point
-/// log-power parabolic ("Jacobsen") interpolation of the sync-tone
-/// power around `base_bin`.
+/// Refine a candidate's frequency to sub-bin precision — see
+/// [`refine_freq_hz_log_power`] for the estimator itself (shared with
+/// `jt9::search`, issue #169's original fix).
 ///
 /// `coarse_search`'s frequency grid is one bin wide (`df` ≈ 2.69 Hz at
 /// JT65A's NSPS/rate) — a signal landing between two bins pays a real
@@ -244,27 +245,9 @@ pub fn score_candidate(spec: &Spectrogram, start_row: usize, base_bin: usize) ->
 /// signal not landing exactly on a bin center pays some fraction of
 /// the same loss).
 fn refine_freq_hz(spec: &Spectrogram, start_row: usize, base_bin: usize, df: f32) -> f32 {
-    if base_bin == 0 || base_bin + 1 >= spec.n_freq {
-        return base_bin as f32 * df;
-    }
-    let y_lo = sync_power_at_bin(spec, start_row, base_bin - 1)
-        .max(1e-12)
-        .ln();
-    let y_mid = sync_power_at_bin(spec, start_row, base_bin).max(1e-12).ln();
-    let y_hi = sync_power_at_bin(spec, start_row, base_bin + 1)
-        .max(1e-12)
-        .ln();
-    let denom = y_lo - 2.0 * y_mid + y_hi;
-    // `denom < 0` at a genuine local peak (concave-down parabola); a
-    // non-negative denom means the 3-point fit isn't peak-shaped
-    // (noise-dominated or `base_bin` isn't actually the local max) —
-    // don't extrapolate, just keep the coarse bin-center frequency.
-    let delta = if denom < -1e-9 {
-        (0.5 * (y_lo - y_hi) / denom).clamp(-0.5, 0.5)
-    } else {
-        0.0
-    };
-    (base_bin as f32 + delta) * df
+    refine_freq_hz_log_power(base_bin, spec.n_freq, df, |bin| {
+        sync_power_at_bin(spec, start_row, bin)
+    })
 }
 
 /// Build a spectrogram of `audio` and return the best-scoring

--- a/mfsk-core/src/jt9/search.rs
+++ b/mfsk-core/src/jt9/search.rs
@@ -13,6 +13,7 @@
 //! know both.
 
 use crate::engine::ModulationParams;
+use crate::engine::sync::refine_freq_hz_log_power;
 use num_complex::Complex;
 use rustfft::FftPlanner;
 
@@ -212,9 +213,9 @@ pub fn score_candidate(spec: &Spectrogram, start_row: usize, base_bin: usize) ->
     sync_pwr / (sync_pwr + noise_floor)
 }
 
-/// Refine a candidate's frequency to sub-bin precision via 3-point
-/// log-power parabolic ("Jacobsen") interpolation of the sync-tone
-/// power around `base_bin`.
+/// Refine a candidate's frequency to sub-bin precision — see
+/// [`refine_freq_hz_log_power`] for the estimator itself (shared with
+/// `jt65::search`).
 ///
 /// `coarse_search`'s frequency grid is one bin wide (`df` ≈ 1.736 Hz,
 /// exactly the tone spacing) — the true signal frequency can land
@@ -226,33 +227,13 @@ pub fn score_candidate(spec: &Spectrogram, start_row: usize, base_bin: usize) ->
 /// 0.3-1.2 Hz away (1399.0 Hz, 1400.5 Hz) converge easily — the same
 /// "coarse bin center isn't close enough to the true frequency, and
 /// nothing downstream fully recovers from it" shape as JT65's own
-/// scalloping-loss fix (issue #169,
-/// `crate::jt65::search::refine_freq_hz`), reused here with the same
-/// technique (interpolate the already-computed spectrogram, no extra
-/// FFTs) and the same non-peak-shaped fallback (keep the coarse
-/// bin-center frequency rather than extrapolate from noise).
+/// scalloping-loss fix (issue #169, originally ported here as its own
+/// copy of the estimator before the two were unified into
+/// [`refine_freq_hz_log_power`]).
 fn refine_freq_hz(spec: &Spectrogram, start_row: usize, base_bin: usize, df: f32) -> f32 {
-    if base_bin == 0 || base_bin + 1 >= spec.n_freq {
-        return base_bin as f32 * df;
-    }
-    let y_lo = sync_power_at_bin(spec, start_row, base_bin - 1)
-        .max(1e-12)
-        .ln();
-    let y_mid = sync_power_at_bin(spec, start_row, base_bin).max(1e-12).ln();
-    let y_hi = sync_power_at_bin(spec, start_row, base_bin + 1)
-        .max(1e-12)
-        .ln();
-    let denom = y_lo - 2.0 * y_mid + y_hi;
-    // `denom < 0` at a genuine local peak (concave-down parabola); a
-    // non-negative denom means the 3-point fit isn't peak-shaped
-    // (noise-dominated or `base_bin` isn't actually the local max) —
-    // don't extrapolate, just keep the coarse bin-center frequency.
-    let delta = if denom < -1e-9 {
-        (0.5 * (y_lo - y_hi) / denom).clamp(-0.5, 0.5)
-    } else {
-        0.0
-    };
-    (base_bin as f32 + delta) * df
+    refine_freq_hz_log_power(base_bin, spec.n_freq, df, |bin| {
+        sync_power_at_bin(spec, start_row, bin)
+    })
 }
 
 /// Sweep (freq × time) and return top-scored candidates.


### PR DESCRIPTION
Stage 0 of the code-sharing audit plan (Step 1: #290, Step 2: #291, both merged).

## What

The lowest-risk consolidation possible: a function already byte-for-byte identical between two protocol modules (`jt65/search.rs:246-266`, `jt9/search.rs:234-254`), confirmed independently reinvented three separate times across the codebase — WSPR (`50e36aa`), then JT65 (#169), then copy-pasted verbatim into JT9 days later (JT9's own prior doc comment said as much: "reused here with the same technique... and the same non-peak-shaped fallback").

`engine::sync::refine_freq_hz_log_power` is the extracted 3-point log-power ("Jacobsen") sub-bin frequency estimator, taking a `power_at(bin)` closure instead of owning a `Spectrogram` type — each protocol's `Spectrogram` and sync-position table stay exactly where they are; only the pure numerical kernel moved.

Deliberately kept **separate** from the existing `engine::sync::parabolic_peak`, despite superficial similarity — they're different algorithms (linear- vs. log-power domain, always-extrapolate vs. decline-on-non-peak-shaped-curve). Collapsing them would be an algorithm change, not a refactor.

## Verification

Behaviour-preserving by construction (same math, same edge cases, same clamps), confirmed against real off-air recall/precision/SNR rather than just "compiles":

- `jt65_wsjtx_samples`: 4/5 recall, unchanged
- `jt9_wsjtx_samples`: 7/7 recall, unchanged
- Both under host f32 and `fixed-point`
- CI's exact `--no-default-features` + single-protocol-feature build matrix combinations verified locally

WSPR's own scalloping-loss fix (`coarse_baseband.rs`) uses a different technique and isn't touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)