### PR TITLE
docs: record Schedule::PhaseSplit in the 0.10.0 CHANGELOG, refresh #312's roadmap entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,8 +97,46 @@ rather than distributing them across patches.
   `full` (40.102 s → 121.281 s) and more than doubles `no8_osd`
   (13.643 s → 34.200 s) for a few recall points, so the production default
   stays `&[0]` and a deployment that can tolerate spanning slots can opt in.
-  Folding `offsets` into cost-ordered scheduling instead of the current
-  offset-major outer loop is #310.
+  Whether to fold `offsets` into cost-ordered scheduling was #310's
+  original proposal; it was **measured and declined** — see below.
+
+- **`fst4::rung_major::Schedule`** — the escalation schedule as an
+  explicit choice, with `decode_phase_split_timed` alongside the existing
+  `decode_rung_major_timed` (issue #310). Both are `internal-testing`-gated
+  and unreachable from `DecodeRequest`, so no shipped decode path changes.
+
+  `Schedule::RungMajor` is what this module shipped with: every rung swept
+  across every candidate. That buys the ordering-independent
+  time-to-first-decode bound — but **the bound is bought entirely by the
+  first rung**. Continuing breadth-first past it defers OSD, where most
+  decodes come from, until every candidate has had every cheaper stage.
+  Measured over 1 263 post-first-rung candidates: **350 vs 380 decodes in
+  386 at a realistic ~50 % budget, 35 vs 166 at 10 %.**
+
+  `Schedule::PhaseSplit` keeps the bound and drops the cost. **Phase A** —
+  `llra` at `offsets[0]` across every candidate, breadth-first, never
+  budget-gated (making the invariant interruptible would give it away).
+  **Phase B** — the rest of that offset's ladder, depth-first, candidates
+  ordered by the `nsync` Phase A already computed for the gate. **Phase C**
+  — the remaining offsets, same order. `budget_ok` is polled before every
+  Phase B/C stage.
+
+  Ordering and schedule are one decision, not two: under breadth-first a
+  10 % budget buys ~98 % of the first-stage sweep, so every candidate
+  ordering visits nearly the same candidates and sorting is worthless. It
+  only pays once Phase B goes depth-first.
+
+  Folding `offsets` into a cost-ordered queue — #310's original shape — was
+  declined on measurement: it would triple the first-rung sweep, offset
+  setup (`symbol_spectra` + bit-metrics rebuild) is not free, and the
+  payoff cannot be aimed, since ranking offsets by sync quality matched
+  exhaustive retry in only 1 of 8 runs. `docs/notes/FST4_BENCHMARK.md`
+  §13/§14 carries the reasoning and the numbers.
+
+  A non-`#[ignore]`d test asserts the two schedules return byte-identical
+  decodes without a budget gate, across three offset configurations × both
+  `skip_llrc` settings — the change is meant to move *when* decodes
+  appear, never *whether*.
 
 ### Fixed
 

--- a/docs/notes/ROADMAP.md
+++ b/docs/notes/ROADMAP.md
@@ -389,8 +389,16 @@ Grouped by the three tracks in **Strategic state** above.
 - **#312** — FST4 sniper: `max_cand = 50` binds before the search
   window width does, so narrowing the window changes nothing on the
   production path today. Sweep the cap as a *retained fraction* across
-  ±25/50/100/250 Hz; leave `sync_min` alone first. Strong-signal
-  golden only so far — a near-threshold sweep gates any default change.
+  ±25/50/100/250 Hz; leave `sync_min` alone first.
+
+  Partly answered. At matched retention, narrowing the window does cut
+  false survivors ~20× (`FST4_BENCHMARK.md` §10), and a preliminary
+  near-threshold run suggests the recall cliff tracks the **absolute
+  cap** rather than the retained fraction — which, if it survives the
+  full grid (§11.2, queued), means "absolute floor for recall, fraction
+  for cost" rather than either alone. A separate defect VK3NV found
+  while auditing this — `coarse_sync` re-admitting candidates its own
+  dedup had rejected — is fixed and shipped in 0.10.0.
 
 - **#307** — `engine::fft` has no generic non-power-of-2 FFT.
   `coarse_sync`'s `nfft1` is non-power-of-two for all five FST4


### PR DESCRIPTION
Two documentation gaps found while checking what was left unanswered before tagging `v0.10.0`. **Docs only** — no code changes.

## The one that matters for the tag

The 0.10.0 CHANGELOG's rung-major entry ended:

> Folding `offsets` into cost-ordered scheduling instead of the current offset-major outer loop is #310.

That was written before the question was measured. #317 landed `Schedule::PhaseSplit` and **declined** the fold on evidence — so tagging with that sentence would publish a CHANGELOG to crates.io that contradicts the code it describes, and #317 had no entry at all.

Replaced with the outcome: the schedule as an explicit choice, why the latency invariant is bought entirely by the first rung, the measured cost of continuing breadth-first past it (**350 vs 380 decodes in 386 at a realistic ~50 % budget, 35 vs 166 at 10 %**), why ordering and schedule are one decision rather than two, and why the cost-ordered fold was declined.

Notes that both entry points are `internal-testing`-gated and unreachable from `DecodeRequest` — which is also why this cannot move the tier-C sweeps that gate the tag.

## The minor one

`ROADMAP.md`'s #312 entry still read "strong-signal golden only so far", predating the measurements. Now records that narrowing the window cuts false survivors ~20× at matched retention, that a preliminary near-threshold run suggests the cliff tracks the **absolute cap** rather than the retained fraction (pending the full grid in §11.2), and that the dedup re-admission defect found while auditing it is fixed and shipped in 0.10.0.

## Verification

`cargo fmt --check` clean. No source changes, so the rest of the gate is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)