### PR TITLE
chore: dead-code campaign — WorkerStack annotation + msk144 CI gap + doc note

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,6 +509,7 @@ jobs:
           - "jt9"
           - "jt65"
           - "q65"
+          - "msk144"
           - "uvpacket"
           - "alloc ft8"            # no_std + alloc baseline (TX-side host compile)
           - "alloc ft8 fft-extern" # no_std + alloc + caller-supplied FFT (RX preset)

--- a/embedded-poc/CLAUDE.md
+++ b/embedded-poc/CLAUDE.md
@@ -7,6 +7,22 @@ for the shared setup / debug list. The repo-root `CLAUDE.md` covers
 flash-and-capture conventions (`scripts/flash-monitor.sh`,
 `logs/` layout) that apply to every embedded crate here.
 
+**No continuous lint gate.** The repo-root `Cargo.toml`'s `exclude =
+["embedded-poc", ...]` keeps these crates out of the host Cargo
+workspace (they need the `+esp` toolchain, which the fast host CI
+jobs don't have), so neither the pre-commit hook's `cargo clippy
+--workspace ...` nor CI's lint-gate job (`ci.yml`'s `rustfmt +
+clippy` job) ever touches this directory — `dead_code` and every
+other lint here accumulates silently until someone manually runs
+`cargo +esp build`/`clippy` per crate (2026-08-14 dead-code sweep
+found exactly one: a stale `field is never read` in
+`embedded-shared::wspr_dual_core::WorkerStack`, fixed). Adding a CI
+job for this was considered and declined for now — same
+cost/benefit tradeoff as the tier-C sensitivity sweeps not being in
+CI (`+esp` toolchain setup, esp-idf checkout, is not cheap for a
+lightweight runner). If you're doing any kind of cleanup/audit pass
+across the repo, remember to check here too — nothing else will.
+
 ## One-time setup (already done on this machine)
 
 - `~/.rustup/toolchains/esp/` — Xtensa-fork Rust toolchain installed

--- a/embedded-poc/embedded-shared/src/wspr_dual_core.rs
+++ b/embedded-poc/embedded-shared/src/wspr_dual_core.rs
@@ -124,7 +124,14 @@ const WORKER_STACK_BYTES: usize = 81_920;
 /// pointer, and so PIE-aligned buffers placed at the bottom of a frame
 /// keep their alignment.
 #[repr(align(16))]
-struct WorkerStack([u8; WORKER_STACK_BYTES]);
+struct WorkerStack(
+    // Never read as a normal field — only its address is taken
+    // (`addr_of_mut!(WORKER_STACK) as *mut u8` below) and handed to
+    // FreeRTOS as a raw stack pointer. The field exists purely to
+    // size and align the static allocation, same shape as
+    // `engine::fft::Align16Quad` on the host side.
+    #[allow(dead_code)] [u8; WORKER_STACK_BYTES],
+);
 
 static mut WORKER_STACK: WorkerStack = WorkerStack([0; WORKER_STACK_BYTES]);
 static mut WORKER_TCB: core::mem::MaybeUninit<esp_idf_svc::sys::StaticTask_t> =


### PR DESCRIPTION
User asked to run a dead-code reduction campaign. Measured first
rather than guessing: ran clippy `-D warnings` across every isolated
feature combination in CI's build matrix (13 combos) plus `msk144`
(not in the matrix at all, see below) — **zero dead_code hits
anywhere in `mfsk-core`**. That's not a coincidence — the pre-commit
hook and CI's lint-gate job already enforce `-D warnings`
continuously, and per-feature isolation is covered by the build
matrix. Nothing left to find there beyond what this session already
fixed earlier (`jt9::demod_bb.rs` removal, `SnrCtx`'s annotation
narrowing).

**The one place with real, unenforced drift: `embedded-poc/`.** The
repo-root `Cargo.toml` excludes it from the host workspace (needs the
`+esp` toolchain), so neither the pre-commit hook nor CI's clippy job
ever compiles it — `dead_code` lint has had zero continuous
enforcement there. Built every app/bench crate with the `+esp`
toolchain to check: found exactly one warning, `field is never read`
on `embedded-shared::wspr_dual_core::WorkerStack`'s backing byte
array.

Fixed with an `#[allow(dead_code)]` annotation (not deletion) — the
field is genuinely needed for its size/alignment, only ever accessed
by taking its address (`addr_of_mut!`) and handing it to FreeRTOS as
a raw stack pointer for `xTaskCreateStaticPinnedToCore`, the same
shape as `engine::fft::Align16Quad` on the host side. Verified the
warning is gone via `m5stack-cores3-app` (the actual consumer) and
confirmed the other three real app/bench crates still build with zero
dead_code warnings.

**Also**, incidentally found while building the isolated-feature
matrix: `msk144` has no entry in `ci.yml`'s build matrix at all,
unlike every other single-protocol feature. Added it — confirmed
clean first (build + clippy `-D warnings`), so this only closes a
coverage gap.

Documented the `embedded-poc` lint-gate gap in
`embedded-poc/CLAUDE.md` so the next cleanup pass doesn't have to
rediscover it. Adding a CI job for the `+esp` toolchain was
considered and declined — same cost/benefit tradeoff as this
project's existing decision to keep the tier-C sensitivity sweeps out
of CI.

**Deliberately out of scope** (user confirmed): the 21
`unreachable_pub` hits in `mfsk-core`. Different category
(visibility, not reachability) — narrowing `pub` to `pub(crate)` is a
semver-relevant decision for a crates.io-published library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)