### PR TITLE
release: 0.10.0 — CHANGELOG catch-up, minor bump, issue-tracking refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,144 @@
 # Changelog
 
-## 0.9.2 — FT8 coarse-sync lag window matches WSJT-X (#278/#280), Q65/JT65 Δt windows + Δt regression harness (#282), early-frame decode (#283), WSPR host/embedded parity + streaming front end (#260), code-sharing audit + cleanup (#290-298), FT8/generic OSD-gate ratchet (#285)
+## 0.10.0 — search windows denominated in seconds (#282, breaking), FT8 coarse-sync lag window matches WSJT-X (#278/#280), early-frame decode (#283), WSPR host/embedded parity + streaming front end + CoreS3 standalone receiver (#260), FST4 npre1/npre2 OSD + i0±1 timing retry + rung-major scheduling (#198/#306/#308), code-sharing audit + cleanup (#290-298), FT8/generic OSD-gate ratchet (#285)
+
+**Why a minor bump.** This crate's convention is that new protocols and
+capabilities are patch-level (MSK144 shipped as `0.7.4`); minor bumps mark
+structural API change. Three public search-parameter fields change type and
+name here — `jt65::search::SearchParams::time_tolerance_symbols: u32` →
+`time_tolerance_sec: f32`, the same rename on `jt9`, and
+`q65::search::SearchParams::time_tolerance_symbols` →
+`time_tolerance_early_sec` + `time_tolerance_late_sec` — because symbols are
+not a transferable unit across sub-modes whose symbol lengths differ by 20×.
+Callers that set these must update; callers that used the defaults get
+corrected (and, for Q65 and JT65, substantially wider) windows automatically.
+Same handling as `0.8.0`, which collected its breaking changes into a minor
+rather than distributing them across patches.
+
+### Added
+
+- **A standalone WSPR receiver application for the CoreS3**
+  (`embedded-poc/m5stack-cores3-app/src/bin/wspr_app.rs`). Phase E (#260)
+  answered the decoder-level question — `wspr::ddc` exists, the steady-state
+  pipeline decodes in 82.8–90.1 s against a 110 s deadline, golden 9/9 holds
+  every slot. This is the application built on top of it: a portrait
+  240×320 spot list, band selection, WiFi with unbounded background retry,
+  an HTTP configuration server, NVS-persisted settings, NTP time sync, and
+  UDP log fanout — the last because a device that has to sit on an antenna
+  for hours can't stay tethered to a serial monitor.
+
+  Real USB audio is wired in. `uac.rs`'s reader-thread → consumer coupling
+  was generalized into an **`AudioSink` trait**, so the FT8 controller
+  (`Ft8ChunkSink`, wrapping the previous behaviour verbatim — `set_chunk_q`
+  keeps its old name and signature, so `main.rs`/`decode_pipeline.rs` needed
+  no changes) and the WSPR receiver (`WsprDdcSink`, feeding a per-slot
+  `StreamingDdcCascade`) share one USB host / class driver / hot-plug /
+  resample implementation instead of two.
+
+  **Not hardware-verified against a real UAC source** — that is issue #163,
+  which this change makes load-bearing for two applications rather than one.
+  Until a device enumerates, `UAC_AUDIO_ACTIVE` never flips and the app
+  keeps running its synthetic generator, so it stays fully functional and
+  host-independently testable with nothing plugged in. Remaining open items
+  (wall-clock slot alignment, `SpotSink::Http` never run against a real
+  wsprnet endpoint) are collected in #313.
+
+- **`wspr::ddc::StreamingDdcCascade`** and the `wspr-ddc-cascade` feature —
+  a two-stage decimator, ~4.5× less compute than the single-stage
+  `StreamingDdc` it sits beside. DDC compute occupancy measured 24.8–39.2 %
+  of the 120 s slot budget on real hardware; pointer-address logging
+  root-caused it to `DdcBufs`' taps and I/Q history (7 172 B / 9 220 B /
+  9 220 B) all exceeding `SPIRAM_MALLOC_ALWAYSINTERNAL=4096` and landing in
+  PSRAM rather than internal DRAM — a gap `StreamingDdc::new_in`'s own doc
+  comment had warned about and nothing in the tree worked around.
+
+  The fix was a from-first-principles Crochiere-Rabiner derivation rather
+  than a reaction to the benchmark number: splitting `DECIM = 32` into 8×4
+  gives stage 1 `N = 43` (loose transition, only needs to keep stage 2
+  honest) and stage 2 `N = 223` (carrying the real 27 Hz [174, 201] Hz
+  requirement, same as the single-stage design). Every resulting buffer is
+  small enough to auto-place in internal DRAM, so no manual placement API
+  was needed. Six new host tests — coherence > 0.99 against the whole-slot
+  FFT reference, out-of-band rejection, and direct agreement with the
+  single-stage implementation — alongside the original five. The two DDC
+  features are mutually exclusive (`compile_error!` in `decode_scan_inner`),
+  each with its own real-signal golden test against the WSJT-X recording.
+
+- **`engine::dsp::fir_decimate`** — the generic filter-and-decimate
+  primitive (`design_lowpass` + `FirStage`) extracted from `wspr::ddc`,
+  which carries no WSPR-specific logic. The mixer table, `REFERENCE_GAIN`
+  and the cascade tap-count constants stay in `wspr/ddc.rs`; both DDC
+  implementations now share the filter core.
+
+- **`fst4::rung_major`** — rung-major candidate scheduling for FST4
+  (#306 item 3, VK3NV), as a separate FST4-specific entry point.
+  `engine::pipeline::process_candidate_basic_impl` stays exactly as-is,
+  serving FT4/FT8/FST4/MSK144 depth-first.
+
+  Depth-first pays every rung for a candidate that never decodes before
+  moving to the next, so one hard candidate early in the list can delay
+  every easy decode after it arbitrarily far. Measured on the FST4-60
+  golden: both real signals decode at ~0.15 s / ~0.30 s *only because they
+  fall early in candidate order*; a worst-case ordering pushes them to
+  ~30 s of a 30.15 s total. Rung-major sweeps each rung across every
+  still-undecided candidate before descending, which bounds worst-case
+  time-to-first-decode to one rung's cost (~7.4 s projected for the first)
+  regardless of ordering. Total work is unchanged — only the order.
+
+  Deliberately a 5-stage, not 6-stage, ladder: a targeted ablation found
+  `llrd` contributes **exactly zero** additional recall beyond
+  `llra`/`llrb`/`llre`/`llrc` + OSD — byte-identical hit counts with and
+  without it in all four configurations tested, on both the AWGN and
+  CCIR-moderate corpora. A stage that never wins shouldn't be scheduled.
+
+  `skip_llrc` and `offsets` are caller choices rather than baked policy.
+  `offsets` in particular: #308's `i0±1` timing retry is an unconditional
+  win on host, but on real hardware porting it here unconditionally triples
+  `full` (40.102 s → 121.281 s) and more than doubles `no8_osd`
+  (13.643 s → 34.200 s) for a few recall points, so the production default
+  stays `&[0]` and a deployment that can tolerate spanning slots can opt in.
+  Folding `offsets` into cost-ordered scheduling instead of the current
+  offset-major outer loop is #310.
+
+### Fixed
+
+- **The `wspr_app` crash loop — PSRAM-backed thread stacks.** With internal
+  DRAM driven down to ~2 KB free by `wifi_driver_init`, the
+  `uac_app`/`usb_events`/`uac_reader` `std::thread` spawns all pulled their
+  stacks from that same tight pool via the ESP-IDF pthread compat layer. On
+  this `esp-idf-svc` std target a later sub-4 KiB allocation failure
+  surfaces as a genuine Rust panic, which poisons whichever `Mutex` it held;
+  the next task to touch that lock panics too. The visible symptom was a
+  double-panic crash loop whose backtrace landed on whichever task lost the
+  race to be second — i.e. never on the actual cause. `spawn_psram_thread()`
+  mirrors the existing `spawn_network_task` fix via `std::thread`'s
+  `ThreadSpawnConfiguration` hook, and all three `uac.rs` spawns route
+  through it.
+
+- **The CoreS3 LCD stayed dark end-to-end — four independent root causes**,
+  none catchable by host build, clippy or test; found over ~15
+  flash-and-observe iterations against the physical panel. (1) AXP2101
+  DLDO1, the backlight power rail, was never enabled — `pmic.rs` read the
+  chip ID as a presence check and relied on power-on defaults for every
+  rail; register readback confirmed bit `0x80` of `0x90` clear beforehand,
+  so the backlight had zero power regardless of what the LCD controller's
+  SPI logic did underneath. Cross-checked against M5Stack's own M5GFX
+  source. (2) `board.rs`'s AW9523B `LCD_RST`/`TP_RST` bits were swapped
+  versus M5GFX's verified mapping (`P1_1` is `LCD_RST`) — harmless today
+  since both are driven together, fixed for when Phase 6-Core touch needs
+  `TP_RST` alone. (3) `DrawTarget::clear()` gave partial or wrapped
+  coverage on this mipidsi/SPI setup every time it was tried. (4) The
+  display task was starved by the scan task sharing its core.
+
+- **Both FT8 controllers drove their ILI9342C panels as ILI9341** — the
+  same model bug in each, fixed in both.
+
+- **WiFi bring-up on the CoreS3**: STA connect now retries on association
+  refusal with a full rescan-and-reconfigure rather than giving up, power
+  save is disabled, and the `httpd` task stack moved to PSRAM. The
+  DHCP-silent symptom that prompted the investigation was confirmed
+  router-side, not a defect in this crate — recorded so it isn't
+  re-investigated here.
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,13 @@ FT8-controller line above** — it never goes through `decode_block` or
 the UAC/controller stack, so it isn't blocked on #163 the way Phase
 B-Core is (both share #163 only for live audio capture; everything
 else already works against WAV-fed/synthetic baseband). Lives in the
-same `m5stack-cores3-app` crate as a separate `src/bin/wspr_bench.rs`
-binary. See `docs/reference/EMBEDDED.md`'s "WSPR on embedded" section
-and `docs/notes/ROADMAP.md` Phase E for status.
+same `m5stack-cores3-app` crate as two separate binaries:
+`src/bin/wspr_bench.rs` (timing measurement) and `src/bin/wspr_app.rs`
+(the standalone receiver — LCD spot list, WiFi, HTTP config, NTP, and
+real UAC audio through `AudioSink`). Note that `wspr_app` *does* now
+share `uac.rs` with the FT8 line, so it shares #163 for that path too
+— open items in #313. See `docs/reference/EMBEDDED.md`'s "WSPR on
+embedded" section and `docs/notes/ROADMAP.md` Phase E for status.
 
 - **Build & flash via `espflash`**, not host cargo. Both crates'
   `.cargo/config.toml` set `runner = "espflash flash --monitor"`, so the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,4 +21,4 @@ resolver = "2"
 # CHANGELOG). `release.yml`'s tag-vs-Cargo.toml check reads this
 # field directly.
 [workspace.package]
-version = "0.9.1"
+version = "0.10.0"

--- a/docs/notes/ROADMAP.md
+++ b/docs/notes/ROADMAP.md
@@ -339,7 +339,7 @@ to a 0.7.x design pass.
 
 ### Open follow-ups
 
-Currently open GitHub issues (state:open as of 2026-08-15, verified
+Currently open GitHub issues (state:open as of 2026-08-17, verified
 directly against the GitHub API — this is the live worklist; if you're
 reading this file to decide what to work on next, trust this section
 over any recall numbers or hardware status stated elsewhere in it).
@@ -347,14 +347,68 @@ Grouped by the three tracks in **Strategic state** above.
 
 **Embedded (frontier):**
 
-- **#163** — CoreS3 Phase 1-Verify: live IC-705 hardware RX
-  confirmation. **The bottleneck for the entire Phase B-Core line** —
-  the UAC host code compiles clean but has never run against real
-  hardware, and there's been no cores3-app feature commit since
-  2026-06-07. Everything downstream (Phase 1.5 / 2 / 5 / 6 / 7-Core) is
-  sequenced behind it. A human-at-the-bench task (1500 Hz tone injection
-  → PCM reaches the pipeline → FT8 candidate in the decoded list → live
-  antenna). See **Phase B-Core** below.
+- **#163** — CoreS3 Phase 1-Verify: live UAC hardware RX confirmation.
+  **The bottleneck for the entire Phase B-Core line** — the UAC host
+  code compiles clean but has never run against real hardware.
+  Everything downstream (Phase 1.5 / 2 / 5 / 6 / 7-Core) is sequenced
+  behind it. A human-at-the-bench task (tone injection → PCM reaches
+  the pipeline → candidate in the decoded list → live antenna). See
+  **Phase B-Core** below.
+
+  Two things changed 2026-08-16/17. The `AudioSink` refactor means the
+  FT8 controller and the WSPR receiver now share one unverified UAC
+  path, so this blocks **two** applications rather than one. But the
+  first checkpoint got easier: any UAC audio source will do, and the
+  WSPR app is an independent second route that needs neither a QSO
+  partner nor a band opening to produce a decode.
+
+- **#313** — CoreS3 WSPR standalone app, open items left after #260
+  closed: no wall-clock slot alignment on the real-audio path (needs
+  the NTP-fed `time_sync` hook; `uac.rs` still cites the stale `#32`/
+  `#34` numbers for it), `SpotSink::Http` never run against a real
+  wsprnet endpoint, and the two-stage DDC decimation that was deferred
+  rather than rejected.
+
+- **#306** — FST4 on ESP32-S3: embedded feasibility. The umbrella, and
+  the most active thread in the repo (VK3NV). Status as of 2026-08-17:
+  the candidate loop measures **40.102 s** (`full`) / **13.643 s**
+  (`no8_osd`) on real CoreS3 hardware over 41 candidates, against
+  FST4-60's ~7 s margin — **not fitting yet, but quantified**, and down
+  from ~13× over at the first measurement. Decoder-only figures: the
+  bench routes around all three FFT sites and is fed host-baked
+  baseband, so an end-to-end receiver still needs #307 or #309. The two
+  live levers are breadth (#312) and depth (#310).
+
+- **#310** — fold `rung_major`'s `offsets` into cost-ordered scheduling
+  instead of an offset-major outer loop. The active next work item.
+  Its real subject is the worst-case **time-to-first-decode** bound
+  (~7.4 s for the first rung, ordering-independent), not the 1.26×
+  total-time improvement. Embedded currently gets zero timing
+  diversity — every caller passes `&[0]`.
+
+- **#312** — FST4 sniper: `max_cand = 50` binds before the search
+  window width does, so narrowing the window changes nothing on the
+  production path today. Sweep the cap as a *retained fraction* across
+  ±25/50/100/250 Hz; leave `sync_min` alone first. Strong-signal
+  golden only so far — a near-threshold sweep gates any default change.
+
+- **#307** — `engine::fft` has no generic non-power-of-2 FFT.
+  `coarse_sync`'s `nfft1` is non-power-of-two for all five FST4
+  sub-modes and needs this regardless; `downsample_cached`'s
+  `fft1_size` can be solved by this *or* by #309. VK3NV's 7776 → two
+  exact 1944-point transforms derivation keeps FST4-15/30/60 under the
+  configured 8192 ESP-DSP ceiling without a Kconfig change.
+
+- **#309** — FST4-120/300 will need a streaming DDC: FST4-120's
+  whole-slot FFT buffer (~11 MiB) is essentially the scale that blocked
+  WSPR, and FST4-300 (~32 MiB) is worse. `wspr::ddc` is the template.
+  Not on any current roadmap phase — filed so the comparison isn't
+  rediscovered.
+
+- **#311** — 3 of 5 CCIR-moderate trials that the unpruned OSD search
+  decoded and the npre1/npre2 port does not remain unexplained after
+  #308's timing fix recovered the other 2. A real `npre2`-pruning
+  question, split out of #308 so it didn't close with it.
 
 **Host DSP / protocol (maturity — tail, not frontier):**
 
@@ -441,6 +495,17 @@ both survive as separate decodes, fixed same-day by scaling the
 window to `(2 × TONE_SPACING_HZ).max(4.0)`. Also closed 2026-08-14,
 not a GitHub issue: a code-sharing audit (#290-298) — see *Strategic
 state*, track 1, for the full account.
+
+Closed since the 2026-08-15 snapshot: **#308** — FST4 had no
+equivalent of WSJT-X's `i0±1` timing-jitter retry
+(`fst4_decode.f90`'s `ijitter ∈ {0, +1, -1}`); ported to
+`engine::pipeline` for FST4 at OSD depth, recovering 2 of the 5
+CCIR-moderate trials the npre1/npre2 OSD port had lost, closed
+2026-08-17. The other two halves of that issue were split out rather
+than closed with it — the remaining 3/5 pruning question to **#311**,
+and the embedded scheduling/cost half to **#310**, since the retry
+triples the real-hardware candidate loop if ported unconditionally
+and every embedded caller therefore still passes `&[0]`.
 
 Closed since the 2026-05-18 snapshot (see the closed issue / `git
 log` for the fix commit, not re-derived here):

--- a/embedded-poc/mfsk-app-shared/src/ui/wspr_row.rs
+++ b/embedded-poc/mfsk-app-shared/src/ui/wspr_row.rs
@@ -103,7 +103,11 @@ mod tests {
         };
         let mut buf = heapless::String::new();
         row.format_row(&mut buf);
-        assert!(buf.len() <= 40, "line too wide for the panel: {buf:?} ({} chars)", buf.len());
+        assert!(
+            buf.len() <= 40,
+            "line too wide for the panel: {buf:?} ({} chars)",
+            buf.len()
+        );
         assert!(buf.starts_with("1234 <PJ4/K1A PM95"), "{buf}");
     }
 }

--- a/mfsk-core/Cargo.toml
+++ b/mfsk-core/Cargo.toml
@@ -206,7 +206,16 @@ q65          = ["fft-rustfft"]
 # uvpacket pulls in fst4 because it reuses the Ldpc240_101 codec
 # whose `Wsjt77Message::verify_info` length-dispatch logic (CRC-24
 # vs CRC-14) is wired through fst4's path.
-uvpacket     = ["fst4"]
+#
+# `std` is declared explicitly rather than inherited: `uvpacket` reaches
+# for `std::f32::consts::PI` and std's prelude (`Vec`, `vec!`) throughout
+# `tx.rs`/`rx.rs`/`interleaver.rs`/`puncture.rs`. It used to get `std` for
+# free through the old `fst4 = ["fft-rustfft"]` grouping, which `aa59720`
+# correctly removed — leaving this feature depending on a transitive it
+# never declared, and `--features uvpacket` alone unbuildable. Making
+# uvpacket genuinely no_std-capable is separate, deliberate work; nothing
+# under `embedded-poc/` references it today.
+uvpacket     = ["fst4", "std"]
 parallel     = ["std", "dep:rayon"]
 
 # Test-only visibility escape hatch (issue #203). `core::pipeline`'s

--- a/mfsk-core/src/engine/dsp/fir_decimate.rs
+++ b/mfsk-core/src/engine/dsp/fir_decimate.rs
@@ -81,7 +81,7 @@ impl FirStage {
     /// `ntaps` must be odd (linear phase, integer group delay).
     /// `fc_norm` is the lowpass cutoff normalised to this stage's
     /// *input* sample rate. `hist_margin` sets how many input samples
-    /// accumulate between [`Self::compact`] calls — larger amortises
+    /// accumulate between `compact` calls — larger amortises
     /// the compaction copy further at the cost of a bigger buffer; see
     /// the caller for the tradeoff against a specific memory budget.
     pub fn new(ntaps: usize, decim: usize, fc_norm: f32, hist_margin: usize) -> Self {

--- a/mfsk-core/src/fec/ldpc/osd.rs
+++ b/mfsk-core/src/fec/ldpc/osd.rs
@@ -1951,7 +1951,8 @@ const OSD_NPRE_WORDS: usize = OSD_NPRE_MAX_N.div_ceil(64); // 4
 ///   equivalent); `true` adds the `npre2` hash-table pass (`ndeep=3`
 ///   equivalent).
 ///
-/// Algorithm identical to [`osd_npre1_pass`]/[`osd_npre2_pass`]
+/// Algorithm identical to `osd_npre1_pass`/`osd_npre2_pass` (both
+/// crate-private, hence unlinked here)
 /// otherwise; only the working-buffer shapes are runtime-sized
 /// (`OSD_NPRE_MAX_N`-bounded) to accommodate any `LdpcParams` instead of
 /// being pinned to `LDPC_N`/`LDPC_K`.

--- a/mfsk-core/src/fec/ldpc240_101/mod.rs
+++ b/mfsk-core/src/fec/ldpc240_101/mod.rs
@@ -21,7 +21,9 @@ use crate::fec::ldpc::bp::{
     BpScratch, bp_decode_generic_kind, bp_decode_generic_kind_with_scratch, bp_llr_zsum,
     bp_llr_zsum_with_scratch,
 };
-use crate::fec::ldpc::osd::{OsdResult, ldpc_encode_generic, osd_decode_generic, osd_decode_npre_generic};
+use crate::fec::ldpc::osd::{
+    OsdResult, ldpc_encode_generic, osd_decode_generic, osd_decode_npre_generic,
+};
 use crate::fec::ldpc::params::Ldpc240_101Params;
 
 pub const LDPC_N: usize = 240;
@@ -145,11 +147,7 @@ pub fn fst4_osd_diag_force_old(force_old: bool) {
 /// FST4's OSD dispatch: WSJT-X-faithful `npre1`/`npre1+npre2` for
 /// `ndeep` 2/3 (see module-level doc comment above), falling back to
 /// [`osd_decode_generic`] for any other depth.
-fn fst4_osd_decode(
-    llr: &[f32],
-    ndeep: u8,
-    verify: Option<fn(&[u8]) -> bool>,
-) -> Option<OsdResult> {
+fn fst4_osd_decode(llr: &[f32], ndeep: u8, verify: Option<fn(&[u8]) -> bool>) -> Option<OsdResult> {
     #[cfg(feature = "internal-testing")]
     let use_npre = !OSD_DIAG_FORCE_OLD.load(core::sync::atomic::Ordering::Relaxed);
     #[cfg(not(feature = "internal-testing"))]
@@ -176,9 +174,7 @@ fn fst4_osd_decode_dispatch(
         return osd_decode_generic::<Ldpc240_101Params>(llr, ndeep, LDPC_K, verify, false);
     }
     match ndeep {
-        2 => {
-            osd_decode_npre_generic::<Ldpc240_101Params>(llr, FST4_NPRE_NTHETA, 0, false, verify)
-        }
+        2 => osd_decode_npre_generic::<Ldpc240_101Params>(llr, FST4_NPRE_NTHETA, 0, false, verify),
         3 => osd_decode_npre_generic::<Ldpc240_101Params>(
             llr,
             FST4_NPRE_NTHETA,
@@ -260,8 +256,7 @@ impl FecCodec for Ldpc240_101 {
         // those bits away from their hinted value.
         if ap_slice.is_none() {
             let zsum = bp_llr_zsum::<Ldpc240_101Params>(&llr_arr, 2);
-            if let Some(r) = fst4_osd_decode(&zsum, opts.osd_depth.min(3) as u8, opts.verify_info)
-            {
+            if let Some(r) = fst4_osd_decode(&zsum, opts.osd_depth.min(3) as u8, opts.verify_info) {
                 return Some(FecResult {
                     info: r.info,
                     hard_errors: r.hard_errors,

--- a/mfsk-core/src/fst4/mod.rs
+++ b/mfsk-core/src/fst4/mod.rs
@@ -138,6 +138,12 @@ macro_rules! fst4_submode {
         #[derive(Copy, Clone, Debug, Default)]
         pub struct $name;
 
+        // `fst4::baseline::fst4_snr_db` is this constant's only consumer
+        // and is itself gated on the FFT meta-feature, so the constant
+        // carries the same gate — otherwise a TX-only `--features fst4`
+        // build trips `dead_code` under CI's `-D warnings` (once per
+        // sub-mode).
+        #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
         impl $name {
             /// `fst4_decode.f90`'s `select case (ntrperiod)` constant
             /// feeding [`crate::fst4::baseline::fst4_snr_db`]'s `arg =

--- a/mfsk-core/src/fst4/mod.rs
+++ b/mfsk-core/src/fst4/mod.rs
@@ -53,10 +53,24 @@ use crate::engine::{FrameLayout, ModulationParams, Protocol, ProtocolId, SyncBlo
 use crate::fec::Ldpc240_101;
 use crate::msg::Wsjt77Message;
 
+// Decode-side modules route through `engine::fft`'s trait and the shared
+// `engine::pipeline`, both of which are gated on the FFT meta-feature — so
+// these have to carry the same gate or `--features fst4` alone (the
+// feature matrix's TX-only single-protocol build) can't compile. `encode`
+// stays available without any FFT backend, same split `ft8`/`wspr` use.
+//
+// Note this is *not* the `fft-rustfft` requirement `aa59720` correctly
+// removed: FST4's decode path is FFT-backend-agnostic and works fine on
+// `fft-extern`. It needs *some* backend, not that specific one.
+#[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub(crate) mod baseline;
+#[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub mod decode;
 pub mod encode;
-#[cfg(feature = "internal-testing")]
+#[cfg(all(
+    feature = "internal-testing",
+    any(feature = "fft-rustfft", feature = "fft-extern")
+))]
 pub mod rung_major;
 
 /// FST4's 77-bit pre-LDPC scrambler — identical to [`crate::ft4::FT4_RVEC`]

--- a/mfsk-core/src/fst4/rung_major.rs
+++ b/mfsk-core/src/fst4/rung_major.rs
@@ -88,7 +88,9 @@ use alloc::vec::Vec;
 
 use num_complex::Complex32;
 
-use super::super::engine::llr::{compute_llr_fast, compute_llr_partial, descramble_info, symbol_spectra, sync_quality};
+use super::super::engine::llr::{
+    compute_llr_fast, compute_llr_partial, descramble_info, symbol_spectra, sync_quality,
+};
 use super::super::engine::pipeline::{DecodeResult, osd_escalation_gates};
 use super::super::engine::protocol::{BpPooledFec, FecOpts, MessageCodec, Protocol};
 use super::super::engine::sync::SyncCandidate;
@@ -142,7 +144,10 @@ pub struct RungMajorCandidate {
 /// wall-clock/scheduling question, not the SNR-reporting one. Callers
 /// that need real SNR should re-derive it from the returned candidate
 /// positions the way `process_candidate_basic` already does.
-pub fn decode_rung_major<P>(candidates: &[RungMajorCandidate], skip_llrc: bool) -> Vec<Option<DecodeResult>>
+pub fn decode_rung_major<P>(
+    candidates: &[RungMajorCandidate],
+    skip_llrc: bool,
+) -> Vec<Option<DecodeResult>>
 where
     P: Protocol,
     P::Fec: BpPooledFec,
@@ -189,11 +194,14 @@ where
     P: Protocol,
     P::Fec: BpPooledFec,
 {
-    assert!(!offsets.is_empty(), "decode_rung_major_timed: offsets must be non-empty");
+    assert!(
+        !offsets.is_empty(),
+        "decode_rung_major_timed: offsets must be non-empty"
+    );
 
-    let nsym_mid = P::LLR_NSYM_MID.expect(
-        "decode_rung_major is FST4-specific: P::LLR_NSYM_MID must be set (see module doc)",
-    ) as usize;
+    let nsym_mid = P::LLR_NSYM_MID
+        .expect("decode_rung_major is FST4-specific: P::LLR_NSYM_MID must be set (see module doc)")
+        as usize;
     let nsym_max = P::LLR_NSYM_MAX as usize;
     let ds_rate = 12_000.0 / P::NDOWN as f32;
     let tx_start = P::TX_START_OFFSET_S;
@@ -328,25 +336,29 @@ where
             match substage {
                 0 => {
                     off.llra = compute_llr_fast::<P, f32>(&off.cs).llra;
-                    if let Some(r) = fec.decode_soft_pooled(&off.llra, &bp_opts(0), &mut bp_scratch) {
+                    if let Some(r) = fec.decode_soft_pooled(&off.llra, &bp_opts(0), &mut bp_scratch)
+                    {
                         st.decoded = Some(build_result::<P>(r, st.input, i0, ds_rate, tx_start, 0));
                     }
                 }
                 1 => {
                     off.llrb = compute_llr_partial::<P, f32, f32>(&off.cs, 2);
-                    if let Some(r) = fec.decode_soft_pooled(&off.llrb, &bp_opts(0), &mut bp_scratch) {
+                    if let Some(r) = fec.decode_soft_pooled(&off.llrb, &bp_opts(0), &mut bp_scratch)
+                    {
                         st.decoded = Some(build_result::<P>(r, st.input, i0, ds_rate, tx_start, 1));
                     }
                 }
                 2 => {
                     off.llre = compute_llr_partial::<P, f32, f32>(&off.cs, nsym_mid);
-                    if let Some(r) = fec.decode_soft_pooled(&off.llre, &bp_opts(0), &mut bp_scratch) {
+                    if let Some(r) = fec.decode_soft_pooled(&off.llre, &bp_opts(0), &mut bp_scratch)
+                    {
                         st.decoded = Some(build_result::<P>(r, st.input, i0, ds_rate, tx_start, 6));
                     }
                 }
                 3 => {
                     off.llrc = compute_llr_partial::<P, f32, f32>(&off.cs, nsym_max);
-                    if let Some(r) = fec.decode_soft_pooled(&off.llrc, &bp_opts(0), &mut bp_scratch) {
+                    if let Some(r) = fec.decode_soft_pooled(&off.llrc, &bp_opts(0), &mut bp_scratch)
+                    {
                         st.decoded = Some(build_result::<P>(r, st.input, i0, ds_rate, tx_start, 2));
                     }
                 }
@@ -364,14 +376,17 @@ where
                     }
                     let mut hit: Option<crate::engine::protocol::FecResult> = None;
                     for llr in variants {
-                        if let Some(r) = fec.decode_soft_pooled(llr, &bp_opts(osd_depth), &mut bp_scratch) {
+                        if let Some(r) =
+                            fec.decode_soft_pooled(llr, &bp_opts(osd_depth), &mut bp_scratch)
+                        {
                             hit = Some(r);
                             break;
                         }
                     }
                     if let Some(r) = hit {
                         let pass = if skip_llrc { 4 } else { 5 };
-                        st.decoded = Some(build_result::<P>(r, st.input, i0, ds_rate, tx_start, pass));
+                        st.decoded =
+                            Some(build_result::<P>(r, st.input, i0, ds_rate, tx_start, pass));
                     }
                 }
                 _ => unreachable!(),

--- a/mfsk-core/src/wspr/ddc.rs
+++ b/mfsk-core/src/wspr/ddc.rs
@@ -409,11 +409,20 @@ pub struct StreamingDdcCascade {
 
 impl StreamingDdcCascade {
     pub fn new() -> Self {
-        assert_eq!(CASCADE_DECIM1 * CASCADE_DECIM2, DECIM, "cascade decimation must match DECIM");
+        assert_eq!(
+            CASCADE_DECIM1 * CASCADE_DECIM2,
+            DECIM,
+            "cascade decimation must match DECIM"
+        );
         Self {
             mixer: mixer_table(),
             n_in: 0,
-            stage1: FirStage::new(CASCADE_N1, CASCADE_DECIM1, 700.0 / AUDIO_RATE_HZ, CASCADE_HIST_MARGIN),
+            stage1: FirStage::new(
+                CASCADE_N1,
+                CASCADE_DECIM1,
+                700.0 / AUDIO_RATE_HZ,
+                CASCADE_HIST_MARGIN,
+            ),
             stage2: FirStage::new(
                 CASCADE_N2,
                 CASCADE_DECIM2,

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -1342,8 +1342,7 @@ fn fst4_60_diag_npre1_pattern_counts() {
         // One LLR variant is enough for a scale estimate -- `llra`
         // (nsym=1), matching the cheapest variant OSD is tried on
         // first in production.
-        if let Some((ntotal, npostgate)) =
-            npre1_pattern_counts::<Ldpc240_101Params>(&llr_set.llra)
+        if let Some((ntotal, npostgate)) = npre1_pattern_counts::<Ldpc240_101Params>(&llr_set.llra)
         {
             eprintln!(
                 "cand freq={:.1} nsync={nsync}: npre1 ntotal={ntotal} npostgate={npostgate} \
@@ -1689,7 +1688,8 @@ fn recall_tradeoff_for_channel(channel: &str, snr_tags: &'static [(&'static str,
     // deterministic per trial index), so this only adds statistical
     // power, it doesn't change what was already measured.
     let dir = sweep_dir();
-    let (osd_attempt_min, osd_depth3_min) = mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
 
     #[derive(Default, Clone, Copy)]
     struct Tally {
@@ -1863,15 +1863,21 @@ fn recall_tradeoff_for_channel(channel: &str, snr_tags: &'static [(&'static str,
             }
         }
 
-        (snr_idx, trial, ok_full, ok_bp_only, ok_no8_osd, ok_no8_no_osd)
+        (
+            snr_idx,
+            trial,
+            ok_full,
+            ok_bp_only,
+            ok_no8_osd,
+            ok_no8_no_osd,
+        )
     };
 
     #[cfg(feature = "parallel")]
     let results: Vec<(usize, u32, bool, bool, bool, bool)> =
         work.par_iter().map(process_one).collect();
     #[cfg(not(feature = "parallel"))]
-    let results: Vec<(usize, u32, bool, bool, bool, bool)> =
-        work.iter().map(process_one).collect();
+    let results: Vec<(usize, u32, bool, bool, bool, bool)> = work.iter().map(process_one).collect();
 
     // Sanity: `full ⊇ no8_osd ⊇ no8_no_osd` and `full ⊇ bp_only` must hold
     // per-*trial*, not just in the aggregate counts — a bookkeeping bug
@@ -1885,7 +1891,9 @@ fn recall_tradeoff_for_channel(channel: &str, snr_tags: &'static [(&'static str,
     for &(idx, trial, full, bp_only, no8_osd, no8_no_osd) in &results {
         let tag = snr_tags[idx].0;
         if !full && (bp_only || no8_osd || no8_no_osd) {
-            eprintln!("MONOTONICITY VIOLATION {tag}_{trial:02}: full=false but a reduced config succeeded");
+            eprintln!(
+                "MONOTONICITY VIOLATION {tag}_{trial:02}: full=false but a reduced config succeeded"
+            );
             violations += 1;
         }
         if bp_only && !full {
@@ -2093,7 +2101,10 @@ fn fst4_60_diag_npre_osd_recall_verify() {
                 pass += 1;
             }
         }
-        println!("{snr_tag}: {pass}/{total} ({:.0}%)", 100.0 * pass as f64 / total.max(1) as f64);
+        println!(
+            "{snr_tag}: {pass}/{total} ({:.0}%)",
+            100.0 * pass as f64 / total.max(1) as f64
+        );
     }
 }
 
@@ -2165,9 +2176,9 @@ fn fst4_60_diag_npre_osd_ccir_trial_probe() {
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
     use mfsk_core::engine::sync::coarse_sync;
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::engine::{MessageCodec, Protocol};
     use mfsk_core::fec::ldpc::osd::{osd_decode_generic, osd_decode_npre_generic};
     use mfsk_core::fec::ldpc::params::Ldpc240_101Params;
-    use mfsk_core::engine::{MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -2181,7 +2192,10 @@ fn fst4_60_diag_npre_osd_ccir_trial_probe() {
     let verify_info =
         Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
 
-    for c in cands.iter().filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ) {
+    for c in cands
+        .iter()
+        .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+    {
         let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
         let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
         if sum2 > f32::EPSILON {
@@ -2206,7 +2220,8 @@ fn fst4_60_diag_npre_osd_ccir_trial_probe() {
             let ord1 = osd_decode_generic::<Ldpc240_101Params>(llr, 1, 101, verify_info, false);
             let ord2 = osd_decode_generic::<Ldpc240_101Params>(llr, 2, 101, verify_info, false);
             let ord3 = osd_decode_generic::<Ldpc240_101Params>(llr, 3, 101, verify_info, false);
-            let npre1 = osd_decode_npre_generic::<Ldpc240_101Params>(llr, 12, 0, false, verify_info);
+            let npre1 =
+                osd_decode_npre_generic::<Ldpc240_101Params>(llr, 12, 0, false, verify_info);
             let npre12 =
                 osd_decode_npre_generic::<Ldpc240_101Params>(llr, 12, 14, true, verify_info);
             println!(
@@ -2275,7 +2290,9 @@ fn fst4_60_diag_npre_osd_bug_hunt_ccir_moderate() {
 /// the channel name and the (SNR tag, trial count) grid is identical.
 fn nsym_depth_sweep_for_channel(channel: &str, snr_tags: &[(&str, u32)]) {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
-    use mfsk_core::engine::llr::{compute_llr_fast, compute_llr_partial, symbol_spectra, sync_quality};
+    use mfsk_core::engine::llr::{
+        compute_llr_fast, compute_llr_partial, symbol_spectra, sync_quality,
+    };
     use mfsk_core::engine::sync::coarse_sync;
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
@@ -2330,7 +2347,10 @@ fn nsym_depth_sweep_for_channel(channel: &str, snr_tags: &[(&str, u32)]) {
 
         let mut outcome = [MISS; 5];
 
-        for c in cands.iter().filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ) {
+        for c in cands
+            .iter()
+            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+        {
             let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
             let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
             if sum2 > f32::EPSILON {
@@ -2375,7 +2395,11 @@ fn nsym_depth_sweep_for_channel(channel: &str, snr_tags: &[(&str, u32)]) {
             // golden message that's the outcome to report, even if a
             // different variant landed a false positive first.
             let best = |variants: &[&Vec<f32>], opts: &FecOpts| -> u8 {
-                variants.iter().map(|llr| classify(llr, opts)).max().unwrap_or(MISS)
+                variants
+                    .iter()
+                    .map(|llr| classify(llr, opts))
+                    .max()
+                    .unwrap_or(MISS)
             };
 
             for (i, &cap) in CAPS.iter().enumerate() {
@@ -2433,7 +2457,9 @@ fn nsym_depth_sweep_for_channel(channel: &str, snr_tags: &[(&str, u32)]) {
         }
     }
 
-    eprintln!("FST4-60 {channel} nsym-depth sweep (cap in {{1,2,4,6,8}}, OSD on for all) -- correct/false-positive:");
+    eprintln!(
+        "FST4-60 {channel} nsym-depth sweep (cap in {{1,2,4,6,8}}, OSD on for all) -- correct/false-positive:"
+    );
     eprintln!(
         "{:>6} {:>10} {:>10} {:>10} {:>10} {:>10} {:>5}",
         "SNR", "cap=1", "cap=2", "cap=4", "cap=6", "cap=8", "n"
@@ -2676,7 +2702,9 @@ fn fst4_60_diag_rung_major_scheduling() {
     use std::time::{Duration, Instant};
 
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
-    use mfsk_core::engine::llr::{compute_llr_fast, compute_llr_partial, symbol_spectra, sync_quality};
+    use mfsk_core::engine::llr::{
+        compute_llr_fast, compute_llr_partial, symbol_spectra, sync_quality,
+    };
     use mfsk_core::engine::sync::coarse_sync;
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
@@ -2712,13 +2740,22 @@ fn fst4_60_diag_rung_major_scheduling() {
     let raw_candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
     let refined: Vec<_> = raw_candidates
         .iter()
-        .map(|c| mfsk_core::engine::pipeline::refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
+        .map(|c| {
+            mfsk_core::engine::pipeline::refine_candidate_position::<Fst4s60>(
+                c,
+                &fft_cache,
+                &FST4_60A_DOWNSAMPLE,
+            )
+        })
         .collect();
     let freq_tol = 0.10 * FST4_60A_DOWNSAMPLE.tone_spacing_hz;
     const I0_TOL: i32 = 2;
     let mut order: Vec<usize> = (0..raw_candidates.len()).collect();
     order.sort_by(|&a, &b| {
-        refined[b].3.partial_cmp(&refined[a].3).unwrap_or(std::cmp::Ordering::Equal)
+        refined[b]
+            .3
+            .partial_cmp(&refined[a].3)
+            .unwrap_or(std::cmp::Ordering::Equal)
     });
     let mut kept_positions: Vec<(f32, i32)> = Vec::new();
     let mut survivors: Vec<usize> = Vec::new();
@@ -2733,7 +2770,10 @@ fn fst4_60_diag_rung_major_scheduling() {
         }
     }
     survivors.sort_unstable();
-    let cands: Vec<_> = survivors.iter().map(|&i| raw_candidates[i].clone()).collect();
+    let cands: Vec<_> = survivors
+        .iter()
+        .map(|&i| raw_candidates[i].clone())
+        .collect();
     eprintln!(
         "{} raw candidates -> {} refined+deduped (matches fst4_bench's baked asset)",
         raw_candidates.len(),
@@ -2917,7 +2957,10 @@ fn fst4_60_diag_rung_major_scheduling() {
     // depth-first schedule with the two decoding candidates moved to
     // the *end* of the list instead, as the honest worst case
     // depth-first's own ordering-dependence can produce.
-    let mut worst_order: Vec<&CandTiming> = timings.iter().filter(|c| !c.ok.iter().any(|&o| o)).collect();
+    let mut worst_order: Vec<&CandTiming> = timings
+        .iter()
+        .filter(|c| !c.ok.iter().any(|&o| o))
+        .collect();
     worst_order.extend(timings.iter().filter(|c| c.ok.iter().any(|&o| o)));
     eprintln!("\ndepth-first order, worst case (decoding candidates moved last):");
     let mut cum = 0.0f64;
@@ -2938,7 +2981,9 @@ fn fst4_60_diag_rung_major_scheduling() {
             );
         }
     }
-    eprintln!("  worst-case depth-first total: {cum:.3}s (same total work, all decodes deferred to the end)");
+    eprintln!(
+        "  worst-case depth-first total: {cum:.3}s (same total work, all decodes deferred to the end)"
+    );
 
     // ---- Rung-major cumulative timeline ----
     eprintln!("\nrung-major order (nsym=1 across all, then nsym=2 across all, ...):");
@@ -2962,10 +3007,14 @@ fn fst4_60_diag_rung_major_scheduling() {
             }
         }
         for (idx, freq_hz) in newly_decoded {
-            eprintln!("  candidate #{idx:2} ({freq_hz:7.1} Hz) decoded at t={cum:7.3}s (cumulative, end of rung {r})");
+            eprintln!(
+                "  candidate #{idx:2} ({freq_hz:7.1} Hz) decoded at t={cum:7.3}s (cumulative, end of rung {r})"
+            );
         }
     }
-    eprintln!("  rung-major total: {cum:.3}s (must equal depth-first total -- same total work, different order)");
+    eprintln!(
+        "  rung-major total: {cum:.3}s (must equal depth-first total -- same total work, different order)"
+    );
 }
 
 /// Ablation: does `llrd` (normalised nsym=1 — tried *last* in
@@ -3047,7 +3096,10 @@ fn stage_ablation_for_channel(channel: &str) {
 
         let mut ok = [false; 4];
 
-        for c in cands.iter().filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ) {
+        for c in cands
+            .iter()
+            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+        {
             let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
             let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
             if sum2 > f32::EPSILON {
@@ -3083,7 +3135,8 @@ fn stage_ablation_for_channel(channel: &str) {
                 if ok[i] {
                     continue;
                 }
-                let mut variants: Vec<&Vec<f32>> = vec![&llr_set.llra, &llr_set.llrb, &llr_set.llre];
+                let mut variants: Vec<&Vec<f32>> =
+                    vec![&llr_set.llra, &llr_set.llrb, &llr_set.llre];
                 if keep_llrc {
                     variants.push(&llr_set.llrc);
                 }
@@ -3190,12 +3243,20 @@ fn fst4_60_diag_decode_rung_major_correctness() {
     let freq_tol = 0.10 * FST4_60A_DOWNSAMPLE.tone_spacing_hz;
     const I0_TOL: i32 = 2;
     let mut order: Vec<usize> = (0..raw.len()).collect();
-    order.sort_by(|&a, &b| refined[b].3.partial_cmp(&refined[a].3).unwrap_or(std::cmp::Ordering::Equal));
+    order.sort_by(|&a, &b| {
+        refined[b]
+            .3
+            .partial_cmp(&refined[a].3)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let mut kept: Vec<(f32, i32)> = Vec::new();
     let mut survivors: Vec<usize> = Vec::new();
     for idx in order {
         let (_, f, i0, _) = &refined[idx];
-        if !kept.iter().any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL) {
+        if !kept
+            .iter()
+            .any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL)
+        {
             kept.push((*f, *i0));
             survivors.push(idx);
         }
@@ -3223,8 +3284,17 @@ fn fst4_60_diag_decode_rung_major_correctness() {
             unpack77(&m77).map(|s| Box::leak(s.into_boxed_str()) as &str)
         })
         .collect();
-    eprintln!("golden WAV: {} candidates, {} decoded: {:?}", cands.len(), results.iter().flatten().count(), msgs);
-    assert_eq!(results.iter().flatten().count(), 2, "must find exactly the 2 real QSOs");
+    eprintln!(
+        "golden WAV: {} candidates, {} decoded: {:?}",
+        cands.len(),
+        results.iter().flatten().count(),
+        msgs
+    );
+    assert_eq!(
+        results.iter().flatten().count(),
+        2,
+        "must find exactly the 2 real QSOs"
+    );
     assert!(msgs.contains(&"CQ N5TM EL29"));
     assert!(msgs.contains(&"CQ K9KFR EN71"));
 
@@ -3236,23 +3306,29 @@ fn fst4_60_diag_decode_rung_major_correctness() {
             let mut pass = 0u32;
             for trial in 1..=trials {
                 let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
-                let Some(audio) = load_wav_i16_opt(&path) else { continue };
+                let Some(audio) = load_wav_i16_opt(&path) else {
+                    continue;
+                };
                 let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
                 let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
-                let cands: Vec<RungMajorCandidate> = raw
-                    .iter()
-                    .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
-                    .map(|c| {
-                        let (cd0, refined_freq_hz, i0, _score) =
-                            refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE);
-                        RungMajorCandidate {
-                            cand: c.clone(),
-                            cd0,
-                            refined_freq_hz,
-                            i0,
-                        }
-                    })
-                    .collect();
+                let cands: Vec<RungMajorCandidate> =
+                    raw.iter()
+                        .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+                        .map(|c| {
+                            let (cd0, refined_freq_hz, i0, _score) =
+                                refine_candidate_position::<Fst4s60>(
+                                    c,
+                                    &fft_cache,
+                                    &FST4_60A_DOWNSAMPLE,
+                                );
+                            RungMajorCandidate {
+                                cand: c.clone(),
+                                cd0,
+                                refined_freq_hz,
+                                i0,
+                            }
+                        })
+                        .collect();
                 let results = decode_rung_major::<Fst4s60>(&cands, false);
                 let found_golden = results.iter().flatten().any(|r| {
                     let mut m77 = [0u8; 77];
@@ -3303,12 +3379,20 @@ fn fst4_60_diag_rung_major_nsync_gate_count() {
     let freq_tol = 0.10 * FST4_60A_DOWNSAMPLE.tone_spacing_hz;
     const I0_TOL: i32 = 2;
     let mut order: Vec<usize> = (0..raw.len()).collect();
-    order.sort_by(|&a, &b| refined[b].3.partial_cmp(&refined[a].3).unwrap_or(std::cmp::Ordering::Equal));
+    order.sort_by(|&a, &b| {
+        refined[b]
+            .3
+            .partial_cmp(&refined[a].3)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let mut kept: Vec<(f32, i32)> = Vec::new();
     let mut survivors: Vec<usize> = Vec::new();
     for idx in order {
         let (_, f, i0, _) = &refined[idx];
-        if !kept.iter().any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL) {
+        if !kept
+            .iter()
+            .any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL)
+        {
             kept.push((*f, *i0));
             survivors.push(idx);
         }
@@ -3326,7 +3410,11 @@ fn fst4_60_diag_rung_major_nsync_gate_count() {
             eprintln!("  candidate idx={i} nsync={nsync} PASSES gate");
         }
     }
-    eprintln!("{} of {} candidates pass nsync > {SYNC_Q_MIN}", n_pass, survivors.len());
+    eprintln!(
+        "{} of {} candidates pass nsync > {SYNC_Q_MIN}",
+        n_pass,
+        survivors.len()
+    );
 }
 
 /// Cross-check for `fst4_60_diag_rung_major_nsync_gate_count`: parses
@@ -3407,6 +3495,7 @@ fn fst4_60_diag_baked_asset_nsync_gate_count() {
 ///     `SYNC_Q_MIN / 2` (8) — computed exactly as
 ///     `process_candidate_basic_impl` does internally
 ///     (`symbol_spectra` + `sync_quality`), immediately before LLR/OSD.
+///
 /// Real vs false is decided by matching each nsync-pass survivor's
 /// refined frequency against both known (freq) golden entries (±4 Hz,
 /// matching `fst4_wsjtx_samples.rs`'s own `FREQ_TOL_HZ`).
@@ -3605,12 +3694,20 @@ fn fst4_60_diag_rung_major_stage_timing_probe() {
     let freq_tol = 0.10 * FST4_60A_DOWNSAMPLE.tone_spacing_hz;
     const I0_TOL: i32 = 2;
     let mut order: Vec<usize> = (0..raw.len()).collect();
-    order.sort_by(|&a, &b| refined[b].3.partial_cmp(&refined[a].3).unwrap_or(std::cmp::Ordering::Equal));
+    order.sort_by(|&a, &b| {
+        refined[b]
+            .3
+            .partial_cmp(&refined[a].3)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let mut kept: Vec<(f32, i32)> = Vec::new();
     let mut survivors: Vec<usize> = Vec::new();
     for idx in order {
         let (_, f, i0, _) = &refined[idx];
-        if !kept.iter().any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL) {
+        if !kept
+            .iter()
+            .any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL)
+        {
             kept.push((*f, *i0));
             survivors.push(idx);
         }
@@ -3632,14 +3729,28 @@ fn fst4_60_diag_rung_major_stage_timing_probe() {
     let (results, timings) =
         decode_rung_major_timed::<Fst4s60>(&cands, false, false, &[0], Some(host_clock_us));
     let timings = timings.unwrap();
-    eprintln!("decoded: {}/{}", results.iter().flatten().count(), cands.len());
-    eprintln!("{:>4} {:>8} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9}", "idx", "freq", "llra_us", "llrb_us", "llre_us", "llrc_us", "osd_us", "decoded");
+    eprintln!(
+        "decoded: {}/{}",
+        results.iter().flatten().count(),
+        cands.len()
+    );
+    eprintln!(
+        "{:>4} {:>8} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9}",
+        "idx", "freq", "llra_us", "llrb_us", "llre_us", "llrc_us", "osd_us", "decoded"
+    );
     for (i, (c, t)) in cands.iter().zip(&timings).enumerate() {
         let total: i64 = t.iter().sum();
         if total > 0 {
             eprintln!(
                 "{:>4} {:>8.1} {:>9} {:>9} {:>9} {:>9} {:>9} {:>9}",
-                i, c.cand.freq_hz, t[0], t[1], t[2], t[3], t[4], results[i].is_some()
+                i,
+                c.cand.freq_hz,
+                t[0],
+                t[1],
+                t[2],
+                t[3],
+                t[4],
+                results[i].is_some()
             );
         }
     }
@@ -3687,7 +3798,10 @@ fn fst4_60_diag_i0_retry_ccir_old_only() {
 
         let mut recovered = false;
         let mut best_nsync_by_offset = [0u32; 3];
-        for c in cands.iter().filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ) {
+        for c in cands
+            .iter()
+            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+        {
             let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
             let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
             if sum2 > f32::EPSILON {
@@ -3767,7 +3881,9 @@ fn fst4_60_diag_i0_jitter_recall_verify() {
         let mut pass = 0u32;
         for trial in 1..=trials {
             let path = dir.join(format!("fst4_60_ccir_moderate_{snr_tag}_{trial:02}.wav"));
-            let Some(audio) = load_wav_i16_opt(&path) else { continue };
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
             if decode_wav_fst4_60(&audio) {
                 pass += 1;
             }
@@ -3844,7 +3960,10 @@ fn stage_ablation_i0_offsets_for_channel(channel: &str) {
         // decode work 4x).
         let mut offset_hit = [false; 3]; // [0, +1, -1]
 
-        for c in cands.iter().filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ) {
+        for c in cands
+            .iter()
+            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+        {
             let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
             let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
             if sum2 > f32::EPSILON {
@@ -3907,9 +4026,7 @@ fn stage_ablation_i0_offsets_for_channel(channel: &str) {
 
         let mut ok = [false; 4];
         for (i, &(try_p1, try_m1)) in CONFIGS.iter().enumerate() {
-            ok[i] = offset_hit[0]
-                || (try_p1 && offset_hit[1])
-                || (try_m1 && offset_hit[2]);
+            ok[i] = offset_hit[0] || (try_p1 && offset_hit[1]) || (try_m1 && offset_hit[2]);
         }
         (snr_idx, ok)
     };
@@ -3986,12 +4103,20 @@ fn fst4_60_diag_i0_offset_host_timing() {
     let freq_tol = 0.10 * FST4_60A_DOWNSAMPLE.tone_spacing_hz;
     const I0_TOL: i32 = 2;
     let mut order: Vec<usize> = (0..raw.len()).collect();
-    order.sort_by(|&a, &b| refined[b].3.partial_cmp(&refined[a].3).unwrap_or(std::cmp::Ordering::Equal));
+    order.sort_by(|&a, &b| {
+        refined[b]
+            .3
+            .partial_cmp(&refined[a].3)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     let mut kept: Vec<(f32, i32)> = Vec::new();
     let mut survivors: Vec<usize> = Vec::new();
     for idx in order {
         let (_, f, i0, _) = &refined[idx];
-        if !kept.iter().any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL) {
+        if !kept
+            .iter()
+            .any(|&(kf, ki)| (f - kf).abs() < freq_tol && (i0 - ki).abs() <= I0_TOL)
+        {
             kept.push((*f, *i0));
             survivors.push(idx);
         }

--- a/mfsk-core/tests/ft4_sweep.rs
+++ b/mfsk-core/tests/ft4_sweep.rs
@@ -540,7 +540,9 @@ fn ft4_diag_k4_tail_direction() {
     // simultaneously) — before the direction question can be answered,
     // the gate has to actually fire at least sometimes. m19-m22 (weaker)
     // included for the same reason.
-    for snr_tag in ["m22", "m21", "m20", "m19", "m18", "m17", "m16", "m15", "m14"] {
+    for snr_tag in [
+        "m22", "m21", "m20", "m19", "m18", "m17", "m16", "m15", "m14",
+    ] {
         for trial in 1..=20u32 {
             let path = dir.join(format!("ft4_awgn_{snr_tag}_{trial:02}.wav"));
             let Some(audio) = load_wav_i16_opt(&path) else {
@@ -553,7 +555,10 @@ fn ft4_diag_k4_tail_direction() {
             let verify_info =
                 Some(<<Ft4 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
 
-            for c in cands.iter().filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ) {
+            for c in cands
+                .iter()
+                .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+            {
                 let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FT4_DOWNSAMPLE);
                 // RMS-normalise — `process_candidate_basic_impl` applies
                 // this before `ft4_sync_search`; omitting it broke an

--- a/mfsk-core/tests/wspr_wsjtx_samples.rs
+++ b/mfsk-core/tests/wspr_wsjtx_samples.rs
@@ -280,7 +280,10 @@ fn wspr_cascade_ddc_golden_recall_and_precision() {
 
     let decodes = decode_scan(&audio, 12_000, 0, &params);
 
-    eprintln!("WSPR sample (cascade DDC) decoded {} message(s):", decodes.len());
+    eprintln!(
+        "WSPR sample (cascade DDC) decoded {} message(s):",
+        decodes.len()
+    );
     for d in &decodes {
         eprintln!(
             "  freq={:6.1} Hz dt={:+.2} s : {}",

--- a/mfsk-ffi-ft8/Cargo.toml
+++ b/mfsk-ffi-ft8/Cargo.toml
@@ -53,8 +53,8 @@ embedded-fixed-point = [
 embedded-runtime = []
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.9.0", default-features = false }
-mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.9.0" }
+mfsk-core = { path = "../mfsk-core", version = "0.10.0", default-features = false }
+mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.10.0" }
 
 [build-dependencies]
 cbindgen = "0.29"

--- a/mfsk-ffi/Cargo.toml
+++ b/mfsk-ffi/Cargo.toml
@@ -11,8 +11,8 @@ name       = "mfsk"
 crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
-mfsk-core = { path = "../mfsk-core", version = "0.9", features = ["full"] }
-mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.9.0" }
+mfsk-core = { path = "../mfsk-core", version = "0.10", features = ["full"] }
+mfsk-ffi-abi = { path = "../mfsk-ffi-abi", version = "0.10.0" }
 
 [build-dependencies]
 cbindgen = "0.29"


### PR DESCRIPTION
Release prep for **0.10.0**. Docs, version, and issue-tracking only — no behaviour change.

## Version: minor, not patch

`0.9.1 → 0.10.0`. This crate ships new protocols and capabilities as patch (MSK144 was `0.7.4`) and reserves minor for structural API change. Three public fields changed type and name this cycle (#282):

- `jt65::search::SearchParams::time_tolerance_symbols: u32` → `time_tolerance_sec: f32`
- the same rename on `jt9`
- `q65::search::SearchParams::time_tolerance_symbols` → `time_tolerance_early_sec` + `time_tolerance_late_sec`

Symbols aren't a transferable unit across sub-modes whose symbol lengths differ by 20× — one constant meant ±0.75 s on Q65-15 and ±17.3 s on Q65-300. Same handling `0.8.0` gave its own breaking batch, rather than distributing them across patches.

**The bump exposed two stale pins a patch bump never would have**: `mfsk-ffi` required `mfsk-core = "0.9"` and `mfsk-ffi-ft8` required `"0.9.0"`. Both stop resolving at `0.10.0` — `cargo metadata` errors outright. Bumped along with the matching `mfsk-ffi-abi` pins.

## CHANGELOG: the embedded batch was missing entirely

The `0.9.2` section covered the host work, but the `feat/wspr-app-cores3-web-config` merge (`9dc8c05`) had **nothing**. Grepping the whole 483-line section for `UAC` / `DDC` / `LCD` / `WiFi` / `PSRAM` / `rung-major` / `wspr-app` returned zero hits each. Same class of gap as the #299/#303 catch-up PRs.

Added:

- **CoreS3 WSPR standalone receiver** (`wspr_app.rs`) and the **`AudioSink`** refactor that lets the FT8 controller and the WSPR receiver share one USB host / class driver / hot-plug / resample implementation. Flagged as not hardware-verified (#163), with remaining items pointed at #313.
- **`wspr::ddc::StreamingDdcCascade`** + the `wspr-ddc-cascade` feature — ~4.5× less compute, from a first-principles Crochiere-Rabiner derivation rather than a reaction to the benchmark; root cause was `DdcBufs` exceeding `SPIRAM_MALLOC_ALWAYSINTERNAL` and landing in PSRAM.
- **`engine::dsp::fir_decimate`**, **`fst4::rung_major`** (including why it's a 5-stage and not 6-stage ladder, and why `offsets` defaults to `&[0]`).
- Four fixes findable only on hardware: PSRAM-backed thread stacks as the crash-loop root cause, the four independent reasons the LCD stayed dark, the shared ILI9342C-as-ILI9341 model bug, WiFi association-refusal retry.

## ROADMAP: "Open follow-ups" predated the whole #306 line

It was dated 2026-08-15 and listed #163 as the only embedded item. Now carries #306/#307/#309/#310/#311/#312/#313 with current numbers — notably that FST4-60's candidate loop measures **40.102 s** (`full`) / **13.643 s** (`no8_osd`) on real CoreS3 hardware against a ~7 s margin: **not fitting yet, but quantified**, and down from ~13× over at first measurement. Also records #308's close and where its two remaining halves went.

## Issue triage done alongside this PR

| | |
|---|---|
| **#311** (new) | 3 of 5 CCIR-moderate `npre2`-pruning misses left unexplained after #308's timing fix — split out so it didn't close with #308 |
| **#312** (new) | FST4 sniper `max_cand = 50` binds before window width; VK3NV's retained-fraction sweep |
| **#313** (new) | CoreS3 WSPR app items left after #260 closed |
| **#308** | Closed — host-side `i0±1` retry shipped in `engine::pipeline`, recovers 2/5 |
| **#306** | Status comment consolidating 35 comments; stays open as the umbrella |
| **#307** | Cross-linked to #309 (alternative routes past the same wall, not sequential); its "89.7 s / ~13× over" figure updated |
| **#163** | Body updated — now blocks two applications, but the first checkpoint got easier |

## Verification

Merge gate green, 0 failures:

```
MFSK_REQUIRE_CORPUS=1 cargo test -p mfsk-core --features full,internal-testing --release
```

`cargo metadata` resolves after the pin fixes.

## ⚠️ Not yet done — blocks tagging

**Tier-C sensitivity sweeps have not been run for this tag.** CLAUDE.md requires them before every tag, and this cycle touched WSPR (Fano cycle budget), FST4 (npre1/npre2 OSD port), FT8 (coarse-sync lag window), and JT65/JT9/Q65 (Δt windows) — so all seven protocols are in scope, `ft4` being the only untouched one. They're pending on the Ryzen 9 box.

Do not tag `v0.10.0` until those results are in and compared against `docs/notes/BENCHMARKS.md`. A move worse than ~0.5 dB needs explaining first, and `BENCHMARKS.md` should be updated in this PR if any number moves for a reason we understand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
