### PR TITLE
refactor(engine): one SAMPLE_RATE_HZ instead of three constants under two names (#321)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -138,6 +138,23 @@ rather than distributing them across patches.
   `skip_llrc` settings — the change is meant to move *when* decodes
   appear, never *whether*.
 
+### Changed
+
+- **`SAMPLE_RATE_HZ` is now one crate-level constant** (issue #321),
+  re-exported at the crate root. It was defined three times under two
+  names — `uvpacket::tx` and `ft8::decode_block::types` privately, and
+  `engine::dsp::msk::FS_HZ` publicly, which advertised the crate's
+  sample rate under a name suggesting it belonged to MSK144. `FS_HZ`
+  remains as a `#[deprecated]` alias since it is public API, with a test
+  pinning it to the constant it now aliases so the two cannot drift.
+
+  Scope is deliberately just that. The ~100 remaining bare `12_000.0`
+  literals are left alone: each reads unambiguously in its own context,
+  and the distinction a future refactor would actually need to draw —
+  definitional rate (`SYMBOL_DT`, `TONE_SPACING_HZ`, invariant) versus
+  analysis-grid rate (`SyncDims`' `df`/`tstep`, variable) — is
+  conceptual and is not addressed by naming the constant. See #307/#309.
+
 ### Fixed
 
 - **`coarse_sync`'s de-duplication decision is now final** (issue #312,

--- a/mfsk-core/src/engine/dsp/analytic.rs
+++ b/mfsk-core/src/engine/dsp/analytic.rs
@@ -21,7 +21,7 @@ use num_complex::Complex32;
 use num_traits::Float;
 
 use super::super::fft::default_planner;
-use super::msk::FS_HZ;
+use crate::engine::protocol::SAMPLE_RATE_HZ;
 
 /// Center frequency of the fixed bandpass filter (`analytic.f90`'s
 /// `f=ff-1500.0`).
@@ -52,7 +52,7 @@ fn bandpass_gain(freq_hz: f32) -> f32 {
 /// negative-frequency bins, double the positive-frequency bins (DC,
 /// and Nyquist if `input.len()` is even, are left unscaled), then
 /// inverse FFT and normalize. Assumes `input` was sampled at
-/// [`FS_HZ`] — the only sample rate this crate's MSK144 pipeline
+/// [`SAMPLE_RATE_HZ`] — the only sample rate this crate's MSK144 pipeline
 /// uses.
 pub fn analytic_signal(input: &[f32]) -> Vec<Complex32> {
     let n = input.len();
@@ -63,7 +63,7 @@ pub fn analytic_signal(input: &[f32]) -> Vec<Complex32> {
     let mut x: Vec<Complex32> = input.iter().map(|&v| Complex32::new(v, 0.0)).collect();
     fwd.process(&mut x);
 
-    let df = FS_HZ / n as f32;
+    let df = SAMPLE_RATE_HZ / n as f32;
     let nyquist = if n.is_multiple_of(2) {
         Some(n / 2)
     } else {
@@ -97,7 +97,7 @@ mod tests {
     /// its Hilbert transform (a sine at the same frequency, 90 deg
     /// lagging) -- i.e. `analytic[n] ~= exp(i*2*pi*k0*n/N)` (positive
     /// frequency only, unit amplitude). `k0` is chosen to land at
-    /// 1500 Hz (assuming [`FS_HZ`]), the center of the fixed bandpass
+    /// 1500 Hz (assuming [`SAMPLE_RATE_HZ`]), the center of the fixed bandpass
     /// filter's full-pass band, so the filter doesn't attenuate it.
     #[test]
     fn analytic_signal_of_pure_cosine_is_a_complex_exponential() {

--- a/mfsk-core/src/engine/dsp/msk.rs
+++ b/mfsk-core/src/engine/dsp/msk.rs
@@ -26,7 +26,15 @@ use num_traits::Float;
 pub const NSPM: usize = 864;
 
 /// PCM sample rate MSK144 operates at (Hz).
-pub const FS_HZ: f32 = 12_000.0;
+///
+/// Deprecated alias for [`crate::engine::SAMPLE_RATE_HZ`] (issue #321):
+/// the value is the crate-wide WSJT-X rate, not an MSK144 property, and
+/// this being `pub` advertised it under a misleading name.
+#[deprecated(
+    since = "0.10.1",
+    note = "not MSK144-specific — use `mfsk_core::SAMPLE_RATE_HZ`"
+)]
+pub const FS_HZ: f32 = crate::engine::protocol::SAMPLE_RATE_HZ;
 
 /// 8-bit MSK144 sync word (natural 0/1 form). Appears twice per
 /// 144-bit frame, at symbol offsets 0 and 56 (`msk144sync.f90:27`).
@@ -298,8 +306,18 @@ mod tests {
     #[test]
     fn frame_constants_match_wsjtx() {
         assert_eq!(NSPM, 864);
-        assert_eq!(FS_HZ, 12_000.0);
+        assert_eq!(crate::engine::protocol::SAMPLE_RATE_HZ, 12_000.0);
         assert_eq!(S8, [0, 1, 1, 1, 0, 0, 1, 0]);
+    }
+
+    /// `FS_HZ` is deprecated but still `pub`, so a downstream consumer
+    /// can still be reading it. Pin it to the constant it now aliases
+    /// so the two cannot drift apart while it remains exported
+    /// (issue #321).
+    #[test]
+    #[allow(deprecated)]
+    fn deprecated_fs_hz_still_tracks_the_crate_rate() {
+        assert_eq!(FS_HZ, crate::engine::protocol::SAMPLE_RATE_HZ);
     }
 
     /// Direct-arithmetic check of bit 1 (Q rail)'s frame-boundary

--- a/mfsk-core/src/engine/mod.rs
+++ b/mfsk-core/src/engine/mod.rs
@@ -66,5 +66,5 @@ pub mod tx;
 
 pub use protocol::{
     BpKind, DecodeContext, FecCodec, FecOpts, FecResult, FrameLayout, MessageCodec, MessageFields,
-    ModulationParams, Protocol, ProtocolId, SpectrumWindow, SyncBlock, SyncMode,
+    ModulationParams, Protocol, ProtocolId, SAMPLE_RATE_HZ, SpectrumWindow, SyncBlock, SyncMode,
 };

--- a/mfsk-core/src/engine/protocol.rs
+++ b/mfsk-core/src/engine/protocol.rs
@@ -15,6 +15,29 @@
 //! `FrameLayout`, so SIMD optimisations to the shared LDPC decoder
 //! automatically benefit every LDPC-based protocol.
 
+/// The PCM sample rate every protocol in this crate is defined against,
+/// in Hz.
+///
+/// Not a tunable: WSJT-X's own modes are specified at 12 kHz, and every
+/// `ModulationParams` constant here derives from it — `SYMBOL_DT =
+/// NSPS / SAMPLE_RATE_HZ`, `TONE_SPACING_HZ = SAMPLE_RATE_HZ / NSPS`.
+/// Faithful porting is the crate's premise, so this is a domain
+/// constant rather than a parameter, and nothing is set up to vary it.
+///
+/// It exists as a name because it was previously spelled three times
+/// under two names in three modules (issue #321) — `uvpacket::tx`,
+/// `ft8::decode_block::types` and `engine::dsp::msk::FS_HZ`, the last
+/// of which is `pub` and so advertised the crate's sample rate under a
+/// name suggesting it belonged to MSK144.
+///
+/// **The ~100 remaining bare `12_000.0` literals are deliberately left
+/// alone.** Each reads unambiguously in its own context, and replacing
+/// them was measured against the churn and declined — see #321 for that
+/// reasoning, and #307/#309 for the distinction (definitional rate vs
+/// analysis-grid rate) that a future refactor would actually need to
+/// draw, which naming this constant does *not* address.
+pub const SAMPLE_RATE_HZ: f32 = 12_000.0;
+
 use alloc::string::String;
 use alloc::vec::Vec;
 

--- a/mfsk-core/src/ft8/decode_block/types.rs
+++ b/mfsk-core/src/ft8/decode_block/types.rs
@@ -156,7 +156,7 @@ pub(super) fn ratio_eps() -> f32 {
 }
 
 /// 12 kHz fixed sample rate.
-pub(super) const SAMPLE_RATE_HZ: f32 = 12_000.0;
+pub(super) use crate::engine::protocol::SAMPLE_RATE_HZ;
 
 /// Slot start offset (FT8 transmits 0.5 s into the slot).
 pub(super) const TX_START_OFFSET_S: f32 = 0.5;

--- a/mfsk-core/src/lib.rs
+++ b/mfsk-core/src/lib.rs
@@ -389,7 +389,7 @@ pub mod registry;
 // Flatten commonly-used types to the crate root.
 pub use crate::engine::{
     DecodeContext, FecCodec, FecOpts, FecResult, FrameLayout, MessageCodec, MessageFields,
-    ModulationParams, Protocol, ProtocolId, SyncBlock, SyncMode,
+    ModulationParams, Protocol, ProtocolId, SAMPLE_RATE_HZ, SyncBlock, SyncMode,
 };
 pub use crate::registry::{PROTOCOLS, ProtocolMeta, by_id, by_name, for_protocol_id};
 

--- a/mfsk-core/src/uvpacket/tx.rs
+++ b/mfsk-core/src/uvpacket/tx.rs
@@ -55,7 +55,7 @@ const K_LDPC: usize = 101;
 const PAYLOAD_BITS_PER_BLOCK: usize = INFO_BYTES_PER_BLOCK * 8;
 
 /// Sample rate (Hz).
-pub(super) const SAMPLE_RATE_HZ: f32 = 12_000.0;
+pub(super) use crate::engine::protocol::SAMPLE_RATE_HZ;
 /// RRC pulse span (symbols on each side of centre tap). Same for
 /// every mode — only the per-symbol sample count varies via
 /// [`Mode::nsps`].


### PR DESCRIPTION
Closes #321 (as rescoped).

## What

12 kHz was defined **three times under two names**:

| location | name | visibility |
|---|---|---|
| `uvpacket/tx.rs` | `SAMPLE_RATE_HZ` | `pub(super)` |
| `ft8/decode_block/types.rs` | `SAMPLE_RATE_HZ` | `pub(super)` |
| `engine/dsp/msk.rs` | `FS_HZ` | **`pub`** |

The last one is the actual wart: it advertised the crate's sample rate under a name suggesting it was an MSK144 property.

Now one `pub const SAMPLE_RATE_HZ` in `engine::protocol` — ungated, next to the `ModulationParams` constants that derive from it (`SYMBOL_DT = NSPS / SAMPLE_RATE_HZ`, `TONE_SPACING_HZ = SAMPLE_RATE_HZ / NSPS`) — re-exported at the crate root. `engine::dsp::analytic` moves off the MSK-namespaced name.

`FS_HZ` stays as a `#[deprecated]` alias because it is public API, with a test pinning it to the constant it now aliases so the two cannot silently drift while it remains exported.

## What this deliberately does *not* do

The ~100 remaining bare `12_000.0` literals are left alone. An earlier draft of #321 argued for replacing them; that was withdrawn and the reasoning recorded in the issue and in the constant's own doc comment.

**Each site reads unambiguously in its own context** — nobody meets `SYMBOL_DT` inside `fst4_submode!` and mistakes it for an analysis-grid quantity — so a 15-file diff for it is churn.

The claim that consolidating would make #307 easier to answer was also overstated. Note that **dimensional analysis does not separate the two roles**:

| | expression | dimension | role |
|---|---|---|---|
| `SYMBOL_DT` | `NSPS / 12_000.0` | seconds | definitional |
| `tstep` | `nstep / 12_000.0` | seconds | analysis grid |
| `TONE_SPACING_HZ` | `12_000.0 / NSPS` | Hz | definitional |
| `df` | `12_000.0 / nfft1` | Hz | analysis grid |

Only the denominator distinguishes them. But that distinction is *conceptual* and has never been drawn anywhere in the crate — naming the constant does not draw it. If a refactor ever needs to vary the analysis rate (#307/#309), classifying the sites is work that refactor should do with the measurement in hand, not speculatively now.

## Verification

Behaviour-identical by construction (same value, same expressions). `cargo fmt --check`, `clippy --workspace --all-targets -D warnings -D clippy::perf`, `cargo doc -D warnings`, the tier-A+B merge gate (`MFSK_REQUIRE_CORPUS=1`, 69 suites), and a feature-matrix spot check including `msk144` and `uvpacket` in isolation are all clean.

CHANGELOG entry added to the pending 0.10.0 section. No decode-path change, so this cannot move the tier-C sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)