### PR TITLE
docs(roadmap) + refactor(msg): audit close-out + callsign28 consolidation

### DIFF
--- a/docs/notes/ROADMAP.md
+++ b/docs/notes/ROADMAP.md
@@ -53,6 +53,38 @@ Three tracks, at very different maturities:
    demand-driven (e.g. VK3NV's FST4-15/30 use case behind #143), not
    pursued for their own sake.
 
+   A 2026-08-14 code-sharing audit (prompted by a user doubt over the
+   README's unsourced "~80% shared" claim) confirmed the doubt but not
+   the diagnosis: the true-generic fraction measures 31.8% (strict,
+   protocol-bound code excluded) / 47.7% (directory), not 80% — fixed
+   with a measured figure + methodology pointer to `LIBRARY.md` §0.5
+   (PR #290), plus a permanent `sharing_ratchet_selftest` regression
+   guard (PR #291). The root cause wasn't faithfulness-driven
+   duplication in general (WSJT-X itself repeats per-protocol code,
+   and QRA/Fano/RS/LDPC are genuinely different algorithms, not one
+   thing written four times) but a narrower, real pattern: shared
+   mechanisms built and adopted by 2-3 protocols, then left there with
+   nothing flagging the rest. Concrete, verified duplication found and
+   consolidated: `refine_freq_hz`/`dedup_known` (PR #292), 9 candidate-
+   dedup call sites across JT9/JT65/WSPR/Q65 (PR #293), a 3x-duplicated
+   `Spectrogram` build/score kernel across JT9/JT65/Q65 found via a
+   bottom-up DSP-level sweep after top-down hit a genuine wall (PR
+   #294), and a 5x-duplicated bit-reversal interleave permutation
+   across WSPR/JT9 (PR #295) — plus, as adjacent cleanup, the dead
+   `jt9::demod_bb` box-car path it should have been deleted alongside
+   in 0.5.9 (PR #296). **Migrating JT9/JT65/WSPR/Q65 onto the generic
+   `engine::pipeline` (the step that would have moved the needle most)
+   is architecturally blocked**, not merely unstarted: the pipeline's
+   `process_candidate_basic`/`decode_frame` require `P::Fec:
+   BpPooledFec`, a soft-LLR belief-propagation scratch-reuse shape
+   only `Ldpc174_91`/`Ldpc240_101` implement — Fano-sequential
+   (JT9/WSPR), Reed-Solomon (JT65), and GF(64) QRA (Q65) can't satisfy
+   it, an algorithmic mismatch rather than missing plumbing. Concluded
+   by explicit user choice rather than a numeric target: no percentage
+   was set as a stopping point, and the session's own retrospective
+   note is that chasing a number here would have meant metric-gaming
+   past this point, not more real consolidation.
+
 2. **Host application / ergonomics — newly opened, consumer-driven.**
    0.9.0's theme ("make the streaming decode surface easy to build host
    UIs on") added `msg::decoded::Decoded`, per-protocol `to_decoded`, the

--- a/mfsk-core/src/msg/callsign28.rs
+++ b/mfsk-core/src/msg/callsign28.rs
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Shared base-37/36/10/27³ callsign encoding — the scheme WSJT-X's
+//! `lib/packjt.f90::packcall`/`unpackcall` implements and which is
+//! called, per that file, from both `wqencode.f90`/`wqdecode.f90`
+//! (the JT65/JT9 message layer) and `wsprcode/wspr_old_subs.f90`
+//! (WSPR) — one upstream routine, not two.
+//!
+//! Extracted (2026-08-14, code-sharing audit, msg-layer sweep) from
+//! two independent Rust ports that were byte-identical on this core:
+//! [`super::jt72::pack_call`]/`unpack_call` and
+//! [`super::wspr::pack_call`]/`unpack_call`. The two callers differ
+//! on exactly one axis — which characters a slot accepts — so that's
+//! the one thing left as a parameter rather than folded in:
+//!
+//! - JT9/JT65's own `nchar` accepts `a`-`z` as well as `A`-`Z`
+//!   (defensive; every caller already uppercases first, so this
+//!   never actually fires on live input, but preserving it here
+//!   keeps the extraction behaviour-neutral).
+//! - WSPR's `callsign_char_code` accepts `A`-`Z` only.
+//!
+//! Special tokens above `NBASE` (JT9/JT65's `CQ`/`QRZ`/`DE`) have no
+//! WSPR analogue — WSPR Type-1 messages are always callsign+grid+
+//! power, never a bare CQ token — so that layer stays in
+//! [`super::jt72`] alone, checked before falling through to
+//! [`pack_call28`]/[`unpack_call28`].
+
+use alloc::string::{String, ToString};
+
+/// 37-entry table used to render an unpacked slot back to a
+/// character: digits, uppercase letters, space. Matches `c[]` in
+/// WSJT-X's `unpackcall`.
+pub const CALL_ALPHA: &[u8; 37] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ ";
+
+/// `NBASE` in WSJT-X: `37 * 36 * 10 * 27³ = 262_177_560` — the
+/// exclusive upper bound of the plain 6-character callsign encoding
+/// range. Values at or above this are protocol-specific special
+/// tokens or reserved; callers check against this before/instead of
+/// calling [`unpack_call28`].
+pub const NBASE: u32 = 37 * 36 * 10 * 27 * 27 * 27;
+
+/// Pack a ≤6-character callsign into its base-37/36/10/27³ integer,
+/// given a per-character `nchar` lookup (digit→0..9, letter→10..35,
+/// space→36, anything else→`None`).
+///
+/// The standard layout expects the digit in position 3 (`K1ABC`) or
+/// position 2 (`K9AN`, right-shifted so the digit lands at index 2).
+/// Returns `None` if the callsign doesn't fit that digit-position
+/// rule, exceeds 6 characters, or any character is rejected by
+/// `nchar`.
+pub fn pack_call28(call: &str, nchar: impl Fn(u8) -> Option<u32>) -> Option<u32> {
+    let bytes = call.as_bytes();
+    if bytes.is_empty() || bytes.len() > 6 {
+        return None;
+    }
+
+    let mut tmp = [b' '; 6];
+    if bytes.len() >= 3 && bytes[2].is_ascii_digit() {
+        for (i, &b) in bytes.iter().enumerate() {
+            tmp[i] = b;
+        }
+    } else if bytes.len() >= 2 && bytes[1].is_ascii_digit() {
+        if bytes.len() > 5 {
+            return None;
+        }
+        for (i, &b) in bytes.iter().enumerate() {
+            tmp[i + 1] = b;
+        }
+    } else {
+        return None;
+    }
+
+    let n = [
+        nchar(tmp[0])?,
+        nchar(tmp[1])?,
+        nchar(tmp[2])?,
+        nchar(tmp[3])?,
+        nchar(tmp[4])?,
+        nchar(tmp[5])?,
+    ];
+    // Slot 1: letter/digit only (space forbidden).
+    if n[1] == 36 {
+        return None;
+    }
+    // Slot 2: digit only.
+    if n[2] >= 10 {
+        return None;
+    }
+    // Slots 3..=5: letter/space only (digit forbidden).
+    for v in &n[3..6] {
+        if *v < 10 {
+            return None;
+        }
+    }
+
+    let mut ncall = n[0];
+    ncall = 36 * ncall + n[1];
+    ncall = 10 * ncall + n[2];
+    ncall = 27 * ncall + n[3] - 10;
+    ncall = 27 * ncall + n[4] - 10;
+    ncall = 27 * ncall + n[5] - 10;
+    Some(ncall)
+}
+
+/// Inverse of [`pack_call28`]. Returns `None` for `ncall >= NBASE`
+/// (special tokens / reserved values are the caller's concern,
+/// checked before calling this).
+pub fn unpack_call28(ncall: u32) -> Option<String> {
+    if ncall >= NBASE {
+        return None;
+    }
+    let mut n = ncall;
+    let mut chars = [b' '; 6];
+    let c6 = (n % 27) + 10;
+    chars[5] = CALL_ALPHA[c6 as usize];
+    n /= 27;
+    let c5 = (n % 27) + 10;
+    chars[4] = CALL_ALPHA[c5 as usize];
+    n /= 27;
+    let c4 = (n % 27) + 10;
+    chars[3] = CALL_ALPHA[c4 as usize];
+    n /= 27;
+    let c3 = n % 10;
+    chars[2] = CALL_ALPHA[c3 as usize];
+    n /= 10;
+    let c2 = n % 36;
+    chars[1] = CALL_ALPHA[c2 as usize];
+    n /= 36;
+    let c1 = n; // 0..=36
+    chars[0] = CALL_ALPHA[c1 as usize];
+
+    let s = core::str::from_utf8(&chars).ok()?;
+    Some(s.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn nchar_upper_only(c: u8) -> Option<u32> {
+        match c {
+            b'0'..=b'9' => Some((c - b'0') as u32),
+            b'A'..=b'Z' => Some((c - b'A' + 10) as u32),
+            b' ' => Some(36),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn round_trip_k1abc() {
+        let n = pack_call28("K1ABC", nchar_upper_only).unwrap();
+        assert_eq!(unpack_call28(n).as_deref(), Some("K1ABC"));
+    }
+
+    #[test]
+    fn round_trip_digit_in_slot_2() {
+        // "K9AN" — digit at position 2, gets shifted right by one.
+        let n = pack_call28("K9AN", nchar_upper_only).unwrap();
+        assert_eq!(unpack_call28(n).as_deref(), Some("K9AN"));
+    }
+
+    #[test]
+    fn nbase_is_wsjtx_constant() {
+        assert_eq!(NBASE, 262_177_560);
+    }
+
+    #[test]
+    fn rejects_lowercase_when_nchar_is_upper_only() {
+        assert_eq!(pack_call28("k1abc", nchar_upper_only), None);
+    }
+}

--- a/mfsk-core/src/msg/jt72.rs
+++ b/mfsk-core/src/msg/jt72.rs
@@ -84,11 +84,13 @@ impl fmt::Display for Jt72Message {
 // Character helpers (WSJT-X `nchar` / `unpackcall` tables)
 // ─────────────────────────────────────────────────────────────────────────
 
-/// 37-char callsign alphabet: digits, uppercase letters, space.
-const CALL_ALPHA: &[u8; 37] = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ ";
-
 /// Translate a callsign char to its `nchar` index: digit→0..9,
 /// letter→10..35, space→36. Returns `None` for anything else.
+/// Accepts lowercase too — defensive; every caller here already
+/// uppercases before this runs (see [`pack_call`]'s digit-position
+/// step), so the lowercase branch never actually fires on live
+/// input, but the extraction into [`crate::msg::callsign28`]
+/// preserves it rather than narrowing behaviour.
 fn nchar(c: u8) -> Option<u32> {
     match c {
         b'0'..=b'9' => Some((c - b'0') as u32),
@@ -111,116 +113,31 @@ fn nchar(c: u8) -> Option<u32> {
 /// Returns `None` if the callsign doesn't fit the base-37/36/10/27³
 /// schema — those cases trigger the "text / compound" fallbacks in
 /// `packcall` that this MVP doesn't yet model.
+///
+/// Special tokens (`CQ`/`QRZ`/`DE`) are JT9/JT65-specific — WSPR has
+/// no bare-CQ message type — so they're handled here, above
+/// [`crate::msg::callsign28::pack_call28`]'s shared core.
 pub fn pack_call(call: &str) -> Option<u32> {
-    let bytes = call.as_bytes();
-    // Special tokens handled by WSJT-X's `packcall`.
     match call {
         "CQ" => return Some(NBASE + 1),
         "QRZ" => return Some(NBASE + 2),
         "DE" => return Some(267_796_945),
         _ => {}
     }
-    if bytes.is_empty() || bytes.len() > 6 {
-        return None;
-    }
-
-    // Build the 6-char right-aligned working copy `tmp`.
-    let mut tmp = [b' '; 6];
-    if bytes.len() >= 3 && bytes[2].is_ascii_digit() {
-        // Digit at position 3 (0-indexed 2) — left-aligned as-is.
-        for (i, &b) in bytes.iter().enumerate() {
-            tmp[i] = b;
-        }
-    } else if bytes.len() >= 2 && bytes[1].is_ascii_digit() {
-        // Digit at position 2 — shift right by one so digit lands at
-        // tmp[2]. Max source length becomes 5.
-        if bytes.len() > 5 {
-            return None;
-        }
-        for (i, &b) in bytes.iter().enumerate() {
-            tmp[i + 1] = b;
-        }
-    } else {
-        return None;
-    }
-
-    // Uppercase.
-    for t in tmp.iter_mut() {
-        if t.is_ascii_lowercase() {
-            *t -= b'a' - b'A';
-        }
-    }
-
-    // Validate slot alphabets.
-    let n = [
-        nchar(tmp[0])?,
-        nchar(tmp[1])?,
-        nchar(tmp[2])?,
-        nchar(tmp[3])?,
-        nchar(tmp[4])?,
-        nchar(tmp[5])?,
-    ];
-    // Slot 0: letter/digit/space (0..=36)
-    // Slot 1: letter/digit (0..=35)
-    if n[1] == 36 {
-        return None;
-    }
-    // Slot 2: digit (0..=9)
-    if n[2] >= 10 {
-        return None;
-    }
-    // Slots 3..=5: letter/space (10..=36)
-    for k in 3..6 {
-        if n[k] < 10 {
-            return None;
-        }
-    }
-
-    let mut ncall = n[0];
-    ncall = 36 * ncall + n[1];
-    ncall = 10 * ncall + n[2];
-    ncall = 27 * ncall + n[3] - 10;
-    ncall = 27 * ncall + n[4] - 10;
-    ncall = 27 * ncall + n[5] - 10;
-    Some(ncall)
+    crate::msg::callsign28::pack_call28(call, nchar)
 }
 
 /// Unpack a 28-bit integer back into a callsign or special token.
 /// Returns `None` for values outside the base-37/36/10/27³ range
 /// (those encode compound-callsign variants).
 pub fn unpack_call(ncall: u32) -> Option<String> {
-    // Special tokens.
     match ncall {
         v if v == NBASE + 1 => return Some("CQ".into()),
         v if v == NBASE + 2 => return Some("QRZ".into()),
         267_796_945 => return Some("DE".into()),
         _ => {}
     }
-    if ncall >= NBASE {
-        return None;
-    }
-    let mut n = ncall;
-    let mut chars = [b' '; 6];
-    let c6 = (n % 27) + 10;
-    chars[5] = CALL_ALPHA[c6 as usize];
-    n /= 27;
-    let c5 = (n % 27) + 10;
-    chars[4] = CALL_ALPHA[c5 as usize];
-    n /= 27;
-    let c4 = (n % 27) + 10;
-    chars[3] = CALL_ALPHA[c4 as usize];
-    n /= 27;
-    let c3 = n % 10;
-    chars[2] = CALL_ALPHA[c3 as usize];
-    n /= 10;
-    let c2 = n % 36;
-    chars[1] = CALL_ALPHA[c2 as usize];
-    n /= 36;
-    let c1 = n; // 0..=36
-    chars[0] = CALL_ALPHA[c1 as usize];
-
-    let s = core::str::from_utf8(&chars).ok()?;
-    Some(s.trim().to_string())
+    crate::msg::callsign28::unpack_call28(ncall)
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/mfsk-core/src/msg/mod.rs
+++ b/mfsk-core/src/msg/mod.rs
@@ -13,6 +13,7 @@
 //! is shared by every message unpack invocation.
 
 pub mod ap;
+pub mod callsign28;
 /// Unified owned decode row for host UIs — see [`decoded::Decoded`].
 pub mod decoded;
 // `DecodeRequest`/`SniperRequest` builder (issue #191); depends on

--- a/mfsk-core/src/msg/wspr.rs
+++ b/mfsk-core/src/msg/wspr.rs
@@ -151,73 +151,22 @@ pub fn unpack50(data: &[u8; 7]) -> (u32, u32) {
 /// Encode a callsign into a 28-bit integer. Returns `None` if the callsign
 /// doesn't fit the compressed form (must be ≤ 6 chars with a digit in
 /// position 1 or 2, and only A-Z / 0-9 / space).
+///
+/// Thin wrapper over [`crate::msg::callsign28::pack_call28`] — WSPR
+/// shares this encoding with JT9/JT65 (`crate::msg::jt72`), both
+/// tracing to WSJT-X's `packjt.f90::packcall` (called from
+/// `wsprcode/wspr_old_subs.f90` too, not just the JT65/JT9 message
+/// layer). WSPR has no CQ/QRZ/DE special-token layer (Type-1 WSPR
+/// messages are always callsign+grid+power), so there's nothing to
+/// check above the shared core here, unlike [`crate::msg::jt72::pack_call`].
 pub fn pack_call(callsign: &str) -> Option<u32> {
-    let bytes = callsign.as_bytes();
-    if bytes.len() > 6 || bytes.is_empty() {
-        return None;
-    }
-    let mut call6 = [b' '; 6];
-    // Right-align to the 3rd slot: if char[2] is a digit keep as-is,
-    // else if char[1] is a digit shift one position right.
-    if bytes.len() >= 3 && bytes[2].is_ascii_digit() {
-        for (i, &b) in bytes.iter().enumerate() {
-            call6[i] = b;
-        }
-    } else if bytes.len() >= 2 && bytes[1].is_ascii_digit() {
-        for (i, &b) in bytes.iter().enumerate() {
-            call6[i + 1] = b;
-        }
-    } else {
-        return None;
-    }
-
-    let codes: [u8; 6] = {
-        let mut c = [0u8; 6];
-        for i in 0..6 {
-            c[i] = callsign_char_code(call6[i])?;
-        }
-        c
-    };
-
-    // n = c0*36 + c1 ...       (first two slots: 37-symbol alphabet)
-    // then digit (c2, 0-9), then three letter/space (c3..c5, 27 symbols).
-    let mut n: u32 = codes[0] as u32;
-    n = n * 36 + codes[1] as u32;
-    n = n * 10 + codes[2] as u32;
-    n = n * 27 + (codes[3].wrapping_sub(10)) as u32;
-    n = n * 27 + (codes[4].wrapping_sub(10)) as u32;
-    n = n * 27 + (codes[5].wrapping_sub(10)) as u32;
-    Some(n)
+    crate::msg::callsign28::pack_call28(callsign, |c| callsign_char_code(c).map(u32::from))
 }
 
 /// Unpack a 28-bit callsign integer. Returns `None` for the "reserved"
 /// range (≥ 262_177_560) that WSJT-X treats as non-Type-1.
 pub fn unpack_call(ncall: u32) -> Option<String> {
-    if ncall >= 262_177_560 {
-        return None;
-    }
-    let mut n = ncall;
-    let mut tmp = [b' '; 6];
-    // Reverse of pack_call: pull digits/letters out LSB-first.
-    let i = (n % 27 + 10) as usize;
-    tmp[5] = CHAR37[i];
-    n /= 27;
-    let i = (n % 27 + 10) as usize;
-    tmp[4] = CHAR37[i];
-    n /= 27;
-    let i = (n % 27 + 10) as usize;
-    tmp[3] = CHAR37[i];
-    n /= 27;
-    let i = (n % 10) as usize;
-    tmp[2] = CHAR37[i];
-    n /= 10;
-    let i = (n % 36) as usize;
-    tmp[1] = CHAR37[i];
-    n /= 36;
-    tmp[0] = CHAR37[n as usize];
-
-    let s = core::str::from_utf8(&tmp).ok()?;
-    Some(s.trim().to_string())
+    crate::msg::callsign28::unpack_call28(ncall)
 }
 
 /// Pack a 4-char grid and transmit power into a 22-bit integer.


### PR DESCRIPTION
Two related commits:

1. **docs(roadmap)**: records the 2026-08-14 code-sharing audit
   (#290-296) in ROADMAP.md's track 1, which had no mention of it.

2. **refactor(msg)**: continuation of the audit's bottom-up sweep, this
   time at the `msg/` layer (per request to check `fec`/`msg`/protocol
   trait layers for gaps, after `engine/`'s DSP layer was already swept).

**Layer-by-layer findings:**
- `fec/`: clean. `fec::ldpc`/`fec::qra` already correctly share their
  bp/osd/QraCode engines with `ldpc240_101`/`ldpc_128_90`/
  `qra15_65_64` as thin per-code-table wrappers; `fec::conv` already
  wraps `ConvFano`/`ConvFano232` over one shared `fano` module.
- Protocol-trait layer (`engine/protocol.rs` impls): clean by design —
  const data that's supposed to differ per protocol.
- Grid packing (`jt72::pack_grid4_plain` vs `wspr::pack_grid4_power`):
  checked, not pursued — the pack side shares arithmetic but the
  unpack sides are genuinely different algorithms (direct-inverse vs
  lat/long round-trip, matching wsprd's own C source), i.e. two
  faithful ports of two different upstream routines.
- `msg/jt72.rs` vs `msg/wspr.rs`'s `pack_call`/`unpack_call`: the real
  find. Byte-identical base-37/36/10/27³ callsign encoding
  (`NBASE=262_177_560`), independently ported from WSJT-X's
  `packjt.f90::packcall`/`unpackcall` — confirmed via grep that
  `wsprcode/wspr_old_subs.f90` calls that same routine, not a
  WSPR-specific one. JT65 already shares `jt72.rs` with JT9, so WSPR
  held the third independent copy.

Extracted to `msg::callsign28::{pack_call28, unpack_call28}`. The one
real behavioural axis (which characters a slot accepts) stays a
closure parameter: JT9/JT65's `nchar` accepts lowercase (dead in
practice, verified `nchar(lower) == nchar(upper)`), WSPR's
`callsign_char_code` is uppercase-only. CQ/QRZ/DE special tokens have
no WSPR analogue, so that layer stays in `jt72` alone.

**One incidental correctness fix**, called out rather than smuggled in:
WSPR's `pack_call` was missing three slot-alphabet checks that
`packjt.f90:97-116` performs (slot 1 ≠ space, slot 2 = digit, slots
3-5 ≠ digit). The shared core carries the full check (already correct
in `jt72`'s copy), so WSPR gains it too. No existing test exercised
the gap; this can only reject previously-malformed input, never
change output on valid input.

No ratchet entry — this consolidation is internal to `msg/` (an
already-shared dir), same category as the pre-existing `fec::ldpc`/
`qra` sharing, not a per-protocol-adoption question the ratchet
tracks.

**Verified:** full merge-gate suite (tier A+B, 428+ tests) green,
JT9/JT65/WSPR golden tests under full + fixed-point features,
isolated `--features {jt9,jt65,wspr}` builds, fmt/clippy/doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)