### PR TITLE
refactor(stage1): consolidate candidate dedup across JT9/JT65/WSPR/Q65

### DIFF
--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -1146,6 +1146,91 @@ pub(crate) fn dedup_known(raw: Vec<DecodeResult>, known: &[DecodeResult]) -> Vec
         .collect()
 }
 
+/// True if `cand` duplicates an entry already in `seen`: same message,
+/// frequency within `freq_tol_hz`, start sample within
+/// `time_tol_samples` of some earlier-accepted decode from the same
+/// scan pass.
+///
+/// This is the "same real signal, decoded twice by two nearby
+/// coarse-search candidates" check every bespoke decode-scan loop in
+/// this crate performs on its own accumulating `seen: Vec<_>` — a
+/// different concern from [`dedup_known`]'s job of filtering against a
+/// *caller-supplied* known-decodes list (the two aren't unified; a
+/// protocol can and does need both).
+///
+/// Extracted (2026-08-14, code-sharing audit) from four independent,
+/// near-identical copies: `jt9::mod` (1 site), `jt65::mod` (2 sites —
+/// see [`scan_dedup_match_cross`], which those use instead of this),
+/// `wspr::decode` (3 sites, one per SIC-pass shape), and `q65::rx` (3
+/// sites, one per decode strategy) — 9 call sites total, each
+/// reimplementing the same three-line predicate with its own
+/// tolerance constants. Tolerances stay exactly what each protocol
+/// used before this extraction (now explicit parameters instead of
+/// scattered local `const`s, so a future change to one is a visible
+/// diff instead of a silent divergence) — issue #287 is what a
+/// tolerance that doesn't scale with a protocol's own parameter range
+/// costs, but changing any of them here is out of scope: this moves
+/// code, not thresholds.
+#[cfg(any(feature = "jt9", feature = "wspr", feature = "q65"))]
+pub(crate) fn scan_dedup_match<T, M: PartialEq>(
+    seen: &[T],
+    cand: &T,
+    msg: impl Fn(&T) -> &M,
+    freq_hz: impl Fn(&T) -> f32,
+    start_sample: impl Fn(&T) -> i64,
+    freq_tol_hz: f32,
+    time_tol_samples: i64,
+) -> bool {
+    scan_dedup_match_cross(
+        seen,
+        cand,
+        &msg,
+        &freq_hz,
+        &start_sample,
+        &msg,
+        &freq_hz,
+        &start_sample,
+        freq_tol_hz,
+        time_tol_samples,
+    )
+}
+
+/// [`scan_dedup_match`], but `seen: &[S]` and `cand: &C` may be
+/// different types.
+///
+/// `jt65::mod`'s two call sites need this rather than the same-type
+/// form: they compare a not-yet-built candidate (raw `(message,
+/// freq_hz, start_sample)` straight from the coarse-search candidate
+/// and the decode call, before a `Jt65Result` exists to hold them)
+/// against the already-pushed `Jt65Result`s in `seen`. Those two also
+/// happen to disagree on `start_sample`'s reference frame whenever
+/// early-frame padding is active (`seen` entries are already
+/// pad-adjusted, the not-yet-built candidate isn't) — a pre-existing
+/// property of the original code, preserved here rather than
+/// "corrected" in what is meant to be a pure extraction.
+#[cfg(any(feature = "jt9", feature = "jt65", feature = "wspr", feature = "q65"))]
+pub(crate) fn scan_dedup_match_cross<S, C, M: PartialEq>(
+    seen: &[S],
+    cand: &C,
+    seen_msg: impl Fn(&S) -> &M,
+    seen_freq_hz: impl Fn(&S) -> f32,
+    seen_start_sample: impl Fn(&S) -> i64,
+    cand_msg: impl Fn(&C) -> &M,
+    cand_freq_hz: impl Fn(&C) -> f32,
+    cand_start_sample: impl Fn(&C) -> i64,
+    freq_tol_hz: f32,
+    time_tol_samples: i64,
+) -> bool {
+    let cand_msg = cand_msg(cand);
+    let cand_freq = cand_freq_hz(cand);
+    let cand_time = cand_start_sample(cand);
+    seen.iter().any(|prev| {
+        seen_msg(prev) == cand_msg
+            && (seen_freq_hz(prev) - cand_freq).abs() <= freq_tol_hz
+            && (seen_start_sample(prev) - cand_time).abs() <= time_tol_samples
+    })
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Frame-level entry points
 // ──────────────────────────────────────────────────────────────────────────

--- a/mfsk-core/src/jt65/mod.rs
+++ b/mfsk-core/src/jt65/mod.rs
@@ -88,6 +88,7 @@
 //! }
 //! ```
 
+use crate::engine::pipeline::scan_dedup_match_cross;
 use crate::engine::{FrameLayout, ModulationParams, Protocol, ProtocolId, SyncMode};
 use crate::fec::Rs63_12;
 use crate::msg::Jt72Codec;
@@ -381,11 +382,18 @@ fn decode_scan_inner(
         else {
             continue;
         };
-        let dup = seen.iter().any(|prev| {
-            prev.message == msg
-                && (prev.freq_hz - c.freq_hz).abs() <= 2.0
-                && (prev.start_sample as i64 - c.start_sample as i64).abs() <= nsps as i64
-        });
+        let dup = scan_dedup_match_cross(
+            &seen,
+            &(msg.clone(), c.freq_hz, c.start_sample as i64),
+            |r| &r.message,
+            |r| r.freq_hz,
+            |r| r.start_sample as i64,
+            |(m, _, _)| m,
+            |(_, f, _)| *f,
+            |(_, _, t)| *t,
+            2.0,
+            nsps as i64,
+        );
         if !dup {
             let result = Jt65Result {
                 message: msg,
@@ -491,11 +499,18 @@ fn decode_scan_chase_inner(
         ) else {
             continue;
         };
-        let dup = seen.iter().any(|prev| {
-            prev.message == msg
-                && (prev.freq_hz - c.freq_hz).abs() <= 2.0
-                && (prev.start_sample as i64 - c.start_sample as i64).abs() <= nsps as i64
-        });
+        let dup = scan_dedup_match_cross(
+            &seen,
+            &(msg.clone(), c.freq_hz, c.start_sample as i64),
+            |r| &r.message,
+            |r| r.freq_hz,
+            |r| r.start_sample as i64,
+            |(m, _, _)| m,
+            |(_, f, _)| *f,
+            |(_, _, t)| *t,
+            2.0,
+            nsps as i64,
+        );
         if !dup {
             let result = Jt65Result {
                 message: msg,

--- a/mfsk-core/src/jt9/mod.rs
+++ b/mfsk-core/src/jt9/mod.rs
@@ -31,6 +31,7 @@
 //! }
 //! ```
 
+use crate::engine::pipeline::scan_dedup_match;
 use crate::engine::{FrameLayout, ModulationParams, Protocol, ProtocolId, SyncMode};
 use crate::fec::ConvFano232;
 use crate::msg::Jt72Codec;
@@ -236,11 +237,15 @@ fn decode_scan_inner(
         let Some(d) = decode::decode_at_baseband_with_fft_depth(&big_fft, c.freq_hz, depth) else {
             continue;
         };
-        let dup = seen.iter().any(|prev| {
-            prev.message == d.message
-                && (prev.freq_hz - d.freq_hz).abs() <= 4.0
-                && (prev.start_sample as i64 - d.start_sample as i64).abs() <= nsps as i64
-        });
+        let dup = scan_dedup_match(
+            &seen,
+            &d,
+            |r| &r.message,
+            |r| r.freq_hz,
+            |r| r.start_sample as i64,
+            4.0,
+            nsps as i64,
+        );
         if !dup {
             if let Some(cb) = on_result {
                 cb(&d);

--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -29,6 +29,7 @@
 use num_complex::Complex;
 use rustfft::FftPlanner;
 
+use crate::engine::pipeline::scan_dedup_match;
 use crate::engine::{DecodeContext, MessageCodec, ModulationParams};
 use crate::fec::qra::{FadingModel, Q65Codec, intrinsics_fast_fading};
 use crate::fec::qra15_65_64::QRA15_65_64_IRR_E23;
@@ -535,11 +536,15 @@ pub(crate) fn decode_scan_fading_for<P: ModulationParams>(
         ) else {
             continue;
         };
-        let dup = seen.iter().any(|prev| {
-            prev.message == decode.message
-                && (prev.freq_hz - decode.freq_hz).abs() <= dedup_freq_tol_hz::<P>()
-                && (prev.start_sample as i64 - decode.start_sample as i64).abs() <= nsps as i64
-        });
+        let dup = scan_dedup_match(
+            &seen,
+            &decode,
+            |r| &r.message,
+            |r| r.freq_hz,
+            |r| r.start_sample as i64,
+            dedup_freq_tol_hz::<P>(),
+            nsps as i64,
+        );
         if !dup {
             if let Some(cb) = on_result {
                 cb(&decode);
@@ -643,11 +648,15 @@ pub(crate) fn decode_scan_with_ap_list_for<P: ModulationParams>(
         ) else {
             continue;
         };
-        let dup = seen.iter().any(|prev| {
-            prev.message == decode.message
-                && (prev.freq_hz - decode.freq_hz).abs() <= dedup_freq_tol_hz::<P>()
-                && (prev.start_sample as i64 - decode.start_sample as i64).abs() <= nsps as i64
-        });
+        let dup = scan_dedup_match(
+            &seen,
+            &decode,
+            |r| &r.message,
+            |r| r.freq_hz,
+            |r| r.start_sample as i64,
+            dedup_freq_tol_hz::<P>(),
+            nsps as i64,
+        );
         if !dup {
             if let Some(cb) = on_result {
                 cb(&decode);
@@ -765,11 +774,15 @@ fn decode_scan_inner<P: ModulationParams>(
         ) else {
             continue;
         };
-        let dup = seen.iter().any(|prev| {
-            prev.message == decode.message
-                && (prev.freq_hz - decode.freq_hz).abs() <= dedup_freq_tol_hz::<P>()
-                && (prev.start_sample as i64 - decode.start_sample as i64).abs() <= nsps as i64
-        });
+        let dup = scan_dedup_match(
+            &seen,
+            &decode,
+            |r| &r.message,
+            |r| r.freq_hz,
+            |r| r.start_sample as i64,
+            dedup_freq_tol_hz::<P>(),
+            nsps as i64,
+        );
         if !dup {
             if let Some(cb) = on_result {
                 cb(&decode);

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -9,6 +9,7 @@ use alloc::vec::Vec;
 #[cfg(feature = "parallel")]
 use rayon::prelude::*;
 
+use crate::engine::pipeline::scan_dedup_match;
 use crate::msg::WsprMessage;
 
 use super::search::SearchParams;
@@ -1406,12 +1407,15 @@ fn decode_scan_inner(
 
         let mut this_pass: Vec<(WsprResult, usize)> = Vec::new();
         for (d, start_refined) in raw {
-            let dup = seen.iter().any(|prev| {
-                prev.message == d.message
-                    && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ
-                    && (prev.start_sample as i64 - d.start_sample as i64).abs()
-                        <= TIME_DEDUP_SAMPLES
-            });
+            let dup = scan_dedup_match(
+                &seen,
+                &d,
+                |r| &r.message,
+                |r| r.freq_hz,
+                |r| r.start_sample as i64,
+                FREQ_DEDUP_HZ,
+                TIME_DEDUP_SAMPLES,
+            );
             if !dup {
                 if let Some(cb) = on_result {
                     cb(&d);
@@ -1523,12 +1527,15 @@ fn decode_scan_inner(
             .collect();
 
         for d in raw2 {
-            let dup = seen.iter().any(|prev| {
-                prev.message == d.message
-                    && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ
-                    && (prev.start_sample as i64 - d.start_sample as i64).abs()
-                        <= TIME_DEDUP_SAMPLES
-            });
+            let dup = scan_dedup_match(
+                &seen,
+                &d,
+                |r| &r.message,
+                |r| r.freq_hz,
+                |r| r.start_sample as i64,
+                FREQ_DEDUP_HZ,
+                TIME_DEDUP_SAMPLES,
+            );
             if !dup {
                 if let Some(cb) = on_result {
                     cb(&d);
@@ -1692,12 +1699,15 @@ fn decode_scan_subtract_inner(
         }
         let mut added = 0usize;
         for d in new_decodes {
-            let dup = all.iter().any(|prev| {
-                prev.message == d.message
-                    && (prev.freq_hz - d.freq_hz).abs() <= FREQ_DEDUP_HZ
-                    && (prev.start_sample as i64 - d.start_sample as i64).abs()
-                        <= TIME_DEDUP_SAMPLES
-            });
+            let dup = scan_dedup_match(
+                &all,
+                &d,
+                |r| &r.message,
+                |r| r.freq_hz,
+                |r| r.start_sample as i64,
+                FREQ_DEDUP_HZ,
+                TIME_DEDUP_SAMPLES,
+            );
             if dup {
                 continue;
             }

--- a/mfsk-core/tests/common_selftest.rs
+++ b/mfsk-core/tests/common_selftest.rs
@@ -539,6 +539,16 @@ mod sharing_ratchet_selftest {
     /// without the trait surface changing too.
     const EXPECTED_SNR_TRAIT_ADOPTERS: &[&str] = &["ft4", "fst4"];
 
+    /// Protocols routing their own decode-scan candidate dedup through
+    /// `engine::pipeline::scan_dedup_match`/`scan_dedup_match_cross`
+    /// (Stage 1 of the code-sharing audit) rather than a hand-rolled
+    /// `seen.iter().any(...)` predicate. FT8 (spread across multiple
+    /// inline sites in a much larger bespoke engine) and MSK144 (a
+    /// structurally different single-slot state machine, not a
+    /// `Vec`-accumulating scan) are deliberately not adopters here —
+    /// see the plan file for why each was out of scope for this pass.
+    const EXPECTED_SCAN_DEDUP_ADOPTERS: &[&str] = &["jt9", "jt65", "wspr", "q65"];
+
     fn assert_no_regression(
         mechanism: &str,
         expected_adopters: &[&str],
@@ -587,6 +597,13 @@ mod sharing_ratchet_selftest {
             EXPECTED_SNR_TRAIT_ADOPTERS,
             |src| src.contains("fn snr_db(ctx"),
         );
+    }
+
+    #[test]
+    fn scan_dedup_adoption_does_not_regress() {
+        assert_no_regression("scan_dedup_match", EXPECTED_SCAN_DEDUP_ADOPTERS, |src| {
+            src.contains("scan_dedup_match")
+        });
     }
 
     /// Sanity check on the scan itself, mirroring


### PR DESCRIPTION
Stage 1 (dedup half) of the code-sharing audit plan (Stage 0: #292, merged).

## What

The audit found candidate dedup reimplemented independently **9 times** across 4 protocols, each with its own tolerance constants (JT9 4.0 Hz, JT65 2.0 Hz, WSPR 5.0 Hz, Q65 tone-spacing-scaled per issue #287) — the exact class of bug #287 was. All 9 sites shared the identical three-line predicate shape: same message, freq within tolerance, start sample within tolerance.

Adds `engine::pipeline::scan_dedup_match` (same-type case — `seen`/`cand` are the same result struct) and `scan_dedup_match_cross` (needed because `jt65::mod`'s callers compare a not-yet-built candidate against already-pushed `Jt65Result`s, which even disagree on `start_sample`'s reference frame under early-frame padding — a pre-existing property preserved exactly, not "fixed", since this is a pure code move).

Migrated all 9 sites:
- **JT9** (1 site) and **JT65** (2 sites — `decode_scan_inner`/`decode_scan_chase_inner` had literally identical dedup blocks)
- **WSPR** (3 sites — pass1/pass2/subtract-loop, sharing the same `FREQ_DEDUP_HZ`/`TIME_DEDUP_SAMPLES` consts) and **Q65** (3 sites, already byte-identical to each other, using #287's `dedup_freq_tol_hz::<P>()`)

Every protocol's own tolerance stays exactly what it was — now an explicit call-site parameter instead of a scattered local `const`, per the plan's "promote the constant, don't change it" rule.

Third commit updates the sharing ratchet (#291) to track this new mechanism's adoption (`jt9`/`jt65`/`wspr`/`q65`), so it can't silently regress the way the pre-existing mechanisms did before this whole audit started.

FT8 (dedup spread across multiple inline sites in a much larger bespoke engine) and MSK144 (a structurally different single-slot state machine) are deliberately out of scope — documented as such in the ratchet.

## Verification

Pure refactor — no threshold/behaviour changes, confirmed via identical results before/after:
- `jt9_wsjtx_samples`: 7/7, unchanged
- `jt65_wsjtx_samples`: 4/5, unchanged; JT65's in-crate chase-path unit tests also pass (the golden test alone doesn't exercise `decode_scan_chase`)
- `wspr_wsjtx_samples`: 9/9 recall, 0 phantoms, identical message/freq/dt list to before
- `q65_wsjtx_samples`: all 7 golden entries unchanged, including 120D at exactly 1/1 + 0 extra (confirms #287's fix survives)
- `q65_ap_list`/`q65_fast_fading`: cover Q65's other two dedup sites
- All of the above also under `fixed-point`
- CI's isolated single-protocol feature-build matrix combinations (jt9-only, jt65-only, wspr-only, wspr+wspr-pass2-topn, q65-only) verified locally
- Full merge gate (`MFSK_REQUIRE_CORPUS=1 cargo test --features full,internal-testing --release`): 0 failures

Tier-C sensitivity sweeps not run — this changes no arithmetic or threshold, only restructures identical control flow (verified byte-identical predicates before extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)