### PR TITLE
refactor: consolidate bit-reversal interleave (WSPR/JT9)

### DIFF
--- a/mfsk-core/src/engine/interleave.rs
+++ b/mfsk-core/src/engine/interleave.rs
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Bit-reversal interleaver — the permutation WSJT-X uses for WSPR
+//! (`interleave9.f90`, `wsprsim_utils.c`'s `bit_reverse_8`) and JT9
+//! (`interleave9.f90` again — JT9 and WSPR share the identical FEC
+//! polynomials and interleave scheme, differing only in frame length).
+//!
+//! Extracted (2026-08-14, code-sharing audit, DSP-level sweep) from
+//! **four** independent copies: `wspr::bit_reverse_8`/`interleave`/
+//! `deinterleave` (`wspr/mod.rs`), a *fifth* inline re-derivation of
+//! the same magic-constant formula in `wspr::decode::deinterleave_llrs`
+//! (its own comment: "avoid exposing a pub helper" — i.e. a
+//! deliberate duplicate of a duplicate), and `jt9::interleave`'s
+//! `bit_reverse_8`/`interleave`/`deinterleave`/`deinterleave_llrs`.
+//! All five were byte-identical modulo frame length (162 for WSPR, 206
+//! for JT9) and the loop-counter's integer type (WSPR walks a native
+//! wrapping `u8`; JT9 masks a `u32` with `& 0xff` — the same "count
+//! mod 256" behaviour either way, already established as an
+//! equivalent-not-identical parametrisation axis when
+//! `engine::sync::refine_freq_hz_log_power` was extracted the same
+//! way).
+//!
+//! JT65's own `interleave`/`deinterleave` (`jt65/interleave.rs`) is a
+//! **different algorithm** — a 7×9 matrix transpose over 63 RS
+//! symbols (`interleave63.f90`), not bit-reversal — and is correctly
+//! left alone.
+
+/// 8-bit bit-reversal by SWAR magic-constant multiplication — the
+/// identity WSJT-X's bit-reversal interleaver uses (`wsprsim_utils.c`
+/// `bit_reverse_8`, a classic Hacker's Delight trick). Input `i` only
+/// needs to be considered modulo 256.
+#[inline]
+pub fn bit_reverse_8(i: u8) -> u8 {
+    let i64 = i as u64;
+    (((i64 * 0x8020_0802u64) & 0x0884_4221_10u64).wrapping_mul(0x0101_0101_01u64) >> 32) as u8
+}
+
+/// Permute a `FRAME`-length buffer using the bit-reversal interleaver:
+/// position `p` goes to position `j = bit_reverse_8(i)`, where `i`
+/// walks `0, 1, 2, …` (mod 256, wrapping) counting only those `i`
+/// where `j < FRAME`. Inverted by [`deinterleave_bitrev`].
+pub fn interleave_bitrev<T: Copy + Default, const FRAME: usize>(buf: &mut [T; FRAME]) {
+    let mut tmp = [T::default(); FRAME];
+    let mut p = 0usize;
+    let mut i: u32 = 0;
+    while p < FRAME {
+        let j = bit_reverse_8((i & 0xff) as u8) as usize;
+        if j < FRAME {
+            tmp[j] = buf[p];
+            p += 1;
+        }
+        i = i.wrapping_add(1);
+    }
+    *buf = tmp;
+}
+
+/// Inverse of [`interleave_bitrev`]: walks the same `(p, j)` sequence
+/// but gathers `tmp[p] = buf[j]`.
+pub fn deinterleave_bitrev<T: Copy + Default, const FRAME: usize>(buf: &mut [T; FRAME]) {
+    let mut tmp = [T::default(); FRAME];
+    let mut p = 0usize;
+    let mut i: u32 = 0;
+    while p < FRAME {
+        let j = bit_reverse_8((i & 0xff) as u8) as usize;
+        if j < FRAME {
+            tmp[p] = buf[j];
+            p += 1;
+        }
+        i = i.wrapping_add(1);
+    }
+    *buf = tmp;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_162() {
+        let mut bits = [0u8; 162];
+        for (i, b) in bits.iter_mut().enumerate() {
+            *b = ((i * 7 + 3) & 1) as u8;
+        }
+        let original = bits;
+        interleave_bitrev(&mut bits);
+        assert_ne!(bits, original, "permutation must change content");
+        deinterleave_bitrev(&mut bits);
+        assert_eq!(bits, original, "deinterleave must invert interleave");
+    }
+
+    #[test]
+    fn round_trip_206() {
+        let mut bits = [0u8; 206];
+        for (i, b) in bits.iter_mut().enumerate() {
+            *b = ((i * 11 + 5) & 1) as u8;
+        }
+        let original = bits;
+        interleave_bitrev(&mut bits);
+        assert_ne!(bits, original, "permutation must change content");
+        deinterleave_bitrev(&mut bits);
+        assert_eq!(bits, original, "deinterleave must invert interleave");
+    }
+
+    #[test]
+    fn llr_variant_round_trips() {
+        let mut llrs = [0f32; 162];
+        for (i, v) in llrs.iter_mut().enumerate() {
+            *v = if i % 3 == 0 { 4.0 } else { -4.0 };
+        }
+        let original = llrs;
+        interleave_bitrev(&mut llrs);
+        deinterleave_bitrev(&mut llrs);
+        assert_eq!(llrs, original);
+    }
+}

--- a/mfsk-core/src/engine/mod.rs
+++ b/mfsk-core/src/engine/mod.rs
@@ -34,6 +34,10 @@ pub mod equalize;
 pub mod fft;
 #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub mod ft4_coarse;
+// Pure bit-permutation, no FFT/complex-number dependency — ungated
+// like `protocol`/`tx`/`scalar` so embedded TX-only builds can use it
+// too (WSPR's own TX path is a potential future consumer).
+pub mod interleave;
 // Decode-side modules go through the `engine::fft` trait abstraction;
 // gated on the meta-feature (true if any of fft-rustfft / fft-microfft
 // / fft-extern is on). Embedded TX-only builds with no FFT backend

--- a/mfsk-core/src/jt9/interleave.rs
+++ b/mfsk-core/src/jt9/interleave.rs
@@ -4,62 +4,30 @@
 //! `interleave9.f90`); only the frame length changes from 162 to
 //! 206. The permutation is its own inverse-pair: calling
 //! [`interleave`] on a buffer and then [`deinterleave`] restores it.
+//!
+//! Thin wrapper over [`crate::engine::interleave`] (extracted
+//! 2026-08-14, code-sharing audit — this module's `bit_reverse_8` was
+//! byte-identical to `wspr::bit_reverse_8`, and this module's loop
+//! shape was the same permutation walk modulo frame length).
+
+use crate::engine::interleave::{deinterleave_bitrev, interleave_bitrev};
 
 const FRAME: usize = 206;
-
-#[inline]
-fn bit_reverse_8(i: u8) -> u8 {
-    let i64 = i as u64;
-    (((i64 * 0x8020_0802u64) & 0x0884_4221_10u64).wrapping_mul(0x0101_0101_01u64) >> 32) as u8
-}
 
 /// Permute 206 bits: `tmp[bit_reverse_8(i)] = src[p]`, iterating `i`
 /// skipping positions whose bit-reverse ≥ 206.
 pub fn interleave(bits: &mut [u8; FRAME]) {
-    let mut tmp = [0u8; FRAME];
-    let mut p = 0usize;
-    let mut i: u32 = 0;
-    while p < FRAME {
-        let j = bit_reverse_8((i & 0xff) as u8) as usize;
-        if j < FRAME {
-            tmp[j] = bits[p];
-            p += 1;
-        }
-        i = i.wrapping_add(1);
-    }
-    bits.copy_from_slice(&tmp);
+    interleave_bitrev(bits);
 }
 
 /// Inverse permutation — `tmp[p] = src[bit_reverse_8(i)]`.
 pub fn deinterleave(bits: &mut [u8; FRAME]) {
-    let mut tmp = [0u8; FRAME];
-    let mut p = 0usize;
-    let mut i: u32 = 0;
-    while p < FRAME {
-        let j = bit_reverse_8((i & 0xff) as u8) as usize;
-        if j < FRAME {
-            tmp[p] = bits[j];
-            p += 1;
-        }
-        i = i.wrapping_add(1);
-    }
-    bits.copy_from_slice(&tmp);
+    deinterleave_bitrev(bits);
 }
 
 /// f32 variant for LLR arrays.
 pub fn deinterleave_llrs(llrs: &mut [f32; FRAME]) {
-    let mut tmp = [0f32; FRAME];
-    let mut p = 0usize;
-    let mut i: u32 = 0;
-    while p < FRAME {
-        let j = bit_reverse_8((i & 0xff) as u8) as usize;
-        if j < FRAME {
-            tmp[p] = llrs[j];
-            p += 1;
-        }
-        i = i.wrapping_add(1);
-    }
-    *llrs = tmp;
+    deinterleave_bitrev(llrs);
 }
 
 #[cfg(test)]

--- a/mfsk-core/src/wspr/decode.rs
+++ b/mfsk-core/src/wspr/decode.rs
@@ -1777,23 +1777,13 @@ fn decode_scan_subtract_inner(
 }
 
 /// Deinterleave 162 LLRs in place (same permutation as [`deinterleave`]
-/// but for `f32` values).
+/// but for `f32` values). Thin wrapper over
+/// [`crate::engine::interleave::deinterleave_bitrev`] — was its own
+/// third inline copy of the bit-reversal formula ("avoid exposing a
+/// pub helper"), no longer needed now that the shared version is
+/// itself the pub helper.
 fn deinterleave_llrs(llrs: &mut [f32; 162]) {
-    let mut tmp = [0f32; 162];
-    let mut p = 0u8;
-    let mut i = 0u8;
-    while p < 162 {
-        // Inline the bit-reverse-8 to avoid exposing a pub helper.
-        let i64 = i as u64;
-        let j = ((((i64 * 0x8020_0802u64) & 0x0884_4221_10u64).wrapping_mul(0x0101_0101_01u64))
-            >> 32) as u8 as usize;
-        if j < 162 {
-            tmp[p as usize] = llrs[j];
-            p += 1;
-        }
-        i = i.wrapping_add(1);
-    }
-    *llrs = tmp;
+    crate::engine::interleave::deinterleave_bitrev(llrs);
 }
 
 #[cfg(test)]

--- a/mfsk-core/src/wspr/mod.rs
+++ b/mfsk-core/src/wspr/mod.rs
@@ -152,51 +152,20 @@ impl Protocol for Wspr {
 // WSPR-specific interleaver
 // ─────────────────────────────────────────────────────────────────────────
 
-/// 8-bit bit-reversal by SWAR magic-constant multiplication — the
-/// identity used by WSJT-X's interleaver (and a classic Hacker's Delight
-/// trick). Input `i` only needs to be considered modulo 256.
-#[inline]
-fn bit_reverse_8(i: u8) -> u8 {
-    // Matches `j = ((i * 0x80200802) & 0x0884422110) * 0x0101010101 >> 32`
-    // from wsprsim_utils.c, with the implicit truncation to `unsigned char`
-    // made explicit via `as u8` on the final result.
-    let i64 = i as u64;
-    (((i64 * 0x8020_0802u64) & 0x0884_4221_10u64).wrapping_mul(0x0101_0101_01u64) >> 32) as u8
-}
-
-/// Permute the 162-symbol stream using WSJT-X's bit-reversal interleaver:
-/// position `p` goes to position `j = bit_reverse_8(i)` where `i` walks
-/// from 0 counting only those where `j < 162`.
+/// Permute the 162-symbol stream using WSJT-X's bit-reversal interleaver.
+/// Thin wrapper over [`crate::engine::interleave`] (extracted
+/// 2026-08-14, code-sharing audit — this was one of five independent
+/// copies of the same SWAR magic-constant formula in the crate,
+/// including a *second* copy within this same protocol,
+/// `decode::deinterleave_llrs`'s own "avoid exposing a pub helper"
+/// inlining).
 pub fn interleave(bits: &mut [u8; 162]) {
-    let mut tmp = [0u8; 162];
-    let mut p = 0u8;
-    let mut i = 0u8;
-    while p < 162 {
-        let j = bit_reverse_8(i) as usize;
-        if j < 162 {
-            tmp[j] = bits[p as usize];
-            p += 1;
-        }
-        i = i.wrapping_add(1);
-    }
-    bits.copy_from_slice(&tmp);
+    crate::engine::interleave::interleave_bitrev(bits);
 }
 
-/// Inverse interleaver — walks the same (p, j) sequence but gathers
-/// `tmp[p] = bits[j]`. `deinterleave(interleave(x)) == x`.
+/// Inverse of [`interleave`].
 pub fn deinterleave(bits: &mut [u8; 162]) {
-    let mut tmp = [0u8; 162];
-    let mut p = 0u8;
-    let mut i = 0u8;
-    while p < 162 {
-        let j = bit_reverse_8(i) as usize;
-        if j < 162 {
-            tmp[p as usize] = bits[j];
-            p += 1;
-        }
-        i = i.wrapping_add(1);
-    }
-    bits.copy_from_slice(&tmp);
+    crate::engine::interleave::deinterleave_bitrev(bits);
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/mfsk-core/tests/common_selftest.rs
+++ b/mfsk-core/tests/common_selftest.rs
@@ -560,6 +560,15 @@ mod sharing_ratchet_selftest {
     /// floor — a real algorithmic difference, not just a naming one.
     const EXPECTED_SPECTROGRAM_ADOPTERS: &[&str] = &["jt9", "jt65", "q65"];
 
+    /// Protocols using the shared `engine::interleave::{interleave_bitrev,
+    /// deinterleave_bitrev}` bit-reversal permutation (found in the same
+    /// DSP-level sweep as the Spectrogram kernel) rather than their own
+    /// copy of the SWAR magic-constant formula. JT65 is a deliberate
+    /// non-adopter: its own interleaver is a 7×9 matrix transpose
+    /// (`interleave63.f90`), a genuinely different algorithm, not bit
+    /// reversal.
+    const EXPECTED_INTERLEAVE_ADOPTERS: &[&str] = &["jt9", "wspr"];
+
     fn assert_no_regression(
         mechanism: &str,
         expected_adopters: &[&str],
@@ -623,6 +632,15 @@ mod sharing_ratchet_selftest {
             "engine::spectrogram::Spectrogram",
             EXPECTED_SPECTROGRAM_ADOPTERS,
             |src| src.contains("engine::spectrogram") || src.contains("spectrogram::Spectrogram"),
+        );
+    }
+
+    #[test]
+    fn interleave_adoption_does_not_regress() {
+        assert_no_regression(
+            "engine::interleave bit-reversal",
+            EXPECTED_INTERLEAVE_ADOPTERS,
+            |src| src.contains("engine::interleave"),
         );
     }
 


### PR DESCRIPTION
DSP-level bottom-up sweep, requested after the Spectrogram consolidation (#294). Checked WSPR's DDC stack and FT8's inline dedup sites first — both confirmed as correctly separate, no action — then swept the remaining protocol-local DSP helper files systematically.

## What

A fifth copy of the same duplication class the Spectrogram find was: `wspr::bit_reverse_8` is byte-identical to `jt9::interleave::bit_reverse_8`'s SWAR magic-constant formula — and JT9's own doc comment already said so ("Same SWAR 8-bit bit-reversal identity WSPR uses"). WSPR itself had *two* copies: the `mod.rs` one, plus a third inline re-derivation in `decode::deinterleave_llrs` with its own comment explaining why ("avoid exposing a pub helper" — a deliberate duplicate of a duplicate).

`engine::interleave::{bit_reverse_8, interleave_bitrev, deinterleave_bitrev}` is the extracted shared kernel, generic over `<T: Copy + Default, const FRAME: usize>` so both `u8` (WSPR 162 / JT9 206) and `f32` (LLR arrays) share it. Ungated — no FFT/complex-number dependency, so embedded TX-only builds can use it too. `jt9::interleave` and WSPR's own `interleave`/`deinterleave`/`deinterleave_llrs` are thin wrappers preserving their exact public signatures — zero call-site changes elsewhere in either protocol.

JT65's own interleaver (7×9 matrix transpose, `interleave63.f90`) is a genuinely different algorithm and correctly left untouched.

## Sweep results (the other candidates checked)

- **WSPR's DDC "3 implementations"**: not duplication. `baseband.rs`/`ddc.rs` are documented intentional alternates (host-exact vs embedded-feasible). `coarse_baseband.rs` is a structurally different algorithm. The one file that *did* share the Spectrogram shape (`wspr::spectrogram.rs`) turned out to be dead code, already flagged as such in `decode.rs`: *"Legacy `coarse_search`... not invoked here."*
- **FT8's 11 dedup call sites**: heterogeneous, not one duplicated pattern — no freq/time tolerance anywhere (FT8's SIC subtraction already prevents spatial re-finding, unlike JT9/JT65/WSPR/Q65).
- **FT8's small DSP files** (`downsample.rs`, `baseline.rs`, `equalizer.rs`, `resample.rs`, `ldpc.rs`): already thin façades over `engine::` from a prior (2026-05, issue #18) consolidation — confirms, doesn't find anything new.
- **Q65's `percentile` helper**: protocol-local, not duplicated elsewhere.
- **GFSK synthesis**: correctly absent from the four plain-FSK protocols (JT9/JT65/WSPR/Q65 have `GFSK_BT: 0.0`).
- **JT9/JT65's AFC**: `twkfreq_poly` (JT9) vs a running-phase NCO (JT65) — different implementations of the same WSJT-X effect, not a shared routine.

One adjacent, out-of-scope observation: `jt9::demod_bb` is legacy code whose own doc comment says it should have been removed once issue #19 closed (which it has, months ago). A cleanup candidate, not a sharing one — flagged, not acted on.

## Verification

- `wspr_wsjtx_samples`: 9/9, unchanged
- `jt9_wsjtx_samples`: 7/7, unchanged
- Both under `fixed-point`
- Interleave round-trip unit tests in both protocols plus the new shared module
- CI's isolated `jt9`-only / `wspr`-only / foundation-only / `alloc,ft8` (no_std, no FFT backend) build matrix combinations verified locally — the last two confirm the module is genuinely FFT-independent as documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)