### PR TITLE
chore: fix two stale dead-code annotations found in the layer audit

### DIFF
--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -443,17 +443,22 @@ pub struct SnrCtx<'a> {
     /// Coarse-sync candidate frequency (Hz) — `candidates(icand,1)`
     /// equivalent. FST4's baseline lookup (`candidates(icand,5)`) is
     /// keyed by this, not the fine-refined frequency.
-    #[allow(dead_code)] // read once FST4's override lands
+    // FST4's `snr_db` override is this field's only reader (mirrors
+    // `cand_score` above, just for the other protocol) — dead in any
+    // build without `fst4`.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub cand_freq_hz: f32,
     /// Big forward-FFT of the whole slot's raw audio
     /// ([`build_fft_cache`]'s output) — WSJT-X `c_bigfft` equivalent.
     /// Already computed by the caller for downsampling; FST4's
     /// baseline extraction reuses it rather than requiring its own.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub fft_cache: &'a [Complex<f32>],
     /// The [`DownsampleCfg`] `fft_cache` was built from — supplies
     /// `fft1_size` (⇒ WSJT-X's `df1`) to FST4's baseline extraction.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub ds_cfg: &'a DownsampleCfg,
     /// Fine-refined candidate frequency (Hz) — the frequency `cs` was
     /// actually computed at (`WSJT-X`'s `fc_synced`), as opposed to
@@ -461,13 +466,15 @@ pub struct SnrCtx<'a> {
     /// re-derivation needs this: WSJT-X's `fst4_decode.f90` downsamples
     /// its bitmetrics input at `fc_synced`, not the coarse candidate
     /// frequency `get_candidates_fst4.f90`'s baseline is keyed by.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub refined_freq_hz: f32,
     /// Sample index (in the *downsampled* baseband) of the first
     /// symbol — the `i_start`/`i0` [`symbol_spectra`] was actually
     /// called with. Needed alongside `refined_freq_hz` to recompute a
     /// fresh, deterministic `cs` at the exact same alignment.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub i_start: i32,
 }
 #[cfg(not(feature = "internal-testing"))]
@@ -486,17 +493,22 @@ pub(crate) struct SnrCtx<'a> {
     /// Coarse-sync candidate frequency (Hz) — `candidates(icand,1)`
     /// equivalent. FST4's baseline lookup (`candidates(icand,5)`) is
     /// keyed by this, not the fine-refined frequency.
-    #[allow(dead_code)] // read once FST4's override lands
+    // FST4's `snr_db` override is this field's only reader (mirrors
+    // `cand_score` above, just for the other protocol) — dead in any
+    // build without `fst4`.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub cand_freq_hz: f32,
     /// Big forward-FFT of the whole slot's raw audio
     /// ([`build_fft_cache`]'s output) — WSJT-X `c_bigfft` equivalent.
     /// Already computed by the caller for downsampling; FST4's
     /// baseline extraction reuses it rather than requiring its own.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub fft_cache: &'a [Complex<f32>],
     /// The [`DownsampleCfg`] `fft_cache` was built from — supplies
     /// `fft1_size` (⇒ WSJT-X's `df1`) to FST4's baseline extraction.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub ds_cfg: &'a DownsampleCfg,
     /// Fine-refined candidate frequency (Hz) — the frequency `cs` was
     /// actually computed at (`WSJT-X`'s `fc_synced`), as opposed to
@@ -504,13 +516,15 @@ pub(crate) struct SnrCtx<'a> {
     /// re-derivation needs this: WSJT-X's `fst4_decode.f90` downsamples
     /// its bitmetrics input at `fc_synced`, not the coarse candidate
     /// frequency `get_candidates_fst4.f90`'s baseline is keyed by.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub refined_freq_hz: f32,
     /// Sample index (in the *downsampled* baseband) of the first
     /// symbol — the `i_start`/`i0` [`symbol_spectra`] was actually
     /// called with. Needed alongside `refined_freq_hz` to recompute a
     /// fresh, deterministic `cs` at the exact same alignment.
-    #[allow(dead_code)] // read once FST4's override lands
+    // Same as `cand_freq_hz` above — FST4-only reader.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
     pub i_start: i32,
 }
 

--- a/mfsk-core/src/wspr/demod.rs
+++ b/mfsk-core/src/wspr/demod.rs
@@ -18,7 +18,6 @@
 //!    in pass 3 and what gets us the W5BIT / NM7J / W3BI weak decodes.
 
 use alloc::vec;
-use alloc::vec::Vec;
 
 use core::f32::consts::PI;
 #[cfg(not(feature = "std"))]
@@ -478,12 +477,6 @@ pub fn bit_metrics_from_audio(
 ) -> [f32; N_SYMBOLS] {
     let (idat, qdat) = super::baseband::decimate_to_baseband(audio);
     bit_metrics_from_baseband(&idat, &qdat, f0_audio_hz, lag_audio, drift_hz)
-}
-
-#[allow(dead_code)]
-fn _silence_unused_imports() {
-    let _ = vec![0u8];
-    let _: Vec<u8> = Vec::new();
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Follow-up to #297's layer sweep — checked the crate for other
`demod_bb`-style stale cleanup debt (self-documented "remove/narrow
this once X happens" comments where X already happened). Two real
findings:

1. **`wspr/demod.rs::_silence_unused_imports`** — dead scaffolding.
   Its only purpose was keeping `use alloc::vec::Vec;` "used" to
   dodge an unused-import warning; the function itself was never
   called from anywhere, and `Vec` had no other reference in the
   file (only `vec!`, a separate macro import, is genuinely used).
   Deleted both the function and the unused import instead of the
   workaround.

2. **`engine/pipeline.rs`'s `SnrCtx` struct**: 10 sites (5 fields × the
   two `internal-testing`/not `cfg` variants) carried an
   unconditional `#[allow(dead_code)] // read once FST4's override
   lands`. Checked `fst4/decode.rs:145-152` — FST4's `snr_db`
   override already reads all five fields, so the comment was stale.
   The unconditional allow was also over-broad: these fields are
   only genuinely dead in a build without `fst4`, exactly mirroring
   the sibling `cand_score` field's already-correct
   `#[cfg_attr(not(feature = "ft4"), allow(dead_code))]` pattern for
   FT4. Narrowed all five to `#[cfg_attr(not(feature = "fst4"),
   allow(dead_code))]` so clippy can actually catch it if FST4's
   override ever stops reading one of these — today that regression
   would be silently masked forever, in every feature combination.

**Verified:** full merge-gate suite (428+ tests) green; clippy `-D
warnings` clean on the specific combinations this touches (ft4-only,
fst4-only, jt9-only, wspr-only, full+internal-testing — ft4-only in
particular is the one meant to newly surface a dead-code warning if
these fields ever stop being fst4-exclusive); fixed-point golden
tests (wspr/fst4/ft4) pass; fmt/doc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)