### PR TITLE
refactor: consolidate the coarse-search Spectrogram kernel (JT9/JT65/Q65)

### DIFF
--- a/mfsk-core/src/engine/mod.rs
+++ b/mfsk-core/src/engine/mod.rs
@@ -45,6 +45,15 @@ pub mod llr;
 pub mod pipeline;
 pub mod protocol;
 pub mod scalar;
+// Hardcodes `rustfft::FftPlanner` directly (matching what JT9/JT65/Q65
+// already did before this was extracted) rather than routing through
+// the `engine::fft` backend-abstraction trait `sync`/`llr`/`pipeline`
+// use — those three protocols' own Cargo features already require
+// `fft-rustfft` specifically (`jt9`/`jt65`/`q65` = [.., "fft-rustfft"]
+// in Cargo.toml, no `fft-extern` alternative), so this gate changes
+// nothing about what builds succeed.
+#[cfg(feature = "fft-rustfft")]
+pub mod spectrogram;
 #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub mod sync;
 #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]

--- a/mfsk-core/src/engine/spectrogram.rs
+++ b/mfsk-core/src/engine/spectrogram.rs
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Shared FFT-based spectrogram builder + tone-0 sync scorer, for
+//! protocols whose sync tone sits at a fixed set of symbol positions
+//! rather than a block-Costas pattern (JT9, JT65, Q65).
+//!
+//! Extracted (2026-08-14, code-sharing audit) from three independent,
+//! near-identical copies — `jt9::search::Spectrogram`,
+//! `jt65::search::Spectrogram`, `q65::search::Spectrogram` — whose own
+//! doc comments already cross-referenced each other as "structurally
+//! identical" without anyone unifying them. `WSPR` has the same shape
+//! FFT loop but is deliberately *not* folded in here: it uses the
+//! crate's fixed-point-capable `engine::fft` abstraction rather than
+//! raw `rustfft` (WSPR alone among these needs that), and its
+//! `score_candidate` normalises against a fitted per-bin baseline
+//! (`sbase_linear`) rather than a single flat noise floor — a real
+//! algorithmic difference, not just a naming one.
+//!
+//! `nstep_per_symbol` and the sync-position list are the only axes
+//! that actually vary between JT9/JT65/Q65: JT9/JT65 both step at
+//! `NSPS/4` (quarter-symbol), Q65 at `NSPS/8` (matching WSJT-X's own
+//! `NSTEP=8` sync resolution, `lib/qra/q65/q65.f90:3`); each protocol
+//! sums FFT-bin power over its own fixed sync-position list. Both are
+//! now explicit parameters instead of a hardcoded constant per module.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use num_complex::Complex;
+use rustfft::FftPlanner;
+
+use super::ModulationParams;
+
+/// FFT-bin spectrogram covering an audio buffer at `nsps /
+/// nstep_per_symbol`-sample time steps. `mags_sqr[t * n_freq + f]` is
+/// `|FFT[f]|²` at time step `t`.
+pub struct Spectrogram {
+    pub mags_sqr: Vec<f32>,
+    pub n_time: usize,
+    pub n_freq: usize,
+    /// Samples between consecutive time rows.
+    pub t_step: usize,
+    /// FFT window size (samples).
+    pub nsps: usize,
+    /// Frequency resolution (Hz per bin).
+    pub df: f32,
+    /// Rough noise-floor estimate (mean of the lower 95% of all cells).
+    pub noise_per_bin: f32,
+}
+
+impl Spectrogram {
+    /// Build a spectrogram for protocol `P` at `nsps / nstep_per_symbol`
+    /// time steps. Returns an empty shell if `audio` is shorter than
+    /// one symbol.
+    pub fn build_for<P: ModulationParams>(
+        audio: &[f32],
+        sample_rate: u32,
+        nstep_per_symbol: usize,
+    ) -> Self {
+        let nsps = (sample_rate as f32 * P::SYMBOL_DT).round() as usize;
+        let t_step = (nsps / nstep_per_symbol).max(1);
+        let n_freq = nsps / 2;
+        if audio.len() < nsps || t_step == 0 {
+            return Self {
+                mags_sqr: Vec::new(),
+                n_time: 0,
+                n_freq: 0,
+                t_step: 0,
+                nsps,
+                df: sample_rate as f32 / nsps as f32,
+                noise_per_bin: 1.0,
+            };
+        }
+        let n_time = (audio.len() - nsps) / t_step + 1;
+        let mut mags_sqr = vec![0f32; n_time * n_freq];
+        let mut planner = FftPlanner::<f32>::new();
+        let fft = planner.plan_fft_forward(nsps);
+        let mut scratch = vec![Complex::new(0f32, 0f32); fft.get_inplace_scratch_len()];
+        let mut buf: Vec<Complex<f32>> = vec![Complex::new(0f32, 0f32); nsps];
+
+        for t in 0..n_time {
+            let start = t * t_step;
+            for (slot, &s) in buf.iter_mut().zip(&audio[start..start + nsps]) {
+                *slot = Complex::new(s, 0.0);
+            }
+            fft.process_with_scratch(&mut buf, &mut scratch);
+            let row = &mut mags_sqr[t * n_freq..(t + 1) * n_freq];
+            for (slot, c) in row.iter_mut().zip(buf.iter().take(n_freq)) {
+                *slot = c.norm_sqr();
+            }
+        }
+
+        // Noise reference: drop the top 5% (strong bins) and average
+        // the rest. Cheap median-ish estimator. Only the *set* of
+        // bottom-95% values is needed (order within that set doesn't
+        // matter, we just sum them), not a full ascending order —
+        // `select_nth_unstable_by` partitions in O(n) average instead
+        // of `sort_unstable_by`'s O(n log n).
+        let mut sorted = mags_sqr.clone();
+        let keep = (sorted.len() as f32 * 0.95) as usize;
+        let noise_per_bin = if keep > 0 {
+            sorted.select_nth_unstable_by(keep - 1, |a, b| {
+                a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal)
+            });
+            sorted[..keep].iter().sum::<f32>() / keep as f32
+        } else {
+            1.0
+        };
+
+        Self {
+            mags_sqr,
+            n_time,
+            n_freq,
+            t_step,
+            nsps,
+            df: sample_rate as f32 / nsps as f32,
+            noise_per_bin: noise_per_bin.max(1e-6),
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, t: usize, f: usize) -> f32 {
+        self.mags_sqr[t * self.n_freq + f]
+    }
+}
+
+/// Sum of sync-tone (tone 0) FFT-bin power at `bin`, across
+/// `sync_positions`' rows starting at spectrogram row `start_row`.
+/// The un-normalised quantity [`score_candidate`] sums before dividing
+/// by the noise floor — factored out so a frequency-refine step (e.g.
+/// `jt65::search::refine_freq_hz` / `jt9::search::refine_freq_hz`) can
+/// read it at the neighbouring bins too.
+pub fn sync_power_at_bin(
+    spec: &Spectrogram,
+    start_row: usize,
+    bin: usize,
+    sync_positions: &[u32],
+    rows_per_symbol: usize,
+) -> f32 {
+    if bin >= spec.n_freq {
+        return 0.0;
+    }
+    let mut sync_pwr = 0.0f32;
+    for &sym_idx in sync_positions {
+        let row = start_row + (sym_idx as usize) * rows_per_symbol;
+        sync_pwr += spec.get(row, bin);
+    }
+    sync_pwr
+}
+
+/// Score one candidate `(start_row, base_bin)`: sum tone-0 power
+/// across `sync_positions`' rows, normalise against the noise floor.
+/// `sync_positions` must be sorted ascending (its last element is used
+/// to bounds-check the frame against `spec.n_time`).
+pub fn score_candidate(
+    spec: &Spectrogram,
+    start_row: usize,
+    base_bin: usize,
+    sync_positions: &[u32],
+    rows_per_symbol: usize,
+) -> f32 {
+    let Some(&last_pos) = sync_positions.last() else {
+        return 0.0;
+    };
+    let last_row = start_row + (last_pos as usize) * rows_per_symbol;
+    if last_row >= spec.n_time || base_bin >= spec.n_freq {
+        return 0.0;
+    }
+    let sync_pwr = sync_power_at_bin(spec, start_row, base_bin, sync_positions, rows_per_symbol);
+    let noise_floor = spec.noise_per_bin * sync_positions.len() as f32;
+    sync_pwr / (sync_pwr + noise_floor)
+}

--- a/mfsk-core/src/jt65/search.rs
+++ b/mfsk-core/src/jt65/search.rs
@@ -6,110 +6,31 @@
 //! scores each candidate (`start_row`, `base_bin`) by summing the
 //! FFT-bin power at `base_bin` across the 63 sync-position rows.
 //!
-//! Reuses the same shape as `crate::jt9::search` — the only differences
-//! are the sync-positions list and the per-frame symbol count.
+//! The spectrogram build and per-candidate scoring are literally
+//! shared with `crate::jt9::search` and `crate::q65::search` (see
+//! [`crate::engine::spectrogram`]) — only the sync-positions list and
+//! the candidate-selection loop below are this protocol's own.
 
 use crate::engine::ModulationParams;
+use crate::engine::spectrogram;
 use crate::engine::sync::refine_freq_hz_log_power;
-use num_complex::Complex;
-use rustfft::FftPlanner;
 
 use super::Jt65;
 use super::sync_pattern::JT65_SYNC_POSITIONS;
 
 /// Precomputed per-time-step FFT magnitudes-squared used by the
-/// coarse (freq × time) search. Each entry `mags_sqr[t * n_freq + f]`
-/// is the squared magnitude of FFT bin `f` at time step `t`.
-pub struct Spectrogram {
-    /// Row-major `(n_time, n_freq)` grid of `|FFT[k]|²` values.
-    pub mags_sqr: Vec<f32>,
-    /// Number of time steps (rows).
-    pub n_time: usize,
-    /// Number of frequency bins per row (`nsps / 2`).
-    pub n_freq: usize,
-    /// Step size between rows, in samples (`nsps / 4`).
-    pub t_step: usize,
-    /// FFT window size in samples.
-    pub nsps: usize,
-    /// Frequency resolution in Hz per bin.
-    pub df: f32,
-    /// Average noise power per bin — used to normalise scores.
-    pub noise_per_bin: f32,
-}
+/// coarse (freq × time) search. Thin alias — see
+/// [`crate::engine::spectrogram::Spectrogram`] for the shared
+/// implementation (extracted 2026-08-14, code-sharing audit; was a
+/// byte-identical copy of `jt9::search::Spectrogram`).
+pub type Spectrogram = spectrogram::Spectrogram;
 
-impl Spectrogram {
-    /// Build the spectrogram from `audio` at quarter-symbol time steps.
-    pub fn build(audio: &[f32], sample_rate: u32) -> Self {
-        let nsps = (sample_rate as f32 * <Jt65 as ModulationParams>::SYMBOL_DT).round() as usize;
-        let t_step = nsps / 4;
-        let n_freq = nsps / 2;
-        if audio.len() < nsps || t_step == 0 {
-            return Self {
-                mags_sqr: Vec::new(),
-                n_time: 0,
-                n_freq: 0,
-                t_step: 0,
-                nsps,
-                df: sample_rate as f32 / nsps as f32,
-                noise_per_bin: 1.0,
-            };
-        }
-        let n_time = (audio.len() - nsps) / t_step + 1;
-        let mut mags_sqr = vec![0f32; n_time * n_freq];
-        let mut planner = FftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(nsps);
-        let mut scratch = vec![Complex::new(0f32, 0f32); fft.get_inplace_scratch_len()];
-        let mut buf: Vec<Complex<f32>> = vec![Complex::new(0f32, 0f32); nsps];
+/// Quarter-symbol time step, matching WSJT-X's own coarse-search
+/// resolution for this protocol family.
+const NSTEP_PER_SYMBOL: usize = 4;
 
-        for t in 0..n_time {
-            let start = t * t_step;
-            for (slot, &s) in buf.iter_mut().zip(&audio[start..start + nsps]) {
-                *slot = Complex::new(s, 0.0);
-            }
-            fft.process_with_scratch(&mut buf, &mut scratch);
-            let row = &mut mags_sqr[t * n_freq..(t + 1) * n_freq];
-            for (slot, c) in row.iter_mut().zip(buf.iter().take(n_freq)) {
-                *slot = c.norm_sqr();
-            }
-        }
-
-        // Noise floor estimate: trimmed-mean of the bottom 95% of FFT
-        // magnitudes (rejects strong narrow-band signals). Only the
-        // *set* of bottom-95% values is needed (order within that set
-        // is irrelevant, we just sum them), not a full ascending
-        // order — `select_nth_unstable_by` partitions in O(n) average
-        // instead of `sort_unstable_by`'s O(n log n). Measured as the
-        // dominant cost of `Spectrogram::build` (13-14ms vs the FFT
-        // loop's 7-8ms on a 300-file JT65 AWGN sweep) before this fix;
-        // same fix already applied to Q65's `Spectrogram::build_for`
-        // and FT8's `xsnr2_db_simple` noise median.
-        let mut sorted = mags_sqr.clone();
-        let keep = (sorted.len() as f32 * 0.95) as usize;
-        let noise_per_bin = if keep > 0 {
-            sorted.select_nth_unstable_by(keep - 1, |a, b| {
-                a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-            });
-            sorted[..keep].iter().sum::<f32>() / keep as f32
-        } else {
-            1.0
-        };
-
-        Self {
-            mags_sqr,
-            n_time,
-            n_freq,
-            t_step,
-            nsps,
-            df: sample_rate as f32 / nsps as f32,
-            noise_per_bin: noise_per_bin.max(1e-6),
-        }
-    }
-
-    /// Fetch the squared FFT magnitude at time step `t`, bin `f`.
-    #[inline]
-    pub fn get(&self, t: usize, f: usize) -> f32 {
-        self.mags_sqr[t * self.n_freq + f]
-    }
+fn build_spectrogram(audio: &[f32], sample_rate: u32) -> Spectrogram {
+    Spectrogram::build_for::<Jt65>(audio, sample_rate, NSTEP_PER_SYMBOL)
 }
 
 /// One candidate surviving the coarse (freq × time) sync search.
@@ -191,38 +112,25 @@ impl Default for SearchParams {
     }
 }
 
-/// Row step between consecutive symbols in a [`Spectrogram`]
-/// (`spec.t_step` is a quarter symbol; this is how many rows that is).
-const ROWS_PER_SYMBOL: usize = 4;
+/// Row step between consecutive symbols in a [`Spectrogram`] built at
+/// [`NSTEP_PER_SYMBOL`] steps.
+const ROWS_PER_SYMBOL: usize = NSTEP_PER_SYMBOL;
 
-/// Sum of sync-tone (tone 0) FFT-bin power at `bin`, across the 63
-/// sync-position rows starting at spectrogram row `start_row`. The
-/// un-normalised quantity [`score_candidate`] sums before dividing by
-/// the noise floor — factored out so [`refine_freq_hz`] can read it at
-/// the neighbouring bins too.
 fn sync_power_at_bin(spec: &Spectrogram, start_row: usize, bin: usize) -> f32 {
-    if bin >= spec.n_freq {
-        return 0.0;
-    }
-    let mut sync_pwr = 0.0f32;
-    for &sym_idx in &JT65_SYNC_POSITIONS {
-        let row = start_row + (sym_idx as usize) * ROWS_PER_SYMBOL;
-        sync_pwr += spec.get(row, bin);
-    }
-    sync_pwr
+    spectrogram::sync_power_at_bin(spec, start_row, bin, &JT65_SYNC_POSITIONS, ROWS_PER_SYMBOL)
 }
 
 /// Score one candidate (start_row, base_bin). Sums FFT-bin power at
 /// `base_bin` over the 63 sync-position rows; normalises against the
 /// noise floor.
 pub fn score_candidate(spec: &Spectrogram, start_row: usize, base_bin: usize) -> f32 {
-    let last_row = start_row + (JT65_SYNC_POSITIONS[62] as usize) * ROWS_PER_SYMBOL;
-    if last_row >= spec.n_time || base_bin >= spec.n_freq {
-        return 0.0;
-    }
-    let sync_pwr = sync_power_at_bin(spec, start_row, base_bin);
-    let noise_floor = spec.noise_per_bin * JT65_SYNC_POSITIONS.len() as f32;
-    sync_pwr / (sync_pwr + noise_floor)
+    spectrogram::score_candidate(
+        spec,
+        start_row,
+        base_bin,
+        &JT65_SYNC_POSITIONS,
+        ROWS_PER_SYMBOL,
+    )
 }
 
 /// Refine a candidate's frequency to sub-bin precision — see
@@ -259,7 +167,7 @@ pub fn coarse_search(
     nominal_start_sample: usize,
     params: &SearchParams,
 ) -> Vec<SyncCandidate> {
-    let spec = Spectrogram::build(audio, sample_rate);
+    let spec = build_spectrogram(audio, sample_rate);
     coarse_search_on_spec(&spec, sample_rate, nominal_start_sample, params)
 }
 

--- a/mfsk-core/src/jt9/search.rs
+++ b/mfsk-core/src/jt9/search.rs
@@ -13,100 +13,24 @@
 //! know both.
 
 use crate::engine::ModulationParams;
+use crate::engine::spectrogram;
 use crate::engine::sync::refine_freq_hz_log_power;
-use num_complex::Complex;
-use rustfft::FftPlanner;
 
 use super::Jt9;
 use super::sync_pattern::JT9_SYNC_POSITIONS;
 
 /// One-symbol-FFT spectrogram, reusable across many candidate scores.
-pub struct Spectrogram {
-    /// Row-major `|FFT|²` table: `mags_sqr[row * n_freq + bin]`.
-    pub mags_sqr: Vec<f32>,
-    pub n_time: usize,
-    pub n_freq: usize,
-    /// Samples per spectrogram row.
-    pub t_step: usize,
-    /// FFT window size (= NSPS).
-    pub nsps: usize,
-    /// Hz per bin (= tone spacing by construction).
-    pub df: f32,
-    /// Rough noise-floor estimate (mean of the lower 95 % of all cells).
-    pub noise_per_bin: f32,
-}
+/// Thin alias — see [`crate::engine::spectrogram::Spectrogram`] for
+/// the shared implementation (extracted 2026-08-14, code-sharing
+/// audit; was a byte-identical copy of `jt65::search::Spectrogram`).
+pub type Spectrogram = spectrogram::Spectrogram;
 
-impl Spectrogram {
-    /// Build a quarter-symbol spectrogram for JT9. Returns an empty
-    /// shell if the audio is shorter than one symbol.
-    pub fn build(audio: &[f32], sample_rate: u32) -> Self {
-        let nsps = (sample_rate as f32 * <Jt9 as ModulationParams>::SYMBOL_DT).round() as usize;
-        let t_step = nsps / 4;
-        let n_freq = nsps / 2;
-        if audio.len() < nsps || t_step == 0 {
-            return Self {
-                mags_sqr: Vec::new(),
-                n_time: 0,
-                n_freq: 0,
-                t_step: 0,
-                nsps,
-                df: sample_rate as f32 / nsps as f32,
-                noise_per_bin: 1.0,
-            };
-        }
-        let n_time = (audio.len() - nsps) / t_step + 1;
-        let mut mags_sqr = vec![0f32; n_time * n_freq];
-        let mut planner = FftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(nsps);
-        let mut scratch = vec![Complex::new(0f32, 0f32); fft.get_inplace_scratch_len()];
-        let mut buf: Vec<Complex<f32>> = vec![Complex::new(0f32, 0f32); nsps];
+/// Quarter-symbol time step, matching WSJT-X's own coarse-search
+/// resolution for this protocol family.
+const NSTEP_PER_SYMBOL: usize = 4;
 
-        for t in 0..n_time {
-            let start = t * t_step;
-            for (slot, &s) in buf.iter_mut().zip(&audio[start..start + nsps]) {
-                *slot = Complex::new(s, 0.0);
-            }
-            fft.process_with_scratch(&mut buf, &mut scratch);
-            let row = &mut mags_sqr[t * n_freq..(t + 1) * n_freq];
-            for (slot, c) in row.iter_mut().zip(buf.iter().take(n_freq)) {
-                *slot = c.norm_sqr();
-            }
-        }
-
-        // Noise reference: drop the top 5 % (strong bins) and average
-        // the rest. Cheap median-ish estimator. Only the *set* of
-        // bottom-95% values is needed (order within that set doesn't
-        // matter, we just sum them), not a full ascending order —
-        // `select_nth_unstable_by` partitions in O(n) average instead
-        // of `sort_unstable_by`'s O(n log n); same fix applied to
-        // JT65's structurally identical `Spectrogram::build` and
-        // Q65's `Spectrogram::build_for`.
-        let mut sorted = mags_sqr.clone();
-        let keep = (sorted.len() as f32 * 0.95) as usize;
-        let noise_per_bin = if keep > 0 {
-            sorted.select_nth_unstable_by(keep - 1, |a, b| {
-                a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-            });
-            sorted[..keep].iter().sum::<f32>() / keep as f32
-        } else {
-            1.0
-        };
-
-        Self {
-            mags_sqr,
-            n_time,
-            n_freq,
-            t_step,
-            nsps,
-            df: sample_rate as f32 / nsps as f32,
-            noise_per_bin: noise_per_bin.max(1e-6),
-        }
-    }
-
-    #[inline]
-    pub fn get(&self, t: usize, f: usize) -> f32 {
-        self.mags_sqr[t * self.n_freq + f]
-    }
+fn build_spectrogram(audio: &[f32], sample_rate: u32) -> Spectrogram {
+    Spectrogram::build_for::<Jt9>(audio, sample_rate, NSTEP_PER_SYMBOL)
 }
 
 /// A candidate JT9 alignment, ranked by sync-tone score.
@@ -177,23 +101,12 @@ impl Default for SearchParams {
     }
 }
 
-const ROWS_PER_SYMBOL: usize = 4;
+/// Row step between consecutive symbols in a [`Spectrogram`] built at
+/// [`NSTEP_PER_SYMBOL`] steps.
+const ROWS_PER_SYMBOL: usize = NSTEP_PER_SYMBOL;
 
-/// Sum of sync-tone (tone 0) FFT-bin power at `bin`, across the 16
-/// sync-position rows starting at spectrogram row `start_row`. The
-/// un-normalised quantity [`score_candidate`] sums before dividing by
-/// the noise floor — factored out so [`refine_freq_hz`] can read it at
-/// the neighbouring bins too.
 fn sync_power_at_bin(spec: &Spectrogram, start_row: usize, bin: usize) -> f32 {
-    if bin >= spec.n_freq {
-        return 0.0;
-    }
-    let mut sync_pwr = 0.0f32;
-    for &sym_idx in &JT9_SYNC_POSITIONS {
-        let row = start_row + (sym_idx as usize) * ROWS_PER_SYMBOL;
-        sync_pwr += spec.get(row, bin);
-    }
-    sync_pwr
+    spectrogram::sync_power_at_bin(spec, start_row, bin, &JT9_SYNC_POSITIONS, ROWS_PER_SYMBOL)
 }
 
 /// Score one candidate using the precomputed spectrogram.
@@ -201,16 +114,13 @@ fn sync_power_at_bin(spec: &Spectrogram, start_row: usize, bin: usize) -> f32 {
 /// `start_row` is the spectrogram row index of symbol 0. Because the
 /// spectrogram step is NSPS/4, consecutive symbols are 4 rows apart.
 pub fn score_candidate(spec: &Spectrogram, start_row: usize, base_bin: usize) -> f32 {
-    // Last sync position uses row offset SYNC_POSITIONS[15] * 4.
-    let last_row = start_row + (JT9_SYNC_POSITIONS[15] as usize) * ROWS_PER_SYMBOL;
-    if last_row >= spec.n_time || base_bin >= spec.n_freq {
-        return 0.0;
-    }
-    let sync_pwr = sync_power_at_bin(spec, start_row, base_bin);
-    // Normalise against the expected noise floor at tone 0 over
-    // 16 sync symbols. Score saturates near 1 for clean signals.
-    let noise_floor = spec.noise_per_bin * JT9_SYNC_POSITIONS.len() as f32;
-    sync_pwr / (sync_pwr + noise_floor)
+    spectrogram::score_candidate(
+        spec,
+        start_row,
+        base_bin,
+        &JT9_SYNC_POSITIONS,
+        ROWS_PER_SYMBOL,
+    )
 }
 
 /// Refine a candidate's frequency to sub-bin precision — see
@@ -243,7 +153,7 @@ pub fn coarse_search(
     nominal_start_sample: usize,
     params: &SearchParams,
 ) -> Vec<SyncCandidate> {
-    let spec = Spectrogram::build(audio, sample_rate);
+    let spec = build_spectrogram(audio, sample_rate);
     coarse_search_on_spec(&spec, sample_rate, nominal_start_sample, params)
 }
 

--- a/mfsk-core/src/q65/rx.rs
+++ b/mfsk-core/src/q65/rx.rs
@@ -1317,7 +1317,7 @@ pub(crate) fn decode_multi_period_for<P: ModulationParams>(
     on_result: Option<&(dyn Fn(&Q65Result) + Sync)>,
     ctx: &DecodeContext,
 ) -> Vec<Q65Result> {
-    use super::search::{Spectrogram, coarse_search_on_spec_for};
+    use super::search::{build_spectrogram, coarse_search_on_spec_for};
 
     let mut output: Vec<Q65Result> = Vec::new();
     if audio_slots.is_empty() {
@@ -1325,7 +1325,7 @@ pub(crate) fn decode_multi_period_for<P: ModulationParams>(
     }
 
     // Initialise EMA from slot 0.
-    let mut ema_spec = Spectrogram::build_for::<P>(audio_slots[0], sample_rate);
+    let mut ema_spec = build_spectrogram::<P>(audio_slots[0], sample_rate);
     if ema_spec.n_time == 0 {
         return output;
     }
@@ -1335,7 +1335,7 @@ pub(crate) fn decode_multi_period_for<P: ModulationParams>(
 
     for (i, &audio) in audio_slots.iter().enumerate() {
         if i > 0 {
-            let slot_spec = Spectrogram::build_for::<P>(audio, sample_rate);
+            let slot_spec = build_spectrogram::<P>(audio, sample_rate);
             // EMA update: weight = 1 / min(navg, 4) — matches WSJT-X's
             // `ntc = min(navg, 4); u = 1.0/ntc` accumulator. After the
             // 4th slot the time constant saturates, so older history

--- a/mfsk-core/src/q65/search.rs
+++ b/mfsk-core/src/q65/search.rs
@@ -4,119 +4,48 @@
 //! Q65's distributed sync (22 symbols all on tone 0) is the
 //! cleanest correlation target across the WSJT family — every sync
 //! symbol carries the full symbol energy on the same frequency bin.
-//! This module mirrors the structure of [`crate::jt65::search`]:
-//! build an NSPS-sized spectrogram at `nsps/8`-symbol time steps
-//! (matching WSJT-X's own `NSTEP=8` sync resolution,
-//! `lib/qra/q65/q65.f90:3`), score each candidate `(start_row,
-//! base_bin)` by summing the tone-0 power across the 22 sync
-//! positions, and return the top-scoring candidates.
+//! The spectrogram build and per-candidate scoring are literally
+//! shared with `crate::jt9::search` and `crate::jt65::search` (see
+//! [`crate::engine::spectrogram`]), built here at `nsps/8`-symbol time
+//! steps (matching WSJT-X's own `NSTEP=8` sync resolution,
+//! `lib/qra/q65/q65.f90:3`) instead of their `nsps/4` — only the
+//! sync-positions list and the candidate-selection loop below are
+//! this protocol's own.
 
 use crate::engine::ModulationParams;
-use num_complex::Complex;
-use rustfft::FftPlanner;
+use crate::engine::spectrogram;
 
-use super::Q65a30;
 use super::sync_pattern::Q65_SYNC_POSITIONS;
 
 /// FFT-bin spectrogram covering the audio buffer at `nsps/8`-symbol
-/// time steps. `mags_sqr[t * n_freq + f]` is `|FFT[f]|²` at time `t`.
-pub struct Spectrogram {
-    pub mags_sqr: Vec<f32>,
-    pub n_time: usize,
-    pub n_freq: usize,
-    pub t_step: usize,
-    pub nsps: usize,
-    pub df: f32,
-    pub noise_per_bin: f32,
-}
+/// time steps. Thin alias — see
+/// [`crate::engine::spectrogram::Spectrogram`] for the shared
+/// implementation (extracted 2026-08-14, code-sharing audit; was
+/// structurally identical to `jt9::search::Spectrogram` /
+/// `jt65::search::Spectrogram`, differing only in the time-step
+/// divisor — [`NSTEP_PER_SYMBOL`] here vs. their fixed 4).
+pub type Spectrogram = spectrogram::Spectrogram;
 
-impl Spectrogram {
-    /// Build the spectrogram from `audio` for Q65 sub-mode `P`. Time
-    /// step = `nsps / NSTEP_PER_SYMBOL`, matching WSJT-X's own sync
-    /// spectrogram resolution (`NSTEP=8`, `lib/qra/q65/q65.f90:3`,
-    /// "Number of time bins per symbol in s1, s1a, s1b") — an earlier
-    /// `nsps/2` here under-resolved the sync search 4× relative to
-    /// `q65_ccf_22`'s own lag search, which was root-caused (verified
-    /// against real jt9) as the source of a multi-dB AWGN sensitivity
-    /// gap at `GridDepth::Fast`'s single-shot decode (no further Δt
-    /// retry to compensate); see `docs/notes/Q65_BENCHMARK.md`.
-    /// Frequency resolution = `sample_rate / nsps` ≈ tone spacing.
-    pub fn build_for<P: ModulationParams>(audio: &[f32], sample_rate: u32) -> Self {
-        const NSTEP_PER_SYMBOL: usize = 8;
-        let nsps = (sample_rate as f32 * P::SYMBOL_DT).round() as usize;
-        let t_step = (nsps / NSTEP_PER_SYMBOL).max(1);
-        let n_freq = nsps / 2;
-        if audio.len() < nsps || t_step == 0 {
-            return Self {
-                mags_sqr: Vec::new(),
-                n_time: 0,
-                n_freq: 0,
-                t_step: 0,
-                nsps,
-                df: sample_rate as f32 / nsps as f32,
-                noise_per_bin: 1.0,
-            };
-        }
-        let n_time = (audio.len() - nsps) / t_step + 1;
-        let mut mags_sqr = vec![0f32; n_time * n_freq];
-        let mut planner = FftPlanner::<f32>::new();
-        let fft = planner.plan_fft_forward(nsps);
-        let mut scratch = vec![Complex::new(0f32, 0f32); fft.get_inplace_scratch_len()];
-        let mut buf: Vec<Complex<f32>> = vec![Complex::new(0f32, 0f32); nsps];
+/// Time step matching WSJT-X's own sync spectrogram resolution
+/// (`NSTEP=8`, `lib/qra/q65/q65.f90:3`, "Number of time bins per
+/// symbol in s1, s1a, s1b") — an earlier `nsps/2` here under-resolved
+/// the sync search 4× relative to `q65_ccf_22`'s own lag search, which
+/// was root-caused (verified against real jt9) as the source of a
+/// multi-dB AWGN sensitivity gap at `GridDepth::Fast`'s single-shot
+/// decode (no further Δt retry to compensate); see
+/// `docs/notes/Q65_BENCHMARK.md`.
+pub const NSTEP_PER_SYMBOL: usize = 8;
 
-        for t in 0..n_time {
-            let start = t * t_step;
-            for (slot, &s) in buf.iter_mut().zip(&audio[start..start + nsps]) {
-                *slot = Complex::new(s, 0.0);
-            }
-            fft.process_with_scratch(&mut buf, &mut scratch);
-            let row = &mut mags_sqr[t * n_freq..(t + 1) * n_freq];
-            for (slot, c) in row.iter_mut().zip(buf.iter().take(n_freq)) {
-                *slot = c.norm_sqr();
-            }
-        }
-
-        // Noise floor estimate: trimmed-mean of the bottom 95 % of
-        // FFT magnitudes (rejects strong narrow-band signals). Only
-        // the *set* of bottom-95% values (order within that set is
-        // irrelevant, we just sum them) is needed, not a full
-        // ascending order — `select_nth_unstable_by` partitions in
-        // O(n) average instead of `sort_unstable_by`'s O(n log n),
-        // same fix already applied to FT8's `xsnr2_db_simple` noise
-        // median. Measured as 64% of `decode_multi_period_for`'s
-        // wall-clock on Q65-60B (short-slot, `build_for` called once
-        // per audio slot).
-        let mut sorted = mags_sqr.clone();
-        let keep = (sorted.len() as f32 * 0.95) as usize;
-        let noise_per_bin = if keep > 0 {
-            sorted.select_nth_unstable_by(keep - 1, |a, b| {
-                a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal)
-            });
-            sorted[..keep].iter().sum::<f32>() / keep as f32
-        } else {
-            1.0
-        };
-
-        Self {
-            mags_sqr,
-            n_time,
-            n_freq,
-            t_step,
-            nsps,
-            df: sample_rate as f32 / nsps as f32,
-            noise_per_bin: noise_per_bin.max(1e-6),
-        }
-    }
-
-    /// Q65-30A convenience wrapper for [`Self::build_for`].
-    pub fn build(audio: &[f32], sample_rate: u32) -> Self {
-        Self::build_for::<Q65a30>(audio, sample_rate)
-    }
-
-    #[inline]
-    pub fn get(&self, t: usize, f: usize) -> f32 {
-        self.mags_sqr[t * self.n_freq + f]
-    }
+/// Build a spectrogram for Q65 sub-mode `P`. Frequency resolution =
+/// `sample_rate / nsps` ≈ tone spacing.
+///
+/// The previous `Spectrogram::build` Q65-30A convenience wrapper
+/// (calling this with `P = Q65a30` hardcoded) had zero callers
+/// anywhere in the crate or its tests — dropped rather than carried
+/// through this extraction, predating the crate's now-10-wired-
+/// sub-mode reality (issue tracking session, 2026-08-14).
+pub fn build_spectrogram<P: ModulationParams>(audio: &[f32], sample_rate: u32) -> Spectrogram {
+    Spectrogram::build_for::<P>(audio, sample_rate, NSTEP_PER_SYMBOL)
 }
 
 /// One candidate surviving the coarse sync search.
@@ -206,17 +135,13 @@ impl Default for SearchParams {
 /// 22 sync positions, divide by `(sum + noise_floor)`.
 pub fn score_candidate(spec: &Spectrogram, start_row: usize, base_bin: usize) -> f32 {
     let rows_per_symbol = (spec.nsps / spec.t_step).max(1);
-    let last_row = start_row + (Q65_SYNC_POSITIONS[21] as usize) * rows_per_symbol;
-    if last_row >= spec.n_time || base_bin >= spec.n_freq {
-        return 0.0;
-    }
-    let mut sync_pwr = 0.0_f32;
-    for &sym_idx in &Q65_SYNC_POSITIONS {
-        let row = start_row + (sym_idx as usize) * rows_per_symbol;
-        sync_pwr += spec.get(row, base_bin);
-    }
-    let noise_floor = spec.noise_per_bin * Q65_SYNC_POSITIONS.len() as f32;
-    sync_pwr / (sync_pwr + noise_floor)
+    spectrogram::score_candidate(
+        spec,
+        start_row,
+        base_bin,
+        &Q65_SYNC_POSITIONS,
+        rows_per_symbol,
+    )
 }
 
 /// Build a spectrogram for Q65 sub-mode `P` and find the top sync
@@ -227,7 +152,7 @@ pub fn coarse_search_for<P: ModulationParams>(
     nominal_start_sample: usize,
     params: &SearchParams,
 ) -> Vec<SyncCandidate> {
-    let spec = Spectrogram::build_for::<P>(audio, sample_rate);
+    let spec = build_spectrogram::<P>(audio, sample_rate);
     coarse_search_on_spec_for::<P>(&spec, sample_rate, nominal_start_sample, params)
 }
 
@@ -238,7 +163,7 @@ pub fn coarse_search(
     nominal_start_sample: usize,
     params: &SearchParams,
 ) -> Vec<SyncCandidate> {
-    coarse_search_for::<Q65a30>(audio, sample_rate, nominal_start_sample, params)
+    coarse_search_for::<super::Q65a30>(audio, sample_rate, nominal_start_sample, params)
 }
 
 /// Same as [`coarse_search_for`] but accepts a pre-built spectrogram
@@ -401,7 +326,7 @@ pub fn coarse_search_on_spec(
     nominal_start_sample: usize,
     params: &SearchParams,
 ) -> Vec<SyncCandidate> {
-    coarse_search_on_spec_for::<Q65a30>(spec, sample_rate, nominal_start_sample, params)
+    coarse_search_on_spec_for::<super::Q65a30>(spec, sample_rate, nominal_start_sample, params)
 }
 
 #[cfg(test)]

--- a/mfsk-core/tests/common_selftest.rs
+++ b/mfsk-core/tests/common_selftest.rs
@@ -549,6 +549,17 @@ mod sharing_ratchet_selftest {
     /// see the plan file for why each was out of scope for this pass.
     const EXPECTED_SCAN_DEDUP_ADOPTERS: &[&str] = &["jt9", "jt65", "wspr", "q65"];
 
+    /// Protocols building their coarse-search spectrogram via the
+    /// shared `engine::spectrogram::Spectrogram` (found in a bottom-up
+    /// sweep after the top-down `BpPooledFec` blocker closed off
+    /// Stage 2/3 — see the plan file) rather than their own copy. WSPR
+    /// is a deliberate non-adopter: it uses the fixed-point-capable
+    /// `engine::fft` backend abstraction (not raw `rustfft`, which
+    /// this shared implementation hardcodes) and normalises scores
+    /// against a fitted per-bin baseline rather than a flat noise
+    /// floor — a real algorithmic difference, not just a naming one.
+    const EXPECTED_SPECTROGRAM_ADOPTERS: &[&str] = &["jt9", "jt65", "q65"];
+
     fn assert_no_regression(
         mechanism: &str,
         expected_adopters: &[&str],
@@ -604,6 +615,15 @@ mod sharing_ratchet_selftest {
         assert_no_regression("scan_dedup_match", EXPECTED_SCAN_DEDUP_ADOPTERS, |src| {
             src.contains("scan_dedup_match")
         });
+    }
+
+    #[test]
+    fn spectrogram_adoption_does_not_regress() {
+        assert_no_regression(
+            "engine::spectrogram::Spectrogram",
+            EXPECTED_SPECTROGRAM_ADOPTERS,
+            |src| src.contains("engine::spectrogram") || src.contains("spectrogram::Spectrogram"),
+        );
     }
 
     /// Sanity check on the scan itself, mirroring

--- a/mfsk-core/tests/q65_wsjtx_samples.rs
+++ b/mfsk-core/tests/q65_wsjtx_samples.rs
@@ -1090,7 +1090,7 @@ fn q65_multi_period_speed_diag() {
 #[test]
 #[ignore = "manual diagnostic — Q65-30A/60B candidate-count profiling (new investigation)"]
 fn q65_multi_period_candidate_count_diag() {
-    use mfsk_core::q65::search::{Spectrogram, coarse_search_on_spec_for};
+    use mfsk_core::q65::search::{build_spectrogram, coarse_search_on_spec_for};
 
     let Some(dir) = samples_dir("30A_Ionoscatter_6m") else {
         eprintln!("skipping: sample tree not found");
@@ -1114,10 +1114,10 @@ fn q65_multi_period_candidate_count_diag() {
         max_candidates: 32,
     };
 
-    let mut ema_spec = Spectrogram::build_for::<Q65a30>(&slots[0], 12_000);
+    let mut ema_spec = build_spectrogram::<Q65a30>(&slots[0], 12_000);
     for (i, audio) in slots.iter().enumerate() {
         if i > 0 {
-            let slot_spec = Spectrogram::build_for::<Q65a30>(audio, 12_000);
+            let slot_spec = build_spectrogram::<Q65a30>(audio, 12_000);
             if slot_spec.n_time == ema_spec.n_time && slot_spec.n_freq == ema_spec.n_freq {
                 let weight = 1.0_f32 / ((i + 1).min(4) as f32);
                 let one_minus = 1.0 - weight;
@@ -1141,7 +1141,7 @@ fn q65_multi_period_candidate_count_diag() {
 #[test]
 #[ignore = "manual diagnostic — Q65-30A candidate-score calibration (new investigation)"]
 fn q65_candidate_score_calibration_diag() {
-    use mfsk_core::q65::search::{Spectrogram, coarse_search_on_spec_for};
+    use mfsk_core::q65::search::{build_spectrogram, coarse_search_on_spec_for};
 
     let Some(dir) = samples_dir("30A_Ionoscatter_6m") else {
         eprintln!("skipping: sample tree not found");
@@ -1166,10 +1166,10 @@ fn q65_candidate_score_calibration_diag() {
         max_candidates: 100_000,
     };
 
-    let mut ema_spec = Spectrogram::build_for::<Q65a30>(&slots[0], 12_000);
+    let mut ema_spec = build_spectrogram::<Q65a30>(&slots[0], 12_000);
     for (i, audio) in slots.iter().enumerate() {
         if i > 0 {
-            let slot_spec = Spectrogram::build_for::<Q65a30>(audio, 12_000);
+            let slot_spec = build_spectrogram::<Q65a30>(audio, 12_000);
             if slot_spec.n_time == ema_spec.n_time && slot_spec.n_freq == ema_spec.n_freq {
                 let weight = 1.0_f32 / ((i + 1).min(4) as f32);
                 let one_minus = 1.0 - weight;


### PR DESCRIPTION
A bottom-up win found after the top-down plan (Stage 2/3: migrate JT9/JT65/WSPR/Q65 onto `engine::pipeline`) hit a hard architectural wall — that pipeline requires `P::Fec: BpPooledFec`, a trait only LDPC implements; Fano/Reed-Solomon/QRA (what these four protocols actually use) can't satisfy it. Full writeup in the plan file. Prompted by the user asking "isn't there a bottom-up angle too?" after that blocker closed off the top-down path.

## What

Three independent, near-identical copies of the same FFT spectrogram builder + tone-0 sync scorer — `jt9::search::Spectrogram`, `jt65::search::Spectrogram`, `q65::search::Spectrogram::build_for`. Their own doc comments already cross-referenced each other as "structurally identical" without anyone unifying them.

Verified precisely before touching anything (not just "looks similar" — diffed the actual function bodies after normalising only the known-different axes): JT9 vs JT65's `build`/`sync_power_at_bin`/`score_candidate` are byte-identical. Q65's `build_for` was already generic over `P`, using the identical FFT loop and `select_nth_unstable_by` noise-floor estimator, differing only in the time-step divisor (8 vs 4).

`engine::spectrogram::Spectrogram` is the extracted shared implementation. Each protocol keeps its own `coarse_search`/`coarse_search_on_spec` candidate-selection loop — JT9 and JT65's loops genuinely differ algorithmically (JT9 collapses to one candidate per frequency bin via a time-max pass mirroring WSJT-X's own `ccfred`; JT65 doesn't), so only the parts verified identical moved.

**WSPR is a deliberate non-adopter**, not an oversight: it uses the crate's fixed-point-capable `engine::fft` abstraction rather than raw `rustfft`, and normalises against a fitted per-bin baseline rather than a flat noise floor — a real algorithmic difference. Documented in the sharing ratchet (`EXPECTED_SPECTROGRAM_ADOPTERS`).

Also dropped `q65::search::Spectrogram::build` (a `Q65a30`-hardcoded convenience wrapper) — zero callers anywhere in the crate or its tests, predating the crate's now-10-wired-submode reality.

## Verification

- `jt9_wsjtx_samples`: 7/7, unchanged
- `jt65_wsjtx_samples`: 4/5, unchanged; JT65's chase-path in-crate unit tests also pass (golden test alone doesn't exercise `decode_scan_chase`)
- `q65_wsjtx_samples`: all 7 entries unchanged, including 120D's issue #287 dedup fix (1/1, 0 extra) surviving through this refactor
- `q65_ap_list`/`q65_fast_fading`: the other two Q65 coarse-search call sites
- All of the above also under `fixed-point`
- CI's isolated single-protocol feature builds (jt9/jt65/q65-only) verified locally
- Full merge gate: 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)