### PR TITLE
diag(fst4): escalation scheduling, cap policy and soft-margin measurements (#310/#311/#312)

### DIFF
--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -787,7 +787,26 @@ What this settles: whether the synergy result (2 of 4 cells) holds at
 n=100, and whether #308's own 2/5 reproduces once the trials it named
 actually exist.
 
-### 11.4 What to bring back
+### 11.4 Cheap `i0` ranking vs exhaustive retry
+
+Section 12's test, full 8-run grid (4 cells × 2 OSD searches):
+
+```sh
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_i0_cheap_rank_vs_exhaustive \
+    -- --ignored --nocapture --test-threads=1
+```
+
+`--test-threads=1` is required (`fst4_osd_diag_force_old` is a
+process-global toggle). Costs are counted in decode units, so unlike the
+sweeps above this one's numbers are machine-independent — the reason to
+run it on the Ryzen 9 is wall-clock to completion, not measurement
+quality.
+
+Read the `argmax nsync == offset 0` line **before** the verdict; see
+section 12 for why.
+
+### 11.5 What to bring back
 
 - Tier-C tables, diffed against `v0.9.1`, for the release decision.
 - The full `fst4_60_diag_sniper_cap_near_threshold` grid — specifically
@@ -797,3 +816,88 @@ actually exist.
 `loop_ms` columns from the Ryzen 9 are worth recording in
 `BENCHMARKS.md`; the laptop's are not, and are marked as relative-shape
 only wherever they appear above.
+
+## 12. Cheap `i0` ranking vs exhaustive retry — and a degenerate metric (2026-08-18)
+
+VK3NV's #308 proposal, measured: #308 ported WSJT-X's control flow
+literally (try `i0`, `i0+1`, `i0-1` at full depth, short-circuit on
+success), which is 3.02× / 2.51× of the embedded candidate loop and is
+why `decode_rung_major` defaults to `offsets = &[0]`. The proposal was
+that cheap sync information already exists before the expensive work, so
+the offsets could be **ranked** and only the best one decoded:
+
+> Could we score `i0`, `i0+1` and `i0-1` cheaply, choose/rank the best
+> timing, and run the expensive decoder only once initially?
+
+```sh
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_i0_cheap_rank_vs_exhaustive \
+    -- --ignored --nocapture --test-threads=1
+```
+
+### Cost is counted, not timed
+
+The metric is **full decode units** (`compute_llr` + the BP/OSD ladder
+for one candidate/offset pair), not wall-clock. That makes these numbers
+machine-independent and directly quotable — unlike every `loop_ms`
+column elsewhere in this document, which is relative-shape-only on a
+laptop.
+
+### The confound: `i0` is not an unranked starting point
+
+`i0` comes from `fst4_sync_search`, whose whole job is to **maximise a
+coherent sync score** over a (Δf, Δt) grid. `sync_quality` measures
+closely related information, so it peaks at `i0` by construction. The
+ranking therefore degenerates to "always pick offset 0", and
+`cheap-rank ≈ base` follows tautologically — it is not evidence about
+the proposal.
+
+The first run of this test printed `PROXY USELESS` on exactly such
+cells. The `units` column gave it away: at ccir_moderate m24/npre,
+`base` was 51 units and `cheap-rank` 52 — one single candidate where the
+ranking picked a non-zero offset — and at m25/npre both were 38, i.e.
+the ranking never once chose anything but offset 0.
+
+The test now **counts** `argmax nsync == offset 0` and short-circuits the
+verdict to `DEGENERATE RANKING` at ≥95 %, rather than leaving it to be
+inferred from a cost column.
+
+### What the degenerate case does establish
+
+Narrower than the original question, but directly useful for #310:
+
+**A cheap proxy for "which timing will decode" cannot be another
+sync-strength measure.** The refine stage has already maximised that, so
+any sync-derived ranking is spending three cheap evaluations to
+rediscover the position it started from. A usable proxy has to be
+**sync-orthogonal** — LLR reliability statistics, or a truncated-BP
+syndrome weight, rather than Costas correlation.
+
+That leaves #310 with two honest options until such a proxy is found and
+measured: pay for exhaustive retry, or keep `&[0]` and forgo the timing
+recall. There is no free third path via sync ranking.
+
+### Partial results (20-trial corpus, first 3 of 8 cell/mode runs)
+
+Recorded because the degeneracy is visible in them, not as a recall
+result — the `argmax` counter was added afterwards, so these predate it:
+
+| cell / OSD | base | exhaustive | cheap-rank | progressive |
+|---|---|---|---|---|
+| ccir_mod m24 / npre | 17/20, 51u | **18/20**, 83u | 17/20, 52u | 18/20, 86u |
+| ccir_mod m24 / unpruned | 19/20, 51u | 19/20, 75u | 19/20, 52u | 19/20, 77u |
+| ccir_mod m25 / npre | 7/20, 38u | **8/20**, 96u | 7/20, 38u | 8/20, 96u |
+
+Two things are real here independent of the confound:
+
+- **Exhaustive retry costs roughly 1.6–2.5× the units of `base`** for
+  +1 decode in two of the three runs. That ratio is measured in
+  algorithm-invocation counts, so it transfers across machines, and it
+  is the same order as the 2.5–3× wall-clock ratio measured on CoreS3.
+- **`progressive` never beats `exhaustive` on cost** (86 vs 83, 96 vs
+  96). Reordering by a degenerate key cannot help, and where it differs
+  it is slightly worse — consistent with the ranking pushing the
+  eventual winner later.
+
+The full 8-run grid and the `argmax` counts belong on the Ryzen 9 box
+alongside the other jobs in section 11.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -703,6 +703,33 @@ the production default — where on one of the two golden signals **3 of
 50 slots (6 %) go to candidates already known to be duplicates**, all
 three inside the reserved near-hint group.
 
+**Follow-up: do the re-admitted duplicates ever decode?**
+`fst4_60_diag_dedup_zero_score_recall_effect` answers it directly, over
+the partial-recall band at the production `max_cand = 50`, sniper-shaped
+(`freq_hint` set). Two columns: recall from the candidate list as
+`coarse_sync` returns it, and recall with `score == 0.0` entries dropped
+before any decode work — i.e. exactly what tightening the gate would do.
+
+| cell | n | zeros reaching the list | zeros that decoded | recall as-is | recall filtered |
+|---|---:|---:|---:|---:|---:|
+| CCIR-mod m24 | 20 | 1 | **0** | 18/20 | 18/20 |
+| CCIR-mod m25 | 20 | 1 | **0** | 9/20 | 9/20 |
+| AWGN m27 | 20 | 4 | **0** | 15/20 | 15/20 |
+| AWGN m28 | 20 | 3 | **0** | 6/20 | 6/20 |
+
+**No re-admitted duplicate decoded anything, and filtering them changes
+no cell's recall.** On this path the OR-gate re-admission buys nothing,
+so tightening `retain` to `score >= sync_min && stage1_pass(fi)` would
+cost no recall and would return the slots the duplicates consume.
+
+Sample is small and the scope is narrow — 9 zero-score candidates across
+80 trials, FST4-60 only, one width (+/-250 Hz), one cap, sniper-shaped
+only. It does not cover the wide-band `DecodeRequest` shape (no
+`freq_hint`, where a zero sorts to the bottom rather than into a
+reserved slot), nor the strong-signal golden case where the 3 zeros in
+the table above appeared. "Never decodes" is supported here, not
+established in general.
+
 Not fixed here: this is a measurement of the existing behaviour, and
 whether the `retain` should test `score >= sync_min && stage1_pass(fi)`
 (or exclude zeroed entries explicitly) is a decision for #312 with its

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -1083,3 +1083,86 @@ it is cheap.
   small relative to a rung, which would weaken reason 2.
 
 All three are open. This decision is provisional on them.
+
+## 14. Soft Costas margin vs raw `nsync` (2026-08-18)
+
+VK3NV's #310 proposal, implemented and measured.
+`engine::llr::sync_quality_generic` inspects all four tone energies per
+known sync symbol and then discards everything except
+`best == expected` — so `E_exp = 9.8, E_wrong = 9.5` and
+`E_exp = 9.8, E_wrong = 1.2` contribute the same `+1`.
+
+`sync_quality_soft_generic` (new, diagnostic-only, nothing in the decode
+path calls it) returns the same `nsync` **and** fills a caller-provided
+`[(E_expected, E_best_wrong); n_sync]`. No new spectral work —
+`symbol_spectra` has already produced these values — and the extra cost
+over the hard version is one comparison per tone, since the loop tracks
+the max over all tones and the max over tones *other than* the expected
+one in the same pass. The buffer is caller-provided rather than
+allocated so it stays usable on embedded, where a per-candidate `Vec` in
+the candidate loop is a shape that has caused trouble before.
+
+```sh
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_soft_costas_margin_separation \
+    -- --ignored --nocapture
+```
+
+### Metric
+
+**AUC** — the fraction of (decoding, non-decoding) candidate pairs the
+score orders correctly, ties counting half; 0.5 is chance. The right
+shape here because #310's intended use is *ranking* candidates for
+escalation budget rather than thresholding them, and because it is
+insensitive to the heavy class imbalance these cells have (~15–46
+decoders against ~700 non-decoders).
+
+Population: every candidate clearing the `nsync` gate, on the
+partial-recall band, `max_cand = 50`, sniper-shaped. "Decodes" means the
+golden message specifically.
+
+### Result — the proposal passes its own kill condition
+
+| cell | candidates (dec / not) | `nsync` | mean margin | min margin | **mean logratio** |
+|---|---|---:|---:|---:|---:|
+| CCIR-mod m24 | 724 (46 / 678) | 0.767 | 0.784 | 0.697 | **0.786** |
+| CCIR-mod m25 | 736 (18 / 718) | 0.701 | 0.779 | 0.718 | **0.800** |
+| AWGN m27 | 742 (35 / 707) | 0.722 | 0.785 | 0.685 | **0.783** |
+| AWGN m28 | 754 (15 / 739) | 0.701 | 0.706 | 0.593 | **0.727** |
+
+- `mean logratio` (mean of `ln(E_exp / E_wrong)`, clamped) beats raw
+  `nsync` in **all four cells**: +0.019, +0.099, +0.061, +0.026.
+- `mean margin` (`(E_exp − E_wrong) / (E_exp + E_wrong)`) beats it
+  clearly in three and ties in the fourth.
+- `min margin` is **worse than `nsync` everywhere** — one bad symbol is
+  not what distinguishes a decodable candidate.
+
+The gains are largest where recall is lowest (m25: 0.701 → 0.800), which
+is the regime the escalation budget is for. So collapsing the four-tone
+observation to 40 hard bits *is* discarding usable information, and the
+unbounded log-ratio form uses it better than the bounded one.
+
+It is an improvement, not a transformation: AUC 0.78–0.80 still
+mis-orders a fifth of the pairs.
+
+### Both groups have negative margins
+
+`mean(dec)` runs −0.067 to −0.153 and `mean(no)` −0.260 to −0.267, so
+the expected tone is *not* the strongest one on average even for
+candidates that go on to decode. That is unsurprising at these SNRs, and
+it means the separation lives in how negative the margin is rather than
+in a sign test — worth knowing before anyone reaches for a threshold.
+
+### The scope limit that matters for #310
+
+This population is **every gate-passing candidate**, including the ones
+that decode cheaply at the first rung. #310's actual question is
+narrower: among candidates that have *already failed* the cheap rung,
+which deserve the expensive BP/OSD/timing budget? That is a subset with
+a different class balance, and the ranking may behave differently on it.
+The result above is necessary but not sufficient for adopting this as an
+escalation-priority signal.
+
+Not wired into anything. `sync_quality` and `sync_quality_generic` are
+untouched and bit-identical; the soft variant asserts equality of the
+`nsync` it returns against the hard one on every candidate in the test.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -344,3 +344,177 @@ underlying quantity behaves differently for the new protocol — FT4's
 code that some real signals depend on. Controlled A/B against the exact
 current codebase (not a possibly-stale prior baseline) is what caught
 it before shipping.
+
+## 9. Attribution ablation — do two rescue mechanisms overlap? (2026-08-17)
+
+Sections 6-7 cover finding *where* a gap is and re-verifying *that* a
+fix moved it. This section covers a third question that neither
+answers: when you have **two** mechanisms that each rescue failing
+trials, do they rescue the *same* trials or *different* ones?
+
+That distinction decides whether an embedded escalation ladder has to
+pay for both (issue #310) or can carry only the cheaper one. It arose
+concretely from issue #306/#308/#311: FST4's OSD had two candidate
+rescue paths — WSJT-X's `i0±1` timing-jitter retry, and a selective
+fallback to the pre-#198 unpruned combinatorial OSD search.
+
+### Counts cannot answer it; only per-trial identity can
+
+Two mechanisms that each recover "2 of 5" are **indistinguishable from
+aggregate recall numbers**. They could be
+
+- **substitutable** — the same 2 trials, so either one alone buys the
+  full benefit,
+- **additive** — 2 different trials each, so the union is 4 and
+  dropping either costs recall, or
+- **interacting** — neither works alone and only the combination
+  rescues anything.
+
+So an ablation for this purpose must record **which trials** each
+configuration decodes, as sets, and print them. A table of pass counts
+is not enough, and a "both mechanisms help by about the same amount"
+summary is actively misleading.
+
+### The knobs
+
+- **OSD search**:
+  `mfsk_core::fec::ldpc240_101::fst4_osd_diag_force_old(bool)` —
+  `internal-testing`-gated, a process-global `AtomicBool`. Forces
+  `fst4_osd_decode` onto the old unpruned search. Reads `false` in any
+  non-`internal-testing` build, so it cannot affect a release artifact.
+  **Not thread-safe**: run with `--test-threads=1`.
+- **Timing offsets**: not exposed on the production entry point. See
+  trap 2.
+
+### Trap 1 — hardcoded trial indices are not portable
+
+The original finding named trials `[2, 15, 33, 45, 67]` from a
+**100-trial-per-cell** corpus. A 20-trial-per-cell generation of the
+same corpus has no trials 33/45/67 at all, and its trial 2 is a
+*different waveform* — `gen_fst4_sweep_wavs.sh` regenerates from
+`fst4sim`, it does not extend an existing set. So those indices
+silently select the wrong signals, or none, in any other environment.
+
+This is the same class of mistake as hardcoding `/home/ubuntu/...`
+asset paths (see `CLAUDE.md`, "Test fixture paths"): an index into a
+generated corpus is environment state, not a fixture identity.
+
+**Derive the trial set from whatever corpus is present, and print both
+the count found and the set used.** A run that silently skipped 3 of 5
+target trials otherwise reads as a real 0/5 result.
+
+### Trap 2 — the selection baseline must not already contain the mechanism
+
+The obvious way to pick trials is to reuse the production-path
+discovery (`decode_wav_fst4_60`, i.e. `DecodeRequest`) that found the
+disagreement in the first place. **That is now circular.**
+`DecodeRequest`'s `osd` flag defaults to `true`, and #308's `i0±1`
+retry is gated on exactly that flag — so the production "npre" arm
+*already includes timing diversity*. Trials selected that way are, by
+construction, ones where timing has already been given its chance and
+failed. The timing arm is then guaranteed to rescue nothing, and the
+run produces a confident "neither mechanism works" verdict that is an
+artifact of the selection, not a measurement.
+
+This bites specifically because the mechanism under test *shipped*
+between the original finding and the re-measurement. Whenever that is
+true, the pre-fix baseline no longer exists in the production entry
+point, and the ablation has to reconstruct it.
+
+Two ways out, in order of preference:
+
+1. **Measure the whole cell across the full configuration grid and
+   read the sets off afterwards.** No selection step, so nothing to
+   bias. This is what `fst4_60_diag_npre_timing_substitutability_ablation`
+   does — 2 timing configurations × 3 OSD configurations over every
+   present trial.
+2. If the grid is too expensive, select using a baseline you have
+   explicitly reconstructed (npre at a single `i0`), never the current
+   production path.
+
+### Why a hand-built pipeline rather than `DecodeRequest`
+
+The production entry point **cannot express "npre with OSD but without
+timing diversity"** — the two are welded together by the `depth.osd`
+gate. So the ablation calls the stages directly:
+
+```
+coarse_sync → fst4_sync_search → freq_shift_cd0
+            → symbol_spectra / sync_quality → compute_llr → decode_soft
+```
+
+Sync runs **once per trial**, cached, and every configuration is
+evaluated against that same prepared candidate set — so any difference
+between configurations is attributable to the OSD/timing axes alone
+rather than to sync jitter.
+
+Two details that are easy to get wrong here:
+
+- `cd0` must be frequency-shifted by `refined − coarse` before
+  `symbol_spectra` (`freq_shift_cd0`). Skipping it zeroes the
+  correction and artificially fails the `nsync` gate for exactly the
+  marginal candidates an ablation is about. This has already caused one
+  implausibly-good measurement in this line of work.
+- Match success against the known golden message, not "something
+  decoded" — otherwise a CRC false-accept counts as a rescue.
+
+**The hand-built path is narrower than production** (candidates filtered
+to ±5 Hz of the golden, single sync pass, no SIC), so it can decode
+fewer trials than `DecodeRequest` on the same corpus. Always
+cross-check against `fst4_60_diag_npre_osd_bug_hunt_ccir_moderate` on
+the same files before attributing a difference to the mechanisms.
+
+### Running it
+
+```sh
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_npre_timing_substitutability_ablation \
+    -- --ignored --nocapture --test-threads=1
+```
+
+~6 min for a 20-trial cell (6 configurations × 20 trials, plus one
+sync pass each). Scoped by test name — never a blanket `-- --ignored`,
+which escalates into the full tier-C campaign (see `CLAUDE.md`).
+
+### Result, 2026-08-17 (`fst4_60_ccir_moderate_m26`, 20 trials)
+
+| configuration | decoded | trials |
+|---|---:|---|
+| `npre @{0}` | 0/20 | — |
+| `npre @{0,+1,-1}` | 0/20 | — |
+| `unpruned @{0}` | 0/20 | — |
+| **`unpruned @{0,+1,-1}`** | **3/20** | 1, 4, 17 |
+| `npre→unpruned @{0}` | 0/20 | — |
+| `npre→unpruned @{0,+1,-1}` | 3/20 | 1, 4, 17 |
+
+**Verdict: interacting, not substitutable and not independently
+additive.** Neither mechanism rescues anything on its own — timing
+diversity does nothing for `npre`, and the unpruned search does nothing
+at a single `i0`. Only the combination decodes, and the fallback
+configuration's hits are *identical* to plain `unpruned + timing`,
+i.e. `npre` contributes nothing on those three trials.
+
+For #310 this means the ladder cannot simply pick the cheaper of the
+two: on this cell the rescue is the combination, so an embedded build
+that keeps `offsets = &[0]` gets no benefit from adding an unpruned-OSD
+fallback either.
+
+**Every trial reached `osd_depth = 3`**, so `npre2` was exercised
+throughout — the remaining misses are a genuine `npre2`-pruning
+limitation, not an artifact of never escalating past `ndeep = 2`. That
+closes the npre1-vs-npre2 localisation question #311 raised.
+
+### Caveats, stated because they are load-bearing
+
+- **n=20, 3 hits.** Directional. Nothing here should move a production
+  default; that needs the near-threshold sweep.
+- **This cell does not reproduce #308's 2/5 timing win at all**
+  (`npre @{0,+1,-1}` is 0/20 here). The difference is a different
+  corpus generation and/or the narrower hand-built pipeline. Unresolved
+  — do not read the table above as contradicting #308 until the same
+  grid has been run on a 100-trial generation.
+- One cell only: FST4-60, CCIR-moderate, m26.
+- **Wall-clock is deliberately not reported.** This is recall
+  attribution. Cost numbers belong on the Ryzen 9 box or real hardware
+  — an Apple laptop's AC/battery state swings host wall-clock ~3×
+  (`BENCHMARKS.md` records the machine for exactly this reason).

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -683,3 +683,117 @@ This is a within-run comparison (25× on the same invocation), so it is
 not the host power-state confound that makes absolute host wall-clock
 unreliable here; but the absolute milliseconds still belong on the
 Ryzen 9 box before they go in a table anyone reasons from.
+
+## 11. Ryzen 9 runbook — what needs the big machine, and why
+
+Three jobs cannot be finished on a laptop. Two are blocked on wall-clock,
+one on absolute-timing reliability (an Apple laptop's AC/battery state
+swings host wall-clock ~3×, so every absolute host number in this
+document that matters is supposed to come from the Ryzen 9 box —
+`BENCHMARKS.md` records the machine for the same reason).
+
+Run each with the corpora present under `embedded-poc/assets/*_sweep/`.
+
+### 11.1 Tier-C sensitivity sweeps — the `v0.10.0` release gate
+
+**Required before tagging** (`CLAUDE.md`, "Releases"). Not run yet for
+this release.
+
+```sh
+scripts/run-sensitivity-sweeps.sh
+```
+
+All seven protocols are in scope this cycle: WSPR (Fano cycle budget),
+FST4 (npre1/npre2 OSD port), FT8 (coarse-sync lag window), and
+JT65/JT9/Q65 (Δt windows). FT4 is the only untouched one.
+
+Compare the printed tables against `docs/notes/*BENCHMARK.md` and the
+`v0.9.1` numbers. A move worse than ~0.5 dB needs explaining before the
+tag; update `BENCHMARKS.md` for any move understood well enough to
+explain, recording the machine.
+
+### 11.2 Near-threshold sniper cap sweep — the open half of #312
+
+Section 10 answered the comparability question on strong signals but
+could not find a recall cliff there. This finds it:
+
+```sh
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_sniper_cap_near_threshold \
+    -- --ignored --nocapture
+```
+
+Default grid is 4 cells × 4 widths × 6 caps. On a 20-trial corpus that
+is 1 920 candidate loops — **~2 h on an M5 laptop**, measured. Narrow it
+with `MFSK_CAP_SWEEP_CELLS` (`channel:snr`, comma-separated),
+`MFSK_CAP_SWEEP_WIDTHS`, `MFSK_CAP_SWEEP_CAPS` rather than editing the
+test.
+
+**Preliminary, 4 of the 96 configurations** (smoke test, ccir_moderate
+m25, 20 trials — enough to prove the sweep works, not enough to
+conclude):
+
+| width | cap | raw | frac | recall |
+|---|---:|---:|---:|---:|
+| ±250 Hz | 4 | 17 049 | 0 % | **6/20** |
+| ±250 Hz | 50 | 17 049 | 6 % | **9/20** |
+| ±25 Hz | 4 | 1 755 | 5 % | **6/20** |
+| ±25 Hz | 50 | 1 755 | 57 % | **9/20** |
+
+**A cliff exists** — truncating to 4 costs 3 of 9 decodes. And note what
+it is *not* tracking: recall is 6/20 at cap 4 and 9/20 at cap 50 at
+**both** widths, while the retained fraction at those points differs by
+an order of magnitude (0 % vs 5 %, 6 % vs 57 %).
+
+If that survives the full grid it is a direct tension with section 10's
+conclusion. Section 10 says false-survivor *cost* tracks the retained
+fraction, which argues for deriving the cap from the width. This says
+weak-signal *recall* tracks the absolute count, which argues for a
+floor on how many ranked candidates must be kept regardless of width.
+Both can be true at once — they are different columns — and if they are,
+the policy is "absolute floor for recall, fraction for cost", not either
+alone. That is the thing worth settling on the big machine, and it is
+the question VK3NV actually asked (#312: *does the cliff sit at a
+similar fraction across widths?* — preliminary answer: no).
+
+### 11.3 Resolving the #308 timing-win tension — needs `fst4sim`
+
+Section 9's open caveat: no cell here reproduces #308's 2/5 timing
+recovery, because #308 measured it on a **100-trial-per-cell**
+generation naming trials 33/45/67, and this environment's corpus has 20
+per cell. Not testable on the laptop — `fst4sim` is not installed there.
+
+On a box that has WSJT-X built:
+
+```sh
+# 100 trials per cell, at least the crossing band
+TRIALS=100 scripts/gen_fst4_sweep_wavs.sh
+
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_npre_baseline_scan \
+    -- --ignored --nocapture          # re-locate the band: it moves with n
+
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_npre_timing_substitutability_ablation \
+    -- --ignored --nocapture --test-threads=1
+```
+
+Re-run the baseline scan **first**: the partial-recall band is a
+property of the corpus generation, and pointing the ablation at a cell
+from a different generation is trap 3 all over again. Update the cell
+list in the ablation's driver to whatever the scan reports.
+
+What this settles: whether the synergy result (2 of 4 cells) holds at
+n=100, and whether #308's own 2/5 reproduces once the trials it named
+actually exist.
+
+### 11.4 What to bring back
+
+- Tier-C tables, diffed against `v0.9.1`, for the release decision.
+- The full `fst4_60_diag_sniper_cap_near_threshold` grid — specifically
+  whether the cliff sits at a fixed count or a fixed fraction.
+- The ablation re-run at n=100, with the band the scan reported.
+
+`loop_ms` columns from the Ryzen 9 are worth recording in
+`BENCHMARKS.md`; the laptop's are not, and are marked as relative-shape
+only wherever they appear above.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -843,61 +843,85 @@ machine-independent and directly quotable — unlike every `loop_ms`
 column elsewhere in this document, which is relative-shape-only on a
 laptop.
 
-### The confound: `i0` is not an unranked starting point
+### The confound to check — and a correction about how to check it
 
-`i0` comes from `fst4_sync_search`, whose whole job is to **maximise a
-coherent sync score** over a (Δf, Δt) grid. `sync_quality` measures
-closely related information, so it peaks at `i0` by construction. The
-ranking therefore degenerates to "always pick offset 0", and
-`cheap-rank ≈ base` follows tautologically — it is not evidence about
-the proposal.
+`i0` does not arrive unranked. It comes from `fst4_sync_search`, whose
+job is to **maximise a coherent Costas amplitude** over a (Δf, Δt) grid.
+`sync_quality` measures related information, so it plausibly peaks at
+`i0` too — which would make `argmax nsync` degenerate to offset 0 and
+`cheap-rank ≈ base` a near-tautology rather than evidence about the
+proposal.
 
-The first run of this test printed `PROXY USELESS` on exactly such
-cells. The `units` column gave it away: at ccir_moderate m24/npre,
-`base` was 51 units and `cheap-rank` 52 — one single candidate where the
-ranking picked a non-zero offset — and at m25/npre both were 38, i.e.
-the ranking never once chose anything but offset 0.
+That is a real hazard and the test now **counts** `argmax nsync == 0`
+explicitly, short-circuiting the verdict to `DEGENERATE RANKING` at
+≥95 %.
 
-The test now **counts** `argmax nsync == offset 0` and short-circuits the
-verdict to `DEGENERATE RANKING` at ≥95 %, rather than leaving it to be
-inferred from a cost column.
+**Correction (2026-08-18).** An earlier revision of this section claimed
+the degeneracy was already demonstrated, inferring it from the `units`
+column: `base` 51 vs `cheap-rank` 52 at one cell, 38 vs 38 at another.
+**That inference is invalid.** Both configurations perform exactly one
+`decode_at` per candidate — `base` at offset 0, `cheap-rank` at the
+argmax — so their unit counts are equal *by construction*, whichever
+offset the ranking picks. The counts only diverge when the two offsets
+land on opposite sides of the `nsync` gate. Equal units say nothing
+about whether the ranking chose differently.
 
-### What the degenerate case does establish
+The evidence in fact points the other way: the `nsync picked the winning
+offset first` line reaches 2/3 and 2/2 on AWGN m28, which is impossible
+if the ranking always returned offset 0. **So the degeneracy is probably
+not what is happening, and the question is open** until the explicit
+counter has been run.
 
-Narrower than the original question, but directly useful for #310:
+A second metric caveat, for whoever reads that counter: agreement is
+counted **per candidate**, recall **per trial**. A candidate where the
+ranking picks the winning offset does not add a decode if another
+candidate in the same trial already decoded at offset 0. The two columns
+are not directly comparable, and a high agreement rate alongside
+`cheap-rank == base` recall is not a contradiction.
 
-**A cheap proxy for "which timing will decode" cannot be another
-sync-strength measure.** The refine stage has already maximised that, so
-any sync-derived ranking is spending three cheap evaluations to
-rediscover the position it started from. A usable proxy has to be
-**sync-orthogonal** — LLR reliability statistics, or a truncated-BP
-syndrome weight, rather than Costas correlation.
+### What holds regardless
 
-That leaves #310 with two honest options until such a proxy is found and
-measured: pay for exhaustive retry, or keep `&[0]` and forgo the timing
-recall. There is no free third path via sync ranking.
+Whether or not the ranking is degenerate, one thing follows from where
+`i0` comes from: **a cheap proxy for "which timing will decode" is
+unlikely to be another sync-strength measure**, since the refine stage
+has already maximised that. If a proxy is to work, the more promising
+direction is sync-orthogonal — LLR reliability statistics, or a
+truncated-BP syndrome weight, rather than Costas correlation.
 
-### Partial results (20-trial corpus, first 3 of 8 cell/mode runs)
+### Results, 20-trial corpus, all 8 runs
 
-Recorded because the degeneracy is visible in them, not as a recall
-result — the `argmax` counter was added afterwards, so these predate it:
+Recall / decode units. Measured before the `argmax` counter existed, so
+the agreement column is the only proxy-quality signal available in this
+table:
 
-| cell / OSD | base | exhaustive | cheap-rank | progressive |
-|---|---|---|---|---|
-| ccir_mod m24 / npre | 17/20, 51u | **18/20**, 83u | 17/20, 52u | 18/20, 86u |
-| ccir_mod m24 / unpruned | 19/20, 51u | 19/20, 75u | 19/20, 52u | 19/20, 77u |
-| ccir_mod m25 / npre | 7/20, 38u | **8/20**, 96u | 7/20, 38u | 8/20, 96u |
+| cell / OSD | base | exhaustive | cheap-rank | progressive | nsync picked winner |
+|---|---|---|---|---|---|
+| ccir-mod m24 / npre | 17, 51u | **18**, 83u | 17, 52u | 18, 86u | 0/6 |
+| ccir-mod m24 / unpruned | 19, 51u | 19, 75u | 19, 52u | 19, 77u | 0/5 |
+| ccir-mod m25 / npre | 7, 38u | **8**, 96u | 7, 38u | 8, 96u | 0/1 |
+| ccir-mod m25 / unpruned | — | — | 8, 38u | **10**, 89u | 1/5 |
+| AWGN m27 / npre | 12, 26u | **13**, 46u | **13, 26u** | 13, 44u | 1/1 |
+| AWGN m27 / unpruned | 13, 26u | **15**, 42u | 13, 26u | 15, 39u | 1/3 |
+| AWGN m28 / npre | 3, 23u | **6**, 61u | 3, 23u | 6, 60u | 2/3 |
+| AWGN m28 / unpruned | 4, 23u | **6**, 60u | 4, 23u | 6, 59u | 2/2 |
 
-Two things are real here independent of the confound:
+**`cheap-rank` matched `exhaustive` in 1 of 8 runs** (AWGN m27 / npre:
+13/20 at 26 units, i.e. exhaustive's recall at base's cost) and matched
+`base` in the other seven. One hit out of eight is not a working proxy,
+but it is also not the flat null the first three runs suggested.
 
-- **Exhaustive retry costs roughly 1.6–2.5× the units of `base`** for
-  +1 decode in two of the three runs. That ratio is measured in
-  algorithm-invocation counts, so it transfers across machines, and it
-  is the same order as the 2.5–3× wall-clock ratio measured on CoreS3.
+Two results hold independently of the open question above:
+
+- **Exhaustive retry costs 1.6–2.7× base in decode units** for +1 to +3
+  decodes. Measured in algorithm-invocation counts, so it transfers
+  across machines, and it is the same order as the 2.5–3× wall-clock
+  measured on CoreS3.
 - **`progressive` never beats `exhaustive` on cost** (86 vs 83, 96 vs
-  96). Reordering by a degenerate key cannot help, and where it differs
-  it is slightly worse — consistent with the ranking pushing the
-  eventual winner later.
+  96, 44 vs 46, 39 vs 42, 60 vs 61, 59 vs 60) — at best a few percent
+  either way, well inside noise for a reordering that cannot change the
+  set. It does confirm the harness: recall matches `exhaustive` in every
+  run, as it must.
 
-The full 8-run grid and the `argmax` counts belong on the Ryzen 9 box
-alongside the other jobs in section 11.
+The AWGN cells rescue more (+3 at m28) than the CCIR-moderate ones (+1),
+which is the opposite of the fading-motivated framing #308 came from and
+worth re-checking at n=100.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -1166,3 +1166,75 @@ escalation-priority signal.
 Not wired into anything. `sync_quality` and `sync_quality_generic` are
 untouched and bit-identical; the soft variant asserts equality of the
 `nsync` it returns against the hard one on every candidate in the test.
+
+### The population #310 actually triages — and the result reverses
+
+§14's population was every gate-passing candidate, which includes the
+ones that decode immediately at `llra`. Those never reach the escalation
+budget, so they are irrelevant to the scheduling decision — and, being
+the easiest candidates in the set, they inflate the apparent benefit of
+any score.
+
+`fst4_60_diag_soft_margin_escalation_priority` restricts the population
+to exactly what #310 has to triage:
+
+- **Population**: passes the `nsync` gate *and* fails BP on `llra` at
+  `offset = 0` — the cheapest rung, the one `decode_rung_major`'s latency
+  invariant guarantees every candidate.
+- **Positive**: goes on to decode with the full escalation budget
+  (`llrb`/`llre`/`llrc`, OSD at the gate-selected depth, and `i0 ± 1`).
+- **Negative**: never decodes — every unit spent on it was wasted.
+
+| cell | post-first-rung candidates (decode) | `nsync` | mean margin | mean logratio |
+|---|---|---:|---:|---:|
+| CCIR-mod m24 | 220 (86) | 0.911 | 0.914 | **0.917** |
+| CCIR-mod m25 | 203 (28) | **0.726** | 0.709 | 0.700 |
+| AWGN m27 | 212 (66) | 0.879 | **0.905** | 0.887 |
+| AWGN m28 | 194 (19) | 0.848 | **0.854** | 0.812 |
+| **pooled** | **829 (199)** | **0.868** | **0.881** | 0.871 |
+
+**Two things change relative to §14.**
+
+**1. The population is very triageable, by any of the three scores.**
+Pooled AUC 0.87–0.88, far above chance. That is good news for #310
+independent of which score wins: after the first rung, the candidates
+worth escalating *are* distinguishable from the ones that will never
+decode.
+
+**2. The soft margin's advantage largely evaporates.** Pooled, `mean
+margin` beats raw `nsync` by **+0.013** and `mean logratio` by **+0.003**
+— against §14's +0.019 to +0.099. And it is no longer consistent: `mean
+margin` loses to `nsync` in CCIR-moderate m25 (0.709 vs 0.726), and
+`mean logratio` loses in two of four cells. The best-performing
+formulation also flips — `mean logratio` won everywhere in §14, `mean
+margin` wins pooled here.
+
+**By VK3NV's own kill condition this fails.** The condition was: *if raw
+`nsync` already separates the expensive false survivors, there is no
+reason to add anything else.* On the population that matters, it does —
+0.868 pooled — and the soft features add ~1 point of AUC inconsistently,
+for 40 extra values per candidate of state.
+
+### The methodological point, which is the more durable result
+
+§14's apparent gain was substantially an artifact of measuring on the
+wrong population. Including candidates that decode at the first rung —
+which no escalation policy ever sees — inflated the margin's advantage
+by roughly 5×.
+
+This is why VK3NV specified the `nsync`-only baseline as part of the
+proposal. Without it, the pooled 0.881 for `mean margin` reads as "the
+soft feature separates well" and would justify wiring it in; against the
+0.868 baseline it reads as "raw `nsync` was already doing this". Same
+number, opposite decision.
+
+The implementation stays in the tree (`sync_quality_soft_generic`,
+diagnostic-only, nothing calls it) because the negative result is worth
+being able to re-derive, and because the per-symbol pairs are the
+instrumentation any future proxy attempt would want. But on this
+evidence #310's escalation ordering should use `nsync`, which it already
+has, and look elsewhere for a better signal.
+
+**Not tested**: whether a *learned* combination of the pairs beats
+`nsync` — the proposal's original neural-net framing. Three hand-picked
+formulations failing is weak evidence against that, not strong.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -664,6 +664,50 @@ candidates decoding the same signal, so it is not a recall figure. At
 ±100/±50/±25 Hz only one known signal is in the window, so `real ≤ 1`
 by construction there; only the ±250 Hz rows contain both.
 
+### Audit: dedup-suppressed candidates re-admitted past the cap
+
+VK3NV's #312 follow-up flagged a reachable path in `engine/sync.rs`:
+the dedup loop marks the losing near-duplicate (4 Hz / 40 ms) with
+`score = 0.0`, but the `retain` right after admits anything satisfying
+`stage1_pass(fi)` regardless of score. `stage1_norm` is only populated
+for FST4, so it is FST4-specific.
+
+`fst4_60_diag_dedup_zero_score_readmission` counts it directly — a
+`score` of exactly `0.0` in the output can only come from that dedup
+assignment, and `SyncCandidate::score` is public, so no library change
+was needed.
+
+**It fires, but not where the concern expected.** Measured over
+4 widths x 6 caps on both golden targets and two near-threshold sweep
+trials:
+
+| source | width | cap | capped | zeros | zeros in reserved near-hint group |
+|---|---|---:|---:|---:|---:|
+| golden / K9KFR | +/-250 Hz | 50 | 50 | 3 | 3 |
+| golden / K9KFR | +/-100 Hz | 50 | 50 | 3 | 3 |
+| golden / K9KFR | +/-50 Hz | 50 | 50 | 3 | 3 |
+| golden / K9KFR | +/-25 Hz | 50 | 50 | 6 | 3 |
+
+Every other row is zero — including **every cap below 50**, both
+near-threshold sweep trials, and N5TM entirely.
+
+The reason is that zeros sort last within their group, so a low cap
+truncates them away before they matter: `reserved =
+min(near.len(), cap.div_ceil(2))` takes the top of `near` *by score*,
+and `near` always held at least `reserved` non-zero candidates here.
+
+**So the caveat lands on the opposite rows from the hypothesis.** The
+low-cap rows in the tables above are unaffected, as are section 11.2's
+near-threshold recall numbers. What is affected is `max_cand = 50` —
+the production default — where on one of the two golden signals **3 of
+50 slots (6 %) go to candidates already known to be duplicates**, all
+three inside the reserved near-hint group.
+
+Not fixed here: this is a measurement of the existing behaviour, and
+whether the `retain` should test `score >= sync_min && stage1_pass(fi)`
+(or exclude zeroed entries explicitly) is a decision for #312 with its
+own recall check, since the OR-gate exists for #146 reasons.
+
 ### One pathological candidate costs ~2 s, and survives at cap = 4
 
 An anomaly worth keeping: N5TM's ±100 Hz and ±50 Hz rows sit at

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -476,7 +476,80 @@ cargo test -p mfsk-core --features full,internal-testing --release \
 sync pass each). Scoped by test name — never a blanket `-- --ignored`,
 which escalates into the full tier-C campaign (see `CLAUDE.md`).
 
-### Result, 2026-08-17 (`fst4_60_ccir_moderate_m26`, 20 trials)
+### Trap 3 — the cell must have partial baseline recall
+
+The grid can only separate mechanisms where the `npre @{0}` baseline is
+non-zero and non-saturated. On a 0/n cell every "rescue" is measured
+against nothing and a mechanism that merely *widens* an existing margin
+is invisible; on an n/n cell there are no failures left to rescue. This
+is section 6's rule, and it applies here with extra force.
+
+The first run of this ablation used m26 CCIR-moderate — the cell #306
+and #308 both name — and it is **0/20 for this harness**.
+`fst4_60_diag_npre_baseline_scan` locates the usable band cheaply (one
+configuration instead of six). Measured 2026-08-17, 20-trial corpus:
+
+| channel | m20 | m22 | m23 | m24 | m25 | m26 | m27 | m28 | m29 |
+|---|---|---|---|---|---|---|---|---|---|
+| AWGN | 20/20 | 20/20 | 20/20 | 20/20 | 20/20 | 19/20 | **12/20** | **3/20** | 0/20 |
+| CCIR-moderate | 20/20 | 20/20 | 20/20 | **17/20** | **7/20** | 0/20 | 0/20 | 0/20 | 0/20 |
+
+That the original finding lives in a cell this harness cannot use is
+itself the quantitative version of "the hand-built path is narrower than
+production": production reaches roughly 1–2 dB deeper, carrying #308's
+timing retry, a wider candidate set, and no ±`FREQ_TOL_HZ` pre-filter.
+
+### Trap 4 — compare the combination against the union, not the singles against each other
+
+The first classifier compared the two single-mechanism sets to each
+other and never compared the *combination* against their union. It
+therefore labelled a cell "substitutable" (identical singles) while the
+combination was in fact rescuing strictly more than either — the one
+outcome that changes the answer for #310. If you write this kind of
+2×2 by hand, the synergy set (`both \ (timing ∪ fallback)`) is the
+column that matters most; it is also the only one the naive comparison
+cannot see.
+
+### Result, 2026-08-17 — the usable band (20-trial corpus, 4 cells)
+
+Relative to the `npre @{0}` baseline in each cell:
+
+| cell | baseline | timing alone | fallback alone | both | only-with-both | verdict |
+|---|---:|---|---|---|---|---|
+| CCIR-mod m24 | 17/20 | 19 | 15, 19 | 15, 19 | — | partial overlap |
+| CCIR-mod m25 | 7/20 | 1 | — | 1, **9, 14** | **9, 14** | **synergistic** |
+| AWGN m27 | 12/20 | 15 | 15 | **3**, 15, **20** | **3, 20** | **synergistic** |
+| AWGN m28 | 3/20 | 5, 12, 18 | 5 | 5, 12, 18 | — | partial overlap |
+
+**In 2 of 4 cells the combination rescues trials that neither mechanism
+rescues alone.** Mechanistically that is coherent: the unpruned search
+explores more patterns but only helps if the LLRs it is handed are good
+enough, and an alternate `i0` is what produces better LLRs. Both
+conditions have to hold at once.
+
+**Which mechanism dominates flips between cells** — at CCIR-moderate m24
+the fallback's set contains timing's; at AWGN m28 timing's strictly
+contains the fallback's. There is no universal escalation order to
+derive from this.
+
+**`npre` never decodes a trial the unpruned search misses** — the
+`npre wins unpruned misses` column is empty in all four cells, at both
+timing settings, and `npre→unpruned` is byte-identical to plain
+`unpruned` throughout. So on this corpus `npre` is a pure recall loss
+bought for speed, and a "selective fallback to unpruned" is
+behaviourally the same thing as always running unpruned. Worth knowing
+before designing an escalation order around the distinction.
+
+**For #310**: the ladder cannot be reduced to one mechanism without
+losing the synergy trials — but the magnitude is 2–3 trials per 20 in
+the crossing band, against a measured 2.5–3× cost for full timing
+diversity on real hardware. That is a trade to make deliberately, not
+an argument that both are mandatory.
+
+### Superseded first reading (`fst4_60_ccir_moderate_m26`, 20 trials)
+
+Kept because it is how traps 3 and 4 were found, not as a result to
+cite.
 
 | configuration | decoded | trials |
 |---|---:|---|
@@ -499,22 +572,114 @@ two: on this cell the rescue is the combination, so an embedded build
 that keeps `offsets = &[0]` gets no benefit from adding an unpruned-OSD
 fallback either.
 
-**Every trial reached `osd_depth = 3`**, so `npre2` was exercised
-throughout — the remaining misses are a genuine `npre2`-pruning
-limitation, not an artifact of never escalating past `ndeep = 2`. That
-closes the npre1-vs-npre2 localisation question #311 raised.
+Every trial in *this* cell reached `osd_depth = 3`, so `npre2` was
+exercised throughout it. That does **not** generalise: in the usable
+band above, some trials decode on BP alone (`depth = 0`, e.g. m24 trials
+7 and 17) and some stop at `depth = 2` (m28 trials 4 and 10). Whether
+`npre2` is even in play is cell-dependent, so the npre1-vs-npre2
+localisation question #311 raised is answered only for the deepest
+cells, not in general.
 
 ### Caveats, stated because they are load-bearing
 
-- **n=20, 3 hits.** Directional. Nothing here should move a production
-  default; that needs the near-threshold sweep.
-- **This cell does not reproduce #308's 2/5 timing win at all**
-  (`npre @{0,+1,-1}` is 0/20 here). The difference is a different
-  corpus generation and/or the narrower hand-built pipeline. Unresolved
-  — do not read the table above as contradicting #308 until the same
-  grid has been run on a 100-trial generation.
-- One cell only: FST4-60, CCIR-moderate, m26.
+- **20 trials per cell, single-digit rescue counts.** Directional.
+  Nothing here should move a production default; that needs the
+  near-threshold sweep, and the cost side needs real hardware.
+- **The verdict is cell-dependent, so cite the cell.** Two of four
+  cells are synergistic and two are not; a single-cell run of this
+  ablation can be made to say either thing. Report the band.
+- **No cell reproduces #308's specific 2/5 timing win.** #308 measured
+  that on a 100-trial generation, naming trials 33/45/67 that this
+  corpus does not contain (trap 1). Unresolved, and **not testable
+  here**: `fst4sim` is not installed, so a 100-trial generation cannot
+  be built in this environment. Do not read these tables as
+  contradicting #308 until the grid has run on that generation.
+- One sub-mode only (FST4-60), one target message, sniper-style
+  candidate pre-filtering to ±`FREQ_TOL_HZ` of the golden frequency.
 - **Wall-clock is deliberately not reported.** This is recall
   attribution. Cost numbers belong on the Ryzen 9 box or real hardware
   — an Apple laptop's AC/battery state swings host wall-clock ~3×
   (`BENCHMARKS.md` records the machine for exactly this reason).
+
+## 10. Sniper candidate cap — retained fraction, not absolute count (2026-08-17)
+
+Issue #312, from VK3NV's follow-up on #306. `fst4_60_diag_sniper_gate_width_sweep`
+sweeps the sniper path's search width **and** its `max_cand` cap over
+the real FST4-60 golden (`210115_0058.wav`, two known signals 230 Hz
+apart: N5TM @ 1101 Hz, K9KFR @ 1331 Hz).
+
+```sh
+cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_sweep fst4_60_diag_sniper_gate_width_sweep \
+    -- --ignored --nocapture
+```
+
+### Why the `frac` column is the point
+
+An absolute cap is **not comparable across widths**. Measured:
+
+| width | raw population | `max_cand = 50` is… |
+|---|---:|---|
+| ±250 Hz | 842 | top **6 %** |
+| ±100 Hz | 332 | top **15 %** |
+| ±50 Hz | 165 | top **30 %** |
+| ±25 Hz | 85 | top **59 %** |
+
+One constant, a 10× spread in retention policy. This is also why the
+false-survivor count *rises* as the window narrows at fixed cap
+(N5TM: 21 → 29 from ±250 to ±25 Hz) — the narrow window keeps a much
+larger fraction of its own smaller pool. Reading that as "narrowing
+makes things worse" is the trap the column exists to prevent.
+
+### At matched retained fraction, narrowing the window does cut false survivors
+
+Comparing cells at ~5 % retention rather than at equal cap:
+
+| width | cap | frac | false survivors (N5TM / K9KFR) |
+|---|---:|---:|---|
+| ±250 Hz | 50 | 6 % | 21 / 18 |
+| ±100 Hz | 16 | 5 % | 9 / 10 |
+| ±50 Hz | 8 | 5 % | 5 / 6 |
+| ±25 Hz | 4 | 5 % | 1 / 3 |
+
+Roughly **20× fewer** false survivors at the same retention policy, and
+monotone in width for both targets. Same shape at ~10 % retention. So
+width and cap are not interchangeable knobs: the width genuinely shrinks
+the noise pool, and the fraction is the right axis on which to compare
+caps. A cap derived from the width is defensible on this evidence; a
+fixed constant across widths is not.
+
+### What this sweep cannot answer, and why
+
+**Both golden signals are strong, and the target still decodes at every
+width down to `max_cand = 4`.** No recall cliff is reached anywhere in
+the table, so this cannot locate where truncation starts costing weak
+decodes — which is the entire question a tighter cap raises. VK3NV
+flagged this scope limit when requesting the sweep; it holds. A
+near-threshold AWGN/CCIR sweep has to run before any production default
+moves.
+
+Also note `decoded` counts decode *successes*, including several
+candidates decoding the same signal, so it is not a recall figure. At
+±100/±50/±25 Hz only one known signal is in the window, so `real ≤ 1`
+by construction there; only the ±250 Hz rows contain both.
+
+### One pathological candidate costs ~2 s, and survives at cap = 4
+
+An anomaly worth keeping: N5TM's ±100 Hz and ±50 Hz rows sit at
+~2 100 ms for *every* cap including 4, while the same target's ±250 Hz
+and ±25 Hz rows at cap 4 are 40–90 ms. K9KFR shows no such plateau.
+
+The reading is that a single candidate in the ±100/±50 Hz window costs
+~2 s on its own, ranks in the top 4 there, is crowded out of ±250 Hz's
+top 4 by stronger candidates, and falls outside ±25 Hz entirely. That is
+a concrete instance of the failure mode #310 exists to bound: **one
+pathological false survivor consuming the expensive depth budget before
+the real candidates have had their cheapest attempt.** Candidate-count
+reduction alone does not fix it — the cost is per-candidate, not
+per-population.
+
+This is a within-run comparison (25× on the same invocation), so it is
+not the host power-state confound that makes absolute host wall-clock
+unreliable here; but the absolute milliseconds still belong on the
+Ryzen 9 box before they go in a table anyone reasons from.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -925,3 +925,90 @@ Two results hold independently of the open question above:
 The AWGN cells rescue more (+3 at m28) than the CCIR-moderate ones (+1),
 which is the opposite of the fading-motivated framing #308 came from and
 worth re-checking at n=100.
+
+## 13. Scheduling decision — why `offsets` stays offset-major (2026-08-18)
+
+Issue #310 proposed folding `decode_rung_major_timed`'s `offsets`
+parameter into a cost-ordered priority queue, so that "cheap attempts
+across all candidates first → timing alternatives → deeper correlation →
+OSD/fallbacks as budget permits" rather than running the whole 5-rung
+ladder at `offset = 0` before touching `offset = -1`'s cheapest rung.
+
+**Current position: don't fold it in. Keep the offset-major structure
+and add a budget gate between offsets instead.** Recorded here with the
+reasoning, because it is contrary to the issue's original framing and
+should not have to be re-derived from the measurement sections above.
+
+### The three measurements this rests on
+
+1. **Timing diversity is expensive and thin** (§12). Exhaustive
+   `{0,+1,-1}` retry costs **1.6–2.7× the decode units** of `{0}` for
+   **+1 to +3 decodes per 20 trials** — same order as the 2.5–3×
+   wall-clock measured on CoreS3, and in invocation counts so it
+   transfers across machines.
+
+2. **It cannot be cheaply targeted** (§12). Ranking the offsets by
+   `sync_quality` and decoding only the best matched exhaustive in
+   **1 of 8 runs** and the single-offset baseline in the other seven.
+   There is a structural reason to expect sync-derived ranking to
+   struggle — `i0` already comes from `fst4_sync_search`, which
+   maximises a coherent sync score — so a working proxy would have to be
+   sync-orthogonal.
+
+3. **The mechanisms interact** (§9). In 2 of 4 cells, alternate timing
+   and the unpruned-OSD fallback together rescue trials that neither
+   rescues alone.
+
+### Why not fold, in order of weight
+
+1. **It would triple the first-rung sweep.** Rung-major's actual
+   contribution is the ordering-independent bound on time-to-first-decode
+   (~7.4 s projected for the first rung across 41 candidates). Mixing
+   offsets into the cheapest rung trades away the property the design
+   exists to provide.
+
+2. **Offset setup is not free.** A new offset rebuilds `symbol_spectra`
+   and the bit metrics. Interleaving individual rungs across offsets pays
+   that setup for every candidate, early, for a mechanism that pays off
+   on 1–3 trials in 20. The natural scheduling unit is
+   *offset setup + a bundle of rungs at that offset*, not a free
+   interleave — which is what offset-major already is.
+
+3. **The payoff cannot be aimed.** If cheap ranking worked, front-loading
+   one well-chosen alternate offset would be attractive. Measurement 2
+   says it doesn't, so early offset work is spent broadly rather than
+   where it will land.
+
+### What to build instead
+
+Keep offset-major; add a **deadline check between offsets**. Run
+`offset = 0`'s full ladder to completion, then spend whatever slot time
+remains on additional offsets. This preserves the first-rung bound,
+keeps the expensive mechanisms off the critical path, and degrades to
+today's `&[0]` behaviour when the slot is tight.
+
+**If a second pass is added, add timing and the unpruned fallback
+together as one escalation step** — measurement 3 says adding only the
+cheaper of the two pays real cost and collects part of the gain. This is
+the one place the measurements changed the design rather than confirming
+it.
+
+Related: `npre` never decodes a trial the unpruned search misses on any
+cell tested (§9), so it buys speed and never recall. There is no reason
+to interleave npre *depth* with timing — only to run npre first because
+it is cheap.
+
+### What would reverse this
+
+- A **sync-orthogonal cheap proxy** that actually predicts the winning
+  offset (LLR reliability statistics, truncated-BP syndrome weight).
+  That would make front-loading one targeted alternate offset cheap, and
+  the cost-ordered fold becomes attractive.
+- The n=100 run (§11.3) showing the synergy trials are a materially
+  larger fraction than 2–3 per 20, raising the second pass's value enough
+  to justify paying for it earlier.
+- Per-offset setup cost measured directly — the instrumentation already
+  exists in `decode_rung_major_timed`'s `clock` hook — showing setup is
+  small relative to a rung, which would weaken reason 2.
+
+All three are open. This decision is provisional on them.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -1318,3 +1318,73 @@ of the ranking is all that ever gets served. That is measurable from
 The non-linear/learned version the proposal originally framed is **not**
 ruled out by this, but the cost argument applies to it more strongly,
 not less.
+
+### The budget curve — what ordering is actually worth
+
+AUC is an ordering metric; #310's currency is **decodes before the slot
+deadline**. Those only connect through the budget: if it covers every
+candidate, ordering changes nothing; if it covers only the head of the
+ranking, a small ordering gain can matter a lot. So the AUC results
+above could not settle the question on their own.
+
+`fst4_60_diag_escalation_budget_curve` measures the missing quantity —
+**per-candidate escalation cost** — and simulates a deadline. Population
+is the post-first-rung set (the `llra` rung at `offset = 0` is sunk: the
+latency invariant spends it on everyone, so it is outside the budget).
+Cost is counted in units of one (offset, stage) evaluation over
+`llrb`/`llre`/`llrc` + OSD at `i0`, `i0+1`, `i0-1`, stopping at success.
+6 cells, 1 263 candidates, 386 of which decode, 12 330 units total
+(mean 9.8 per candidate).
+
+| budget | arrival order | `nsync` | mean margin | **oracle** |
+|---:|---:|---:|---:|---:|
+| 10 % | 49 | 166 | 172 | **358** |
+| 20 % | 111 | 288 | 306 | 386 |
+| 30 % | 165 | 361 | 365 | 386 |
+| 40 % | 187 | 377 | 382 | 386 |
+| 50 % | 198 | 380 | **386** | 386 |
+| 70 % | 316 | 384 | 386 | 386 |
+| 100 % | 386 | 386 | 386 | 386 |
+
+`oracle` = decoders first, cheapest decoder first. Unachievable — it
+knows the answers — but it bounds what *any* ranking could buy.
+
+**Three things fall out.**
+
+**1. Having a priority signal at all is worth a great deal.** At a 10 %
+budget, `nsync` returns 166 decodes against arrival order's 49 — 3.4×.
+Whatever else is true, #310's escalation-ordering idea is sound.
+
+**2. The soft margin's advantage stays small, but is not zero.** +6
+decodes at 10 %, **+18 at 20 %** (306 vs 288, 6.3 % relative), +4 at
+30 %, and it reaches the oracle's ceiling at 50 % where `nsync` is still
+6 short. Consistent with the +0.014 AUC, and it does not change the cost
+verdict: 18 decodes in 386 at one budget point is not worth 320 B per
+candidate plus a maintained model.
+
+**3. The interesting number is the oracle gap, and it is large.** At a
+10 % budget the oracle recovers 358 of 386 (93 %) where `nsync` gets 166
+(43 %). Neither score is close. That headroom exists because the oracle
+sorts by cost as well as by decodability — **a cheap decoder is worth far
+more per unit than an expensive one, and neither `nsync` nor the margin
+knows anything about cost.**
+
+So the useful redirection for #310 is: **the missing signal is not "will
+this decode" but "will this decode cheaply".** Both scores here predict
+the former. Cost is partly structural and may be cheaper to predict than
+decodability — `nsync` already determines whether OSD runs at all
+(`osd_attempt_min`), and OSD is the expensive stage.
+
+### The qualifier that keeps this in proportion
+
+FST4-60's real situation is roughly a 7 s margin against a 13.6 s
+`no8_osd` candidate loop — call it a ~50 % budget. **At 50 %, `nsync`
+already returns 380 of 386 (98.4 %).** The dramatic ordering effects live
+at 10–20 % budgets, which would mean a deadline several times tighter
+than the one this mode actually has.
+
+So: ordering is worth having (point 1), `nsync` is enough of it at the
+budget that exists, and the oracle headroom (point 3) only becomes worth
+chasing if the budget gets much tighter — a shorter sub-mode, a slower
+target, or a wideband candidate list far larger than the sniper-shaped
+50 used here.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -1388,3 +1388,87 @@ budget that exists, and the oracle headroom (point 3) only becomes worth
 chasing if the budget gets much tighter — a shorter sub-mode, a slower
 target, or a wideband candidate list far larger than the sniper-shaped
 50 used here.
+
+### Breadth-first vs depth-first — the schedule matters more than the ordering
+
+The budget curve above used a **depth-first** escalation (each candidate
+runs its ladder to success before the next starts).
+`decode_rung_major` is **breadth-first** (one rung swept across every
+candidate before any descends), so those ordering conclusions could not
+be carried over to the design without checking.
+`fst4_60_diag_budget_curve_breadth_vs_depth` runs both schedules over
+the same candidates and the same per-stage outcomes.
+
+Ladder is offset-major per §13: `llrb`/`llre`/`llrc`/OSD at `i0`
+(the `llra` rung being sunk), then the full five stages at `i0+1`, then
+at `i0-1`. 1 263 candidates, 386 decode, 12 330 units, longest ladder 14
+stages.
+
+| budget | depth: arrival | depth: `nsync` | depth: oracle | breadth: arrival | breadth: `nsync` | breadth: oracle |
+|---:|---:|---:|---:|---:|---:|---:|
+| 10 % | 49 | **166** | 358 | 35 | 35 | 35 |
+| 20 % | 111 | **288** | 386 | 80 | 80 | 80 |
+| 30 % | 165 | **361** | 386 | 137 | 150 | 152 |
+| 40 % | 187 | 377 | 386 | 350 | 350 | 350 |
+| 50 % | 198 | **380** | 386 | 350 | 350 | 350 |
+| 70 % | 316 | 384 | 386 | 360 | 366 | 366 |
+| 100 % | 386 | 386 | 386 | 386 | 386 | 386 |
+
+**1. Ordering does essentially nothing under breadth-first.** All three
+orderings are identical at 10 % and 20 %, and within a couple of decodes
+everywhere else. The reason is mechanical: a 10 % budget buys ~1 233 of
+the 1 263 stage-0 evaluations, so nearly every candidate gets the first
+escalation stage regardless of the order they are visited in. **The
+"re-sort survivors by `nsync`" idea is dead for rung-major** — it buys
+nothing, and one less thing needs justifying.
+
+**2. Breadth-first is markedly worse under a tight budget.** At 10 %,
+depth-first with `nsync` returns 166 decodes against breadth-first's 35;
+at 20 %, 288 against 80; at the realistic ~50 %, **380 against 350**.
+
+**3. The mechanism is the OSD stage.** Breadth-first's jump from 137 to
+350 between the 30 % and 40 % budget points is a stage boundary:
+sweeping stages 0-3 (the offset-0 ladder, OSD included) across ~1 263
+candidates costs ~5 050 units, just under the 4 932 units that 40 %
+buys. Below that, breadth-first has spent its entire budget on cheap BP
+stages and **has not reached OSD for anybody** — and OSD is where most
+of these decodes come from. Deferring the highest-yield stage until
+every candidate has had every cheaper one is exactly what breadth-first
+is for, and under a deadline it is exactly what costs decodes.
+
+### The trade-off this quantifies, and the resulting design
+
+This is not an argument against rung-major. Rung-major exists for the
+**ordering-independent bound on time-to-first-decode** — depth-first has
+no such guarantee, and a bad candidate order pushes the first decode
+arbitrarily late (~30 s of a 30.15 s total in the worst case measured
+earlier). The two properties are in genuine tension and the numbers
+above are the price:
+
+| | time-to-first-decode | decodes at ~50 % budget |
+|---|---|---|
+| breadth-first (rung-major) | **bounded by one rung** | 350 / 386 |
+| depth-first + `nsync` | unbounded (ordering-dependent) | **380 / 386** |
+
+**Both are available at once**, and the phase split already recorded in
+§13 is where:
+
+- **Phase A — first rung, breadth-first, unconditional.** `llra` at
+  `offset 0` across every candidate. This *is* the latency invariant:
+  every candidate gets its cheapest attempt within a bounded time
+  regardless of ordering. Keep exactly as-is.
+- **Phase B — escalation, depth-first, ordered by `nsync`, budget-gated.**
+  Once the bound has been honoured, breadth-first has no remaining
+  advantage and costs 30 decodes at the realistic budget. `nsync` is free
+  here — Phase A computed it for every candidate to run the gate.
+- **Phase C — second pass (alternate timing *and* unpruned OSD together,
+  per §9), only if budget remains.**
+
+So the answer to "should the escalation phase re-sort by `nsync`" is
+**yes, but only because Phase B should be depth-first** — under
+breadth-first the sort is worthless. The two decisions are coupled and
+neither is right alone.
+
+Unmeasured: this models the escalation as sequential units and ignores
+the per-offset setup cost (`symbol_spectra` + bit-metrics rebuild) that
+§13's reason 2 turns on. Phase C's cost is therefore understated here.

--- a/docs/notes/FST4_BENCHMARK.md
+++ b/docs/notes/FST4_BENCHMARK.md
@@ -1238,3 +1238,83 @@ has, and look elsewhere for a better signal.
 **Not tested**: whether a *learned* combination of the pairs beats
 `nsync` — the proposal's original neural-net framing. Three hand-picked
 formulations failing is weak evidence against that, not strong.
+
+### Correction: the soft margin *does* carry information beyond `nsync`
+
+The section above concluded the soft features add nothing. **That was
+wrong**, and the way it was wrong is instructive: an unconditional AUC
+comparison cannot separate "no information" from "information masked by
+correlation with the baseline".
+
+`fst4_60_diag_soft_margin_conditional_value` tests it three ways on a
+larger population — 6 cells, 1 263 post-first-rung candidates (386
+decode, 877 don't), 9 feature formulations instead of 3.
+
+**1. Stratified AUC — within a fixed `nsync` value.** If a feature were
+only a proxy for `nsync`, holding `nsync` constant would leave it with
+nothing to say and the AUC would sit at 0.5. It doesn't:
+
+| feature | unconditional AUC | **stratified AUC** |
+|---|---:|---:|
+| `nsync` (baseline) | 0.920 | — |
+| mean margin | 0.932 | **0.717** |
+| mean logratio | 0.926 | **0.704** |
+| sum logratio | 0.926 | 0.704 |
+| mean worst-10 | 0.913 | 0.689 |
+| p25 margin | 0.916 | 0.638 |
+| median margin | 0.917 | 0.579 |
+| min margin | 0.724 | 0.542 |
+| count margin>0 | 0.921 | 0.530 |
+| margin variance | 0.345 | 0.412 |
+
+Within a fixed `nsync`, the mean normalised margin still orders
+decode-from-never-decode at 0.717. **VK3NV was right that collapsing the
+four-tone observation to 40 hard bits discards usable information.**
+
+(`margin variance` inverts — below 0.5 both ways — i.e. *lower*
+dispersion associates with decoding. Real but not actionable here.)
+
+**2. A fitted linear rule, and what it actually buys.** Logistic
+regression over `nsync` + all nine features:
+
+| | AUC |
+|---|---:|
+| `nsync` alone | 0.920 |
+| in-sample fit (optimistic upper bound) | 0.935 |
+| **2-fold cross-validated (honest)** | **0.934** |
+
+So the whole feature set, optimally combined, is worth **+0.014 AUC**
+over the `nsync` this crate already computes.
+
+### The decision is unchanged, and the reason is now cost, not absence
+
+Both possible outcomes of this experiment led to the same action, which
+is worth stating because it is why the elaborate version was still worth
+running:
+
+- had the stratified AUCs been ~0.5, there is no signal → use `nsync`;
+- they are ~0.7, so there is signal → **it still does not clear the cost
+  bar** → use `nsync`.
+
+`nsync` is a `u32` that is already computed on the path. The soft
+alternative costs 40 × 2 f32 = 320 B of state per candidate on a target
+where per-candidate allocation in the candidate loop has caused real
+trouble, plus fitted weights and standardisation constants that would
+have to be re-validated across sub-modes, channel conditions and corpus
+generations — a tuned constant that rots. **+0.014 AUC does not buy
+that.**
+
+Recorded this way deliberately: "measured, and not adopted because the
+gain is 1.4 points against a maintained model" is a much more durable
+answer than "tried three formulas and they lost", and it answers the
+same proposal if it comes back.
+
+**What would change it**: a use where the ranking quality translates
+into a large wall-clock saving rather than a small ordering improvement
+— e.g. if the escalation budget were tight enough that the top decile
+of the ranking is all that ever gets served. That is measurable from
+`decode_rung_major_timed`'s existing `clock` hook and has not been done.
+
+The non-linear/learned version the proposal originally framed is **not**
+ruled out by this, but the cost argument applies to it more strongly,
+not less.

--- a/mfsk-core/src/engine/llr.rs
+++ b/mfsk-core/src/engine/llr.rs
@@ -596,3 +596,100 @@ where
     }
     count
 }
+
+/// Number of known sync symbols `sync_quality_generic` inspects — the
+/// buffer length [`sync_quality_soft_generic`] wants. 40 for FST4
+/// (5 Costas blocks x 8), 21 for FT8, and so on.
+pub fn sync_symbol_count<P: Protocol>() -> usize {
+    P::SYNC_MODE.blocks().iter().map(|b| b.pattern.len()).sum()
+}
+
+/// Soft counterpart to [`sync_quality_generic`] (issue #310, VK3NV):
+/// same `nsync` return value, plus the per-sync-symbol tone energies the
+/// hard version computes and throws away.
+///
+/// `sync_quality_generic` examines all `NTONES` energies per known sync
+/// symbol, finds the winner, and reduces the observation to
+/// `best == expected` — one bit. So
+///
+/// ```text
+/// E_expected = 9.8, best wrong = 9.5   ->  +1
+/// E_expected = 9.8, best wrong = 1.2   ->  +1
+/// ```
+///
+/// contribute identically despite carrying very different confidence.
+/// This fills `out[i] = (E_expected, E_best_wrong)` for each sync symbol
+/// so a caller can compare margin formulations
+/// (`E_exp - E_wrong`, `E_exp / E_wrong`,
+/// `(E_exp - E_wrong) / (E_exp + E_wrong)`, …) offline without another
+/// instrumentation pass.
+///
+/// **No new spectral work**: `symbol_spectra` has already produced these
+/// values before any `sync_quality*` call runs. The extra cost over the
+/// hard version is one comparison per tone — the loop tracks the maximum
+/// over all tones (for `best`, unchanged) *and* the maximum over tones
+/// other than the expected one, in the same pass.
+///
+/// `out` is caller-provided rather than allocated so this stays usable
+/// on embedded, where a per-candidate `Vec` in the candidate loop is
+/// exactly the shape that has caused trouble before. Size it with
+/// [`sync_symbol_count`]; a shorter slice is filled as far as it goes
+/// and the `nsync` return stays correct either way.
+///
+/// **Diagnostic for now.** Nothing in the decode path calls this, and
+/// whether the extra information separates expensive false survivors
+/// from decode-bearing candidates any better than raw `nsync` is the
+/// open question (#310) — see
+/// `tests/fst4_sweep.rs::fst4_60_diag_soft_costas_margin_separation`.
+pub fn sync_quality_soft_generic<P: Protocol, S: SpecScalar>(
+    cs: &[Cmplx<S>],
+    out: &mut [(f32, f32)],
+) -> u32
+where
+    S::Wide: PartialOrd,
+{
+    let ntones = P::NTONES as usize;
+    let mut count = 0u32;
+    let mut idx = 0usize;
+    for block in P::SYNC_MODE.blocks() {
+        let start = block.start_symbol as usize;
+        for (t, &expected) in block.pattern.iter().enumerate() {
+            let sym = start + t;
+            let exp = expected as usize;
+
+            // Tone 0 seeds both maxima. Same strict-`>` tie-break as
+            // `sync_quality_generic`, which matches Fortran `maxloc`
+            // returning the FIRST index on ties.
+            let v0 = cs[sym * ntones].norm_sqr_wide();
+            let mut best = 0usize;
+            let mut best_val = v0;
+            let mut e_exp = if exp == 0 { Some(v0) } else { None };
+            let mut e_wrong = if exp == 0 { None } else { Some(v0) };
+
+            for a in 1..ntones {
+                let v = cs[sym * ntones + a].norm_sqr_wide();
+                if v > best_val {
+                    best_val = v;
+                    best = a;
+                }
+                if a == exp {
+                    e_exp = Some(v);
+                } else if e_wrong.is_none_or(|w| v > w) {
+                    e_wrong = Some(v);
+                }
+            }
+
+            if best == exp {
+                count += 1;
+            }
+            if let Some(slot) = out.get_mut(idx) {
+                *slot = (
+                    e_exp.map(S::wide_to_f32).unwrap_or(0.0),
+                    e_wrong.map(S::wide_to_f32).unwrap_or(0.0),
+                );
+            }
+            idx += 1;
+        }
+    }
+    count
+}

--- a/mfsk-core/src/fst4/rung_major.rs
+++ b/mfsk-core/src/fst4/rung_major.rs
@@ -75,6 +75,20 @@
 //! | `&[0, -1]` | 1.84× | 79/100 / 21/100 |
 //! | `&[0, 1, -1]` | 2.83× (real hardware: `full` 3.02×, `no8_osd` 2.51×) | 82/100 / 23/100 |
 //!
+//! **On the scheduling of `offsets` themselves** (issue #310): the
+//! offset-major outer loop below is a deliberate choice, not an
+//! unexamined default — see `docs/notes/FST4_BENCHMARK.md` §13 for the
+//! decision and §9/§12 for the measurements behind it. Short version:
+//! folding offsets into a cost-ordered queue would triple the first-rung
+//! sweep, which is the ordering-independent time-to-first-decode bound
+//! this module exists to provide; offset setup (`symbol_spectra` + bit
+//! metrics rebuild) is not free, so the natural unit is offset-setup +
+//! a bundle of rungs; and the payoff can't be aimed, since ranking the
+//! offsets by sync quality matched exhaustive retry in only 1 of 8
+//! measured runs. The intended next step is a deadline check *between*
+//! offsets, not a re-ordering within them. Provisional on three open
+//! measurements listed in §13.
+//!
 //! (`-1` alone consistently outperforms `+1` alone at these SNRs, which
 //! is why `&[0, -1]` is the natural two-offset middle ground rather than
 //! `&[0, 1]` — see `fst4_60_diag_i0_offset_ablation`'s full 4-way table

--- a/mfsk-core/src/fst4/rung_major.rs
+++ b/mfsk-core/src/fst4/rung_major.rs
@@ -89,6 +89,20 @@
 //! offsets, not a re-ordering within them. Provisional on three open
 //! measurements listed in §13.
 //!
+//! **The escalation phase after the first rung should be depth-first,
+//! not rung-major** — measured 2026-08-18, `FST4_BENCHMARK.md` §14's
+//! breadth-vs-depth table. Rung-major's value is the latency bound, and
+//! that bound is bought entirely by the *first* rung. Past it,
+//! continuing breadth-first defers OSD — where most decodes come from —
+//! until every candidate has had every cheaper stage, which costs 30
+//! decodes in 386 at a realistic ~50 % budget (350 vs 380) and far more
+//! at tighter ones (35 vs 166 at 10 %). Candidate ordering also stops
+//! mattering under breadth-first: a 10 % budget buys ~98 % of the
+//! first-stage sweep, so every ordering visits nearly the same
+//! candidates. So the two decisions are coupled — order by `nsync`
+//! (free; the first rung computed it for the gate) *and* go depth-first,
+//! or neither is worth doing.
+//!
 //! (`-1` alone consistently outperforms `+1` alone at these SNRs, which
 //! is why `&[0, -1]` is the natural two-offset middle ground rather than
 //! `&[0, 1]` — see `fst4_60_diag_i0_offset_ablation`'s full 4-way table

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -4386,14 +4386,10 @@ fn fst4_60_diag_npre_baseline_scan() {
 }
 
 fn npre_timing_grid_for_cell(channel: &str, snr_tag: &str) {
-    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
-    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fec::ldpc240_101::fst4_osd_diag_force_old;
     use mfsk_core::fst4::Fst4s60;
-    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
     /// Upper bound on trial index to probe; missing files are skipped, so
     /// this works against any corpus generation (20-, 100-trial, …).
@@ -4415,13 +4411,11 @@ fn npre_timing_grid_for_cell(channel: &str, snr_tag: &str) {
         NpreThenUnpruned,
     }
 
-    let dir = sweep_dir();
     let (osd_attempt_min, osd_depth3_min) =
         mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
     let fec = <Fst4s60 as Protocol>::Fec::default();
     let verify_info =
         Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
-    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
 
     // Per-trial cached sync so selection and all four arms share it.
     // Each prepared candidate is (baseband already frequency-corrected to
@@ -4495,36 +4489,7 @@ fn npre_timing_grid_for_cell(channel: &str, snr_tag: &str) {
     };
 
     // ── Prepare every present trial once ─────────────────────────────
-    // One prepared candidate: baseband already frequency-corrected to the
-    // refined estimate, plus that estimate's `i0`.
-    type PreparedCand = (Vec<num_complex::Complex<f32>>, i32);
-    let mut prepared: Vec<(u32, Vec<PreparedCand>)> = Vec::new();
-    for trial in 1..=MAX_TRIAL {
-        let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
-        let Some(audio) = load_wav_i16_opt(&path) else {
-            continue;
-        };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
-        let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-        let mut prep = Vec::new();
-        for c in cands
-            .iter()
-            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
-        {
-            let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
-            let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
-            if sum2 > f32::EPSILON {
-                let inv = 1.0 / sum2.sqrt();
-                for z in cd0.iter_mut() {
-                    *z *= inv;
-                }
-            }
-            let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
-            let shifted = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
-            prep.push((shifted, s2.i0));
-        }
-        prepared.push((trial, prep));
-    }
+    let prepared = prepare_fst4_60_cell(channel, snr_tag, MAX_TRIAL);
 
     // ── The full 2 × 3 grid, no trial pre-selection ───────────────────
     // Selecting a subset first is what makes this measurement circular
@@ -5020,4 +4985,373 @@ fn fst4_60_diag_sniper_cap_near_threshold() {
             }
         }
     }
+}
+
+/// One prepared FST4-60 candidate: baseband already frequency-corrected
+/// to the refined estimate, plus that estimate's `i0`.
+type Fst4PreparedCand = (Vec<num_complex::Complex<f32>>, i32);
+
+/// Sync one sweep-corpus cell once, so every configuration downstream
+/// sees identical input and differences are attributable to the axis
+/// under test rather than to sync jitter.
+///
+/// Shared by [`npre_timing_grid_for_cell`] and
+/// [`fst4_60_diag_i0_cheap_rank_vs_exhaustive`]. Candidates are
+/// pre-filtered to ±[`FREQ_TOL_HZ`] of [`GOLDEN_FREQ_HZ`] — this is the
+/// known-target (sniper-shaped) question, deliberately not the wide-band
+/// unknown-frequency one, and it is why this path decodes ~1-2 dB
+/// shallower than `DecodeRequest` (see `FST4_BENCHMARK.md` §9 trap 3).
+///
+/// Returns `(trial_index, candidates)` for every trial file present;
+/// missing indices are skipped, so it works against any corpus
+/// generation.
+fn prepare_fst4_60_cell(
+    channel: &str,
+    snr_tag: &str,
+    max_trial: u32,
+) -> Vec<(u32, Vec<Fst4PreparedCand>)> {
+    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    let dir = sweep_dir();
+    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
+    let mut prepared = Vec::new();
+
+    for trial in 1..=max_trial {
+        let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+        let Some(audio) = load_wav_i16_opt(&path) else {
+            continue;
+        };
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+        let mut prep = Vec::new();
+        for c in cands
+            .iter()
+            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+        {
+            let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
+            let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+            if sum2 > f32::EPSILON {
+                let inv = 1.0 / sum2.sqrt();
+                for z in cd0.iter_mut() {
+                    *z *= inv;
+                }
+            }
+            let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+            let shifted = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
+            prep.push((shifted, s2.i0));
+        }
+        prepared.push((trial, prep));
+    }
+    prepared
+}
+
+/// **Can timing diversity be had cheaply?** VK3NV's proposal on #308,
+/// measured.
+///
+/// #308 ported WSJT-X's control flow literally: try `i0`, then `i0+1`,
+/// then `i0-1`, rebuilding the full bit-metric ladder at each and
+/// short-circuiting on success. On host that is free enough to be
+/// unconditional. On embedded it is not — real-hardware measurement put
+/// it at 3.02× (`full`) / 2.51× (`no8_osd`) of the candidate loop, which
+/// is why `decode_rung_major`'s production default stays at `&[0]` and
+/// #310 exists.
+///
+/// VK3NV's observation was that cheap sync-quality information already
+/// exists *before* the expensive LLR/OSD work, so the offsets could be
+/// **ranked** rather than exhaustively tried:
+///
+/// > Could we score `i0`, `i0+1` and `i0-1` cheaply, choose/rank the best
+/// > timing, and run the expensive decoder only once initially?
+///
+/// This measures whether that works, i.e. whether `sync_quality` is a
+/// good enough proxy for "which offset will decode".
+///
+/// ## Configurations
+///
+/// | | offsets tried at full depth | cost shape |
+/// |---|---|---|
+/// | `base` | `{0}` | 1 unit |
+/// | `exhaustive` | `{0,+1,-1}`, short-circuit on success | ≤3 units |
+/// | `cheap-rank` | **only** the `argmax nsync` offset | 1 unit + 3 cheap `nsync` |
+/// | `progressive` | all three, ordered by `nsync` descending | ≤3 units, better ordering |
+///
+/// `progressive` must match `exhaustive` on recall by construction (same
+/// set, different order) — if it doesn't, the harness is broken. Its
+/// point is the *cost* column.
+///
+/// ## Cost is counted, not timed
+///
+/// The metric is the number of full decode units executed
+/// (`compute_llr` + the BP/OSD ladder for one (candidate, offset)), not
+/// wall-clock. That makes it machine-independent, which matters because
+/// absolute host timing on an Apple laptop swings ~3× with power state —
+/// so unlike every `loop_ms` column in this file, these numbers are
+/// directly comparable and can be quoted as-is.
+///
+/// ## The confound that has to be checked first
+///
+/// `i0` does not arrive unranked. It comes from `fst4_sync_search`,
+/// whose entire job is to **maximise a coherent sync score** over a
+/// (Δf, Δt) grid. `sync_quality` is a closely related measure of the
+/// same thing, so it is expected to peak at `i0` — which makes
+/// `argmax nsync` degenerate to offset 0, and `cheap-rank ≈ base` a
+/// near-tautology rather than evidence about the proposal.
+///
+/// The output therefore reports `argmax nsync == offset 0` as a counted
+/// fraction, and the verdict short-circuits to DEGENERATE when it is
+/// ≥95 %. **Do not read "cheap-rank recovered nothing" as "ranking
+/// cannot work" without checking that line first.** The first run of
+/// this test (2026-08-17) hit exactly this: it printed "PROXY USELESS"
+/// on cells where the ranking had never actually chosen a non-zero
+/// offset, which is not the same claim at all.
+///
+/// What the degenerate case does establish is narrower but still useful
+/// for #310: a cheap proxy for "which timing will decode" **cannot be
+/// another sync-strength measure**, because the refine stage has already
+/// maximised that. It would have to be sync-orthogonal — something
+/// derived from LLR reliability, or a truncated-BP syndrome weight,
+/// rather than from Costas correlation.
+///
+/// ## Reading the result
+///
+/// - If `cheap-rank` ≈ `exhaustive` on recall, `sync_quality` is a
+///   sufficient proxy and #310 can buy most of the timing benefit for
+///   roughly one unit instead of three.
+/// - If `cheap-rank` ≈ `base`, the proxy is useless: the offset that
+///   decodes is not the one that syncs best, and there is no cheap
+///   substitute for actually trying them.
+/// - `progressive` vs `exhaustive` shows whether ranking at least
+///   reduces the *expected* cost even when it can't reduce the worst
+///   case.
+///
+/// Both OSD searches are reported, because §9's ablation found timing
+/// diversity only pays off in combination with the unpruned search on
+/// some cells — a proxy that works for one may not work for the other.
+///
+/// Single-threaded (`fst4_osd_diag_force_old` is process-global):
+/// `--test-threads=1`.
+#[test]
+#[ignore = "manual diagnostic — cheap i0 ranking vs exhaustive retry (issue #308/#310, VK3NV)"]
+fn fst4_60_diag_i0_cheap_rank_vs_exhaustive() {
+    use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
+    use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::fec::ldpc240_101::fst4_osd_diag_force_old;
+    use mfsk_core::fst4::Fst4s60;
+
+    const NSYNC_GATE: u32 = 16;
+    const OFFSETS: [i32; 3] = [0, 1, -1];
+    // Same band `fst4_60_diag_npre_baseline_scan` reported; see §9 trap 3.
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let fec = <Fst4s60 as Protocol>::Fec::default();
+    let verify_info =
+        Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+
+    eprintln!();
+    eprintln!("=== cheap i0 ranking vs exhaustive retry (FST4-60) ===");
+    eprintln!("cost = full decode units (compute_llr + BP/OSD ladder), not wall-clock");
+
+    for &(channel, snr_tag) in CELLS {
+        let prepared = prepare_fst4_60_cell(channel, snr_tag, 100);
+        if prepared.is_empty() {
+            eprintln!("{channel}_{snr_tag}: no WAVs present, skip");
+            continue;
+        }
+        let n = prepared.len();
+
+        for use_npre in [true, false] {
+            fst4_osd_diag_force_old(!use_npre);
+            let osd_name = if use_npre { "npre    " } else { "unpruned" };
+
+            // (recall, decode units) per configuration.
+            let mut stats = [(0u32, 0u32); 4];
+            // How often the offset that decoded was also argmax nsync,
+            // among trials where an alternate offset was needed at all.
+            // Degeneracy check — see this test's doc comment. `i0` came
+            // from `fst4_sync_search`, which *maximises* a coherent sync
+            // score, so `sync_quality` (a closely related measure) is
+            // expected to peak at `i0` too. If `argmax nsync` is almost
+            // always offset 0, the ranking has no information to give and
+            // `cheap-rank ≈ base` is near-tautological rather than a
+            // finding about the proposal. Count it instead of inferring
+            // it from the `units` column.
+            let mut argmax_zero = 0u32;
+            let mut argmax_seen = 0u32;
+            let mut argmax_agreed = 0u32;
+            let mut argmax_total = 0u32;
+
+            for (_trial, cands) in &prepared {
+                // Per-configuration success flags for this trial.
+                let mut ok = [false; 4];
+
+                for (cd0, i0_ref) in cands {
+                    // Cheap pass: nsync at all three offsets. This is the
+                    // information VK3NV pointed out is already available.
+                    let mut cheap: Vec<(i32, u32)> = OFFSETS
+                        .iter()
+                        .map(|&d| {
+                            let cs = symbol_spectra::<Fst4s60>(cd0, i0_ref + d);
+                            (d, sync_quality::<Fst4s60>(&cs))
+                        })
+                        .collect();
+
+                    // One full decode attempt at one offset. Returns
+                    // whether the golden message came out, and bumps the
+                    // unit counter.
+                    let decode_at = |d: i32, units: &mut u32| -> bool {
+                        let cs = symbol_spectra::<Fst4s60>(cd0, i0_ref + d);
+                        let nsync = sync_quality::<Fst4s60>(&cs);
+                        if nsync <= NSYNC_GATE {
+                            return false;
+                        }
+                        *units += 1;
+                        let llr_set = compute_llr::<Fst4s60, f32>(&cs);
+                        let variants: [&Vec<f32>; 4] =
+                            [&llr_set.llra, &llr_set.llrb, &llr_set.llre, &llr_set.llrc];
+                        let is_golden = |llr: &Vec<f32>, opts: &FecOpts| -> bool {
+                            fec.decode_soft(llr, opts).is_some_and(|mut r| {
+                                mfsk_core::engine::llr::descramble_info::<Fst4s60>(&mut r.info);
+                                let mut m77 = [0u8; 77];
+                                m77.copy_from_slice(&r.info[..77]);
+                                unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                            })
+                        };
+                        let bp_opts = FecOpts {
+                            bp_max_iter: 30,
+                            osd_depth: 0,
+                            ap_mask: None,
+                            verify_info,
+                            ..FecOpts::default()
+                        };
+                        if variants.iter().any(|llr| is_golden(llr, &bp_opts)) {
+                            return true;
+                        }
+                        if nsync >= osd_attempt_min {
+                            let osd_depth: u32 = if nsync >= osd_depth3_min { 3 } else { 2 };
+                            let osd_opts = FecOpts {
+                                bp_max_iter: 30,
+                                osd_depth,
+                                ap_mask: None,
+                                verify_info,
+                                ..FecOpts::default()
+                            };
+                            if variants.iter().any(|llr| is_golden(llr, &osd_opts)) {
+                                return true;
+                            }
+                        }
+                        false
+                    };
+
+                    // base: offset 0 only.
+                    if decode_at(0, &mut stats[0].1) {
+                        ok[0] = true;
+                    }
+
+                    // exhaustive: WSJT-X order, short-circuit.
+                    let mut winner: Option<i32> = None;
+                    for &d in &OFFSETS {
+                        if decode_at(d, &mut stats[1].1) {
+                            ok[1] = true;
+                            winner = Some(d);
+                            break;
+                        }
+                    }
+
+                    // cheap-rank: argmax nsync only.
+                    cheap.sort_by(|a, b| b.1.cmp(&a.1));
+                    let best = cheap[0].0;
+                    argmax_seen += 1;
+                    if best == 0 {
+                        argmax_zero += 1;
+                    }
+                    if decode_at(best, &mut stats[2].1) {
+                        ok[2] = true;
+                    }
+
+                    // progressive: all three in nsync-descending order.
+                    for &(d, _) in &cheap {
+                        if decode_at(d, &mut stats[3].1) {
+                            ok[3] = true;
+                            break;
+                        }
+                    }
+
+                    // Proxy quality, counted only where the answer isn't
+                    // trivially offset 0: did nsync rank the winner first?
+                    if let Some(w) = winner
+                        && w != 0
+                    {
+                        argmax_total += 1;
+                        if best == w {
+                            argmax_agreed += 1;
+                        }
+                    }
+                }
+
+                for (i, hit) in ok.iter().enumerate() {
+                    if *hit {
+                        stats[i].0 += 1;
+                    }
+                }
+            }
+
+            eprintln!();
+            eprintln!("{channel}_{snr_tag}  n={n}  OSD={osd_name}");
+            for (i, name) in ["base {0}", "exhaustive", "cheap-rank", "progressive"]
+                .iter()
+                .enumerate()
+            {
+                eprintln!(
+                    "  {:<12} recall {:>2}/{n}   units {:>5}",
+                    name, stats[i].0, stats[i].1
+                );
+            }
+            let degenerate = argmax_seen > 0 && argmax_zero * 20 >= argmax_seen * 19;
+            eprintln!(
+                "  argmax nsync == offset 0 in {argmax_zero}/{argmax_seen} candidates{}",
+                if degenerate {
+                    "  <-- ranking is degenerate, see below"
+                } else {
+                    ""
+                }
+            );
+            if argmax_total > 0 {
+                eprintln!(
+                    "  nsync picked the winning offset first: {argmax_agreed}/{argmax_total} \
+                     (cases where an alternate offset was what decoded)"
+                );
+            } else {
+                eprintln!("  no candidate needed an alternate offset in this cell/OSD mode");
+            }
+
+            let (base_r, exh_r, cheap_r) = (stats[0].0, stats[1].0, stats[2].0);
+            let reading = if degenerate {
+                "DEGENERATE RANKING — nsync peaks at offset 0 almost always, because \
+                 fst4_sync_search already chose i0 to maximise a closely-related sync \
+                 score. cheap-rank ~ base is near-tautological here and says nothing \
+                 about the proposal; a usable cheap proxy has to be sync-orthogonal"
+            } else if exh_r <= base_r {
+                "timing buys nothing here — the proxy question is moot in this cell"
+            } else if cheap_r >= exh_r {
+                "PROXY WORKS — cheap nsync ranking matches exhaustive recall at ~1 unit"
+            } else if cheap_r <= base_r {
+                "PROXY USELESS — the offset that decodes is not the one that syncs best"
+            } else {
+                "PROXY PARTIAL — recovers some of the timing gain, not all"
+            };
+            eprintln!("  => {reading}");
+        }
+    }
+    fst4_osd_diag_force_old(false);
 }

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -6590,3 +6590,303 @@ fn fst4_60_diag_soft_margin_conditional_value() {
          signal masked by correlation with nsync and would justify a learned model."
     );
 }
+
+/// **The condition under which the ranking would matter**: does a better
+/// escalation order convert into more decodes *under a budget*?
+///
+/// [`fst4_60_diag_soft_margin_conditional_value`] established that the
+/// soft margin carries real information beyond `nsync` (stratified AUC
+/// ~0.72) but that an optimally-fitted linear rule is worth only +0.014
+/// AUC. AUC is an ordering metric, though, and #310's actual currency is
+/// **decodes recovered before the slot deadline**. A small ordering gain
+/// can still matter a lot if the budget is tight enough that only the
+/// head of the ranking is ever served — and not at all if the budget
+/// covers everything anyway.
+///
+/// So this measures the thing the decision actually turns on.
+///
+/// ## Model
+///
+/// Population is the same as the conditional-value test: candidates that
+/// pass the `nsync` gate and fail BP on `llra` at `offset = 0`. That
+/// first rung is sunk cost — `decode_rung_major`'s latency invariant
+/// spends it on everyone regardless — so it is excluded from the budget
+/// here.
+///
+/// Each candidate then carries a **cost in decode units**, one unit per
+/// (offset, stage) actually executed over the escalation ladder
+/// (`llrb`/`llre`/`llrc` BP attempts and the OSD attempt, at each of
+/// `i0`, `i0+1`, `i0-1`), stopping at success. A candidate that decodes
+/// early is cheap; one that never decodes pays the full ladder. Units
+/// rather than wall-clock, so the result is machine-independent and
+/// doesn't inherit this laptop's ~3x power-state swing.
+///
+/// A scheduler with budget `B` walks the candidates in its ranking's
+/// order and spends each one's cost until `B` is exhausted, counting
+/// decodes obtained. Sweeping `B` from 10 % to 100 % of the total gives
+/// a decodes-vs-budget curve per ranking.
+///
+/// ## Rankings compared
+///
+/// - `nsync` — what the crate already has.
+/// - `mean margin` — the best single soft feature from the stratified
+///   test.
+/// - `fitted` — the cross-validated logistic combination, i.e. the best
+///   linear rule available.
+/// - `oracle` — decoders first, cheapest decoder first. Not achievable;
+///   it bounds how much *any* ranking could buy, which is the number
+///   that says whether this axis is worth more work at all.
+/// - `arrival` — the candidate list order as `coarse_sync` returns it,
+///   i.e. what happens with no priority signal.
+///
+/// ## Reading it
+///
+/// If `nsync` already tracks `oracle` closely at tight budgets, ordering
+/// is not where the remaining decodes are and #310 should stop looking
+/// here. If `fitted`/`mean margin` open a real gap over `nsync` at 10-30 %
+/// budget, that is the wall-clock argument the cost objection was
+/// waiting for.
+#[test]
+#[ignore = "manual diagnostic — does escalation ordering buy decodes under a budget? (issue #310)"]
+fn fst4_60_diag_escalation_budget_curve() {
+    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::engine::llr::{
+        compute_llr, symbol_spectra, sync_quality, sync_quality_soft_generic, sync_symbol_count,
+    };
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const NSYNC_GATE: u32 = 16;
+    const MAX_CAND: usize = 50;
+    const WIDTH_HZ: f32 = 250.0;
+    const OFFSETS: [i32; 3] = [0, 1, -1];
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m23"),
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m26"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+
+    // (nsync, mean_margin, cost_units, decodes)
+    struct Cand {
+        nsync: f64,
+        margin: f64,
+        cost: f64,
+        decodes: bool,
+    }
+    let mut cands_all: Vec<Cand> = Vec::new();
+
+    let dir = sweep_dir();
+    let n_sync = sync_symbol_count::<Fst4s60>();
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let fec = <Fst4s60 as Protocol>::Fec::default();
+    let verify_info =
+        Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
+
+    for &(channel, snr_tag) in CELLS {
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            let cands = coarse_sync::<Fst4s60>(
+                &audio,
+                (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
+                (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
+                SNIPER_SYNC_MIN,
+                Some(GOLDEN_FREQ_HZ),
+                MAX_CAND,
+            );
+            let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+
+            for c in &cands {
+                let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
+                let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+                if sum2 > f32::EPSILON {
+                    let inv = 1.0 / sum2.sqrt();
+                    for z in cd0.iter_mut() {
+                        *z *= inv;
+                    }
+                }
+                let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+                let cd0 = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
+                let cs0 = symbol_spectra::<Fst4s60>(&cd0, s2.i0);
+                let nsync = sync_quality::<Fst4s60>(&cs0);
+                if nsync <= NSYNC_GATE {
+                    continue;
+                }
+
+                let mut pairs = vec![(0.0f32, 0.0f32); n_sync];
+                assert_eq!(
+                    nsync,
+                    sync_quality_soft_generic::<Fst4s60, f32>(&cs0, &mut pairs)
+                );
+                let margin = pairs
+                    .iter()
+                    .map(|&(e, w)| {
+                        let (a, b) = (e as f64, w as f64);
+                        let d = a + b;
+                        if d > 0.0 { (a - b) / d } else { 0.0 }
+                    })
+                    .sum::<f64>()
+                    / pairs.len() as f64;
+
+                let is_golden = |llr: &Vec<f32>, opts: &FecOpts| -> bool {
+                    fec.decode_soft(llr, opts).is_some_and(|mut r| {
+                        mfsk_core::engine::llr::descramble_info::<Fst4s60>(&mut r.info);
+                        let mut m77 = [0u8; 77];
+                        m77.copy_from_slice(&r.info[..77]);
+                        unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                    })
+                };
+                let bp_opts = FecOpts {
+                    bp_max_iter: 30,
+                    osd_depth: 0,
+                    ap_mask: None,
+                    verify_info,
+                    ..FecOpts::default()
+                };
+
+                // Sunk first rung — excluded from the budget below.
+                let llr0 = compute_llr::<Fst4s60, f32>(&cs0);
+                if is_golden(&llr0.llra, &bp_opts) {
+                    continue;
+                }
+
+                // Escalation, counting one unit per (offset, stage) run.
+                let mut cost = 0.0f64;
+                let mut decodes = false;
+                'esc: for &d in &OFFSETS {
+                    let cs = if d == 0 {
+                        cs0.clone()
+                    } else {
+                        symbol_spectra::<Fst4s60>(&cd0, s2.i0 + d)
+                    };
+                    let ns = sync_quality::<Fst4s60>(&cs);
+                    if ns <= NSYNC_GATE {
+                        continue;
+                    }
+                    let ls = compute_llr::<Fst4s60, f32>(&cs);
+                    // llra is only re-run at alternate offsets; at
+                    // offset 0 it is the sunk first rung.
+                    let variants: [&Vec<f32>; 4] = [&ls.llra, &ls.llrb, &ls.llre, &ls.llrc];
+                    for (vi, v) in variants.iter().enumerate() {
+                        if d == 0 && vi == 0 {
+                            continue;
+                        }
+                        cost += 1.0;
+                        if is_golden(v, &bp_opts) {
+                            decodes = true;
+                            break 'esc;
+                        }
+                    }
+                    if ns >= osd_attempt_min {
+                        let o = FecOpts {
+                            bp_max_iter: 30,
+                            osd_depth: if ns >= osd_depth3_min { 3 } else { 2 },
+                            ap_mask: None,
+                            verify_info,
+                            ..FecOpts::default()
+                        };
+                        cost += 1.0;
+                        if variants.iter().any(|v| is_golden(v, &o)) {
+                            decodes = true;
+                            break 'esc;
+                        }
+                    }
+                }
+
+                cands_all.push(Cand {
+                    nsync: nsync as f64,
+                    margin,
+                    cost,
+                    decodes,
+                });
+            }
+        }
+    }
+
+    let total_cost: f64 = cands_all.iter().map(|c| c.cost).sum();
+    let total_dec = cands_all.iter().filter(|c| c.decodes).count();
+    eprintln!();
+    eprintln!("=== escalation budget curve (post-first-rung, 6 cells) ===");
+    eprintln!(
+        "{} candidates, {total_dec} decode, total escalation cost {total_cost:.0} units \
+         (mean {:.1}/candidate)",
+        cands_all.len(),
+        total_cost / cands_all.len() as f64
+    );
+
+    // Order by a score descending; oracle and arrival are special.
+    let run = |order: &[usize], budget: f64| -> usize {
+        let mut spent = 0.0;
+        let mut got = 0usize;
+        for &i in order {
+            let c = &cands_all[i];
+            if spent + c.cost > budget {
+                continue; // skip what doesn't fit; keep filling
+            }
+            spent += c.cost;
+            if c.decodes {
+                got += 1;
+            }
+        }
+        got
+    };
+    let by = |key: &dyn Fn(&Cand) -> f64| -> Vec<usize> {
+        let mut ix: Vec<usize> = (0..cands_all.len()).collect();
+        ix.sort_by(|&a, &b| {
+            key(&cands_all[b])
+                .partial_cmp(&key(&cands_all[a]))
+                .unwrap_or(core::cmp::Ordering::Equal)
+        });
+        ix
+    };
+
+    let ord_nsync = by(&|c| c.nsync);
+    let ord_margin = by(&|c| c.margin);
+    let ord_arrival: Vec<usize> = (0..cands_all.len()).collect();
+    let mut ord_oracle: Vec<usize> = (0..cands_all.len()).collect();
+    ord_oracle.sort_by(|&a, &b| {
+        let (x, y) = (&cands_all[a], &cands_all[b]);
+        // decoders first, cheapest decoder first
+        y.decodes.cmp(&x.decodes).then(
+            x.cost
+                .partial_cmp(&y.cost)
+                .unwrap_or(core::cmp::Ordering::Equal),
+        )
+    });
+
+    eprintln!();
+    eprintln!(
+        "{:>7} {:>9} {:>9} {:>9} {:>9}",
+        "budget", "arrival", "nsync", "margin", "oracle"
+    );
+    for pct in [10, 20, 30, 40, 50, 70, 100] {
+        let b = total_cost * pct as f64 / 100.0;
+        eprintln!(
+            "{:>6}% {:>9} {:>9} {:>9} {:>9}",
+            pct,
+            run(&ord_arrival, b),
+            run(&ord_nsync, b),
+            run(&ord_margin, b),
+            run(&ord_oracle, b)
+        );
+    }
+
+    eprintln!();
+    eprintln!(
+        "If `nsync` already tracks `oracle` at 10-30% budget, ordering is not where the \
+         remaining decodes are and #310 should stop looking here. A real gap between \
+         `margin` and `nsync` at tight budgets is the wall-clock argument the cost \
+         objection was waiting for."
+    );
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -6166,3 +6166,427 @@ fn fst4_60_diag_soft_margin_escalation_priority() {
          the broader result in §14 does not transfer to escalation ordering."
     );
 }
+
+/// **Strengthened refutation** of the soft-Costas-margin proposal
+/// (#310). [`fst4_60_diag_soft_margin_escalation_priority`] showed three
+/// hand-picked margin formulations failing to beat raw `nsync` on the
+/// post-first-rung population — but "three formulations I chose failed"
+/// cannot distinguish *the features carry no information beyond `nsync`*
+/// from *I picked the wrong formulas*. This closes that gap three ways.
+///
+/// ## 1. Conditional separation — the assumption-free test
+///
+/// If a margin adds nothing beyond `nsync`, then **within a fixed
+/// `nsync` value** it should not separate at all. So: stratify by
+/// `nsync`, compute each margin's AUC inside each stratum, and pool the
+/// strata by weight. A stratified AUC of ~0.5 means the feature is a
+/// proxy for `nsync` and nothing more; materially above 0.5 means it
+/// carries genuinely additional information even if the unconditional
+/// comparison is muddied by correlation.
+///
+/// This needs no model, no fitting, and no choice of combination rule —
+/// which is why it is the primary result here.
+///
+/// ## 2. A fitted combination, scored in-sample
+///
+/// Logistic regression on the standardised feature vector, evaluated on
+/// the data it was fitted to. That is deliberately optimistic: in-sample
+/// AUC is an **upper bound** on what any linear rule could achieve
+/// out-of-sample. If even the fitted optimum barely beats `nsync`, no
+/// linear combination of these features is going to, and the "maybe a
+/// learned model would work" objection is answered for the linear case.
+/// A 2-fold split (by candidate index parity — deterministic, no RNG in
+/// a `no_std`-adjacent test) gives the honest number alongside it.
+///
+/// ## 3. More formulations, so the choice isn't the confound
+///
+/// Nine features rather than three, spanning bounded and unbounded
+/// margins, order statistics, dispersion, and counts:
+/// mean / min / median / p25 of the normalised margin, mean and **sum**
+/// of the clamped log-ratio (the sum correlates with `nsync` very
+/// differently from the mean), margin variance, the count of symbols
+/// with margin above zero, and the mean margin over the *worst ten*
+/// symbols.
+///
+/// ## Reading it
+///
+/// The refutation is strong if: stratified AUCs sit near 0.5, **and**
+/// the in-sample fitted combination gains little over `nsync`. It is
+/// weak — and the proposal deserves a learned non-linear model — if
+/// stratified AUCs are well above 0.5 while the unconditional ones
+/// aren't, since that is the signature of a real signal being masked by
+/// correlation with `nsync`.
+#[test]
+#[ignore = "manual diagnostic — does the soft margin add anything beyond nsync? (issue #310)"]
+fn fst4_60_diag_soft_margin_conditional_value() {
+    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::engine::llr::{
+        compute_llr, symbol_spectra, sync_quality, sync_quality_soft_generic, sync_symbol_count,
+    };
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const NSYNC_GATE: u32 = 16;
+    const MAX_CAND: usize = 50;
+    const WIDTH_HZ: f32 = 250.0;
+    const OFFSETS: [i32; 3] = [0, 1, -1];
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m23"),
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m26"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+    const FEATURES: &[&str] = &[
+        "mean margin",
+        "min margin",
+        "median margin",
+        "p25 margin",
+        "mean logratio",
+        "sum logratio",
+        "margin variance",
+        "count margin>0",
+        "mean worst-10",
+    ];
+    const NF: usize = 9;
+
+    fn auc_of(scored: &[(f64, bool)]) -> f64 {
+        let pos: Vec<f64> = scored.iter().filter(|(_, d)| *d).map(|(s, _)| *s).collect();
+        let neg: Vec<f64> = scored
+            .iter()
+            .filter(|(_, d)| !*d)
+            .map(|(s, _)| *s)
+            .collect();
+        if pos.is_empty() || neg.is_empty() {
+            return f64::NAN;
+        }
+        let mut acc = 0.0;
+        for p in &pos {
+            for n in &neg {
+                acc += if p > n {
+                    1.0
+                } else if (p - n).abs() < f64::EPSILON {
+                    0.5
+                } else {
+                    0.0
+                };
+            }
+        }
+        acc / (pos.len() * neg.len()) as f64
+    }
+
+    // Batch gradient descent on standardised features. Deterministic;
+    // `train` selects which rows contribute to the gradient.
+    fn fit_logistic(rows: &[([f64; NF], f64, bool)], train: &dyn Fn(usize) -> bool) -> Vec<f64> {
+        let idx: Vec<usize> = (0..rows.len()).filter(|&i| train(i)).collect();
+        if idx.is_empty() {
+            return vec![0.0; NF + 2];
+        }
+        // Feature vector is [nsync, f0..f8, bias].
+        let dim = NF + 1;
+        let mut mean = vec![0.0; dim];
+        let mut sd = vec![0.0; dim];
+        let get =
+            |r: &([f64; NF], f64, bool), k: usize| -> f64 { if k == 0 { r.1 } else { r.0[k - 1] } };
+        for &i in &idx {
+            for (k, m) in mean.iter_mut().enumerate() {
+                *m += get(&rows[i], k);
+            }
+        }
+        for m in mean.iter_mut() {
+            *m /= idx.len() as f64;
+        }
+        for &i in &idx {
+            for k in 0..dim {
+                let d = get(&rows[i], k) - mean[k];
+                sd[k] += d * d;
+            }
+        }
+        for s in sd.iter_mut() {
+            *s = (*s / idx.len() as f64).sqrt().max(1e-9);
+        }
+        let mut w = vec![0.0f64; dim + 1]; // + bias
+        for _ in 0..4000 {
+            let mut grad = vec![0.0f64; dim + 1];
+            for &i in &idx {
+                let mut z = w[dim];
+                for k in 0..dim {
+                    z += w[k] * (get(&rows[i], k) - mean[k]) / sd[k];
+                }
+                let p = 1.0 / (1.0 + (-z).exp());
+                let e = p - if rows[i].2 { 1.0 } else { 0.0 };
+                for k in 0..dim {
+                    grad[k] += e * (get(&rows[i], k) - mean[k]) / sd[k];
+                }
+                grad[dim] += e;
+            }
+            let lr = 0.5 / idx.len() as f64;
+            for k in 0..=dim {
+                w[k] -= lr * grad[k];
+            }
+        }
+        // Return weights plus the standardisation so scoring matches.
+        let mut out = w;
+        out.extend(mean);
+        out.extend(sd);
+        out
+    }
+
+    fn score_logistic(model: &[f64], r: &([f64; NF], f64)) -> f64 {
+        let dim = NF + 1;
+        let (w, rest) = model.split_at(dim + 1);
+        let (mean, sd) = rest.split_at(dim);
+        let get = |k: usize| -> f64 { if k == 0 { r.1 } else { r.0[k - 1] } };
+        let mut z = w[dim];
+        for k in 0..dim {
+            z += w[k] * (get(k) - mean[k]) / sd[k];
+        }
+        z
+    }
+
+    let dir = sweep_dir();
+    let n_sync = sync_symbol_count::<Fst4s60>();
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let fec = <Fst4s60 as Protocol>::Fec::default();
+    let verify_info =
+        Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
+
+    // (features, nsync, eventually_decodes)
+    let mut rows: Vec<([f64; NF], f64, bool)> = Vec::new();
+
+    for &(channel, snr_tag) in CELLS {
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            let cands = coarse_sync::<Fst4s60>(
+                &audio,
+                (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
+                (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
+                SNIPER_SYNC_MIN,
+                Some(GOLDEN_FREQ_HZ),
+                MAX_CAND,
+            );
+            let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+
+            for c in &cands {
+                let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
+                let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+                if sum2 > f32::EPSILON {
+                    let inv = 1.0 / sum2.sqrt();
+                    for z in cd0.iter_mut() {
+                        *z *= inv;
+                    }
+                }
+                let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+                let cd0 = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
+                let cs0 = symbol_spectra::<Fst4s60>(&cd0, s2.i0);
+                let nsync = sync_quality::<Fst4s60>(&cs0);
+                if nsync <= NSYNC_GATE {
+                    continue;
+                }
+
+                let mut pairs = vec![(0.0f32, 0.0f32); n_sync];
+                assert_eq!(
+                    nsync,
+                    sync_quality_soft_generic::<Fst4s60, f32>(&cs0, &mut pairs)
+                );
+                let mut m: Vec<f64> = Vec::with_capacity(n_sync);
+                let mut lr: Vec<f64> = Vec::with_capacity(n_sync);
+                for &(e, w) in &pairs {
+                    let (a, b) = (e as f64, w as f64);
+                    let d = a + b;
+                    m.push(if d > 0.0 { (a - b) / d } else { 0.0 });
+                    lr.push(if a > 0.0 && b > 0.0 {
+                        (a / b).ln().clamp(-8.0, 8.0)
+                    } else {
+                        0.0
+                    });
+                }
+                let mut sorted = m.clone();
+                sorted.sort_by(|x, y| x.partial_cmp(y).unwrap());
+                let mean_m = m.iter().sum::<f64>() / m.len() as f64;
+                let var_m = m.iter().map(|v| (v - mean_m).powi(2)).sum::<f64>() / m.len() as f64;
+                let worst10 = sorted[..10.min(sorted.len())].iter().sum::<f64>() / 10.0;
+                let feats = [
+                    mean_m,
+                    sorted[0],
+                    sorted[sorted.len() / 2],
+                    sorted[sorted.len() / 4],
+                    lr.iter().sum::<f64>() / lr.len() as f64,
+                    lr.iter().sum::<f64>(),
+                    var_m,
+                    m.iter().filter(|v| **v > 0.0).count() as f64,
+                    worst10,
+                ];
+
+                let is_golden = |llr: &Vec<f32>, opts: &FecOpts| -> bool {
+                    fec.decode_soft(llr, opts).is_some_and(|mut r| {
+                        mfsk_core::engine::llr::descramble_info::<Fst4s60>(&mut r.info);
+                        let mut m77 = [0u8; 77];
+                        m77.copy_from_slice(&r.info[..77]);
+                        unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                    })
+                };
+                let bp_opts = FecOpts {
+                    bp_max_iter: 30,
+                    osd_depth: 0,
+                    ap_mask: None,
+                    verify_info,
+                    ..FecOpts::default()
+                };
+                let llr0 = compute_llr::<Fst4s60, f32>(&cs0);
+                if is_golden(&llr0.llra, &bp_opts) {
+                    continue;
+                }
+
+                let mut eventually = false;
+                'esc: for &d in &OFFSETS {
+                    let cs = if d == 0 {
+                        cs0.clone()
+                    } else {
+                        symbol_spectra::<Fst4s60>(&cd0, s2.i0 + d)
+                    };
+                    let ns = sync_quality::<Fst4s60>(&cs);
+                    if ns <= NSYNC_GATE {
+                        continue;
+                    }
+                    let ls = compute_llr::<Fst4s60, f32>(&cs);
+                    let variants: [&Vec<f32>; 4] = [&ls.llra, &ls.llrb, &ls.llre, &ls.llrc];
+                    if variants.iter().any(|l| is_golden(l, &bp_opts)) {
+                        eventually = true;
+                        break 'esc;
+                    }
+                    if ns >= osd_attempt_min {
+                        let o = FecOpts {
+                            bp_max_iter: 30,
+                            osd_depth: if ns >= osd_depth3_min { 3 } else { 2 },
+                            ap_mask: None,
+                            verify_info,
+                            ..FecOpts::default()
+                        };
+                        if variants.iter().any(|l| is_golden(l, &o)) {
+                            eventually = true;
+                            break 'esc;
+                        }
+                    }
+                }
+                rows.push((feats, nsync as f64, eventually));
+            }
+        }
+    }
+
+    let np = rows.iter().filter(|r| r.2).count();
+    eprintln!();
+    eprintln!("=== does the soft margin add anything beyond nsync? ===");
+    eprintln!(
+        "post-first-rung population: {} candidates ({np} decode, {} don't), {} cells",
+        rows.len(),
+        rows.len() - np,
+        CELLS.len()
+    );
+    if np < 20 || rows.len() - np < 20 {
+        eprintln!("!! population too small for these comparisons to mean much");
+    }
+
+    let base: Vec<(f64, bool)> = rows.iter().map(|r| (r.1, r.2)).collect();
+    let base_auc = auc_of(&base);
+    eprintln!();
+    eprintln!("unconditional AUC (higher = separates decode from never-decode):");
+    eprintln!(
+        "  {:<18} {:>6}",
+        "nsync (baseline)",
+        format!("{base_auc:.3}")
+    );
+    for (k, name) in FEATURES.iter().enumerate() {
+        let s: Vec<(f64, bool)> = rows.iter().map(|r| (r.0[k], r.2)).collect();
+        eprintln!("  {name:<18} {:>6.3}", auc_of(&s));
+    }
+
+    // ── 1. Stratified by nsync ────────────────────────────────────────
+    eprintln!();
+    eprintln!("stratified AUC within fixed nsync (0.5 = no information beyond nsync):");
+    let mut strata: std::collections::BTreeMap<i64, Vec<usize>> = Default::default();
+    for (i, r) in rows.iter().enumerate() {
+        strata.entry(r.1 as i64).or_default().push(i);
+    }
+    let usable: Vec<(&i64, &Vec<usize>)> = strata
+        .iter()
+        .filter(|(_, ix)| {
+            let p = ix.iter().filter(|&&i| rows[i].2).count();
+            p > 0 && p < ix.len()
+        })
+        .collect();
+    let total_w: f64 = usable
+        .iter()
+        .map(|(_, ix)| {
+            let p = ix.iter().filter(|&&i| rows[i].2).count() as f64;
+            p * (ix.len() as f64 - p)
+        })
+        .sum();
+    eprintln!(
+        "  ({} usable strata of {}, weight = pos*neg pairs)",
+        usable.len(),
+        strata.len()
+    );
+    for (k, name) in FEATURES.iter().enumerate() {
+        let mut acc = 0.0;
+        for (_, ix) in &usable {
+            let s: Vec<(f64, bool)> = ix.iter().map(|&i| (rows[i].0[k], rows[i].2)).collect();
+            let p = ix.iter().filter(|&&i| rows[i].2).count() as f64;
+            let w = p * (ix.len() as f64 - p);
+            acc += auc_of(&s) * w;
+        }
+        eprintln!("  {name:<18} {:>6.3}", acc / total_w);
+    }
+
+    // ── 2. Fitted combination ─────────────────────────────────────────
+    let all = |_: usize| true;
+    let even = |i: usize| i.is_multiple_of(2);
+    let odd = |i: usize| !i.is_multiple_of(2);
+    let m_all = fit_logistic(&rows, &all);
+    let in_sample: Vec<(f64, bool)> = rows
+        .iter()
+        .map(|r| (score_logistic(&m_all, &(r.0, r.1)), r.2))
+        .collect();
+    let m_even = fit_logistic(&rows, &even);
+    let m_odd = fit_logistic(&rows, &odd);
+    let cv: Vec<(f64, bool)> = rows
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let m = if i.is_multiple_of(2) { &m_odd } else { &m_even };
+            (score_logistic(m, &(r.0, r.1)), r.2)
+        })
+        .collect();
+
+    eprintln!();
+    eprintln!("fitted linear combination of [nsync + all 9 features]:");
+    eprintln!("  {:<18} {:>6.3}", "nsync alone", base_auc);
+    eprintln!(
+        "  {:<18} {:>6.3}   <- optimistic upper bound",
+        "in-sample fit",
+        auc_of(&in_sample)
+    );
+    eprintln!(
+        "  {:<18} {:>6.3}   <- honest (2-fold, by index parity)",
+        "cross-validated",
+        auc_of(&cv)
+    );
+
+    eprintln!();
+    eprintln!(
+        "Refutation is STRONG if the stratified AUCs sit near 0.5 and the in-sample \
+         fit barely beats nsync — no linear rule over these features can then help. \
+         It is WEAK if stratified AUCs are well above 0.5, which would mean real \
+         signal masked by correlation with nsync and would justify a learned model."
+    );
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -5908,3 +5908,261 @@ fn fst4_60_diag_soft_costas_margin_separation() {
          extra per-symbol state isn't worth carrying and #310 should look elsewhere."
     );
 }
+
+/// **#310's actual question**, narrower than
+/// [`fst4_60_diag_soft_costas_margin_separation`]: among candidates that
+/// have **already failed the cheap first rung**, does the soft Costas
+/// margin rank the ones that go on to decode above the ones that never
+/// will?
+///
+/// The broader test scored every gate-passing candidate, which includes
+/// the ones that decode immediately at `llra` — those never reach the
+/// escalation budget, so their contribution to the AUC is irrelevant to
+/// the scheduling decision and, being the easiest candidates, inflates
+/// it. This restricts the population to exactly the set #310 has to
+/// triage:
+///
+/// - **Population**: passes the `nsync` gate, and **fails** BP on `llra`
+///   at `offset = 0` — the cheapest rung of `decode_rung_major`'s ladder
+///   and the one the latency invariant guarantees every candidate.
+/// - **Positive**: goes on to decode with the full escalation budget —
+///   the remaining LLR variants (`llrb`/`llre`/`llrc`), OSD at the depth
+///   the existing gates select, and the `i0 ± 1` timing offsets.
+/// - **Negative**: never decodes, i.e. every unit of escalation spent on
+///   it was wasted.
+///
+/// A score that ranks positives above negatives here is directly usable
+/// as "who gets the remaining budget first" once the first rung has
+/// given every retained candidate its cheap attempt — which is the shape
+/// this issue's scheduling position (`FST4_BENCHMARK.md` §13) leaves
+/// open.
+///
+/// Cells are pooled as well as reported individually: the positive class
+/// is small by construction here (these are the *hard* candidates), and
+/// a per-cell AUC over a handful of positives is noise. Read the pooled
+/// row first.
+#[test]
+#[ignore = "manual diagnostic — soft margin as escalation-priority signal, post-first-rung (issue #310)"]
+fn fst4_60_diag_soft_margin_escalation_priority() {
+    use mfsk_core::engine::dsp::downsample::build_fft_cache;
+    use mfsk_core::engine::llr::{
+        compute_llr, symbol_spectra, sync_quality, sync_quality_soft_generic, sync_symbol_count,
+    };
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const NSYNC_GATE: u32 = 16;
+    const MAX_CAND: usize = 50;
+    const WIDTH_HZ: f32 = 250.0;
+    const OFFSETS: [i32; 3] = [0, 1, -1];
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+
+    fn auc(scored: &[(f64, bool)]) -> f64 {
+        let pos: Vec<f64> = scored.iter().filter(|(_, d)| *d).map(|(s, _)| *s).collect();
+        let neg: Vec<f64> = scored
+            .iter()
+            .filter(|(_, d)| !*d)
+            .map(|(s, _)| *s)
+            .collect();
+        if pos.is_empty() || neg.is_empty() {
+            return f64::NAN;
+        }
+        let mut acc = 0.0;
+        for p in &pos {
+            for n in &neg {
+                acc += if p > n {
+                    1.0
+                } else if (p - n).abs() < f64::EPSILON {
+                    0.5
+                } else {
+                    0.0
+                };
+            }
+        }
+        acc / (pos.len() * neg.len()) as f64
+    }
+
+    let dir = sweep_dir();
+    let n_sync = sync_symbol_count::<Fst4s60>();
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let fec = <Fst4s60 as Protocol>::Fec::default();
+    let verify_info =
+        Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
+
+    // (nsync, mean_margin, mean_logratio, eventually_decodes)
+    let mut pooled: Vec<(f64, f64, f64, bool)> = Vec::new();
+
+    eprintln!();
+    eprintln!("=== soft margin as escalation-priority signal (post-first-rung) ===");
+    eprintln!("population: passes nsync gate AND fails BP on llra at offset 0");
+
+    for &(channel, snr_tag) in CELLS {
+        let mut rows: Vec<(f64, f64, f64, bool)> = Vec::new();
+
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            let cands = coarse_sync::<Fst4s60>(
+                &audio,
+                (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
+                (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
+                SNIPER_SYNC_MIN,
+                Some(GOLDEN_FREQ_HZ),
+                MAX_CAND,
+            );
+            let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+
+            for c in &cands {
+                let mut cd0 = mfsk_core::engine::dsp::downsample::downsample_cached(
+                    &fft_cache,
+                    c.freq_hz,
+                    &FST4_60A_DOWNSAMPLE,
+                );
+                let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+                if sum2 > f32::EPSILON {
+                    let inv = 1.0 / sum2.sqrt();
+                    for z in cd0.iter_mut() {
+                        *z *= inv;
+                    }
+                }
+                let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+                let cd0 = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
+
+                let cs0 = symbol_spectra::<Fst4s60>(&cd0, s2.i0);
+                let nsync = sync_quality::<Fst4s60>(&cs0);
+                if nsync <= NSYNC_GATE {
+                    continue;
+                }
+
+                let mut pairs = vec![(0.0f32, 0.0f32); n_sync];
+                let nsync_soft = sync_quality_soft_generic::<Fst4s60, f32>(&cs0, &mut pairs);
+                assert_eq!(nsync, nsync_soft);
+                let mut margins = Vec::with_capacity(n_sync);
+                let mut logratios = Vec::with_capacity(n_sync);
+                for &(e_exp, e_wrong) in &pairs {
+                    let (a, b) = (e_exp as f64, e_wrong as f64);
+                    let d = a + b;
+                    margins.push(if d > 0.0 { (a - b) / d } else { 0.0 });
+                    logratios.push(if a > 0.0 && b > 0.0 {
+                        (a / b).ln().clamp(-8.0, 8.0)
+                    } else {
+                        0.0
+                    });
+                }
+                let mean_margin = margins.iter().sum::<f64>() / margins.len() as f64;
+                let mean_logratio = logratios.iter().sum::<f64>() / logratios.len() as f64;
+
+                let is_golden = |llr: &Vec<f32>, opts: &FecOpts| -> bool {
+                    fec.decode_soft(llr, opts).is_some_and(|mut r| {
+                        mfsk_core::engine::llr::descramble_info::<Fst4s60>(&mut r.info);
+                        let mut m77 = [0u8; 77];
+                        m77.copy_from_slice(&r.info[..77]);
+                        unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                    })
+                };
+                let bp_opts = FecOpts {
+                    bp_max_iter: 30,
+                    osd_depth: 0,
+                    ap_mask: None,
+                    verify_info,
+                    ..FecOpts::default()
+                };
+
+                // Cheap first rung: llra only, offset 0.
+                let llr0 = compute_llr::<Fst4s60, f32>(&cs0);
+                if is_golden(&llr0.llra, &bp_opts) {
+                    continue; // decoded cheaply — never reaches the budget
+                }
+
+                // Everything the escalation budget would buy.
+                let mut eventually = false;
+                'esc: for &d in &OFFSETS {
+                    let cs = if d == 0 {
+                        cs0.clone()
+                    } else {
+                        symbol_spectra::<Fst4s60>(&cd0, s2.i0 + d)
+                    };
+                    let ns = sync_quality::<Fst4s60>(&cs);
+                    if ns <= NSYNC_GATE {
+                        continue;
+                    }
+                    let ls = compute_llr::<Fst4s60, f32>(&cs);
+                    let variants: [&Vec<f32>; 4] = [&ls.llra, &ls.llrb, &ls.llre, &ls.llrc];
+                    if variants.iter().any(|l| is_golden(l, &bp_opts)) {
+                        eventually = true;
+                        break 'esc;
+                    }
+                    if ns >= osd_attempt_min {
+                        let osd_opts = FecOpts {
+                            bp_max_iter: 30,
+                            osd_depth: if ns >= osd_depth3_min { 3 } else { 2 },
+                            ap_mask: None,
+                            verify_info,
+                            ..FecOpts::default()
+                        };
+                        if variants.iter().any(|l| is_golden(l, &osd_opts)) {
+                            eventually = true;
+                            break 'esc;
+                        }
+                    }
+                }
+
+                rows.push((nsync as f64, mean_margin, mean_logratio, eventually));
+            }
+        }
+
+        if rows.is_empty() {
+            eprintln!("{channel}_{snr_tag}: no candidates in population, skip");
+            continue;
+        }
+        let np = rows.iter().filter(|r| r.3).count();
+        eprintln!();
+        eprintln!(
+            "{channel}_{snr_tag}: {} post-first-rung candidates ({np} eventually decode)",
+            rows.len()
+        );
+        for (name, f) in [
+            ("nsync", (|r: &(f64, f64, f64, bool)| r.0) as fn(&_) -> f64),
+            ("mean margin", |r: &(f64, f64, f64, bool)| r.1),
+            ("mean logratio", |r: &(f64, f64, f64, bool)| r.2),
+        ] {
+            let scored: Vec<(f64, bool)> = rows.iter().map(|r| (f(r), r.3)).collect();
+            eprintln!("  {name:<14} AUC {:>6.3}", auc(&scored));
+        }
+        pooled.extend(rows);
+    }
+
+    let np = pooled.iter().filter(|r| r.3).count();
+    eprintln!();
+    eprintln!(
+        "POOLED: {} post-first-rung candidates ({np} eventually decode, {} don't)",
+        pooled.len(),
+        pooled.len() - np
+    );
+    for (name, f) in [
+        ("nsync", (|r: &(f64, f64, f64, bool)| r.0) as fn(&_) -> f64),
+        ("mean margin", |r: &(f64, f64, f64, bool)| r.1),
+        ("mean logratio", |r: &(f64, f64, f64, bool)| r.2),
+    ] {
+        let scored: Vec<(f64, bool)> = pooled.iter().map(|r| (f(r), r.3)).collect();
+        eprintln!("  {name:<14} AUC {:>6.3}", auc(&scored));
+    }
+    eprintln!();
+    eprintln!(
+        "This is the population #310 actually triages. If no score beats chance here, \
+         the broader result in §14 does not transfer to escalation ordering."
+    );
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -6890,3 +6890,317 @@ fn fst4_60_diag_escalation_budget_curve() {
          objection was waiting for."
     );
 }
+
+/// **The budget curve under the schedule actually proposed.**
+///
+/// [`fst4_60_diag_escalation_budget_curve`] compared priority orderings
+/// under a **depth-first** escalation — each candidate runs its whole
+/// ladder before the next one starts. `decode_rung_major` is
+/// **breadth-first**: one rung swept across every candidate before any
+/// candidate descends. Those are different schedules and they spend a
+/// budget differently, so that test's ordering conclusions do not
+/// transfer to the design this issue is actually about.
+///
+/// The distinction matters in a specific way: breadth-first gives every
+/// candidate its cheaper stages before any candidate gets an expensive
+/// one, which is *itself* a form of cost-ordering. So it should already
+/// capture part of what the oracle exploited there — and the apparent
+/// "43 % vs 93 %" headroom is probably overstated for the real schedule.
+///
+/// This measures both schedules over the same candidates and stage
+/// outcomes, so the comparison is like-for-like.
+///
+/// ## Stage ladder
+///
+/// Offset-major, matching the decision recorded in
+/// `FST4_BENCHMARK.md` §13 (and `rung_major.rs`'s module doc):
+///
+/// ```text
+/// offset  0:        llrb, llre, llrc, OSD     (llra is the sunk first rung)
+/// offset +1:  llra, llrb, llre, llrc, OSD
+/// offset -1:  llra, llrb, llre, llrc, OSD
+/// ```
+///
+/// One unit per stage executed; a candidate stops at its first success,
+/// and a candidate whose `nsync` never reaches `osd_attempt_min` simply
+/// has no OSD stage at that offset.
+///
+/// ## Schedules
+///
+/// - **depth-first** — for each candidate in priority order, run its
+///   ladder to success or exhaustion. What
+///   `process_candidate_basic_impl` does today.
+/// - **breadth-first** — for each stage index, sweep every still-undecided
+///   candidate in priority order. What `decode_rung_major` does.
+///
+/// Orderings: arrival (what `rank_candidates` returns, i.e. no priority
+/// signal), `nsync`, and an unachievable oracle (decoders first, cheapest
+/// decoder first) to bound the headroom.
+///
+/// ## What it decides
+///
+/// Whether the escalation phase should re-sort its survivors by `nsync`
+/// before descending. `nsync` is free at that point — the first rung
+/// computed it for every candidate to run the gate — so if it buys
+/// decodes under breadth-first, it is close to a free win. If
+/// breadth-first flattens the difference, the current arrival order is
+/// fine and one less thing needs justifying.
+#[test]
+#[ignore = "manual diagnostic — budget curve under rung-major (breadth-first) scheduling (issue #310)"]
+fn fst4_60_diag_budget_curve_breadth_vs_depth() {
+    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const NSYNC_GATE: u32 = 16;
+    const MAX_CAND: usize = 50;
+    const WIDTH_HZ: f32 = 250.0;
+    const OFFSETS: [i32; 3] = [0, 1, -1];
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m23"),
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m26"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+
+    struct Cand {
+        nsync: f64,
+        /// One entry per stage this candidate would execute, in ladder
+        /// order; `true` at the stage where it decodes (there is at most
+        /// one, and nothing after it runs).
+        stages: Vec<bool>,
+    }
+    impl Cand {
+        fn cost(&self) -> f64 {
+            // Stages actually run: everything up to and including the
+            // first success, or all of them if it never decodes.
+            match self.stages.iter().position(|d| *d) {
+                Some(i) => (i + 1) as f64,
+                None => self.stages.len() as f64,
+            }
+        }
+        fn decodes(&self) -> bool {
+            self.stages.iter().any(|d| *d)
+        }
+    }
+
+    let dir = sweep_dir();
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let fec = <Fst4s60 as Protocol>::Fec::default();
+    let verify_info =
+        Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
+    let mut all: Vec<Cand> = Vec::new();
+
+    for &(channel, snr_tag) in CELLS {
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            let cands = coarse_sync::<Fst4s60>(
+                &audio,
+                (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
+                (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
+                SNIPER_SYNC_MIN,
+                Some(GOLDEN_FREQ_HZ),
+                MAX_CAND,
+            );
+            let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+
+            for c in &cands {
+                let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
+                let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+                if sum2 > f32::EPSILON {
+                    let inv = 1.0 / sum2.sqrt();
+                    for z in cd0.iter_mut() {
+                        *z *= inv;
+                    }
+                }
+                let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+                let cd0 = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
+                let cs0 = symbol_spectra::<Fst4s60>(&cd0, s2.i0);
+                let nsync = sync_quality::<Fst4s60>(&cs0);
+                if nsync <= NSYNC_GATE {
+                    continue;
+                }
+
+                let is_golden = |llr: &Vec<f32>, opts: &FecOpts| -> bool {
+                    fec.decode_soft(llr, opts).is_some_and(|mut r| {
+                        mfsk_core::engine::llr::descramble_info::<Fst4s60>(&mut r.info);
+                        let mut m77 = [0u8; 77];
+                        m77.copy_from_slice(&r.info[..77]);
+                        unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                    })
+                };
+                let bp_opts = FecOpts {
+                    bp_max_iter: 30,
+                    osd_depth: 0,
+                    ap_mask: None,
+                    verify_info,
+                    ..FecOpts::default()
+                };
+
+                let llr0 = compute_llr::<Fst4s60, f32>(&cs0);
+                if is_golden(&llr0.llra, &bp_opts) {
+                    continue; // sunk first rung decoded it
+                }
+
+                // Record the outcome of every stage the ladder would run,
+                // in offset-major order, stopping at the first success.
+                let mut stages: Vec<bool> = Vec::new();
+                'ladder: for &d in &OFFSETS {
+                    let cs = if d == 0 {
+                        cs0.clone()
+                    } else {
+                        symbol_spectra::<Fst4s60>(&cd0, s2.i0 + d)
+                    };
+                    let ns = sync_quality::<Fst4s60>(&cs);
+                    if ns <= NSYNC_GATE {
+                        continue;
+                    }
+                    let ls = compute_llr::<Fst4s60, f32>(&cs);
+                    let variants: [&Vec<f32>; 4] = [&ls.llra, &ls.llrb, &ls.llre, &ls.llrc];
+                    for (vi, v) in variants.iter().enumerate() {
+                        if d == 0 && vi == 0 {
+                            continue; // sunk
+                        }
+                        let hit = is_golden(v, &bp_opts);
+                        stages.push(hit);
+                        if hit {
+                            break 'ladder;
+                        }
+                    }
+                    if ns >= osd_attempt_min {
+                        let o = FecOpts {
+                            bp_max_iter: 30,
+                            osd_depth: if ns >= osd_depth3_min { 3 } else { 2 },
+                            ap_mask: None,
+                            verify_info,
+                            ..FecOpts::default()
+                        };
+                        let hit = variants.iter().any(|v| is_golden(v, &o));
+                        stages.push(hit);
+                        if hit {
+                            break 'ladder;
+                        }
+                    }
+                }
+                all.push(Cand {
+                    nsync: nsync as f64,
+                    stages,
+                });
+            }
+        }
+    }
+
+    let total_cost: f64 = all.iter().map(|c| c.cost()).sum();
+    let total_dec = all.iter().filter(|c| c.decodes()).count();
+    let max_stage = all.iter().map(|c| c.stages.len()).max().unwrap_or(0);
+    eprintln!();
+    eprintln!("=== budget curve: breadth-first (rung-major) vs depth-first ===");
+    eprintln!(
+        "{} candidates, {total_dec} decode, {total_cost:.0} units total, \
+         longest ladder {max_stage} stages",
+        all.len()
+    );
+
+    // Depth-first: each candidate runs to success or exhaustion.
+    let depth = |order: &[usize], budget: f64| -> usize {
+        let mut spent = 0.0;
+        let mut got = 0;
+        for &i in order {
+            let c = &all[i];
+            if spent + c.cost() > budget {
+                continue;
+            }
+            spent += c.cost();
+            if c.decodes() {
+                got += 1;
+            }
+        }
+        got
+    };
+    // Breadth-first: sweep stage s across every still-active candidate.
+    let breadth = |order: &[usize], budget: f64| -> usize {
+        let mut spent = 0.0;
+        let mut got = 0;
+        let mut done = vec![false; all.len()];
+        for s in 0..max_stage {
+            for &i in order {
+                if done[i] {
+                    continue;
+                }
+                let c = &all[i];
+                if s >= c.stages.len() {
+                    done[i] = true;
+                    continue;
+                }
+                if spent + 1.0 > budget {
+                    return got;
+                }
+                spent += 1.0;
+                if c.stages[s] {
+                    got += 1;
+                    done[i] = true;
+                }
+            }
+        }
+        got
+    };
+
+    let mut ord_nsync: Vec<usize> = (0..all.len()).collect();
+    ord_nsync.sort_by(|&a, &b| {
+        all[b]
+            .nsync
+            .partial_cmp(&all[a].nsync)
+            .unwrap_or(core::cmp::Ordering::Equal)
+    });
+    let ord_arrival: Vec<usize> = (0..all.len()).collect();
+    let mut ord_oracle: Vec<usize> = (0..all.len()).collect();
+    ord_oracle.sort_by(|&a, &b| {
+        all[b]
+            .decodes()
+            .cmp(&all[a].decodes())
+            .then(all[a].cost().partial_cmp(&all[b].cost()).unwrap())
+    });
+
+    eprintln!();
+    eprintln!(
+        "{:>7} | {:>17} | {:>17}",
+        "", "depth-first", "breadth-first (rung-major)"
+    );
+    eprintln!(
+        "{:>7} | {:>5} {:>5} {:>5} | {:>5} {:>5} {:>5}",
+        "budget", "arriv", "nsync", "oracl", "arriv", "nsync", "oracl"
+    );
+    for pct in [10, 20, 30, 40, 50, 70, 100] {
+        let b = total_cost * pct as f64 / 100.0;
+        eprintln!(
+            "{:>6}% | {:>5} {:>5} {:>5} | {:>5} {:>5} {:>5}",
+            pct,
+            depth(&ord_arrival, b),
+            depth(&ord_nsync, b),
+            depth(&ord_oracle, b),
+            breadth(&ord_arrival, b),
+            breadth(&ord_nsync, b),
+            breadth(&ord_oracle, b),
+        );
+    }
+
+    eprintln!();
+    eprintln!(
+        "If breadth-first flattens the arrival-vs-nsync gap, rung-major's \
+         cheapest-stage-first sweep is already doing the prioritisation and the \
+         escalation phase does not need to re-sort. If the gap survives, re-sorting \
+         survivors by nsync is close to free -- the first rung computed it for the gate."
+    );
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -4796,3 +4796,228 @@ fn npre_baseline_for_cell(channel: &str, snr_tag: &str) -> (u32, u32) {
     }
     (hits, present)
 }
+
+/// **The near-threshold half of issue #312** — where does truncating the
+/// ranked candidate list start costing *weak* decodes?
+///
+/// [`fst4_60_diag_sniper_gate_width_sweep`] answers the comparability
+/// half (an absolute `max_cand` means a different retained fraction at
+/// every width) but cannot answer this one: both signals on the real
+/// golden are strong, and the target still decodes at `max_cand = 4` in
+/// every width, so no recall cliff appears anywhere in that table. VK3NV
+/// scoped it that way explicitly, and no production default can move on
+/// strong-signal evidence alone.
+///
+/// This runs the same width × cap grid against the *generated sweep
+/// corpus* at SNRs in the crossing band instead, where recall is
+/// partial by construction and a cliff can therefore exist.
+///
+/// ## Read the `frac` column, not the cap
+///
+/// The question is whether the cliff sits at a similar *retained
+/// fraction* across widths. If it does, the cap can be derived from the
+/// width. If it doesn't — plausible, since a wide window's top 5 % is
+/// drawn from a much longer noise tail than a narrow window's top 60 %
+/// — that argues for a score-based or distribution-adaptive criterion
+/// instead of any fixed count or fraction.
+///
+/// ## Cell choice
+///
+/// Cells come from [`fst4_60_diag_npre_baseline_scan`]: only a partial-
+/// recall cell can show a cliff, and `FST4_BENCHMARK.md` section 9's
+/// trap 3 is the account of getting this wrong. The defaults below are
+/// the band measured on a 20-trial corpus on 2026-08-17; re-run the scan
+/// if the corpus generation changes, since the band moves with it.
+///
+/// ## Cost
+///
+/// `cells × widths × caps × trials` full candidate loops — with the
+/// defaults and a 20-trial corpus that is 4 × 4 × 6 × 20 = 1 920 decode
+/// attempts, on the order of an hour or more. **This is a big-machine
+/// job**; see `FST4_BENCHMARK.md` section 11 for the runbook. Narrow it
+/// with the env overrides rather than editing the source:
+///
+/// - `MFSK_CAP_SWEEP_CELLS` — e.g. `ccir_moderate:m25,awgn:m27`
+/// - `MFSK_CAP_SWEEP_WIDTHS` — e.g. `250,25`
+/// - `MFSK_CAP_SWEEP_CAPS` — e.g. `4,16,50`
+///
+/// Unset means the documented default grid. `loop_ms` is reported for
+/// relative shape only — absolute host timing is unreliable on a laptop
+/// (AC/battery swings it ~3×), which is the other reason this belongs on
+/// the Ryzen 9 box.
+#[test]
+#[ignore = "manual sweep — near-threshold sniper cap cliff (issue #312); big-machine job, see FST4_BENCHMARK.md §11"]
+fn fst4_60_diag_sniper_cap_near_threshold() {
+    use std::time::Instant;
+
+    use mfsk_core::engine::dsp::downsample::build_fft_cache;
+    use mfsk_core::engine::equalize::EqMode;
+    use mfsk_core::engine::llr::{symbol_spectra, sync_quality};
+    use mfsk_core::engine::pipeline::{
+        DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
+    };
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const SYNC_Q_MIN: u32 = 16;
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const SNIPER_SYNC_Q_MIN: u32 = SYNC_Q_MIN / 2;
+
+    // Defaults: the partial-recall band from `fst4_60_diag_npre_baseline_scan`
+    // on the 20-trial corpus (2026-08-17). Both channels, because a cap
+    // policy that only holds under one is a different claim.
+    const DEFAULT_CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+    const DEFAULT_WIDTHS_HZ: &[f32] = &[250.0, 100.0, 50.0, 25.0];
+    const DEFAULT_CAPS: &[usize] = &[4, 8, 10, 16, 32, 50];
+
+    let cells: Vec<(String, String)> = match std::env::var("MFSK_CAP_SWEEP_CELLS") {
+        Ok(s) => s
+            .split(',')
+            .filter_map(|t| t.split_once(':'))
+            .map(|(c, snr)| (c.trim().to_string(), snr.trim().to_string()))
+            .collect(),
+        Err(_) => DEFAULT_CELLS
+            .iter()
+            .map(|(c, s)| (c.to_string(), s.to_string()))
+            .collect(),
+    };
+    let widths: Vec<f32> = match std::env::var("MFSK_CAP_SWEEP_WIDTHS") {
+        Ok(s) => s.split(',').filter_map(|t| t.trim().parse().ok()).collect(),
+        Err(_) => DEFAULT_WIDTHS_HZ.to_vec(),
+    };
+    let caps: Vec<usize> = match std::env::var("MFSK_CAP_SWEEP_CAPS") {
+        Ok(s) => s.split(',').filter_map(|t| t.trim().parse().ok()).collect(),
+        Err(_) => DEFAULT_CAPS.to_vec(),
+    };
+    assert!(
+        !cells.is_empty() && !widths.is_empty() && !caps.is_empty(),
+        "empty sweep grid — check MFSK_CAP_SWEEP_* syntax (cells are `channel:snr`, \
+         comma-separated)"
+    );
+
+    let dir = sweep_dir();
+
+    eprintln!(
+        "{:>14} {:>5} {:>7} {:>7} {:>6} {:>7} {:>8} {:>8} {:>10}",
+        "cell", "n", "width", "maxcand", "raw", "frac", "nsyncOK", "recall", "loop_ms"
+    );
+
+    for (channel, snr_tag) in &cells {
+        // Load the cell once — every (width, cap) configuration sees the
+        // same waveforms, so differences are attributable to the grid.
+        let mut trials: Vec<Vec<i16>> = Vec::new();
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            if let Some(audio) = load_wav_i16_opt(&path) {
+                trials.push(audio);
+            }
+        }
+        if trials.is_empty() {
+            eprintln!("{channel}_{snr_tag}: no WAVs present, skip");
+            continue;
+        }
+        let n = trials.len();
+
+        for &width in &widths {
+            let freq_min = (GOLDEN_FREQ_HZ - width).max(100.0);
+            let freq_max = (GOLDEN_FREQ_HZ + width).min(3000.0);
+
+            for &max_cand in &caps {
+                let t0 = Instant::now();
+                let mut raw_total = 0usize;
+                let mut gate_total = 0usize;
+                let mut nsync_total = 0usize;
+                let mut recall = 0usize;
+
+                for audio in &trials {
+                    // `raw` with the score gate wide open, for the
+                    // retained-fraction denominator — the same shape
+                    // `fst4_60_diag_sniper_gate_width_sweep` uses.
+                    let raw = coarse_sync::<Fst4s60>(
+                        audio,
+                        freq_min,
+                        freq_max,
+                        f32::NEG_INFINITY,
+                        Some(GOLDEN_FREQ_HZ),
+                        5000,
+                    );
+                    let gated = coarse_sync::<Fst4s60>(
+                        audio,
+                        freq_min,
+                        freq_max,
+                        SNIPER_SYNC_MIN,
+                        Some(GOLDEN_FREQ_HZ),
+                        max_cand,
+                    );
+                    raw_total += raw.len();
+                    gate_total += gated.len();
+
+                    let fft_cache = build_fft_cache(audio, &FST4_60A_DOWNSAMPLE);
+                    let mut decoded = false;
+                    for c in &gated {
+                        let (cd0, _refined_freq_hz, i0, _score) =
+                            refine_candidate_position::<Fst4s60>(
+                                c,
+                                &fft_cache,
+                                &FST4_60A_DOWNSAMPLE,
+                            );
+                        let cs = symbol_spectra::<Fst4s60>(&cd0, i0);
+                        if sync_quality::<Fst4s60>(&cs) <= SNIPER_SYNC_Q_MIN {
+                            continue;
+                        }
+                        nsync_total += 1;
+                        let r = process_candidate_basic::<Fst4s60>(
+                            c,
+                            &fft_cache,
+                            &FST4_60A_DOWNSAMPLE,
+                            DecodeDepth::FULL,
+                            DecodeStrictness::Normal,
+                            &[],
+                            EqMode::Off,
+                            SNIPER_SYNC_Q_MIN,
+                        );
+                        // Recall means *the transmitted message*, not any
+                        // decode — a CRC false-accept must not count.
+                        if let Some(d) = r {
+                            let mut m77 = [0u8; 77];
+                            m77.copy_from_slice(d.message77());
+                            if unpack77(&m77).as_deref() == Some(GOLDEN_MSG) {
+                                decoded = true;
+                                break;
+                            }
+                        }
+                    }
+                    if decoded {
+                        recall += 1;
+                    }
+                }
+
+                let loop_ms = t0.elapsed().as_secs_f64() * 1000.0;
+                let frac = if raw_total == 0 {
+                    0.0
+                } else {
+                    100.0 * gate_total as f64 / raw_total as f64
+                };
+                eprintln!(
+                    "{:>14} {:>5} {:>6.0}Hz {:>7} {:>6} {:>6.0}% {:>8} {:>5}/{:<2} {:>10.1}",
+                    format!("{channel}_{snr_tag}"),
+                    n,
+                    width,
+                    max_cand,
+                    raw_total,
+                    frac,
+                    nsync_total,
+                    recall,
+                    n,
+                    loop_ms
+                );
+            }
+        }
+    }
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -5668,3 +5668,243 @@ fn fst4_60_diag_dedup_zero_score_recall_effect() {
          cost. Any non-zero `zeros_decode` means it is load-bearing — leave it alone."
     );
 }
+
+/// **#310, VK3NV's soft Costas-margin proposal — does it separate?**
+///
+/// `engine::llr::sync_quality_generic` inspects all four tone energies
+/// per known sync symbol and then discards everything except
+/// `best == expected`. `sync_quality_soft_generic` keeps
+/// `(E_expected, E_best_wrong)` for each. The question this answers is
+/// the one that decides whether the extra information is worth carrying:
+/// **does a soft margin separate candidates that decode from candidates
+/// that don't, any better than raw `nsync` already does?**
+///
+/// ## Metric
+///
+/// Separation is reported as **AUC** — the fraction of
+/// (decoding, non-decoding) candidate pairs the score orders correctly,
+/// ties counting a half. 0.5 is chance, 1.0 is perfect. It is the right
+/// shape here because the intended use (#310) is *ranking* candidates
+/// for escalation budget, not thresholding them, and because it is
+/// insensitive to the class imbalance these cells have.
+///
+/// Four scores compared on the same candidate population:
+///
+/// - `nsync` — the existing hard count. **The baseline that has to be
+///   beaten**; VK3NV's kill condition, and the same discipline that
+///   retired the `llrd` rung.
+/// - `mean margin` — mean over sync symbols of
+///   `(E_exp − E_wrong) / (E_exp + E_wrong)`. Scale-free, so it doesn't
+///   just re-measure candidate amplitude.
+/// - `min margin` — the worst symbol's normalised margin. A candidate
+///   can have a good mean and one catastrophic symbol.
+/// - `mean logratio` — mean of `ln(E_exp / E_wrong)`, clamped. Weights
+///   large ratios differently from the bounded form above; included
+///   because the raw pairs are kept precisely so formulations can be
+///   compared without re-instrumenting.
+///
+/// ## Population
+///
+/// Every candidate that clears the `nsync` gate on the partial-recall
+/// band (`fst4_60_diag_npre_baseline_scan`) — a saturated or empty cell
+/// cannot show separation either way. "Decodes" means the golden message
+/// specifically, so a CRC false-accept is not counted as a positive.
+///
+/// ## Reading it
+///
+/// If `nsync` alone already separates as well as the margins, stop —
+/// there is no reason to carry the extra state. If a margin beats it
+/// materially, the next question (not answered here) is whether it also
+/// *retains* the decode-bearing candidates rather than merely finding
+/// the junk: the trials worth rescuing are the marginal ones, so a score
+/// that demotes expensive-and-real alongside expensive-and-false is
+/// worse than useless for #310's escalation ordering. The per-group
+/// means printed alongside are there to make that visible.
+#[test]
+#[ignore = "manual diagnostic — soft Costas margin vs raw nsync separation (issue #310, VK3NV)"]
+fn fst4_60_diag_soft_costas_margin_separation() {
+    use mfsk_core::engine::dsp::downsample::build_fft_cache;
+    use mfsk_core::engine::equalize::EqMode;
+    use mfsk_core::engine::llr::{
+        symbol_spectra, sync_quality, sync_quality_soft_generic, sync_symbol_count,
+    };
+    use mfsk_core::engine::pipeline::{
+        DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
+    };
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const SNIPER_SYNC_Q_MIN: u32 = 8;
+    const MAX_CAND: usize = 50;
+    const WIDTH_HZ: f32 = 250.0;
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+
+    /// Rank-based AUC: fraction of (positive, negative) pairs ordered
+    /// correctly, ties half. O(n²) is fine at these populations.
+    fn auc(scored: &[(f64, bool)]) -> f64 {
+        let pos: Vec<f64> = scored.iter().filter(|(_, d)| *d).map(|(s, _)| *s).collect();
+        let neg: Vec<f64> = scored
+            .iter()
+            .filter(|(_, d)| !*d)
+            .map(|(s, _)| *s)
+            .collect();
+        if pos.is_empty() || neg.is_empty() {
+            return f64::NAN;
+        }
+        let mut acc = 0.0;
+        for p in &pos {
+            for n in &neg {
+                acc += if p > n {
+                    1.0
+                } else if (p - n).abs() < f64::EPSILON {
+                    0.5
+                } else {
+                    0.0
+                };
+            }
+        }
+        acc / (pos.len() * neg.len()) as f64
+    }
+
+    fn mean(v: &[f64]) -> f64 {
+        if v.is_empty() {
+            f64::NAN
+        } else {
+            v.iter().sum::<f64>() / v.len() as f64
+        }
+    }
+
+    let dir = sweep_dir();
+    let n_sync = sync_symbol_count::<Fst4s60>();
+    eprintln!();
+    eprintln!("=== soft Costas margin vs raw nsync (FST4-60, {n_sync} sync symbols) ===");
+    eprintln!("AUC: fraction of (decoding, non-decoding) pairs ordered correctly; 0.5 = chance");
+
+    for &(channel, snr_tag) in CELLS {
+        // (nsync, mean_margin, min_margin, mean_logratio, decoded)
+        let mut rows: Vec<(f64, f64, f64, f64, bool)> = Vec::new();
+
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            let cands = coarse_sync::<Fst4s60>(
+                &audio,
+                (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
+                (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
+                SNIPER_SYNC_MIN,
+                Some(GOLDEN_FREQ_HZ),
+                MAX_CAND,
+            );
+            let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+
+            for c in &cands {
+                let (cd0, _f, i0, _s) =
+                    refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE);
+                let cs = symbol_spectra::<Fst4s60>(&cd0, i0);
+                let nsync = sync_quality::<Fst4s60>(&cs);
+                if nsync <= SNIPER_SYNC_Q_MIN {
+                    continue;
+                }
+
+                let mut pairs = vec![(0.0f32, 0.0f32); n_sync];
+                let nsync_soft = sync_quality_soft_generic::<Fst4s60, f32>(&cs, &mut pairs);
+                assert_eq!(
+                    nsync, nsync_soft,
+                    "soft variant must return the same nsync as the hard one"
+                );
+
+                let mut margins = Vec::with_capacity(n_sync);
+                let mut logratios = Vec::with_capacity(n_sync);
+                for &(e_exp, e_wrong) in &pairs {
+                    let (a, b) = (e_exp as f64, e_wrong as f64);
+                    let denom = a + b;
+                    margins.push(if denom > 0.0 { (a - b) / denom } else { 0.0 });
+                    // Clamped: a zero energy is a numerical artefact, not
+                    // infinite confidence.
+                    let r = if b > 0.0 && a > 0.0 {
+                        (a / b).ln()
+                    } else {
+                        0.0
+                    };
+                    logratios.push(r.clamp(-8.0, 8.0));
+                }
+                let min_margin = margins.iter().copied().fold(f64::INFINITY, f64::min);
+
+                let decoded = process_candidate_basic::<Fst4s60>(
+                    c,
+                    &fft_cache,
+                    &FST4_60A_DOWNSAMPLE,
+                    DecodeDepth::FULL,
+                    DecodeStrictness::Normal,
+                    &[],
+                    EqMode::Off,
+                    SNIPER_SYNC_Q_MIN,
+                )
+                .is_some_and(|d| {
+                    let mut m77 = [0u8; 77];
+                    m77.copy_from_slice(d.message77());
+                    unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                });
+
+                rows.push((
+                    nsync as f64,
+                    mean(&margins),
+                    min_margin,
+                    mean(&logratios),
+                    decoded,
+                ));
+            }
+        }
+
+        if rows.is_empty() {
+            eprintln!("{channel}_{snr_tag}: no candidates, skip");
+            continue;
+        }
+        let n_pos = rows.iter().filter(|r| r.4).count();
+        let n_neg = rows.len() - n_pos;
+
+        let pick = |f: fn(&(f64, f64, f64, f64, bool)) -> f64| -> (f64, f64, f64) {
+            let scored: Vec<(f64, bool)> = rows.iter().map(|r| (f(r), r.4)).collect();
+            let pos: Vec<f64> = rows.iter().filter(|r| r.4).map(f).collect();
+            let neg: Vec<f64> = rows.iter().filter(|r| !r.4).map(f).collect();
+            (auc(&scored), mean(&pos), mean(&neg))
+        };
+
+        eprintln!();
+        eprintln!(
+            "{channel}_{snr_tag}: {} candidates ({n_pos} decode, {n_neg} don't)",
+            rows.len()
+        );
+        eprintln!(
+            "  {:<14} {:>6}   {:>10} {:>10}",
+            "score", "AUC", "mean(dec)", "mean(no)"
+        );
+        for (name, f) in [
+            (
+                "nsync",
+                (|r: &(f64, f64, f64, f64, bool)| r.0) as fn(&_) -> f64,
+            ),
+            ("mean margin", |r: &(f64, f64, f64, f64, bool)| r.1),
+            ("min margin", |r: &(f64, f64, f64, f64, bool)| r.2),
+            ("mean logratio", |r: &(f64, f64, f64, f64, bool)| r.3),
+        ] {
+            let (a, mp, mn) = pick(f);
+            eprintln!("  {name:<14} {a:>6.3}   {mp:>10.3} {mn:>10.3}");
+        }
+    }
+
+    eprintln!();
+    eprintln!(
+        "Kill condition (VK3NV): if no margin beats `nsync`'s AUC materially, the \
+         extra per-symbol state isn't worth carrying and #310 should look elsewhere."
+    );
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -3548,12 +3548,13 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
     eprintln!(
-        "{:>6} {:>7} {:>6} {:>5} {:>6} {:>8} {:>6} {:>7} {:>9} {:>9}",
+        "{:>6} {:>7} {:>6} {:>5} {:>6} {:>7} {:>8} {:>6} {:>7} {:>9} {:>9}",
         "target",
         "width",
         "maxcand",
         "raw",
         "gate",
+        "frac",
         "nsyncOK",
         "real",
         "false",
@@ -3575,15 +3576,27 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
                 5000,
             );
 
-            // Both `SniperRequest`'s real `max_cand` default (50, to
-            // reproduce production truncation behaviour) and an
-            // effectively-uncapped run (5000, larger than any `raw`
-            // count observed at any width here) — the 50-cap row alone
-            // conflates "narrower window" with "hit the cap", since
-            // sniper's real `sync_min=0.8` is loose enough that even
-            // the ±25 Hz window's `raw` population (85) has ≥50
-            // candidates clearing it.
-            for max_cand in [50usize, 5000] {
+            // VK3NV's issue #312 cap ladder, plus `SniperRequest`'s real
+            // default (50, to reproduce production truncation) and an
+            // effectively-uncapped run (5000, larger than any `raw` count
+            // observed at any width here).
+            //
+            // Why the ladder and not just 50-vs-uncapped: the 50-cap row
+            // alone conflates "narrower window" with "hit the cap", since
+            // sniper's `sync_min = 0.8` is loose enough that even the
+            // ±25 Hz window's raw population (85) still has ≥50
+            // candidates clearing it — so at production settings the cap,
+            // not the width, is what gates deep-decode entry.
+            //
+            // The `frac` column is the point of the exercise (VK3NV,
+            // #312): an absolute cap is not comparable across widths.
+            // 50 of 842 is the top 6 %; 50 of 85 is the top 60 %. If the
+            // recall cliff sits at a similar *fraction* across widths,
+            // the cap can be derived from the width; if it doesn't — the
+            // wide window's top 6 % being drawn from a much longer noise
+            // tail than the narrow window's top 60 % — that argues for a
+            // score-based or distribution-adaptive criterion instead.
+            for max_cand in [4usize, 8, 10, 16, 32, 50, 5000] {
                 let gated = coarse_sync::<Fst4s60>(
                     &audio,
                     freq_min,
@@ -3632,13 +3645,22 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
                 }
                 let loop_ms = t0.elapsed().as_secs_f64() * 1000.0;
 
+                // Retained fraction of *this width's* raw population —
+                // the column that makes caps comparable across widths.
+                let frac = if raw.is_empty() {
+                    0.0
+                } else {
+                    100.0 * gated.len() as f64 / raw.len() as f64
+                };
+
                 eprintln!(
-                    "{:>6} {:>6.0}Hz {:>7} {:>5} {:>6} {:>8} {:>6} {:>7} {:>9} {:>9.1}",
+                    "{:>6} {:>6.0}Hz {:>7} {:>5} {:>6} {:>6.0}% {:>8} {:>6} {:>7} {:>9} {:>9.1}",
                     t.name,
                     width,
                     max_cand,
                     raw.len(),
                     gated.len(),
+                    frac,
                     n_nsync_pass,
                     n_real,
                     n_false,
@@ -4293,11 +4315,77 @@ fn fst4_60_diag_i0_offset_host_timing() {
 /// `npre2` pruning this is about, which localises a remaining miss to a
 /// pruning stage rather than to the architecture.
 ///
+/// ## Choosing the cell — this matters more than it looks
+///
+/// Section 6 of `FST4_BENCHMARK.md` says to diagnose on a cell with
+/// *partial* recall, and that applies here with extra force: the grid
+/// can only separate mechanisms where the `npre @{0}` baseline is
+/// non-zero and non-saturated. On a cell so deep that the baseline is
+/// 0/20, every "rescue" is measured against nothing, and a mechanism
+/// that would merely *widen* an existing margin is invisible. The first
+/// run of this ablation used m26 and hit exactly that — see
+/// [`fst4_60_diag_npre_baseline_scan`], which exists to locate the
+/// usable band before spending 6 minutes per cell here.
+///
 /// Single-threaded by construction (`fst4_osd_diag_force_old` is a
 /// process-global toggle): run with `--test-threads=1`.
 #[test]
 #[ignore = "manual ablation — npre-vs-timing rescue substitutability (issue #311, VK3NV)"]
 fn fst4_60_diag_npre_timing_substitutability_ablation() {
+    // Cells to run the full grid over. Keep this pointed at the partial-
+    // recall band `fst4_60_diag_npre_baseline_scan` reports, not at
+    // whichever cell a previous finding happened to name.
+    // The partial-recall band `fst4_60_diag_npre_baseline_scan` measured
+    // for this harness on 2026-08-17 (20-trial corpus): ccir_moderate
+    // crosses between m24 (17/20) and m26 (0/20), awgn between m26
+    // (19/20) and m29 (0/20). Both channels are included to test whether
+    // the verdict is channel-dependent — the fading channel is where the
+    // original #306 finding lives, but a mechanism that only interacts
+    // under fading is a different claim from one that always does.
+    //
+    // NOT m26 ccir_moderate, despite that being the cell #306/#308 named:
+    // this harness decodes 0/20 there, so nothing can be measured against
+    // it. Production reaches deeper (timing retry + a wider candidate set
+    // + no ±FREQ_TOL_HZ pre-filter), which is why the original finding
+    // could live in a cell this one cannot use.
+    for (channel, snr_tag) in [
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ] {
+        npre_timing_grid_for_cell(channel, snr_tag);
+    }
+}
+
+/// Cheap locator for the band where the full grid is informative:
+/// `npre @{0}` recall only (1 configuration instead of 6), over every
+/// SNR cell present for a channel. Roughly a sixth of the grid's cost
+/// per cell.
+///
+/// Read it the way section 6 of `FST4_BENCHMARK.md` says: pick cells
+/// that are neither 0/n nor n/n. A 0/n cell cannot show a mechanism
+/// widening an existing margin, and an n/n cell has no failures left to
+/// rescue.
+#[test]
+#[ignore = "manual scan — locate FST4-60's partial-recall band for the npre baseline (issue #311)"]
+fn fst4_60_diag_npre_baseline_scan() {
+    for channel in ["awgn", "ccir_moderate"] {
+        eprintln!();
+        eprintln!("=== npre @{{0}} baseline recall, fst4_60_{channel} ===");
+        for snr in [
+            "m20", "m22", "m23", "m24", "m25", "m26", "m27", "m28", "m29", "m30",
+        ] {
+            let (hits, n) = npre_baseline_for_cell(channel, snr);
+            if n == 0 {
+                continue;
+            }
+            eprintln!("  {snr}: {hits}/{n}");
+        }
+    }
+}
+
+fn npre_timing_grid_for_cell(channel: &str, snr_tag: &str) {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
     use mfsk_core::engine::sync::coarse_sync;
@@ -4412,7 +4500,7 @@ fn fst4_60_diag_npre_timing_substitutability_ablation() {
     type PreparedCand = (Vec<num_complex::Complex<f32>>, i32);
     let mut prepared: Vec<(u32, Vec<PreparedCand>)> = Vec::new();
     for trial in 1..=MAX_TRIAL {
-        let path = dir.join(format!("fst4_60_ccir_moderate_m26_{trial:02}.wav"));
+        let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
         let Some(audio) = load_wav_i16_opt(&path) else {
             continue;
         };
@@ -4495,7 +4583,7 @@ fn fst4_60_diag_npre_timing_substitutability_ablation() {
 
     let n = prepared.len();
     eprintln!();
-    eprintln!("=== npre-vs-timing rescue ablation (fst4_60_ccir_moderate_m26) ===");
+    eprintln!("=== npre-vs-timing rescue ablation (fst4_60_{channel}_{snr_tag}) ===");
     eprintln!("corpus: {n} trials present (probed 1..={MAX_TRIAL})");
     eprintln!();
     for (gi, cfg) in GRID.iter().enumerate() {
@@ -4534,30 +4622,57 @@ fn fst4_60_diag_npre_timing_substitutability_ablation() {
     union.extend(extra);
     union.sort_unstable();
 
+    // Trials only the *combination* reaches. Comparing `both` against the
+    // union of the two single-mechanism sets is the test for a genuine
+    // interaction, and the first version of this classifier omitted it —
+    // it compared only the two singles against each other, which labelled
+    // a cell "substitutable" (identical singles) while the combination was
+    // in fact rescuing strictly more than either. Keep this check.
+    let synergy: Vec<u32> = both
+        .iter()
+        .copied()
+        .filter(|t| !union.contains(t))
+        .collect();
+
+    // Does npre ever decode a trial the unpruned search misses? If not,
+    // npre is a pure recall loss bought for speed, and a "selective
+    // fallback to unpruned" is behaviourally identical to just running
+    // unpruned — worth knowing before designing an escalation order.
+    let npre_wins_over_unpruned: Vec<u32> = hits[0]
+        .iter()
+        .copied()
+        .filter(|t| !hits[2].contains(t))
+        .collect();
+
     eprintln!();
     eprintln!("relative to `npre @{{0}}` (the pre-#308 production shape):");
     eprintln!("  timing alone rescues:    {timing_only:?}");
     eprintln!("  fallback alone rescues:  {fallback_only:?}");
     eprintln!("  overlap:                 {overlap:?}");
-    eprintln!("  union:                   {union:?}");
+    eprintln!("  union of singles:        {union:?}");
     eprintln!("  both together rescue:    {both:?}");
+    eprintln!("  ONLY-with-both (synergy):{synergy:?}");
     eprintln!("  (unpruned+timing, for reference: {unpruned_timing:?})");
+    eprintln!("  npre wins unpruned misses: {npre_wins_over_unpruned:?}");
 
     let verdict = if timing_only.is_empty() && fallback_only.is_empty() && both.is_empty() {
         "NO MECHANISM HELPS on this corpus cell at these candidate/gate settings — \
          see the note below before reading this as a statement about the mechanisms"
+    } else if !synergy.is_empty() {
+        "SYNERGISTIC — the combination rescues trials NEITHER mechanism rescues \
+         alone, so #310 cannot reduce the ladder to one of them without losing \
+         those trials (check the magnitude before paying for it)"
     } else if timing_only.is_empty() && fallback_only.is_empty() {
-        "INTERACTING — neither mechanism rescues anything alone, but both together do. \
-         #310 cannot pick one: the rescue requires the combination"
-    } else if union.len() == overlap.len() && !union.is_empty() {
-        "SUBSTITUTABLE — identical trial sets; #310 can carry whichever is cheaper \
-         and lose no recall on this corpus"
+        "INTERACTING — neither mechanism rescues anything alone, but both together do"
+    } else if union.len() == overlap.len() {
+        "SUBSTITUTABLE — identical trial sets and no synergy; #310 can carry \
+         whichever is cheaper and lose no recall on this cell"
     } else if overlap.is_empty() {
-        "ADDITIVE — disjoint trial sets; dropping either costs recall, so #310 has \
-         to budget for both"
+        "ADDITIVE — disjoint trial sets, no synergy; dropping either costs exactly \
+         its own set"
     } else {
-        "PARTIAL OVERLAP — the second mechanism's marginal value is union minus the \
-         cheaper one's own set"
+        "PARTIAL OVERLAP, no synergy — the second mechanism's marginal value is \
+         union minus the cheaper one's own set"
     };
     eprintln!();
     eprintln!("VERDICT: {verdict}");
@@ -4573,4 +4688,111 @@ fn fst4_60_diag_npre_timing_substitutability_ablation() {
              before concluding anything about the mechanisms."
         );
     }
+}
+
+/// `npre @{0}` recall for one cell — the single configuration
+/// [`fst4_60_diag_npre_baseline_scan`] needs, without paying for the
+/// other five. Returns `(hits, trials_present)`; `(0, 0)` when the cell
+/// isn't in this corpus generation.
+///
+/// Deliberately the same hand-built pipeline
+/// [`npre_timing_grid_for_cell`] uses, not `DecodeRequest` — the point
+/// is to locate the band where *that* harness is informative, and
+/// production's own recall differs (it carries #308's timing retry, a
+/// wider candidate set, and no ±`FREQ_TOL_HZ` pre-filter).
+fn npre_baseline_for_cell(channel: &str, snr_tag: &str) -> (u32, u32) {
+    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::fec::ldpc240_101::fst4_osd_diag_force_old;
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const NSYNC_GATE: u32 = 16;
+
+    let dir = sweep_dir();
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let fec = <Fst4s60 as Protocol>::Fec::default();
+    let verify_info =
+        Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
+
+    // Production npre path throughout.
+    fst4_osd_diag_force_old(false);
+
+    let mut hits = 0u32;
+    let mut present = 0u32;
+    for trial in 1..=100u32 {
+        let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+        let Some(audio) = load_wav_i16_opt(&path) else {
+            continue;
+        };
+        present += 1;
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+        let mut ok = false;
+        'cands: for c in cands
+            .iter()
+            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+        {
+            let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
+            let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+            if sum2 > f32::EPSILON {
+                let inv = 1.0 / sum2.sqrt();
+                for z in cd0.iter_mut() {
+                    *z *= inv;
+                }
+            }
+            let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+            let cd0 = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
+            let cs = symbol_spectra::<Fst4s60>(&cd0, s2.i0);
+            let nsync = sync_quality::<Fst4s60>(&cs);
+            if nsync <= NSYNC_GATE {
+                continue;
+            }
+            let llr_set = compute_llr::<Fst4s60, f32>(&cs);
+            let variants: [&Vec<f32>; 4] =
+                [&llr_set.llra, &llr_set.llrb, &llr_set.llre, &llr_set.llrc];
+            let is_golden = |llr: &Vec<f32>, opts: &FecOpts| -> bool {
+                fec.decode_soft(llr, opts).is_some_and(|mut r| {
+                    mfsk_core::engine::llr::descramble_info::<Fst4s60>(&mut r.info);
+                    let mut m77 = [0u8; 77];
+                    m77.copy_from_slice(&r.info[..77]);
+                    unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                })
+            };
+            let bp_opts = FecOpts {
+                bp_max_iter: 30,
+                osd_depth: 0,
+                ap_mask: None,
+                verify_info,
+                ..FecOpts::default()
+            };
+            if variants.iter().any(|llr| is_golden(llr, &bp_opts)) {
+                ok = true;
+                break 'cands;
+            }
+            if nsync >= osd_attempt_min {
+                let osd_depth: u32 = if nsync >= osd_depth3_min { 3 } else { 2 };
+                let osd_opts = FecOpts {
+                    bp_max_iter: 30,
+                    osd_depth,
+                    ap_mask: None,
+                    verify_info,
+                    ..FecOpts::default()
+                };
+                if variants.iter().any(|llr| is_golden(llr, &osd_opts)) {
+                    ok = true;
+                    break 'cands;
+                }
+            }
+        }
+        if ok {
+            hits += 1;
+        }
+    }
+    (hits, present)
 }

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -5506,3 +5506,165 @@ fn fst4_60_diag_dedup_zero_score_readmission() {
         );
     }
 }
+
+/// **Does the re-admitted duplicate ever decode?** The question that
+/// decides whether #312's `retain` OR-gate can be tightened for free.
+///
+/// [`fst4_60_diag_dedup_zero_score_readmission`] established that
+/// dedup-suppressed candidates (`score == 0.0`) do reach the capped
+/// list. That alone doesn't say whether they are harmful, harmless, or
+/// load-bearing. Three possibilities, and they need different actions:
+///
+/// - **Never decode** → the OR-gate is buying nothing on this path and
+///   tightening `retain` to `score >= sync_min && stage1_pass(fi)` costs
+///   no recall. Free cleanup, plus whatever budget the duplicates were
+///   consuming.
+/// - **Sometimes decode** → the gate is genuinely buying recall (a
+///   near-duplicate is not always the *wrong* one of the pair), and
+///   tightening it is a sensitivity regression. Leave it.
+/// - **Decode, but only signals another candidate also decodes** →
+///   they're redundant; tightening is still free, and the dedup itself
+///   is what needs looking at.
+///
+/// Measured two ways per cell, at the production `max_cand = 50` and
+/// sniper-shaped (`freq_hint` set — that is the configuration where a
+/// zero can take a *reserved* slot rather than sorting to the bottom):
+///
+/// 1. `as-is` — the candidate list exactly as `coarse_sync` returns it.
+/// 2. `filtered` — the same list with `score == 0.0` entries dropped
+///    before any decode work, i.e. what tightening the gate would do.
+///
+/// Equal recall across those two columns is the "free to tighten"
+/// result. `zeros_decode` counts candidates that were themselves
+/// zero-score *and* produced the golden message, which is the direct
+/// form of the same question and distinguishes case 2 from case 3.
+///
+/// Cells are the partial-recall band from
+/// [`fst4_60_diag_npre_baseline_scan`] — a saturated or empty cell
+/// cannot show a recall difference either way.
+#[test]
+#[ignore = "manual audit — do dedup-suppressed candidates ever decode? (issue #312)"]
+fn fst4_60_diag_dedup_zero_score_recall_effect() {
+    use mfsk_core::engine::dsp::downsample::build_fft_cache;
+    use mfsk_core::engine::equalize::EqMode;
+    use mfsk_core::engine::llr::{symbol_spectra, sync_quality};
+    use mfsk_core::engine::pipeline::{
+        DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
+    };
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const SNIPER_SYNC_Q_MIN: u32 = 8; // fst4::decode's __sniper literal
+    const MAX_CAND: usize = 50; // production default
+    const WIDTH_HZ: f32 = 250.0; // sniper's own literal
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+
+    let dir = sweep_dir();
+    eprintln!(
+        "{:>18} {:>4} {:>7} {:>13} {:>10} {:>10}",
+        "cell", "n", "zeros", "zeros_decode", "recall", "filtered"
+    );
+
+    for &(channel, snr_tag) in CELLS {
+        let mut n = 0u32;
+        let mut zeros_total = 0u32;
+        let mut zeros_decode = 0u32;
+        let mut recall_asis = 0u32;
+        let mut recall_filtered = 0u32;
+
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            n += 1;
+
+            let cands = coarse_sync::<Fst4s60>(
+                &audio,
+                (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
+                (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
+                SNIPER_SYNC_MIN,
+                Some(GOLDEN_FREQ_HZ),
+                MAX_CAND,
+            );
+            let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+
+            let mut hit_asis = false;
+            let mut hit_filtered = false;
+            for c in &cands {
+                let is_zero = c.score == 0.0;
+                if is_zero {
+                    zeros_total += 1;
+                }
+                let (cd0, _f, i0, _s) =
+                    refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE);
+                let cs = symbol_spectra::<Fst4s60>(&cd0, i0);
+                if sync_quality::<Fst4s60>(&cs) <= SNIPER_SYNC_Q_MIN {
+                    continue;
+                }
+                let decoded = process_candidate_basic::<Fst4s60>(
+                    c,
+                    &fft_cache,
+                    &FST4_60A_DOWNSAMPLE,
+                    DecodeDepth::FULL,
+                    DecodeStrictness::Normal,
+                    &[],
+                    EqMode::Off,
+                    SNIPER_SYNC_Q_MIN,
+                )
+                .is_some_and(|d| {
+                    let mut m77 = [0u8; 77];
+                    m77.copy_from_slice(d.message77());
+                    unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                });
+                if !decoded {
+                    continue;
+                }
+                hit_asis = true;
+                if is_zero {
+                    zeros_decode += 1;
+                } else {
+                    // Only non-zero candidates survive the tightened gate.
+                    hit_filtered = true;
+                }
+            }
+            if hit_asis {
+                recall_asis += 1;
+            }
+            if hit_filtered {
+                recall_filtered += 1;
+            }
+        }
+
+        if n == 0 {
+            eprintln!("{channel}_{snr_tag}: no WAVs present, skip");
+            continue;
+        }
+        eprintln!(
+            "{:>18} {:>4} {:>7} {:>13} {:>7}/{:<2} {:>7}/{:<2}",
+            format!("{channel}_{snr_tag}"),
+            n,
+            zeros_total,
+            zeros_decode,
+            recall_asis,
+            n,
+            recall_filtered,
+            n
+        );
+    }
+
+    eprintln!();
+    eprintln!(
+        "Equal `recall` and `filtered` columns, with zeros_decode = 0, means the \
+         OR-gate re-admission buys no recall on this path and `retain` could be \
+         tightened to `score >= sync_min && stage1_pass(fi)` without a sensitivity \
+         cost. Any non-zero `zeros_decode` means it is load-bearing — leave it alone."
+    );
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -5279,8 +5279,12 @@ fn fst4_60_diag_i0_cheap_rank_vs_exhaustive() {
                         }
                     }
 
-                    // cheap-rank: argmax nsync only.
-                    cheap.sort_by(|a, b| b.1.cmp(&a.1));
+                    // cheap-rank: argmax nsync only. `Reverse` for
+                    // descending — stable, so ties keep OFFSETS order
+                    // (offset 0 first), which is the conservative
+                    // tie-break: a tie must not silently prefer an
+                    // alternate offset over the refined position.
+                    cheap.sort_by_key(|&(_, nsync)| core::cmp::Reverse(nsync));
                     let best = cheap[0].0;
                     argmax_seen += 1;
                     if best == 0 {

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -4202,3 +4202,375 @@ fn fst4_60_diag_i0_offset_host_timing() {
         tall / t0
     );
 }
+
+/// **Substitutable-vs-additive ablation** for the two rescue mechanisms
+/// #308 split apart (VK3NV, issue #311).
+///
+/// #306 found CCIR-moderate m26 trials where the pre-port unpruned
+/// combinatorial OSD decoded and the WSJT-X-faithful `npre1`/`npre2`
+/// port (#198) did not. #308 showed `i0±1` timing diversity recovers
+/// some of them, so part of the apparent OSD-pruning gap was really a
+/// missing-timing-diversity gap. That leaves two independent "retry the
+/// failure with something more expensive" mechanisms:
+///
+/// - alternate timing (`i0±1`)
+/// - a selective fallback to the old unpruned OSD search
+///
+/// The question is **not** whether each helps — that is known — but
+/// whether they rescue the *same* trials or *different* ones. Aggregate
+/// recall counts cannot distinguish those: two mechanisms each
+/// recovering "2 of 5" look identical in counts. Only the per-trial
+/// identity separates
+///
+/// - **substitutable** — same trials, so the embedded escalation ladder
+///   (#310) can carry the cheaper one and lose nothing, from
+/// - **additive** — different trials, so dropping either costs recall
+///   and #310 has to budget for both.
+///
+/// Hence the 2×2, and hence per-trial sets rather than tallies.
+///
+/// ## Two traps this harness exists to avoid
+///
+/// **1. Hardcoded trial indices are not portable across corpus
+/// generations.** The original finding named trials `[2, 15, 33, 45, 67]`
+/// out of a 100-trial-per-cell corpus. A 20-trial-per-cell generation of
+/// the same corpus has no trials 33/45/67, and its trial 2 is a
+/// *different waveform* — so those indices silently select the wrong
+/// signals (or nothing) elsewhere. This test therefore **derives its own
+/// trial set from whatever corpus is present**, and prints it.
+///
+/// **2. The selection baseline must be npre *without* timing.** It is
+/// tempting to reuse `fst4_60_diag_npre_osd_bug_hunt_ccir_moderate`'s
+/// production-path discovery (`decode_wav_fst4_60`) to pick the trials.
+/// That is now circular: `DecodeRequest`'s `osd` defaults to `true`, and
+/// #308's `i0±1` retry is gated on exactly that flag, so the production
+/// "npre" arm *already includes timing diversity*. Trials selected that
+/// way are ones where timing has already been given its chance and
+/// failed, which forces arm B to rescue nothing by construction and
+/// yields a spurious "neither mechanism works" verdict. The set here is
+/// selected with arm A (npre, single `i0`) — the genuine pre-#308
+/// baseline — against the unpruned search at the same single `i0`.
+///
+/// ## Arms
+///
+/// | arm | timing | OSD |
+/// |---|---|---|
+/// | A | `{0}` | npre only — pre-#308 baseline, and the selection basis |
+/// | B | `{0,+1,-1}` | npre only — host as shipped by #308 |
+/// | C | `{0}` | npre, falling back to unpruned **on failure** |
+/// | D | `{0,+1,-1}` | npre, falling back to unpruned **on failure** |
+///
+/// C/D are a *selective* fallback (npre first, unpruned only when npre
+/// returns nothing for every LLR variant), which is what was proposed —
+/// deliberately not "unpruned instead of npre", which is what
+/// [`mfsk_core::fec::Ldpc240_101::fst4_osd_diag_force_old`] does alone.
+///
+/// ## Method
+///
+/// One hand-built pipeline (`coarse_sync` → `fst4_sync_search` →
+/// `freq_shift_cd0` → `symbol_spectra`/`sync_quality` → `compute_llr` →
+/// FEC) shared by selection and all four arms, rather than
+/// `DecodeRequest`, because the production entry point cannot express
+/// "npre with OSD but without timing diversity" (arm A) at all — see
+/// trap 2. Sync runs once per trial, so any difference between arms is
+/// attributable to the OSD/timing axes alone.
+///
+/// Success is matched against [`GOLDEN_MSG`], not merely "something
+/// decoded", so a CRC false-accept cannot be counted as a rescue.
+///
+/// ## What this cannot tell you
+///
+/// The trial set is small by construction (it is the disagreement set,
+/// not the corpus). Enough to answer same-trials-or-not; **not** enough
+/// for any recall claim, and nothing here should move a production
+/// default — that needs the near-threshold sweep VK3NV flagged.
+/// Wall-clock is deliberately not reported: this is recall attribution,
+/// and cost belongs on the Ryzen 9 box or real hardware (an Apple
+/// laptop's AC/battery state swings host wall-clock ~3×).
+///
+/// `osd_depth` reached per trial is printed because `npre2` only runs at
+/// `ndeep=3`: a trial that never got past `ndeep=2` never exercised the
+/// `npre2` pruning this is about, which localises a remaining miss to a
+/// pruning stage rather than to the architecture.
+///
+/// Single-threaded by construction (`fst4_osd_diag_force_old` is a
+/// process-global toggle): run with `--test-threads=1`.
+#[test]
+#[ignore = "manual ablation — npre-vs-timing rescue substitutability (issue #311, VK3NV)"]
+fn fst4_60_diag_npre_timing_substitutability_ablation() {
+    use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+    use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
+    use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
+    use mfsk_core::fec::ldpc240_101::fst4_osd_diag_force_old;
+    use mfsk_core::fst4::Fst4s60;
+    use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+
+    /// Upper bound on trial index to probe; missing files are skipped, so
+    /// this works against any corpus generation (20-, 100-trial, …).
+    const MAX_TRIAL: u32 = 100;
+
+    /// `sync_quality`'s pre-ladder gate — same literal
+    /// `fst4_60_diag_i0_retry_ccir_old_only` uses, matching
+    /// `fst4::decode`'s own (deliberately non-`pub`) `SYNC_Q_MIN / 2`.
+    const NSYNC_GATE: u32 = 16;
+
+    /// Which OSD search(es) an attempt may use.
+    #[derive(Copy, Clone, PartialEq)]
+    enum Osd {
+        /// Production: `npre1`/`npre2` only.
+        Npre,
+        /// Pre-port unpruned combinatorial search only.
+        Unpruned,
+        /// `npre` first; unpruned only if `npre` found nothing.
+        NpreThenUnpruned,
+    }
+
+    let dir = sweep_dir();
+    let (osd_attempt_min, osd_depth3_min) =
+        mfsk_core::engine::pipeline::osd_escalation_gates::<Fst4s60>();
+    let fec = <Fst4s60 as Protocol>::Fec::default();
+    let verify_info =
+        Some(<<Fst4s60 as Protocol>::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);
+    let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
+
+    // Per-trial cached sync so selection and all four arms share it.
+    // Each prepared candidate is (baseband already frequency-corrected to
+    // the refined estimate, refined `i0`) — sync is done once per trial so
+    // every arm sees identical input and only the OSD/timing axes vary.
+    let attempt = |cands: &[(Vec<num_complex::Complex<f32>>, i32)],
+                   offsets: &[i32],
+                   osd_mode: Osd,
+                   max_depth: &mut u32|
+     -> bool {
+        for (cd0, i0_ref) in cands {
+            for &di0 in offsets {
+                let cs = symbol_spectra::<Fst4s60>(cd0, i0_ref + di0);
+                let nsync = sync_quality::<Fst4s60>(&cs);
+                if nsync <= NSYNC_GATE {
+                    continue;
+                }
+                let llr_set = compute_llr::<Fst4s60, f32>(&cs);
+                let variants: [&Vec<f32>; 4] =
+                    [&llr_set.llra, &llr_set.llrb, &llr_set.llre, &llr_set.llrc];
+                let is_golden = |llr: &Vec<f32>, opts: &FecOpts| -> bool {
+                    fec.decode_soft(llr, opts).is_some_and(|mut r| {
+                        mfsk_core::engine::llr::descramble_info::<Fst4s60>(&mut r.info);
+                        let mut m77 = [0u8; 77];
+                        m77.copy_from_slice(&r.info[..77]);
+                        unpack77(&m77).as_deref() == Some(GOLDEN_MSG)
+                    })
+                };
+
+                // BP staircase first — identical in every arm, and
+                // unaffected by the OSD axis (`osd_depth: 0`).
+                let bp_opts = FecOpts {
+                    bp_max_iter: 30,
+                    osd_depth: 0,
+                    ap_mask: None,
+                    verify_info,
+                    ..FecOpts::default()
+                };
+                if variants.iter().any(|llr| is_golden(llr, &bp_opts)) {
+                    return true;
+                }
+
+                if nsync >= osd_attempt_min {
+                    let osd_depth: u32 = if nsync >= osd_depth3_min { 3 } else { 2 };
+                    *max_depth = (*max_depth).max(osd_depth);
+                    let osd_opts = FecOpts {
+                        bp_max_iter: 30,
+                        osd_depth,
+                        ap_mask: None,
+                        verify_info,
+                        ..FecOpts::default()
+                    };
+                    if osd_mode != Osd::Unpruned {
+                        fst4_osd_diag_force_old(false);
+                        if variants.iter().any(|llr| is_golden(llr, &osd_opts)) {
+                            return true;
+                        }
+                    }
+                    if osd_mode != Osd::Npre {
+                        fst4_osd_diag_force_old(true);
+                        let hit = variants.iter().any(|llr| is_golden(llr, &osd_opts));
+                        fst4_osd_diag_force_old(false);
+                        if hit {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        false
+    };
+
+    // ── Prepare every present trial once ─────────────────────────────
+    // One prepared candidate: baseband already frequency-corrected to the
+    // refined estimate, plus that estimate's `i0`.
+    type PreparedCand = (Vec<num_complex::Complex<f32>>, i32);
+    let mut prepared: Vec<(u32, Vec<PreparedCand>)> = Vec::new();
+    for trial in 1..=MAX_TRIAL {
+        let path = dir.join(format!("fst4_60_ccir_moderate_m26_{trial:02}.wav"));
+        let Some(audio) = load_wav_i16_opt(&path) else {
+            continue;
+        };
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
+        let mut prep = Vec::new();
+        for c in cands
+            .iter()
+            .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
+        {
+            let mut cd0 = downsample_cached(&fft_cache, c.freq_hz, &FST4_60A_DOWNSAMPLE);
+            let sum2: f32 = cd0.iter().map(|z| z.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+            if sum2 > f32::EPSILON {
+                let inv = 1.0 / sum2.sqrt();
+                for z in cd0.iter_mut() {
+                    *z *= inv;
+                }
+            }
+            let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+            let shifted = freq_shift_cd0(&cd0, s2.freq_hz - c.freq_hz, ds_rate);
+            prep.push((shifted, s2.i0));
+        }
+        prepared.push((trial, prep));
+    }
+
+    // ── The full 2 × 3 grid, no trial pre-selection ───────────────────
+    // Selecting a subset first is what makes this measurement circular
+    // (see trap 2 above); measuring the whole cell and reading the sets
+    // off afterwards cannot be. 6 configurations × every present trial.
+    struct Cfg {
+        label: &'static str,
+        offsets: &'static [i32],
+        osd: Osd,
+    }
+    const GRID: &[Cfg] = &[
+        Cfg {
+            label: "npre        @{0}",
+            offsets: &[0],
+            osd: Osd::Npre,
+        },
+        Cfg {
+            label: "npre        @{0,+1,-1}",
+            offsets: &[0, 1, -1],
+            osd: Osd::Npre,
+        },
+        Cfg {
+            label: "unpruned    @{0}",
+            offsets: &[0],
+            osd: Osd::Unpruned,
+        },
+        Cfg {
+            label: "unpruned    @{0,+1,-1}",
+            offsets: &[0, 1, -1],
+            osd: Osd::Unpruned,
+        },
+        Cfg {
+            label: "npre→unprun @{0}",
+            offsets: &[0],
+            osd: Osd::NpreThenUnpruned,
+        },
+        Cfg {
+            label: "npre→unprun @{0,+1,-1}",
+            offsets: &[0, 1, -1],
+            osd: Osd::NpreThenUnpruned,
+        },
+    ];
+
+    let mut hits: Vec<Vec<u32>> = vec![Vec::new(); GRID.len()];
+    let mut depth_seen: Vec<(u32, u32)> = Vec::new();
+    for (trial, prep) in &prepared {
+        let mut depth = 0u32;
+        for (gi, cfg) in GRID.iter().enumerate() {
+            if attempt(prep, cfg.offsets, cfg.osd, &mut depth) {
+                hits[gi].push(*trial);
+            }
+        }
+        depth_seen.push((*trial, depth));
+    }
+    fst4_osd_diag_force_old(false);
+
+    let n = prepared.len();
+    eprintln!();
+    eprintln!("=== npre-vs-timing rescue ablation (fst4_60_ccir_moderate_m26) ===");
+    eprintln!("corpus: {n} trials present (probed 1..={MAX_TRIAL})");
+    eprintln!();
+    for (gi, cfg) in GRID.iter().enumerate() {
+        eprintln!(
+            "{:<24} {:>2}/{n}  {:?}",
+            cfg.label,
+            hits[gi].len(),
+            hits[gi]
+        );
+    }
+    eprintln!();
+    eprintln!("max osd_depth reached per trial: {depth_seen:?}   (npre2 only runs at depth 3)");
+
+    // Read the mechanisms off the grid relative to the production
+    // baseline (npre at a single i0 — the pre-#308 shape).
+    let base = &hits[0];
+    let over_base = |set: &Vec<u32>| -> Vec<u32> {
+        set.iter().copied().filter(|t| !base.contains(t)).collect()
+    };
+    let timing_only = over_base(&hits[1]); // npre + timing
+    let fallback_only = over_base(&hits[4]); // npre + selective fallback
+    let both = over_base(&hits[5]); // npre + timing + fallback
+    let unpruned_timing = over_base(&hits[3]); // unpruned + timing
+
+    let overlap: Vec<u32> = timing_only
+        .iter()
+        .copied()
+        .filter(|t| fallback_only.contains(t))
+        .collect();
+    let mut union: Vec<u32> = timing_only.clone();
+    let extra: Vec<u32> = fallback_only
+        .iter()
+        .copied()
+        .filter(|t| !union.contains(t))
+        .collect();
+    union.extend(extra);
+    union.sort_unstable();
+
+    eprintln!();
+    eprintln!("relative to `npre @{{0}}` (the pre-#308 production shape):");
+    eprintln!("  timing alone rescues:    {timing_only:?}");
+    eprintln!("  fallback alone rescues:  {fallback_only:?}");
+    eprintln!("  overlap:                 {overlap:?}");
+    eprintln!("  union:                   {union:?}");
+    eprintln!("  both together rescue:    {both:?}");
+    eprintln!("  (unpruned+timing, for reference: {unpruned_timing:?})");
+
+    let verdict = if timing_only.is_empty() && fallback_only.is_empty() && both.is_empty() {
+        "NO MECHANISM HELPS on this corpus cell at these candidate/gate settings — \
+         see the note below before reading this as a statement about the mechanisms"
+    } else if timing_only.is_empty() && fallback_only.is_empty() {
+        "INTERACTING — neither mechanism rescues anything alone, but both together do. \
+         #310 cannot pick one: the rescue requires the combination"
+    } else if union.len() == overlap.len() && !union.is_empty() {
+        "SUBSTITUTABLE — identical trial sets; #310 can carry whichever is cheaper \
+         and lose no recall on this corpus"
+    } else if overlap.is_empty() {
+        "ADDITIVE — disjoint trial sets; dropping either costs recall, so #310 has \
+         to budget for both"
+    } else {
+        "PARTIAL OVERLAP — the second mechanism's marginal value is union minus the \
+         cheaper one's own set"
+    };
+    eprintln!();
+    eprintln!("VERDICT: {verdict}");
+    if hits.iter().all(|h| h.is_empty()) {
+        eprintln!();
+        eprintln!(
+            "NOTE: every configuration decoded 0/{n}. This hand-built pipeline is \
+             narrower than `DecodeRequest` (candidates filtered to ±{FREQ_TOL_HZ} Hz \
+             of the golden, single sync pass, no SIC), so a cell this deep into \
+             near-threshold can be empty here while the production path still finds \
+             a couple. Compare against \
+             `fst4_60_diag_npre_osd_bug_hunt_ccir_moderate` on the same corpus \
+             before concluding anything about the mechanisms."
+        );
+    }
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -5370,3 +5370,139 @@ fn fst4_60_diag_i0_cheap_rank_vs_exhaustive() {
     }
     fst4_osd_diag_force_old(false);
 }
+
+/// **VK3NV's #312 audit**: does `coarse_sync`'s dedup-suppressed loser
+/// come back and consume a capped slot?
+///
+/// `engine/sync.rs`'s dedup marks the losing near-duplicate (within 4 Hz
+/// / 40 ms) with `score = 0.0`, but the `retain` immediately after
+/// admits any candidate for which `stage1_pass(fi)` holds, *regardless
+/// of score*:
+///
+/// ```text
+/// if c.score >= sync_min { return true; }
+/// stage1_pass(fi)
+/// ```
+///
+/// `stage1_norm`/`stage1_pass` is only populated for FST4
+/// (`P::ID == ProtocolId::Fst4`), so this is FST4-specific rather than a
+/// property of the generic candidate path or #146's OR-gate.
+///
+/// Why it could matter for the #312 cap rows: `rank_candidates` sorts by
+/// score (so a zero sorts last *within its group*), then partitions into
+/// a near-`freq_hint` group (±10 Hz, `FREQ_HINT_NEAR_HZ`) and the rest,
+/// and reserves `min(near.len(), max_cand.div_ceil(2))` slots for the
+/// near group. At `max_cand = 4` that is **2 reserved slots** — so if
+/// the near group holds fewer than 2 non-zero candidates, a re-admitted
+/// zero-score duplicate takes a reserved slot instead of simply falling
+/// off the bottom of the score sort. The sniper path always passes a
+/// `freq_hint`, so the low-cap rows in #312 are exactly where this would
+/// bite.
+///
+/// A `score` of exactly `0.0` in the output can only come from that
+/// dedup assignment — real scores are normalised sync ratios — so
+/// counting zeros in the capped list is a direct count of re-admitted
+/// duplicates. No library change needed: `SyncCandidate::score` is
+/// public.
+///
+/// Reports, per (width, cap): capped size, zero-score entries, and how
+/// many of those sit inside the reserved near-hint group.
+#[test]
+#[ignore = "manual audit — dedup-suppressed candidates re-admitted past the cap (issue #312, VK3NV)"]
+fn fst4_60_diag_dedup_zero_score_readmission() {
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::fst4::Fst4s60;
+
+    // `engine::sync::FREQ_HINT_NEAR_HZ` is pub(crate); mirrored here.
+    const NEAR_HZ: f32 = 10.0;
+    const SNIPER_SYNC_MIN: f32 = 0.8;
+    const WIDTHS_HZ: &[f32] = &[250.0, 100.0, 50.0, 25.0];
+    const CAPS: &[usize] = &[4, 8, 10, 16, 32, 50];
+
+    let mut audits: Vec<(String, f32, Vec<i16>)> = Vec::new();
+
+    // 1. The real golden, both known signals — the corpus §10's table
+    //    was measured on.
+    if let Some(path) = common::corpus::golden_path_or_upstream(
+        "fst4/210115_0058.wav",
+        Some("FST4+FST4W/210115_0058.wav"),
+    ) && let Some(audio) = load_wav_i16_opt(&path)
+    {
+        audits.push(("golden/N5TM".into(), 1101.0, audio.clone()));
+        audits.push(("golden/K9KFR".into(), 1331.0, audio));
+    }
+
+    // 2. One near-threshold sweep trial — §11.2's rows come from cells
+    //    like this, and a strong-signal-only audit would not represent
+    //    them.
+    let dir = sweep_dir();
+    for (cell, trial) in [("ccir_moderate_m25", 1u32), ("awgn_m28", 1)] {
+        let path = dir.join(format!("fst4_60_{cell}_{trial:02}.wav"));
+        if let Some(audio) = load_wav_i16_opt(&path) {
+            audits.push((format!("sweep/{cell}#{trial}"), GOLDEN_FREQ_HZ, audio));
+        }
+    }
+
+    if audits.is_empty() {
+        eprintln!("skip: neither golden nor sweep corpus available");
+        return;
+    }
+
+    eprintln!(
+        "{:>22} {:>7} {:>7} {:>7} {:>7} {:>10}",
+        "source", "width", "maxcand", "capped", "zeros", "zeros_near"
+    );
+
+    let mut total_zeros = 0usize;
+    let mut total_zeros_near = 0usize;
+
+    for (name, hint, audio) in &audits {
+        for &width in WIDTHS_HZ {
+            let freq_min = (hint - width).max(100.0);
+            let freq_max = (hint + width).min(3000.0);
+            for &cap in CAPS {
+                let capped = coarse_sync::<Fst4s60>(
+                    audio,
+                    freq_min,
+                    freq_max,
+                    SNIPER_SYNC_MIN,
+                    Some(*hint),
+                    cap,
+                );
+                let zeros = capped.iter().filter(|c| c.score == 0.0).count();
+                let zeros_near = capped
+                    .iter()
+                    .filter(|c| c.score == 0.0 && (c.freq_hz - hint).abs() <= NEAR_HZ)
+                    .count();
+                total_zeros += zeros;
+                total_zeros_near += zeros_near;
+                eprintln!(
+                    "{:>22} {:>6.0}Hz {:>7} {:>7} {:>7} {:>10}",
+                    name,
+                    width,
+                    cap,
+                    capped.len(),
+                    zeros,
+                    zeros_near
+                );
+            }
+        }
+    }
+
+    eprintln!();
+    if total_zeros == 0 {
+        eprintln!(
+            "No re-admitted duplicates reached any capped list. The OR-gate is \
+             reachable in principle but not exercised here, so #312's rows stand \
+             as measured."
+        );
+    } else {
+        eprintln!(
+            "{total_zeros} zero-score entries reached capped lists, {total_zeros_near} \
+             of them inside the reserved near-hint group. The near-hint ones are the \
+             ones that displace a real candidate from a reserved slot rather than \
+             falling off the bottom of the score sort — #312's low-cap rows need a \
+             caveat proportional to that column."
+        );
+    }
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -5104,17 +5104,28 @@ fn prepare_fst4_60_cell(
 /// The output therefore reports `argmax nsync == offset 0` as a counted
 /// fraction, and the verdict short-circuits to DEGENERATE when it is
 /// ≥95 %. **Do not read "cheap-rank recovered nothing" as "ranking
-/// cannot work" without checking that line first.** The first run of
-/// this test (2026-08-17) hit exactly this: it printed "PROXY USELESS"
-/// on cells where the ranking had never actually chosen a non-zero
-/// offset, which is not the same claim at all.
+/// cannot work" without checking that line first.**
 ///
-/// What the degenerate case does establish is narrower but still useful
-/// for #310: a cheap proxy for "which timing will decode" **cannot be
-/// another sync-strength measure**, because the refine stage has already
-/// maximised that. It would have to be sync-orthogonal — something
-/// derived from LLR reliability, or a truncated-BP syndrome weight,
-/// rather than from Costas correlation.
+/// **Do not try to infer the degeneracy from the `units` column either**
+/// — an earlier revision of this comment did, and it was wrong. `base`
+/// and `cheap-rank` each perform exactly one `decode_at` per candidate,
+/// so their unit counts are equal *by construction* whichever offset the
+/// ranking picks; they diverge only when the two offsets fall on
+/// opposite sides of the `nsync` gate. That is why the explicit counter
+/// exists.
+///
+/// A second caveat when reading the counter: agreement is counted **per
+/// candidate**, recall **per trial**. A candidate where the ranking
+/// picks the winning offset adds no decode if another candidate in the
+/// same trial already decoded at offset 0, so high agreement alongside
+/// `cheap-rank == base` recall is not a contradiction.
+///
+/// What holds regardless of the outcome, and is the useful part for
+/// #310: a cheap proxy for "which timing will decode" is unlikely to be
+/// another **sync-strength** measure, because the refine stage has
+/// already maximised that. A promising proxy would be sync-orthogonal —
+/// LLR reliability statistics, or a truncated-BP syndrome weight, rather
+/// than Costas correlation.
 ///
 /// ## Reading the result
 ///


### PR DESCRIPTION
FST4 escalation/scheduling measurements for #310, #311 and #312. **Diagnostics and documentation only** — one new library function that nothing calls, and no change to any decode path.

## What this settles

**#311 — are timing diversity and the unpruned-OSD fallback substitutable?** Neither. In 2 of 4 cells the combination rescues trials *neither mechanism rescues alone*. Which one dominates also flips by channel, so there is no universal escalation order. Separately: `npre` never decodes a trial the unpruned search misses, on any cell tested — it buys speed, never recall.

**#312 — the dedup re-admission path.** VK3NV's reading was right, it fires, but not where expected: only at `max_cand = 50` (the production default), never below. And the re-admitted duplicates **never decode** — filtering them changes no cell's recall, so tightening `retain` to `score >= sync_min && stage1_pass(fi)` would be free. Not done here; the OR-gate exists for #146 reasons and the check should be wider than one sub-mode first.

**#310 — the scheduling design.** Settled as a three-phase split, recorded in `FST4_BENCHMARK.md` §13/§14 and cross-referenced from `rung_major.rs`:

- **Phase A** — first rung, breadth-first, unconditional. This *is* the latency invariant. Unchanged.
- **Phase B** — escalation, **depth-first**, ordered by `nsync`, budget-gated.
- **Phase C** — second pass (alternate timing **and** unpruned OSD together), only if budget remains.

`offsets` stays offset-major rather than folded into a cost-ordered queue.

## Three results that changed a decision

**The escalation phase should not stay breadth-first.** Rung-major's value is the ordering-independent time-to-first-decode bound — and that bound is bought entirely by the *first* rung. Continuing breadth-first past it defers OSD, where most decodes come from, until every candidate has had every cheaper stage. Measured cost: 350 vs 380 decodes at a realistic ~50 % budget, 35 vs 166 at 10 %.

**Candidate ordering is worthless under breadth-first and valuable under depth-first.** A 10 % budget buys ~98 % of the first-stage sweep, so every ordering visits nearly the same candidates. The two decisions are coupled: order by `nsync` *and* go depth-first, or neither is worth doing.

**VK3NV's soft-Costas-margin proposal works, and is still not worth adopting.** `sync_quality_generic` collapses four tone energies per sync symbol to one bit, and that does discard usable information — stratified AUC within a fixed `nsync` is 0.717, so it is not merely an `nsync` proxy. But an optimally-fitted linear rule over nine formulations is worth +0.014 AUC cross-validated, and at the budget FST4-60 actually has, `nsync` alone already returns 380 of 386 decodes. Not worth 320 B per candidate plus a model requiring re-validation across sub-modes, channels and corpus generations.

## Two methodology traps, both of which produced confident wrong answers here

**Trial indices don't survive corpus regeneration.** #306's original set `[2, 15, 33, 45, 67]` comes from a 100-trial-per-cell generation; a 20-trial generation has no trials 33/45/67 and its trial 2 is a different waveform. A run that silently skips 3 of 5 targets reads as a real 0/5. Harnesses here derive their trial set from whatever corpus is present and print it.

**A mechanism that shipped between the finding and the re-measurement makes the obvious selection circular.** `DecodeRequest`'s `osd` defaults to `true` and #308's `i0` retry is gated on that flag, so the production "npre" arm already contains timing diversity. Selecting trials that way guarantees the timing arm rescues nothing.

Both are written up in `FST4_BENCHMARK.md` §9 alongside two more found later: cells must have *partial* baseline recall (m26 CCIR-moderate, the cell #306/#308 both name, is 0/20 for this harness), and a 2×2 must compare the combination against the union of the singles, not the singles against each other.

## Contents

| | |
|---|---|
| `mfsk-core/src/engine/llr.rs` | `sync_quality_soft_generic` + `sync_symbol_count`. Parallel function; `sync_quality`/`sync_quality_generic` untouched and bit-identical. Caller-provided buffer, no allocation. Nothing calls it. |
| `mfsk-core/tests/fst4_sweep.rs` | 10 `#[ignore]`d diagnostics, all deriving their own trial sets |
| `docs/notes/FST4_BENCHMARK.md` | §9-§14: ablation methodology and traps, cap sweep, Ryzen 9 runbook, scheduling decision, soft-margin measurements |
| `mfsk-core/src/fst4/rung_major.rs` | module-doc cross-references to the scheduling decisions |

## Not included, deliberately

No production behaviour change. The two measured-as-safe changes — #312's `retain` tightening and #310's Phase A/B split — each want their own verification and their own PR.

## Verification

`cargo fmt --check`, `cargo clippy --workspace --all-targets -D warnings -D clippy::perf`, `cargo doc -D warnings`, and the tier-A+B merge gate (`MFSK_REQUIRE_CORPUS=1`, 69 suites) all clean. Feature matrix spot-checked with `RUSTFLAGS=-D warnings`.

Four jobs are queued for a faster machine in §11, including the tier-C sweeps that gate the `v0.10.0` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
