### PR TITLE
test(ft8): ratchet FT8's OSD-escalation threshold against the generic gate (issue #285)

### DIFF
--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -213,7 +213,10 @@ impl DecodeDepth {
 /// (private module), reached by bypassing [`crate::engine::FecCodec`]
 /// entirely (same root cause as issue #198). Independent
 /// implementation, independently calibrated — review both when
-/// tuning either (issue #192).
+/// tuning either (issue #285, split from #192). A test in that
+/// module (`q_ndeep3_threshold_matches_generic_gate`) asserts FT8's
+/// `Q_NDEEP3_THRESHOLD` against this function's fallback branch, so
+/// a silent divergence fails CI rather than only a doc comment.
 ///
 /// `pub` only under the `internal-testing` feature (issue #203) — no
 /// in-crate production caller (FT4/FST4 reach this gate through

--- a/mfsk-core/src/ft8/decode_block/osd_strategy.rs
+++ b/mfsk-core/src/ft8/decode_block/osd_strategy.rs
@@ -39,7 +39,11 @@
 //! (same root cause as issue #198). FT4/FST4 get their OSD escalation
 //! through [`crate::engine::pipeline::osd_escalation_gates`] instead —
 //! an independent implementation, independently calibrated. Review
-//! both when tuning either (issue #192).
+//! both when tuning either (issue #285, split from #192).
+//! [`Q_NDEEP3_THRESHOLD`]'s doc comment carries a ratchet test against
+//! `osd_escalation_gates::<Ft8>()`'s fallback-branch value so a future
+//! silent divergence fails CI instead of relying on this comment being
+//! read.
 
 #![cfg(feature = "fft-rustfft")]
 
@@ -56,6 +60,15 @@ use crate::fec::ldpc::params::Ldpc174_91Params;
 /// `q >= 18` split between `osd_decode_deep(_, 3, _)` and
 /// `osd_decode(_)` (ndeep=2), now with WSJT-X-faithful internals on
 /// both sides.
+///
+/// **Generic analog**: [`crate::engine::pipeline::osd_escalation_gates`]
+/// is FT4/FST4's equivalent gate — a `(low, high)` pair rather than
+/// this module's single threshold, structurally different but
+/// covering the same decision. They agree today (both `18` for FT8
+/// via that function's fallback branch) because neither has been
+/// retuned since the other; `tests::q_ndeep3_threshold_matches_generic_gate`
+/// below asserts it so a future silent divergence fails CI rather
+/// than waiting on someone to reread this comment (issue #285).
 const Q_NDEEP3_THRESHOLD: u32 = 18;
 
 // OSD `nharderrors` ceiling — now [`DecodeStrictness::ft8_nharderrors_max`]
@@ -261,4 +274,34 @@ pub(super) fn try_fallback(
     }
 
     None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Q_NDEEP3_THRESHOLD;
+
+    /// Issue #285: `Q_NDEEP3_THRESHOLD` and
+    /// `engine::pipeline::osd_escalation_gates`'s FT4/FST4-independent
+    /// fallback branch are two separately-tuned implementations of the
+    /// same OSD-escalation decision, with nothing keeping them in sync
+    /// beyond neither having been retuned recently. Asserting equality
+    /// here doesn't unify the mechanisms (that's the issue's "Heavier"
+    /// direction, deliberately not attempted — same WSJT-X-fidelity
+    /// regression risk as the rejected #192 proposal) — it just turns
+    /// "review both when tuning either" from a doc comment someone has
+    /// to remember to read into something CI enforces. If this ever
+    /// fails, it means one side was retuned against real WSJT-X
+    /// reference data and the other wasn't reviewed yet — go do that
+    /// review, then update whichever side is still correct to match
+    /// (or leave them intentionally different with an explanatory
+    /// comment, if the retune reveals they never should have matched).
+    #[test]
+    fn q_ndeep3_threshold_matches_generic_gate() {
+        let (_low, high) = crate::engine::pipeline::osd_escalation_gates::<crate::ft8::Ft8>();
+        assert_eq!(
+            Q_NDEEP3_THRESHOLD, high,
+            "FT8's Q_NDEEP3_THRESHOLD and the generic osd_escalation_gates \
+             fallback branch have diverged — see issue #285"
+        );
+    }
 }

--- a/mfsk-core/src/ft8/decode_block/process_candidates.rs
+++ b/mfsk-core/src/ft8/decode_block/process_candidates.rs
@@ -1804,7 +1804,11 @@ where
 /// bespoke equivalent of [`crate::msg::pipeline_ap::ap_passes`]'s
 /// `pass 7` (CQ + DX call), which FT4/FST4 reach via
 /// `msg::pipeline_ap`. Independent implementations, independently
-/// tuned — review both when adjusting either (issue #192).
+/// tuned — review both when adjusting either (issue #285, split from
+/// #192). No shared numeric threshold to ratchet-test here (unlike
+/// FT8's OSD-escalation `Q_NDEEP3_THRESHOLD`, see
+/// `ft8::decode_block::osd_strategy`) — `ap_passes` doesn't gate pass
+/// 7 on an nsync value of its own.
 #[cfg(feature = "fft-rustfft")]
 const BLIND_CQ_MIN_NSYNC: u32 = 12;
 

--- a/mfsk-core/src/msg/pipeline_ap.rs
+++ b/mfsk-core/src/msg/pipeline_ap.rs
@@ -57,7 +57,14 @@ where
 /// **FT8 analog for pass 7**: `ft8::decode_block::process_candidates`'s
 /// own blind-CQ `Pass 12` (gated by `BLIND_CQ_MIN_NSYNC`) is FT8's
 /// bespoke equivalent, independently implemented and tuned — review
-/// both when adjusting either (issue #192).
+/// both when adjusting either (issue #285, split from #192). Unlike
+/// the OSD-escalation pair (`osd_escalation_gates` /
+/// `Q_NDEEP3_THRESHOLD`), this pass has no single paired numeric
+/// threshold to ratchet-test against — `ap_passes` doesn't gate pass 7
+/// on an nsync value of its own, so there's nothing here for
+/// `BLIND_CQ_MIN_NSYNC` to be asserted equal to. Prose cross-reference
+/// only; a future retune of either still needs a human to remember
+/// this comment.
 pub(crate) fn ap_passes(base: &ApHint) -> Vec<(ApHint, u8)> {
     let mut passes = Vec::new();
     if base.call1.is_some() && base.call2.is_some() {


### PR DESCRIPTION
Picks up the "Minimal" direction from #285 (split from #192): FT8's
own OSD-escalation dispatch (`ft8::decode_block::osd_strategy`'s
`Q_NDEEP3_THRESHOLD = 18`) and the generic
`engine::pipeline::osd_escalation_gates<P>` (FT4/FST4's equivalent,
whose fallback branch for any non-FT4/FST4 protocol including FT8
also returns `18`) are two independently-tuned implementations of the
same decision, with nothing keeping them in sync beyond neither having
been retuned recently.

The issue's own citation of prior art — `tests/fst4_sweep.rs` once
copied `osd_escalation_gates`'s literals directly and the copy went
stale, fixed by exposing the real function for diagnostics to call —
suggested "shared read access, not shared logic" as the right shape.
Went one step further here since `osd_escalation_gates::<Ft8>()` is
already callable (it only requires `P: Protocol`, which `Ft8`
implements, and correctly falls through to the same `(12, 18)`
default branch FT4/FST4 don't hit): added an in-crate test asserting
`Q_NDEEP3_THRESHOLD == osd_escalation_gates::<Ft8>().1`, so a future
silent divergence fails CI instead of relying on a doc comment being
reread. **Verified the ratchet actually catches drift** (temporarily
changed the constant to `19`, confirmed the test fails with a clear
message, reverted).

Also fixed four doc comments that cross-referenced FT8's blind-CQ
pass / OSD dispatch against their FT4/FST4 generic counterparts but
still cited the now-closed `#192` instead of `#285`. Added a note on
the blind-CQ side (`BLIND_CQ_MIN_NSYNC` / `pipeline_ap::ap_passes`)
explaining why it does NOT get an equivalent ratchet: `ap_passes`'s
pass 7 has no paired numeric nsync threshold of its own to assert
equal to, unlike the OSD-escalation pair.

**Deliberately NOT attempted:** #285's "Heavier" direction (actually
reconciling the two OSD-gate shapes). The issue itself flags this as
carrying the same WSJT-X-fidelity regression risk as the #192
proposal that was rejected for exactly that reason, just with two
consumers now where #192 had one — not enough to change the risk
calculus without a concrete reason to unify beyond "the numbers
currently match."

**Verified:** full merge-gate suite (429 tests, +1 for the new
ratchet) green, isolated `--features ft8` build clean, fmt/clippy/doc
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)