### PR TITLE
fix(fst4): coarse_sync's dedup decision is final (#312)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,33 @@ rather than distributing them across patches.
 
 ### Fixed
 
+- **`coarse_sync`'s de-duplication decision is now final** (issue #312,
+  found by VK3NV). The dedup pass marks the losing near-duplicate (within
+  4 Hz / 40 ms) with `score = 0.0`, but the `retain` immediately after is
+  an OR — `score >= sync_min || stage1_pass(fi)` — so on FST4, where
+  `stage1_norm` is populated, a candidate the dedup had just rejected was
+  re-admitted through the second arm and went on to occupy a slot after
+  `max_cand` truncation.
+
+  Measured before the fix: **3 of the 50 slots** at the production
+  `max_cand = 50` on the FST4-60 golden's K9KFR target, all three inside
+  `rank_candidates`' reserved near-`freq_hint` group, i.e. displacing
+  real candidates rather than falling off the bottom of the score sort.
+
+  **No sensitivity cost.** Across 80 near-threshold sweep trials not one
+  re-admitted duplicate ever decoded, and on the wideband production path
+  (`DecodeRequest`, 100-3000 Hz, no hint) recall over the partial-recall
+  band is byte-identical before and after — 82/120, unchanged in every
+  cell.
+
+  Deliberately *not* the narrower-looking `score >= sync_min &&
+  stage1_pass(fi)`: that would also drop candidates which clear the score
+  gate but fail stage 1, which is exactly what #146's OR-gate exists to
+  keep. The defect was only that a rejected duplicate came back, so the
+  suppression is now tracked separately from the score and only that is
+  fixed.
+
+
 - **The `wspr_app` crash loop — PSRAM-backed thread stacks.** With internal
   DRAM driven down to ~2 KB free by `wifi_driver_init`, the
   `uac_app`/`usb_events`/`uac_reader` `std::thread` spawns all pulled their

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -634,6 +634,28 @@ pub fn coarse_sync<P: Protocol>(
     let _ = pattern_len; // currently unused; kept for future scoring weights
 
     // De-duplicate: within 4 Hz and 40 ms, keep highest score.
+    //
+    // `suppressed` records the decision separately from the score
+    // because the score alone cannot carry it past the `retain` below:
+    // that gate is an OR (issue #146 — an FST4 candidate under
+    // `sync_min` is still kept when the stage-1 normalised score passes),
+    // so a loser zeroed here would be re-admitted by the `stage1_pass`
+    // arm and go on to occupy a slot after `max_cand` truncation.
+    //
+    // Measured before this was tracked (issue #312, VK3NV): 3 of the 50
+    // slots at the production `max_cand = 50` on the golden's K9KFR
+    // target, all three inside `rank_candidates`' reserved
+    // near-`freq_hint` group — and across 80 near-threshold sweep trials
+    // not one such candidate ever decoded, so honouring the dedup here
+    // costs no recall (`fst4_60_diag_dedup_zero_score_recall_effect`,
+    // and `fst4_60_diag_wideband_band_recall` for the no-hint path).
+    //
+    // Deliberately *not* the narrower-looking `score >= sync_min &&
+    // stage1_pass(fi)`: that would also drop candidates which clear the
+    // score gate but fail stage 1, which is what the #146 OR-gate exists
+    // to keep. The defect is only that a rejected duplicate comes back,
+    // so only that is fixed.
+    let mut suppressed = alloc::vec![false; cands.len()];
     for i in 1..cands.len() {
         for j in 0..i {
             let fdiff = (cands[i].freq_hz - cands[j].freq_hz).abs();
@@ -641,13 +663,19 @@ pub fn coarse_sync<P: Protocol>(
             if fdiff < 4.0 && tdiff < 0.04 {
                 if cands[i].score >= cands[j].score {
                     cands[j].score = 0.0;
+                    suppressed[j] = true;
                 } else {
                     cands[i].score = 0.0;
+                    suppressed[i] = true;
                 }
             }
         }
     }
+    let mut keep = suppressed.iter().map(|s| !s);
     cands.retain(|c| {
+        if !keep.next().unwrap_or(true) {
+            return false;
+        }
         if c.score >= sync_min {
             return true;
         }

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -7204,3 +7204,104 @@ fn fst4_60_diag_budget_curve_breadth_vs_depth() {
          survivors by nsync is close to free -- the first rung computed it for the gate."
     );
 }
+
+/// Regression: `coarse_sync`'s de-duplication decision must be final.
+///
+/// The dedup loop marks the losing near-duplicate (within 4 Hz / 40 ms)
+/// with `score = 0.0`, but the `retain` that follows admits any candidate
+/// satisfying `stage1_pass(fi)` *regardless of score* — and `stage1_norm`
+/// is only populated for FST4. So on FST4 a candidate the dedup had just
+/// rejected could come back, sort to the bottom of its group, and still
+/// occupy a slot once `max_cand` truncated the list (issue #312, VK3NV).
+///
+/// Measured before the fix: 3 of the 50 slots at the production
+/// `max_cand = 50` on the golden's K9KFR target, all three inside
+/// `rank_candidates`' reserved near-`freq_hint` group; and across 80
+/// near-threshold sweep trials, **not one of them ever decoded**
+/// (`fst4_60_diag_dedup_zero_score_recall_effect`).
+///
+/// A `score` of exactly `0.0` in `coarse_sync`'s output can only come
+/// from that dedup assignment — real scores are normalised sync ratios —
+/// so this asserts the observable property directly.
+#[test]
+fn fst4_coarse_sync_output_has_no_deduped_candidates() {
+    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::fst4::Fst4s60;
+
+    let Some(path) = common::corpus::golden_path_or_upstream(
+        "fst4/210115_0058.wav",
+        Some("FST4+FST4W/210115_0058.wav"),
+    ) else {
+        eprintln!("skip: FST4-60 golden not vendored");
+        return;
+    };
+    let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
+
+    // Both shapes: sniper (freq_hint set, where a zero could take a
+    // reserved slot) and wideband (no hint, what `DecodeRequest` uses).
+    for (name, lo, hi, hint) in [
+        ("sniper/K9KFR", 1081.0, 1581.0, Some(1331.0)),
+        ("wideband", 100.0, 3000.0, None),
+    ] {
+        for cap in [4usize, 16, 50, 200] {
+            let out = coarse_sync::<Fst4s60>(&audio, lo, hi, 0.8, hint, cap);
+            let zeros = out.iter().filter(|c| c.score == 0.0).count();
+            assert_eq!(
+                zeros,
+                0,
+                "{name} @max_cand={cap}: {zeros} de-duplicated candidate(s) survived \
+                 into the capped list of {} — coarse_sync's dedup decision must be \
+                 final (issue #312)",
+                out.len()
+            );
+        }
+    }
+}
+
+/// FST4-60 recall on the **wideband** production path, over the
+/// partial-recall band — the sensitivity check for the #312 dedup fix.
+///
+/// The audit that justified the fix
+/// (`fst4_60_diag_dedup_zero_score_recall_effect`) ran sniper-shaped
+/// only: one width, one cap, `freq_hint` set. `DecodeRequest` uses none
+/// of that — it searches 100-3000 Hz with no hint, where a zero-score
+/// re-admission sorts to the bottom rather than into a reserved slot.
+/// This is the same-population before/after comparison on the path that
+/// actually ships.
+///
+/// Prints rather than asserts: it is a sensitivity measurement, and the
+/// band is small enough that a one-trial move is noise. Compare the two
+/// runs directly.
+#[test]
+#[ignore = "manual verification — wideband recall across the partial-recall band (issue #312)"]
+fn fst4_60_diag_wideband_band_recall() {
+    let dir = sweep_dir();
+    const CELLS: &[(&str, &str)] = &[
+        ("ccir_moderate", "m23"),
+        ("ccir_moderate", "m24"),
+        ("ccir_moderate", "m25"),
+        ("awgn", "m26"),
+        ("awgn", "m27"),
+        ("awgn", "m28"),
+    ];
+    let mut grand = (0u32, 0u32);
+    for &(channel, snr_tag) in CELLS {
+        let (mut pass, mut n) = (0u32, 0u32);
+        for trial in 1..=100u32 {
+            let path = dir.join(format!("fst4_60_{channel}_{snr_tag}_{trial:02}.wav"));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            n += 1;
+            if decode_wav_fst4_60(&audio) {
+                pass += 1;
+            }
+        }
+        if n > 0 {
+            eprintln!("{channel}_{snr_tag}: {pass}/{n}");
+            grand.0 += pass;
+            grand.1 += n;
+        }
+    }
+    eprintln!("TOTAL: {}/{}", grand.0, grand.1);
+}


### PR DESCRIPTION
Closes the defect VK3NV found on #312.

## The defect

`engine/sync.rs`'s dedup pass marks the losing near-duplicate (within 4 Hz / 40 ms) with `score = 0.0`, but the `retain` immediately after is an **OR**:

```rust
score >= sync_min || stage1_pass(fi)
```

`stage1_norm` is only populated for FST4, so on that protocol a candidate the dedup had *just rejected* was re-admitted through the second arm — and then occupied a slot once `max_cand` truncated the list.

## What it cost

At the production `max_cand = 50`, on the FST4-60 golden's K9KFR target: **3 of the 50 slots**, all three inside `rank_candidates`' reserved near-`freq_hint` group — so they displaced real candidates rather than falling off the bottom of the score sort. N5TM is clean at every cap in the same WAV, so it is signal-dependent.

Worth noting the direction, since it is the opposite of what the issue expected: **low caps are unaffected**. Zeros sort last within their group, so a small cap truncates them before they matter. It is the shipping default that pays.

## Why not `&&`

The issue discussion — mine included — reached for `score >= sync_min && stage1_pass(fi)`. **That is not the right fix.** It would also drop candidates which clear the score gate but fail stage 1, which is exactly what #146's OR-gate exists to keep, and a far larger behaviour change than the defect warrants.

The defect is only that a *rejected duplicate* comes back. So the suppression is now tracked in its own vector rather than smuggled through the score, and the OR-gate keeps working for the case it was built for.

## No sensitivity cost, verified twice

**Do the re-admitted duplicates ever decode?** Across 80 near-threshold sweep trials, not one (`fst4_60_diag_dedup_zero_score_recall_effect`, merged in #315).

**Does removing them move recall on the path that ships?** The audit above was sniper-shaped — one width, one cap, `freq_hint` set. `DecodeRequest` uses none of that. So this PR adds `fst4_60_diag_wideband_band_recall`, measuring FST4-60 over the partial-recall band through the wideband production path (100–3000 Hz, no hint), before and after:

| cell | before | after |
|---|---|---|
| CCIR-mod m23 | 19/20 | 19/20 |
| CCIR-mod m24 | 17/20 | 17/20 |
| CCIR-mod m25 | 7/20 | 7/20 |
| AWGN m26 | 20/20 | 20/20 |
| AWGN m27 | 13/20 | 13/20 |
| AWGN m28 | 6/20 | 6/20 |
| **total** | **82/120** | **82/120** |

Identical in every cell.

## Regression test

`fst4_coarse_sync_output_has_no_deduped_candidates` — **not** `#[ignore]`d — asserts the observable property (no `score == 0.0` survives into the capped list) on both the sniper and wideband shapes at four caps. It fails against the pre-fix code, which is how it was checked to be testing something.

## Verification

`cargo fmt --check`, `clippy --workspace --all-targets -D warnings -D clippy::perf`, `cargo doc -D warnings`, the tier-A+B merge gate (`MFSK_REQUIRE_CORPUS=1`, 69 suites), and a feature-matrix spot check under `RUSTFLAGS=-D warnings` are all clean.

## Release

CHANGELOG entry added to the **0.10.0** section rather than deferred. This is on the FST4 decode path, so it moves the tier-C sensitivity sweeps — landing it before the sweeps run means sweeping once instead of twice, and the cadence has room (last tag 2026-08-11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
