### PR TITLE
feat(engine): FST4 DDC stage 1 — rational polyphase resampler + FirStage::push_block

### DIFF
--- a/docs/notes/FST4_DDC_DESIGN.md
+++ b/docs/notes/FST4_DDC_DESIGN.md
@@ -1,0 +1,251 @@
+# FST4 embedded DDC — 解析グリッドの複素パラメータ化
+
+設計ドラフト、2026-08-20。実装前の記録であり、測定値はまだ入っていない
+（見積りは「〜」付きで区別してある）。議論の出発点は #307 の VK3NV
+コメント（2026-08-19）と、それに対する分類パス（#307, 同日）。
+
+関連 issue: [#307](https://github.com/jl1nie/mfsk-core/issues/307)（非2冪 FFT）、
+[#309](https://github.com/jl1nie/mfsk-core/issues/309)（ストリーミング DDC）、
+[#306](https://github.com/jl1nie/mfsk-core/issues/306)（FST4 埋め込み実現性の傘）、
+[#323](https://github.com/jl1nie/mfsk-core/issues/323)（12 kHz リテラルの分類）。
+
+## 1. なぜ必要か
+
+埋め込み FST4 の `coarse_sync` は**今そのままでは動かない**。
+`compute_spectra` が張る `nfft1 = NSPS × NFFT_PER_SYMBOL_FACTOR` は FST4-60 で
+7776 で、埋め込み FFT バックエンド
+(`embedded-poc/embedded-shared/src/esp_dsp_fft.rs`) は
+`len.is_power_of_two() && len >= 4` を assert するため panic する。
+非 2 冪長は `DirectDft`（`DIRECT_DFT_MAX_LEN = 64`）しか経路がない。
+
+そして panic するのは `coarse_sync` だけではない。候補精査側の
+`downsample_cached` は **fwd 746 496 点（2¹⁰·3⁶）と inv 6 912 点（2⁸·27）**を
+要求し、どちらも非 2 冪である。埋め込み FST4 を成立させるには両方が要る。
+
+### なぜ DDC で解くのか
+
+**NSPS = 3888 = 2⁴·3⁵ なので、整数間引きでは 2 冪の `nfft1` に到達できない。**
+どんな整数 D で割っても 3ᵏ が残る。`nfos` を変えても（`nfft1 = nfos·nsps`、
+`nfos` は整数）3⁻⁵ を供給できないので同じ。**有理リサンプリングが不可避**で、
+それを担うのが DDC。
+
+VK3NV の `K = 2^m` 案 — 1 シンボルが 2 冪個のサンプルになるよう RX 解析レートを
+選べば `nfft1 = 2K` が**構成上つねに radix-2** になる — がこの設計の出発点。
+
+### 主目的はメモリ削減ではない
+
+VK3NV 自身が #307 で書いている通り:
+
+> For a wideband search the transform-size reduction may only be around 2×;
+> for a narrow search it can be much larger. **The more important point is
+> guaranteed access to ESP-DSP's optimized radix-2 path.**
+
+実数広帯域だと Nyquist 制約から間引きは 2 倍弱にしかならない。**得られるのは
+Bluestein 実装も Kconfig 変更も不要になること**であって、メモリではない。
+
+## 2. 不変量
+
+`K` をどう選んでも物理格子は変わらない（VK3NV の主張、コードで確認済み）:
+
+| 量 | 式 | FST4-60 |
+|---|---|---|
+| `df` | `Fs/nfft1 = 1/(2·SYMBOL_DT)` | 1.5432 Hz（レート不変） |
+| `tstep` | `nstep/Fs = SYMBOL_DT/2` | 0.162 s（レート不変） |
+| `nhsym` | `2·T_SLOT/SYMBOL_DT − 3` | 367 行（レート不変） |
+| `nfos` | `nfft1/nsps` | 2（`i + nfos·k` のトーン索引が保たれる） |
+
+**スペクトログラムの形は K に依らない。**変わるのは FFT 長と音声バッファだけ。
+
+## 3. スコープ
+
+統一・複素パラメータ化。`(center_freq, bandwidth)` で広帯域とスナイパーの
+両方を同一機構で表現する。最初の実装対象は **FST4-60 のみ**。
+FST4-120/300 は今回対象外（K の切り上げで `nfft1` が 8192 上限を超えるため、
+別途 Kconfig 変更が要る — §8 参照）。
+
+## 4. 設計
+
+### 4.1 `RxGrid` — 解析グリッド記述子（新規、`engine::sync`）
+
+VK3NV の `RxAnalysisDescriptor` に相当。ビン↔Hz 写像を 1 箇所に集約する。
+
+```rust
+pub struct RxGrid {
+    pub sample_rate_hz: f32,
+    pub center_hz: f32,     // 0.0 = 実数・DC 基準（現行 12 kHz 経路）
+    pub complex_input: bool,
+}
+```
+
+- 実数経路: `bin = hz/df`、`usable = nh1` → **現行と完全に同一挙動**
+- 複素経路: **fftshift-on-store**、`bin = (hz−center)/df + nfft1/2`、`usable = nfft1`
+
+**fftshift が効く理由**: 周波数軸が単調になるので `coarse_sync` の相関ループ
+（`abs_bin = i + d.nfos * k`、`engine/sync.rs`）が**無変更のまま**動く。
+ラップ処理がホットループに入らない。変更が要るのは `ia`/`ib` の算出と
+`nh1` クランプだけで、どちらも `RxGrid` メソッド呼び出しに置き換わる。
+
+### 4.2 `engine::dsp::polyphase` — 有理リサンプラ（新規・汎用）
+
+既存の `engine::dsp::fir_decimate`（`FirStage` / `design_lowpass`）は
+**整数間引き専用**。有理 L/M を担う兄弟モジュールを追加する。
+`design_lowpass` はそのまま再利用。`FirStage` と同じく I/Q を
+**planar 分離**して保持する（esp-dsp が実数ストリーム前提なのでこの形が活きる）。
+
+### 4.3 `engine::dsp::ddc` — 汎用複素ダウンコンバータ（新規）
+
+```
+12 kHz 実数 i16
+  └ mixer (exp(-j2π·center·n/Fs))            → 複素 12 kHz
+  └ FirStage 整数段カスケード（緩いフィルタ）  → 複素 12000/D
+  └ PolyphaseResampler（鋭いフィルタ・最終段） → 複素 Fs_c = K/SYMBOL_DT
+  └ compute_spectra（複素入力）                → Spectrogram (nfft1 = 2K)
+```
+
+鋭い段を**最後（最低レート）**に置くのが要点。単段だと総 MAC 数は間引き率に
+依らず遷移帯域比だけで決まる（＝狭帯域にしても安くならない）ため、WSPR が
+`StreamingDdcCascade` を必要としたのと同じ理由でカスケードが必須。
+
+FST4-60 の粗同期段パラメータ（見積り）:
+
+| 用途 | 必要 BW | K | Fs_c | nfft1 | 全体比 | カスケード | 〜MAC/slot (I+Q) |
+|---|---:|---:|---:|---:|---:|---|---:|
+| スナイパー ±250 Hz | 600 Hz | 256 | 790.12 Hz | **512** | 16/243 | /3 → 16/81 (〜84 taps/phase) | 〜15M |
+| 広帯域 100–3000 Hz | 2900 Hz | 1024 | 3160.49 Hz | **2048** | 64/243 | /1 → 64/243 (〜184 taps/phase) | 〜79M |
+
+いずれも radix-2 かつ 8192 上限内。単段実装比でそれぞれ 〜3.1× / 〜1.8× 安い。
+
+### 4.4 refine 段 — 有理リサンプラは不要
+
+**K と K′ が両方 2 冪なら比 K/K′ は必ず 2 冪。**この帰結が refine 段を単純にする。
+
+現行 refine は `ds_spb = NSPS/NDOWN = 36`、`ds_rate = 111.11 Hz`。
+DDC ベースバンド（`Fs_c = K/SYMBOL_DT`）からここへ降ろす比は:
+
+| 用途 | K | Fs_c | ds_spb | ds_rate | 比 | 段の形 |
+|---|---:|---:|---:|---:|---:|---|
+| スナイパー | 256 | 790.12 Hz | 36 | 111.11 Hz | 9/64 | 有理（L=9、小さい） |
+| 広帯域 | 1024 | 3160.49 Hz | 36 | 111.11 Hz | 9/256 | 有理（L=9、小さい） |
+
+refine 帯域占有は 4 tones + 1.5+1.5 pad = 7 tones = 21.6 Hz で、111 Hz の
+ベースバンドに対して余裕が大きいためフィルタは緩く済む。
+
+**`ds_spb = 32` にすれば全段 radix-2 になる**（比が 1/8 と 1/32 の純 2 冪整数
+間引きになり、`symbol_spectra` も 36 点 `DirectDft` → 32 点 radix-2 になる）。
+魅力的だが **`NDOWN` 幾何を WSJT-X から動かす**変更であり、`symbol_spectra` /
+`fine_sync_power` / Costas 参照表 / LLR 経路すべてに波及して**フロントエンド
+ではなくデコード挙動を変える**。#23（FST4-60A ゴールデン固定 — `NSPS`/`NDOWN`/
+`GFSK_BT` の取り違え）の前例もあるため、**既定は `ds_spb = 36` 据え置き**とし、
+`ds_spb = 32` は感度スイープを通した上での後追い候補として記録に留める。
+
+### 4.5 esp-dsp / LX7 PIE 経路
+
+**接続点は「タップ 1 本」ではなく FIR 段まるごと。**esp-dsp の `fir_f32_t` が
+自前の遅延線と位置状態を持つため、`dot()` だけ差し替える形にすると状態機械が
+二重になる。`fft-extern`（`engine/fft.rs` の
+`mfsk_core_make_default_fft_planner`）と同じ extern フック方式にする:
+
+```rust
+// engine/dsp/fir_kernel.rs
+pub trait FirDecimator {
+    fn push_block(&mut self, xi: &[f32], xq: &[f32],
+                  yi: &mut Vec<f32>, yq: &mut Vec<f32>);
+}
+pub fn default_fir_decimator(..) -> Box<dyn FirDecimator>;
+```
+
+`embedded-shared` 側が `dsps_fird_f32_aes3`（LX7 PIE）を I/Q 各 1 本の
+`fir_f32_t` として束ねる。esp-dsp バインディングは現状 FFT 系のみ
+（`esp_dsp_fft.rs`）なので FIR 系は新規追加。Phase D1（commit `053bd67`）で
+FFT を `_ae32_` → `_aes3_` に移した前例に倣う（`docs/notes/PHASE_D_PIE_SIMD.md`）。
+
+**block API が前提**: esp-dsp の FIR は `(fir, input, output, len)` のブロック形。
+現行 `FirStage::push_one` はサンプル単位なので `push_block` を**追加**する
+（既存 `push_one` と `wspr::ddc` は無変更のまま）。FFI 呼び出しコストが
+ブロック長で償却されるのも block 形が要る理由。
+
+**実装時に header で要確認**（この環境に esp-dsp が無く未検証）:
+
+- `dsps_fird_f32_aes3` のタップ数制約（4 の倍数か 8 の倍数か）
+- coeffs / delay の 16 バイト境界要求
+- `len` が `decim` の倍数である必要の有無
+
+**タップ数の衝突と解法**: `FirStage::new` は `ntaps` 奇数を assert する
+（線形位相・整数群遅延のため）が、PIE は 4 の倍数を要求する見込み。
+対称・奇数長のコアを保ったまま**末尾にゼロタップを詰めて**揃える。
+ゼロ詰め版と非ゼロ詰め版が 1 サンプルオフセットを除いて bit-identical で
+あることをテストで固定する。16 バイト境界は既存の `Align16Quad` /
+`AlignedComplexBuf`（`engine/fft.rs`）と commit `1b14f56`
+(`perf(wspr): 16-byte-align subtract's FFT buffers`) の先例に倣う。
+
+## 5. 変更ファイル
+
+**新規**
+
+- `mfsk-core/src/engine/dsp/polyphase.rs` — 有理リサンプラ
+- `mfsk-core/src/engine/dsp/ddc.rs` — ミキサ + カスケード組み立て
+- `mfsk-core/src/engine/dsp/fir_kernel.rs` — `FirDecimator` + extern フック
+- `mfsk-core/src/fst4/ddc.rs` — FST4 固有の K 選定 / カスケード分解
+- `embedded-poc/embedded-shared/src/esp_dsp_fir.rs` — esp-dsp `dsps_fird_f32_aes3`
+
+**変更**
+
+- `mfsk-core/src/engine/sync.rs` — `RxGrid`、`compute_spectra` 複素経路、
+  `coarse_sync` の `ia`/`ib`/`nh1`（相関ループ本体は無変更）
+- `mfsk-core/src/engine/pipeline.rs` — refine を DDC ベースバンド起点に
+- `mfsk-core/src/engine/dsp/fir_decimate.rs` — `push_block` 追加（`push_one` 保持）
+- `mfsk-core/src/engine/dsp/mod.rs`, `mfsk-core/Cargo.toml` — 登録
+
+## 6. 検証
+
+WSPR の DDC が通った基準（`wspr-ddc` / `wspr-ddc-cascade`）を踏襲する。
+
+1. **実数経路の非回帰（最優先）** — `RxGrid { center: 0.0, complex_input: false }`
+   で既存マージゲートが緑のまま。`sync_dims_of_matches_nsps_at_12khz` と
+   同じ形で bit-exact を固定。
+2. **リサンプラ単体** — 通過帯域内単一トーンの振幅/位相、帯域外除去
+   （エイリアス折返しが指定ストップバンド以下）、ゼロ詰めタップ版の bit-identical。
+3. **エンドツーエンド等価（本命）** — FST4-60 ゴールデン WAV
+   (`210115_0058.wav`, N5TM @1101 Hz / K9KFR @1331 Hz) で、12 kHz 実数
+   `coarse_sync` と DDC 経由の候補集合が freq/dt 許容内で一致すること。
+4. **感度** — `scripts/run-sensitivity-sweeps.sh fst4` で 50% クロッシングが
+   `docs/notes/sweep-baseline.json` から 0.5 dB 以上動かないこと。
+5. **実機** — `cargo +esp build --release --bin fst4-bench` が通り、
+   `coarse_sync` が S3 上で **panic せず完走**すること（今日時点では
+   `is_power_of_two` assert で落ちる）。`embedded-poc/scripts/flash-monitor.sh`
+   でログ取得。
+
+```sh
+# 1
+MFSK_REQUIRE_CORPUS=1 cargo test -p mfsk-core --features full,internal-testing --release
+# 3
+MFSK_REQUIRE_CORPUS=1 cargo test -p mfsk-core --features full,internal-testing --release \
+    --test fst4_wsjtx_samples
+# 4
+scripts/run-sensitivity-sweeps.sh fst4
+```
+
+## 7. 段階
+
+1. `polyphase.rs` + `fir_decimate::push_block`（純ホスト、検証 2）
+2. `RxGrid` + `compute_spectra` 複素経路（検証 1 で非回帰を固定）
+3. `ddc.rs` + `fst4/ddc.rs` の粗同期段（検証 3）
+4. refine 段を DDC ベースバンド起点に（検証 3 + 4）
+5. esp-dsp `dsps_fird_f32_aes3` バックエンド + 実機（検証 5）
+
+段 1-4 はホストのみで完結し、段 5 の esp-dsp 差し替えは `FirDecimator` の
+入れ替えなので前段の検証結果を無効化しない。
+
+## 8. 未解決 / 対象外
+
+- **FST4-120/300**: K の 2 冪切り上げで `nfft1` がそれぞれ 16384 / 32768 と
+  なり 8192 上限を超える。`CONFIG_DSP_MAX_FFT_SIZE_32768` への変更で解けるが
+  今回対象外。FST4-120 は必要 K が 4100 で 4096 をわずかに超えるため次の 2 冪
+  まで切り上がり、**実効間引きがほぼ 1.0 倍になる**（rate が 12 kHz に戻る）
+  という縮退が起きる点は記録しておく。
+- **デコーダ側のギャップは別問題**: #306 の結論どおり、フロントエンドを
+  完璧にしてもデコーダの超過（`full` 40.1 s / `no8_osd` 13.6 s 対 予算 7.2 s）は
+  埋まらない。本設計は #307 の FFT 制約を解くものであって、#306 の
+  時間予算問題を解くものではない。
+- **`ds_spb = 32` 全段 radix-2 案**: §4.4 参照。感度スイープを通した上での
+  後追い候補。

--- a/embedded-poc/embedded-shared/src/apps/fst4_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_bench.rs
@@ -939,7 +939,7 @@ fn run_rung_major(refined_bin: &[u8]) {
     ] {
         let t0 = now_us();
         let results = mfsk_core::fst4::rung_major::decode_rung_major_timed::<Fst4s60>(
-            &inputs, skip_llrc, skip_osd, &[0], None,
+            &inputs, skip_llrc, skip_osd, &[0], None, 12_000.0,
         )
         .0;
         let total_us = now_us() - t0;

--- a/mfsk-core/src/engine/dsp/fir_decimate.rs
+++ b/mfsk-core/src/engine/dsp/fir_decimate.rs
@@ -150,6 +150,31 @@ impl FirStage {
         out
     }
 
+    /// Block-mode counterpart to [`push_one`](Self::push_one): consume
+    /// `xi.len()` complex input samples at once, appending any
+    /// outputs this stage completes. Behaviourally identical to
+    /// calling [`push_one`](Self::push_one) once per sample — exists
+    /// so callers can amortise per-call overhead over a block rather
+    /// than a sample, which is what an esp-dsp-backed `FirDecimator`
+    /// (`docs/notes/FST4_DDC_DESIGN.md` §4.5) needs: `dsps_fird_f32_aes3`
+    /// is itself block-shaped, so a sample-at-a-time `push_one` there
+    /// would pay the FFI hop per sample instead of per block.
+    pub fn push_block(
+        &mut self,
+        xi: &[f32],
+        xq: &[f32],
+        out_i: &mut Vec<f32>,
+        out_q: &mut Vec<f32>,
+    ) {
+        assert_eq!(xi.len(), xq.len(), "I/Q blocks must be the same length");
+        for (&i, &q) in xi.iter().zip(xq.iter()) {
+            if let Some((oi, oq)) = self.push_one(i, q) {
+                out_i.push(oi);
+                out_q.push(oq);
+            }
+        }
+    }
+
     fn compact(&mut self) {
         // `win_start` is the same quantity `hist_len - ntaps` would
         // give, already maintained without the constant-folded
@@ -195,5 +220,38 @@ impl FirStage {
             sq += h[k] * hq[k];
         }
         (si, sq)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `push_block` is defined as "the same as `push_one` in a loop" —
+    /// this pins that down bit-for-bit, including across a compaction
+    /// boundary (`hist_margin` small enough that a 500-sample block
+    /// forces at least one `compact()`).
+    #[test]
+    fn push_block_matches_repeated_push_one() {
+        let audio: Vec<f32> = (0..500).map(|k| (k as f32 * 0.037).sin()).collect();
+
+        let mut one = FirStage::new(31, 4, 0.1, 32);
+        let mut oi = Vec::new();
+        let mut oq = Vec::new();
+        for &s in &audio {
+            if let Some((i, q)) = one.push_one(s, -s) {
+                oi.push(i);
+                oq.push(q);
+            }
+        }
+
+        let mut block = FirStage::new(31, 4, 0.1, 32);
+        let neg: Vec<f32> = audio.iter().map(|&s| -s).collect();
+        let mut bi = Vec::new();
+        let mut bq = Vec::new();
+        block.push_block(&audio, &neg, &mut bi, &mut bq);
+
+        assert_eq!(oi, bi);
+        assert_eq!(oq, bq);
     }
 }

--- a/mfsk-core/src/engine/dsp/mod.rs
+++ b/mfsk-core/src/engine/dsp/mod.rs
@@ -20,6 +20,7 @@ pub mod fft_sc16_r2;
 pub mod fir_decimate;
 pub mod gfsk;
 pub mod msk;
+pub mod polyphase;
 pub mod resample;
 pub mod subtract;
 

--- a/mfsk-core/src/engine/dsp/polyphase.rs
+++ b/mfsk-core/src/engine/dsp/polyphase.rs
@@ -36,9 +36,6 @@
 use alloc::vec;
 use alloc::vec::Vec;
 
-#[cfg(not(feature = "std"))]
-use num_traits::Float;
-
 use super::fir_decimate::design_lowpass;
 
 /// Streaming `L`/`M` rational resampler over a complex (I, Q) stream.
@@ -189,6 +186,13 @@ impl PolyphaseResampler {
 #[cfg(test)]
 mod tests {
     use super::*;
+    // Only the test module below calls `f32` methods needing the
+    // `Float` trait in `no_std` (design_lowpass's `.sin()`/`.cos()`
+    // live in `fir_decimate`, which carries its own copy of this
+    // import) — a crate-level `use` outside `#[cfg(test)]` would be
+    // unused (and `-D warnings`-denied) on every real no_std build.
+    #[cfg(not(feature = "std"))]
+    use num_traits::Float;
 
     /// `f64` phase accumulation — see `wspr::ddc`'s own `tone` helper
     /// for why: `f32` phase noise at large sample counts would put a

--- a/mfsk-core/src/engine/dsp/polyphase.rs
+++ b/mfsk-core/src/engine/dsp/polyphase.rs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Streaming rational (`L`/`M`) resampler over a complex (I, Q) history.
+//!
+//! [`FirStage`](super::fir_decimate::FirStage) only decimates by an
+//! integer factor. This is its rational sibling — needed wherever the
+//! target rate is not an integer divisor of the input rate. The FST4
+//! embedded DDC needs exactly one such stage, right before
+//! `compute_spectra`, because `NSPS = 3888 = 2^4·3^5` has no integer
+//! divisor that lands on a power-of-two `nfft1` — see
+//! `docs/notes/FST4_DDC_DESIGN.md` §1, §4.2.
+//!
+//! ## The identity
+//!
+//! Implements "insert `L-1` zeros between samples, low-pass, keep
+//! every `M`-th sample" without ever materialising the zero-stuffed
+//! intermediate. For a unit-DC-gain prototype `h` (length `ntaps`,
+//! [`design_lowpass`] as usual, scaled by `L` to restore the passband
+//! gain the zero-stuffing would otherwise dilute), output `y[m]` is
+//!
+//! ```text
+//! y[m] = Σ_j h[p + j·L] · x[n0 - j],   p = (m·M) mod L,   n0 = ⌊m·M/L⌋
+//! ```
+//!
+//! i.e. only the taps at phase `p` participate — a `⌈ntaps/L⌉`-deep
+//! dot product per output, no multiplies against the zeros a literal
+//! upsample would introduce. Consecutive outputs' `n0` differ by
+//! `⌊(p+M)/L⌋`, with the same quantity giving the next phase
+//! (`(p+M) mod L`) — a Bresenham-style carry, so the whole thing runs
+//! as one pass over the input stream with no division in the hot path.
+//!
+//! Each phase's taps are stored pre-reversed and zero-padded to a
+//! common `max_depth`, so every phase's dot product walks the same
+//! trailing window shape [`FirStage::dot`](super::fir_decimate::FirStage)
+//! does — same history-buffer/compaction structure, reused here.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
+use super::fir_decimate::design_lowpass;
+
+/// Streaming `L`/`M` rational resampler over a complex (I, Q) stream.
+/// Input at rate `Fs`, output at rate `Fs·L/M`.
+pub struct PolyphaseResampler {
+    l: u32,
+    m: u32,
+    ntaps: usize,
+    /// Per-phase reversed tap tables, `l` of them, each `max_depth`
+    /// long and zero-padded at the front — see the module doc comment.
+    taps_rev: Vec<Vec<f32>>,
+    max_depth: usize,
+    hist_i: Vec<f32>,
+    hist_q: Vec<f32>,
+    hist_len: usize,
+    win_start: usize,
+    /// Current output phase `p = (m·M) mod L`, for the *next* output
+    /// not yet produced.
+    phase: u32,
+    /// Absolute input-sample index of the newest sample the next
+    /// output needs (`n0` for that same next output).
+    next_n0: usize,
+    /// Absolute index of the newest sample pushed so far (`None`
+    /// before the first [`push`](Self::push)).
+    n_in_abs: Option<usize>,
+}
+
+impl PolyphaseResampler {
+    /// `ntaps` must be odd, matching [`design_lowpass`]'s symmetric
+    /// design. `hist_margin` behaves like
+    /// [`FirStage::new`](super::fir_decimate::FirStage::new)'s: how
+    /// many extra input samples accumulate between compactions.
+    pub fn new(l: u32, m: u32, ntaps: usize, hist_margin: usize) -> Self {
+        assert!(ntaps % 2 == 1, "ntaps must be odd for linear phase");
+        assert!(l > 0 && m > 0, "l and m must be nonzero");
+
+        let fc_norm = (1.0 / (2.0 * l as f32)).min(1.0 / (2.0 * m as f32));
+        let mut h = design_lowpass(ntaps, fc_norm);
+        for tap in h.iter_mut() {
+            *tap *= l as f32;
+        }
+
+        let max_depth = ntaps.div_ceil(l as usize);
+        let mut taps_rev = Vec::with_capacity(l as usize);
+        for p in 0..l as usize {
+            let mut phase_taps = vec![0.0f32; max_depth];
+            let mut j = 0usize;
+            while p + j * (l as usize) < ntaps {
+                // window[k] holds x[n0-(max_depth-1-k)] (oldest at 0,
+                // newest at max_depth-1 — same convention FirStage's
+                // taps_rev uses), so the j-th tap (multiplying
+                // x[n0-j]) lands at k = max_depth-1-j.
+                phase_taps[max_depth - 1 - j] = h[p + j * (l as usize)];
+                j += 1;
+            }
+            taps_rev.push(phase_taps);
+        }
+
+        let hist_cap = max_depth + hist_margin;
+        let hist_i = vec![0.0f32; hist_cap];
+        let hist_q = vec![0.0f32; hist_cap];
+
+        Self {
+            l,
+            m,
+            ntaps,
+            taps_rev,
+            max_depth,
+            hist_i,
+            hist_q,
+            hist_len: max_depth,
+            win_start: 0,
+            phase: 0,
+            next_n0: 0,
+            n_in_abs: None,
+        }
+    }
+
+    /// This stage's group delay, in *output* samples (`(ntaps-1)/2`
+    /// at the interpolated rate, converted down by `M`) — for a
+    /// caller that wants to trim the transient the way
+    /// [`StreamingDdc::flush`](crate::wspr::ddc::StreamingDdc::flush)
+    /// does for the integer case.
+    pub fn group_delay_output(&self) -> usize {
+        ((self.ntaps - 1) / 2) / self.m as usize
+    }
+
+    /// Push one complex input sample; appends every output it
+    /// completes (0, 1, or more — more than 1 only when `l > m`,
+    /// upsampling) to the caller's buffers.
+    pub fn push(&mut self, i: f32, q: f32, out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
+        self.hist_i[self.hist_len] = i;
+        self.hist_q[self.hist_len] = q;
+        self.hist_len += 1;
+        self.win_start += 1;
+        let cur_abs = self.n_in_abs.map_or(0, |a| a + 1);
+        self.n_in_abs = Some(cur_abs);
+
+        while self.next_n0 <= cur_abs {
+            // How far behind the newest held sample this output's
+            // window ends — always 0 once the stream is running (see
+            // the module doc comment), kept general rather than
+            // asserted so `l > m` (interpolation) stays correct too.
+            let back = cur_abs - self.next_n0;
+            let end = self.win_start + self.max_depth - back;
+            let start = end - self.max_depth;
+            let (oi, oq) = self.dot(start);
+            out_i.push(oi);
+            out_q.push(oq);
+
+            let carry = (self.phase + self.m) / self.l;
+            self.phase = (self.phase + self.m) % self.l;
+            self.next_n0 += carry as usize;
+        }
+
+        if self.hist_len == self.hist_i.len() {
+            self.compact();
+        }
+    }
+
+    fn compact(&mut self) {
+        let keep = self.win_start;
+        self.hist_i.copy_within(keep..self.hist_len, 0);
+        self.hist_q.copy_within(keep..self.hist_len, 0);
+        self.hist_len = self.max_depth;
+        self.win_start = 0;
+    }
+
+    /// `Σ taps_rev[phase][k]·hist[start+k]`, over both channels — same
+    /// shape as [`FirStage::dot`](super::fir_decimate::FirStage), just
+    /// against a phase-selected tap table instead of a fixed one.
+    fn dot(&self, start: usize) -> (f32, f32) {
+        let depth = self.max_depth;
+        let hi = &self.hist_i[start..start + depth];
+        let hq = &self.hist_q[start..start + depth];
+        let h = &self.taps_rev[self.phase as usize][..];
+
+        let mut si = 0.0f32;
+        let mut sq = 0.0f32;
+        for k in 0..depth {
+            si += h[k] * hi[k];
+            sq += h[k] * hq[k];
+        }
+        (si, sq)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `f64` phase accumulation — see `wspr::ddc`'s own `tone` helper
+    /// for why: `f32` phase noise at large sample counts would put a
+    /// floor under any rejection measurement made with it.
+    fn tone(freq_hz: f32, fs_hz: f32, amp: f32, n: usize) -> Vec<f32> {
+        let w = 2.0 * core::f64::consts::PI * freq_hz as f64 / fs_hz as f64;
+        (0..n)
+            .map(|k| (amp as f64 * (w * k as f64).cos()) as f32)
+            .collect()
+    }
+
+    fn run(r: &mut PolyphaseResampler, audio: &[f32]) -> (Vec<f32>, Vec<f32>) {
+        let mut out_i = Vec::new();
+        let mut out_q = Vec::new();
+        for &s in audio {
+            r.push(s, 0.0, &mut out_i, &mut out_q);
+        }
+        (out_i, out_q)
+    }
+
+    /// A DC-centred real input, resampled at unity ratio (`L=M=1`),
+    /// should reproduce the input on the real channel once the filter
+    /// has settled — the ratio-1 case is the identity, so this checks
+    /// the phase-carry bookkeeping produces exactly one output per
+    /// input with no drift.
+    #[test]
+    fn unity_ratio_produces_one_output_per_input() {
+        let mut r = PolyphaseResampler::new(1, 1, 31, 64);
+        let n = 2000;
+        let audio = tone(0.0, 12_000.0, 0.7, n);
+        let (out_i, out_q) = run(&mut r, &audio);
+        assert_eq!(out_i.len(), n);
+        assert_eq!(out_q.len(), n);
+        let settled = 40..n;
+        for k in settled {
+            assert!(
+                (out_i[k] - 0.7).abs() < 0.01,
+                "k={k} out_i={} expected ~0.7",
+                out_i[k]
+            );
+            assert!(
+                out_q[k].abs() < 0.01,
+                "k={k} out_q={} expected ~0",
+                out_q[k]
+            );
+        }
+    }
+
+    /// `ntaps` for a target transition width (Hz) at this `L`/`Fs_in`
+    /// pair — `design_lowpass`'s own `4/NTAPS`-of-the-design-rate rule
+    /// (see `wspr::ddc::NTAPS`'s doc comment), with the design rate
+    /// being the interpolated one, `L·Fs_in`. Odd, for linear phase.
+    fn ntaps_for_transition(l: u32, fs_in: f32, transition_hz: f32) -> usize {
+        let n = (4.0 * l as f32 * fs_in / transition_hz).ceil() as usize;
+        if n.is_multiple_of(2) { n + 1 } else { n }
+    }
+
+    /// In-band tone: amplitude preserved (within the filter's ripple)
+    /// after resampling by a representative small ratio (`9/64`, the
+    /// FST4-60 sniper refine stage per the design doc's §4.4 table).
+    #[test]
+    fn in_band_tone_amplitude_is_preserved() {
+        let l = 9u32;
+        let m = 64u32;
+        let fs_in = 790.12f32;
+        let ntaps = ntaps_for_transition(l, fs_in, 20.0);
+        let mut r = PolyphaseResampler::new(l, m, ntaps, 128);
+        let n = 20_000;
+        // Well inside both the input and output Nyquist (output rate
+        // ~111 Hz, so keep the tone under ~50 Hz).
+        let audio = tone(10.0, fs_in, 0.5, n);
+        let (out_i, out_q) = run(&mut r, &audio);
+
+        let expected_len = (n as u64 * l as u64 / m as u64) as usize;
+        assert!(
+            out_i.len().abs_diff(expected_len) <= 1,
+            "got {} outputs, expected ~{expected_len}",
+            out_i.len()
+        );
+
+        let settle = out_i.len() / 4;
+        let span = settle..(out_i.len() - settle);
+        let mut peak = 0.0f32;
+        for k in span {
+            let mag = (out_i[k] * out_i[k] + out_q[k] * out_q[k]).sqrt();
+            if mag > peak {
+                peak = mag;
+            }
+        }
+        assert!(
+            (peak - 0.5).abs() < 0.05,
+            "peak magnitude {peak}, expected ~0.5"
+        );
+    }
+
+    /// Out-of-band content (above the output Nyquist) must not alias
+    /// into the resampled stream at any level that would read as
+    /// signal.
+    #[test]
+    fn out_of_band_tone_is_rejected() {
+        let l = 9u32;
+        let m = 64u32;
+        let fs_in = 790.12f32;
+        let fs_out = fs_in * l as f32 / m as f32; // ~111.11 Hz
+        let ntaps = ntaps_for_transition(l, fs_in, 20.0);
+
+        let mut in_band = PolyphaseResampler::new(l, m, ntaps, 128);
+        let mut out_band = PolyphaseResampler::new(l, m, ntaps, 128);
+        let n = 20_000;
+
+        let (i1, q1) = run(&mut in_band, &tone(10.0, fs_in, 0.5, n));
+        // Comfortably past fs_out/2 (~55.5 Hz) so it must be
+        // suppressed rather than folded back near the passband.
+        let (i2, q2) = run(&mut out_band, &tone(fs_out, fs_in, 0.5, n));
+
+        let rms = |i: &[f32], q: &[f32]| -> f32 {
+            let settle = i.len() / 4;
+            let span = settle..(i.len() - settle);
+            let s: f32 =
+                span.clone().map(|k| i[k] * i[k] + q[k] * q[k]).sum::<f32>() / span.len() as f32;
+            s.sqrt()
+        };
+        let db = 20.0 * (rms(&i2, &q2) / rms(&i1, &q1)).log10();
+        assert!(db < -40.0, "out-of-band rejection only {db} dB");
+    }
+
+    /// Down-sampling by an integer ratio expressed rationally (`L=1`)
+    /// should track [`FirStage`](super::super::fir_decimate::FirStage)
+    /// with an equivalent design — same identity, two code paths.
+    #[test]
+    fn integer_ratio_tracks_fir_stage() {
+        use super::super::fir_decimate::FirStage;
+
+        let decim = 8u32;
+        let ntaps = 63;
+        let mut poly = PolyphaseResampler::new(1, decim, ntaps, 128);
+        let mut fir = FirStage::new(ntaps, decim as usize, 1.0 / (2.0 * decim as f32), 128);
+
+        let n = 4000;
+        let audio = tone(20.0, 12_000.0, 0.6, n);
+        let (pi, pq) = run(&mut poly, &audio);
+        let mut fi = Vec::new();
+        let mut fq = Vec::new();
+        for &s in &audio {
+            if let Some((i, q)) = fir.push_one(s, 0.0) {
+                fi.push(i);
+                fq.push(q);
+            }
+        }
+
+        // FirStage emits its first output only once its own group
+        // delay has elapsed (so its output 0 is already
+        // centre-aligned); PolyphaseResampler emits from n0=0
+        // instead, so its stream leads FirStage's by
+        // `group_delay_output()` samples. Skip that many before
+        // comparing — same shift the design doc's DDC callers would
+        // apply via a `flush`-style trim (`wspr::ddc::StreamingDdc`'s
+        // own doc comment: "group delay already removed").
+        let lead = poly.group_delay_output();
+        let (pi, pq) = (&pi[lead..], &pq[lead..]);
+        let len = pi.len().min(fi.len());
+
+        let settle = len / 4;
+        let span = settle..len;
+        let (mut num_re, mut num_im, mut pf, mut pp) = (0.0f64, 0.0f64, 0.0f64, 0.0f64);
+        for k in span {
+            let (f, p) = ((fi[k], fq[k]), (pi[k], pq[k]));
+            num_re += (f.0 * p.0 + f.1 * p.1) as f64;
+            num_im += (f.1 * p.0 - f.0 * p.1) as f64;
+            pf += (f.0 * f.0 + f.1 * f.1) as f64;
+            pp += (p.0 * p.0 + p.1 * p.1) as f64;
+        }
+        let coh = (num_re * num_re + num_im * num_im).sqrt() / (pf * pp).sqrt();
+        assert!(coh > 0.99, "coherence with FirStage only {coh}");
+    }
+}

--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -1709,7 +1709,9 @@ where
     let candidates = if P::ID == super::ProtocolId::Ft4 {
         super::ft4_coarse::ft4_coarse_sync(audio, freq_min, freq_max, sync_min, freq_hint, max_cand)
     } else {
-        coarse_sync::<P>(audio, freq_min, freq_max, sync_min, freq_hint, max_cand)
+        coarse_sync::<P>(
+            audio, freq_min, freq_max, sync_min, freq_hint, max_cand, 12_000.0,
+        )
     };
     #[cfg(feature = "std")]
     if let Some(t0) = __trace_t0 {
@@ -1991,6 +1993,7 @@ where
                 sync_min * factor,
                 freq_hint,
                 max_cand,
+                12_000.0,
             )
         };
         #[cfg(feature = "std")]

--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -796,7 +796,10 @@ where
 {
     let ntones = P::NTONES as usize;
     let n_sym = P::N_SYMBOLS as usize;
-    let ds_rate = 12_000.0 / P::NDOWN as f32;
+    // #323: was an independent `12_000.0 / P::NDOWN` hardcode — `cfg`
+    // (already a parameter here) carries the real input rate a DDC-fed
+    // caller would set to something other than 12 kHz.
+    let ds_rate = cfg.input_rate as f32 / P::NDOWN as f32;
     let tx_start = P::TX_START_OFFSET_S;
 
     let precomputed_freq = precomputed_refine

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -126,12 +126,40 @@ pub struct SyncDims {
 }
 
 impl SyncDims {
+    /// `sample_rate_hz` is the rate `audio` fed to
+    /// [`compute_spectra`]/[`coarse_sync`] is actually at — the
+    /// "analysis-grid" rate issue #323 classified as needing to vary
+    /// for a future DDC front end (#309), separate from
+    /// `downsample_cached`'s own rate below.
+    ///
+    /// `nfft1`/`nstep`/`nsps`/`nmax`/`nhsym`/`nh1`/`df`/`tstep`/`jstrt`/
+    /// `jz` (all derived from `sample_rate_hz`) are this rate's fields.
+    /// **`ds_spb`/`ds_rate` are not** — those describe
+    /// `downsample_cached`'s separate per-candidate baseband pipeline,
+    /// which starts from the canonical 12 kHz raw ingest via
+    /// `DownsampleCfg::input_rate` regardless of what rate `coarse_sync`
+    /// searches at (the two are independent pipeline stages that
+    /// happen to coincide at 12 kHz today). Left untouched here —
+    /// #323 already routed their three other redundant copies through
+    /// `cfg.input_rate` directly; this one stays `P::NSPS`-derived
+    /// until a caller actually needs `downsample_cached` itself fed by
+    /// something other than the canonical 12 kHz stream.
     #[inline]
-    pub const fn of<P: Protocol>() -> Self {
-        let nsps = P::NSPS as usize;
+    pub fn of<P: Protocol>(sample_rate_hz: f32) -> Self {
+        // `SYMBOL_DT = NSPS / 12_000.0` (`fst4_submode!`) is the
+        // protocol's physical symbol duration in seconds — rate
+        // independent. At `sample_rate_hz == 12_000.0` (every caller
+        // today) this recovers `P::NSPS` exactly: `SYMBOL_DT *
+        // 12_000.0 == NSPS` round-trips bit-exact in f32 for every
+        // FST4/FT4 `NSPS` value in the crate (verified by
+        // `sync_dims_of_matches_nsps_at_12khz` below).
+        let nsps = (P::SYMBOL_DT * sample_rate_hz).round() as usize;
         let nstep = nsps / P::NSTEP_PER_SYMBOL as usize;
         let nfft1 = nsps * P::NFFT_PER_SYMBOL_FACTOR as usize;
-        let nmax = (P::T_SLOT_S * 12_000.0) as usize;
+        let nmax = (P::T_SLOT_S * sample_rate_hz) as usize;
+        let tstep = nstep as f32 / sample_rate_hz;
+
+        // `downsample_cached`'s rate — see the doc comment above.
         let ndown = P::NDOWN as usize;
         Self {
             nfft1,
@@ -142,11 +170,11 @@ impl SyncDims {
             nmax,
             nhsym: nmax / nstep - 3,
             nh1: nfft1 / 2,
-            df: 12_000.0 / nfft1 as f32,
-            tstep: nstep as f32 / 12_000.0,
-            jstrt: (P::TX_START_OFFSET_S / (nstep as f32 / 12_000.0)) as i32,
-            jz: (2.5 / (nstep as f32 / 12_000.0)) as i32,
-            ds_spb: nsps / ndown,
+            df: sample_rate_hz / nfft1 as f32,
+            tstep,
+            jstrt: (P::TX_START_OFFSET_S / tstep) as i32,
+            jz: (2.5 / tstep) as i32,
+            ds_spb: P::NSPS as usize / ndown,
             ds_rate: 12_000.0 / ndown as f32,
         }
     }
@@ -263,12 +291,19 @@ pub(crate) fn nuttall_window(n: usize) -> Vec<f32> {
 /// signals would otherwise inflate the per-bin polynomial baseline and
 /// mask weak signals); FT8 stays on `Rectangular` (its synth-roundtrip
 /// path is calibrated against rectangular).
+///
+/// `sample_rate_hz`: the rate `audio` is actually sampled at —
+/// `12_000.0` for every caller today (issue #323/#309; see
+/// [`SyncDims::of`]'s doc). Not yet reachable from a DDC-fed front end;
+/// threaded through now so wiring one up later is a call-site change,
+/// not a rediscovery of this function's own rate assumption.
 pub fn compute_spectra<P: Protocol>(
     audio: &[i16],
     bin_lo: usize,
     bin_hi_incl: usize,
+    sample_rate_hz: f32,
 ) -> Spectrogram {
-    let d = SyncDims::of::<P>();
+    let d = SyncDims::of::<P>(sample_rate_hz);
     let fac = 1.0f32 / 300.0;
     let mut planner = default_planner();
     let fft = planner.plan_forward(d.nfft1);
@@ -343,6 +378,12 @@ pub fn compute_spectra<P: Protocol>(
 /// implementations (verified via `grep coarse_sync::<` — nothing outside
 /// `engine/pipeline.rs` and `msg/pipeline_ap.rs` calls this generic
 /// function with a non-FST4/FT4 protocol).
+///
+/// `sample_rate_hz`: the rate `audio` is actually sampled at —
+/// `12_000.0` for every caller today (issue #323/#309; see
+/// [`SyncDims::of`]'s doc). Not yet reachable from a DDC-fed front end;
+/// threaded through now so wiring one up later is a call-site change,
+/// not a rediscovery of this function's own rate assumption.
 pub fn coarse_sync<P: Protocol>(
     audio: &[i16],
     freq_min: f32,
@@ -350,8 +391,9 @@ pub fn coarse_sync<P: Protocol>(
     sync_min: f32,
     freq_hint: Option<f32>,
     max_cand: usize,
+    sample_rate_hz: f32,
 ) -> Vec<SyncCandidate> {
-    let d = SyncDims::of::<P>();
+    let d = SyncDims::of::<P>(sample_rate_hz);
     let ntones = P::NTONES as usize;
     let pattern_len = P::SYNC_MODE.blocks()[0].pattern.len();
 
@@ -368,7 +410,12 @@ pub fn coarse_sync<P: Protocol>(
     // plus `headroom` bins above `ib` for their reference tones.
     // `Spectrogram::get` stays absolute-bin-indexed (subtracts
     // `freq_offset` internally) so nothing below needs to change.
-    let s = compute_spectra::<P>(audio, ia, (ib + headroom).min(d.nh1.saturating_sub(1)));
+    let s = compute_spectra::<P>(
+        audio,
+        ia,
+        (ib + headroom).min(d.nh1.saturating_sub(1)),
+        sample_rate_hz,
+    );
 
     let n_freq = ib - ia + 1;
     let n_lag = (2 * d.jz + 1) as usize;
@@ -885,7 +932,10 @@ pub fn fine_sync_power<P: Protocol>(cd0: &[Complex<f32>], i0: i32) -> f32 {
 /// reference table, scoped to this smaller, protocol-generic case).
 pub fn fine_sync_power_per_block<P: Protocol>(cd0: &[Complex<f32>], i0: i32) -> Vec<f32> {
     type CachedCsync = (&'static [u8], Vec<Vec<Complex<f32>>>);
-    let d = SyncDims::of::<P>();
+    // Only `d.ds_spb` is read below — a `SyncDims::of` field that
+    // `downsample_cached`'s own rate governs, not the `sample_rate_hz`
+    // parameter (see that doc comment), so the argument here is inert.
+    let d = SyncDims::of::<P>(12_000.0);
     let blocks = P::SYNC_MODE.blocks();
     let mut out = Vec::with_capacity(blocks.len());
     let mut last: Option<CachedCsync> = None;
@@ -979,7 +1029,9 @@ pub fn refine_candidate<P: Protocol>(
     candidate: &SyncCandidate,
     search_steps: i32,
 ) -> SyncCandidate {
-    let d = SyncDims::of::<P>();
+    // Only `d.ds_rate` is read below — see `fine_sync_power_per_block`'s
+    // identical comment.
+    let d = SyncDims::of::<P>(12_000.0);
     let nominal_i0 = ((candidate.dt_sec + P::TX_START_OFFSET_S) * d.ds_rate).round() as i32;
     let (best_i0, best_score) = (-search_steps..=search_steps)
         .map(|delta| {
@@ -999,5 +1051,39 @@ pub fn refine_candidate<P: Protocol>(
         freq_hz: candidate.freq_hz,
         dt_sec: (best_i0 as f32 + frac) / d.ds_rate - P::TX_START_OFFSET_S,
         score: best_score,
+    }
+}
+
+#[cfg(all(test, feature = "fst4", feature = "ft4"))]
+mod tests {
+    use super::{Protocol, SyncDims};
+    use crate::engine::protocol::ModulationParams;
+    use crate::fst4::{Fst4s15, Fst4s30, Fst4s60, Fst4s120, Fst4s300};
+    use crate::ft4::Ft4;
+
+    /// `SyncDims::of::<P>(12_000.0)`'s `nsps` is derived from
+    /// `P::SYMBOL_DT * sample_rate_hz` (issue #309/#323), not read
+    /// directly from `P::NSPS` as before this refactor — this is the
+    /// "verified to round-trip bit-exact" claim that refactor's commit
+    /// makes. `SYMBOL_DT = NSPS / 12_000.0` (`fst4_submode!`), so at
+    /// `sample_rate_hz == 12_000.0` (every caller today) the two must
+    /// agree exactly, for every real NSPS value in the crate — a
+    /// mismatch here would silently shift `nfft1`/`nmax`/`df`/`tstep`
+    /// for every existing decode path.
+    #[test]
+    fn sync_dims_of_matches_nsps_at_12khz() {
+        fn check<P: Protocol + ModulationParams>(name: &str) {
+            let d = SyncDims::of::<P>(12_000.0);
+            assert_eq!(
+                d.nsps, P::NSPS as usize,
+                "{name}: SyncDims::of(12_000.0).nsps != P::NSPS"
+            );
+        }
+        check::<Fst4s15>("Fst4s15");
+        check::<Fst4s30>("Fst4s30");
+        check::<Fst4s60>("Fst4s60");
+        check::<Fst4s120>("Fst4s120");
+        check::<Fst4s300>("Fst4s300");
+        check::<Ft4>("Ft4");
     }
 }

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -1075,7 +1075,8 @@ mod tests {
         fn check<P: Protocol + ModulationParams>(name: &str) {
             let d = SyncDims::of::<P>(12_000.0);
             assert_eq!(
-                d.nsps, P::NSPS as usize,
+                d.nsps,
+                P::NSPS as usize,
                 "{name}: SyncDims::of(12_000.0).nsps != P::NSPS"
             );
         }

--- a/mfsk-core/src/engine/sync2d.rs
+++ b/mfsk-core/src/engine/sync2d.rs
@@ -181,7 +181,11 @@ pub fn fst4_sync_search<P: Protocol>(
     cd0: &[Complex<f32>],
     candidate: &SyncCandidate,
 ) -> Sync2dResult {
-    let d = SyncDims::of::<P>();
+    // Only `d.ds_spb`/`d.ds_rate` are read below — governed by
+    // `downsample_cached`'s own rate, not `SyncDims::of`'s
+    // `sample_rate_hz` parameter (see that doc comment), so the
+    // argument here is inert.
+    let d = SyncDims::of::<P>(12_000.0);
     let ds_spb = d.ds_spb;
     let ds_rate = d.ds_rate;
     let baud = P::TONE_SPACING_HZ;
@@ -340,7 +344,9 @@ pub fn ft4_sync_search_window<P: Protocol>(
     ib_min: i32,
     ib_max: i32,
 ) -> Sync2dResult {
-    let d = SyncDims::of::<P>();
+    // Only `d.ds_spb`/`d.ds_rate` are read below — see
+    // `fst4_sync_search`'s identical comment.
+    let d = SyncDims::of::<P>(12_000.0);
     let ds_spb = d.ds_spb;
     let ds_rate = d.ds_rate;
     const COARSE_DT_STEP: i32 = 4;

--- a/mfsk-core/src/fst4/rung_major.rs
+++ b/mfsk-core/src/fst4/rung_major.rs
@@ -212,7 +212,10 @@ where
     P: Protocol,
     P::Fec: BpPooledFec,
 {
-    decode_rung_major_timed::<P>(candidates, skip_llrc, false, &[0], None).0
+    // 12 kHz: `candidates` here are always the canonical raw-ingest
+    // downsample (see `decode_scheduled`'s `sample_rate_hz` doc) — this
+    // convenience wrapper has no caller that varies it.
+    decode_rung_major_timed::<P>(candidates, skip_llrc, false, &[0], None, 12_000.0).0
 }
 
 /// Same as [`decode_rung_major`], plus `offsets` (which `i0` timing
@@ -234,12 +237,20 @@ where
 /// `s % 5` selects the sub-stage in llra/llrb/llre/llrc/OSD order) — `0`
 /// for any stage this candidate never reached, e.g. filtered by the
 /// `nsync` gate or `skip_llrc`.
+///
+/// `sample_rate_hz` is the input rate `candidates`' `cd0` was
+/// downsampled *from* (divide by `P::NDOWN` for `cd0`'s own rate) —
+/// `12_000.0` for every caller today, matching `DownsampleCfg::input_rate`
+/// (issue #323). Not yet reachable from a DDC-fed front end (#309);
+/// threaded through now so wiring one up later is a call-site change
+/// here, not a rediscovery of this function's own `ds_rate` hardcode.
 pub fn decode_rung_major_timed<P>(
     candidates: &[RungMajorCandidate],
     skip_llrc: bool,
     skip_osd: bool,
     offsets: &[i32],
     clock: Option<fn() -> i64>,
+    sample_rate_hz: f32,
 ) -> (Vec<Option<DecodeResult>>, Option<Vec<Vec<i64>>>)
 where
     P: Protocol,
@@ -253,6 +264,7 @@ where
         clock,
         Schedule::RungMajor,
         None,
+        sample_rate_hz,
     )
 }
 
@@ -271,6 +283,8 @@ where
 /// Same `(results, per_candidate_stage_us)` shape and the same
 /// offset-major stage indexing as [`decode_rung_major_timed`], so the
 /// two are directly comparable on one corpus.
+///
+/// `sample_rate_hz`: see [`decode_rung_major_timed`]'s doc.
 pub fn decode_phase_split_timed<P>(
     candidates: &[RungMajorCandidate],
     skip_llrc: bool,
@@ -278,6 +292,7 @@ pub fn decode_phase_split_timed<P>(
     offsets: &[i32],
     clock: Option<fn() -> i64>,
     budget_ok: Option<fn() -> bool>,
+    sample_rate_hz: f32,
 ) -> (Vec<Option<DecodeResult>>, Option<Vec<Vec<i64>>>)
 where
     P: Protocol,
@@ -291,6 +306,7 @@ where
         clock,
         Schedule::PhaseSplit,
         budget_ok,
+        sample_rate_hz,
     )
 }
 
@@ -313,6 +329,11 @@ fn decode_scheduled<P>(
     clock: Option<fn() -> i64>,
     schedule: Schedule,
     budget_ok: Option<fn() -> bool>,
+    // Input rate `candidates`' `cd0` was downsampled from (issue #323)
+    // — was an independent `12_000.0 / P::NDOWN` hardcode, duplicating
+    // `DownsampleCfg::input_rate` without reading it (there's no `cfg`
+    // in scope here; `candidates` arrive pre-downsampled).
+    sample_rate_hz: f32,
 ) -> (Vec<Option<DecodeResult>>, Option<Vec<Vec<i64>>>)
 where
     P: Protocol,
@@ -327,7 +348,7 @@ where
         .expect("decode_rung_major is FST4-specific: P::LLR_NSYM_MID must be set (see module doc)")
         as usize;
     let nsym_max = P::LLR_NSYM_MAX as usize;
-    let ds_rate = 12_000.0 / P::NDOWN as f32;
+    let ds_rate = sample_rate_hz / P::NDOWN as f32;
     let tx_start = P::TX_START_OFFSET_S;
     let (osd_attempt_min, osd_depth3_min) = osd_escalation_gates::<P>();
     let verify_info = Some(<P::Msg as MessageCodec>::verify_info as fn(&[u8]) -> bool);

--- a/mfsk-core/src/ft8/decode.rs
+++ b/mfsk-core/src/ft8/decode.rs
@@ -1990,7 +1990,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )
@@ -2087,7 +2089,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )
@@ -2540,7 +2544,9 @@ mod tests {
             // computation bug.
             if let Ok(raw) = std::fs::read("/tmp/jt9_post_sic_dd.raw") {
                 let jt9_residual: Vec<i16> = raw
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|b| i16::from_le_bytes([b[0], b[1]]))
                     .collect();
                 println!(
@@ -2674,7 +2680,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )
@@ -2839,7 +2847,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )
@@ -2873,7 +2883,9 @@ mod tests {
             }
         };
         let jt9_residual: Vec<i16> = jt9_bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| i16::from_le_bytes([c[0], c[1]]))
             .collect();
 
@@ -3008,7 +3020,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )
@@ -3042,7 +3056,9 @@ mod tests {
             }
         };
         let jt9_residual: Vec<i16> = jt9_bytes
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| i16::from_le_bytes([c[0], c[1]]))
             .collect();
 
@@ -3178,7 +3194,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )
@@ -3311,7 +3329,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )
@@ -3371,7 +3391,9 @@ mod tests {
             let end = off.saturating_add(data_len).min(bytes.len());
             Some(
                 bytes[off..end]
-                    .chunks_exact(2)
+                    .as_chunks::<2>()
+                    .0
+                    .iter()
                     .map(|c| i16::from_le_bytes([c[0], c[1]]))
                     .collect(),
             )

--- a/mfsk-core/src/jt9/decode.rs
+++ b/mfsk-core/src/jt9/decode.rs
@@ -234,7 +234,9 @@ mod gate_diag {
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let audio: Vec<f32> = bytes[44..44 + dl]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32_768.0)
             .collect();
 
@@ -319,7 +321,9 @@ mod gate_diag {
                     let start = i + 8;
                     let samples: &[u8] = &bytes[start..start + len];
                     return samples
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
                         .collect();
                 }
@@ -393,7 +397,9 @@ mod gate_diag {
                     let start = i + 8;
                     let samples: &[u8] = &bytes[start..start + len];
                     return samples
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
                         .collect();
                 }

--- a/mfsk-core/src/jt9/mod.rs
+++ b/mfsk-core/src/jt9/mod.rs
@@ -385,7 +385,9 @@ mod tests {
                     let start = i + 8;
                     let samples: &[u8] = &bytes[start..start + len];
                     return samples
-                        .chunks_exact(2)
+                        .as_chunks::<2>()
+                        .0
+                        .iter()
                         .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
                         .collect();
                 }
@@ -483,7 +485,9 @@ mod tests {
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let audio: Vec<f32> = bytes[44..44 + dl]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32_768.0)
             .collect();
 

--- a/mfsk-core/src/jt9/rx.rs
+++ b/mfsk-core/src/jt9/rx.rs
@@ -219,7 +219,9 @@ mod diag_tests {
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let data = &bytes[44..44 + dl];
         let audio: Vec<f32> = data
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
             .collect();
 
@@ -264,7 +266,9 @@ mod diag_tests {
         let bytes = std::fs::read(path).unwrap();
         let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let audio: Vec<f32> = bytes[44..44 + dl]
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
             .collect();
 
@@ -333,7 +337,9 @@ fn freq_sweep_1224hz() {
     let bytes = std::fs::read(path).unwrap();
     let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
     let audio: Vec<f32> = bytes[44..44 + dl]
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
         .collect();
     use crate::engine::{DecodeContext, FecOpts, MessageCodec};
@@ -371,7 +377,9 @@ fn wide_freq_time_sweep() {
     let bytes = std::fs::read(path).unwrap();
     let dl = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
     let audio: Vec<f32> = bytes[44..44 + dl]
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
         .collect();
     use crate::engine::{DecodeContext, FecOpts, MessageCodec};

--- a/mfsk-core/src/jt9/search.rs
+++ b/mfsk-core/src/jt9/search.rs
@@ -264,7 +264,9 @@ mod diag_tests {
         let data_len = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let data = &bytes[44..44 + data_len];
         let audio: Vec<f32> = data
-            .chunks_exact(2)
+            .as_chunks::<2>()
+            .0
+            .iter()
             .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
             .collect();
         let params = SearchParams {

--- a/mfsk-core/src/jt9/softsym.rs
+++ b/mfsk-core/src/jt9/softsym.rs
@@ -636,7 +636,9 @@ mod tests {
         let data_len = u32::from_le_bytes([bytes[40], bytes[41], bytes[42], bytes[43]]) as usize;
         let data = &bytes[44..44 + data_len];
         Some(
-            data.chunks_exact(2)
+            data.as_chunks::<2>()
+                .0
+                .iter()
                 .map(|c| i16::from_le_bytes([c[0], c[1]]) as f32 / 32768.0)
                 .collect(),
         )

--- a/mfsk-core/src/msg/pipeline_ap.rs
+++ b/mfsk-core/src/msg/pipeline_ap.rs
@@ -105,7 +105,10 @@ where
     P::Fec: crate::engine::protocol::BpPooledFec,
     P::Msg: WsjtApCompatible,
 {
-    let ds_rate = 12_000.0 / P::NDOWN as f32;
+    // #323: was an independent `12_000.0 / P::NDOWN` hardcode — `ds_cfg`
+    // (already a parameter here) carries the real input rate a DDC-fed
+    // caller would set to something other than 12 kHz.
+    let ds_rate = ds_cfg.input_rate as f32 / P::NDOWN as f32;
     let tx_start = P::TX_START_OFFSET_S;
     let _ = refine_steps; // superseded by refine_candidate_position's own P-specific search below
 

--- a/mfsk-core/src/msg/pipeline_ap.rs
+++ b/mfsk-core/src/msg/pipeline_ap.rs
@@ -456,6 +456,7 @@ where
         sync_min,
         Some(target_freq),
         max_cand,
+        12_000.0,
     );
     if candidates.is_empty() {
         return Vec::new();

--- a/mfsk-core/tests/common/mod.rs
+++ b/mfsk-core/tests/common/mod.rs
@@ -86,8 +86,10 @@ pub fn load_wav_i16_opt(path: impl AsRef<std::path::Path>) -> Option<Vec<i16>> {
     let samples = &bytes[data_off..data_off + data_len];
     Some(
         samples
-            .chunks_exact(2)
-            .map(|b| i16::from_le_bytes([b[0], b[1]]))
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|b| i16::from_le_bytes(*b))
             .collect(),
     )
 }

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -3743,8 +3743,14 @@ fn fst4_60_diag_rung_major_stage_timing_probe() {
         })
         .collect();
 
-    let (results, timings) =
-        decode_rung_major_timed::<Fst4s60>(&cands, false, false, &[0], Some(host_clock_us));
+    let (results, timings) = decode_rung_major_timed::<Fst4s60>(
+        &cands,
+        false,
+        false,
+        &[0],
+        Some(host_clock_us),
+        12_000.0,
+    );
     let timings = timings.unwrap();
     eprintln!(
         "decoded: {}/{}",
@@ -7498,10 +7504,12 @@ fn fst4_phase_split_matches_rung_major_without_a_budget() {
 
     for offsets in [&[0i32][..], &[0, -1][..], &[0, 1, -1][..]] {
         for skip_llrc in [false, true] {
-            let (a, _) =
-                decode_rung_major_timed::<Fst4s60>(&cands, skip_llrc, false, offsets, None);
-            let (b, _) =
-                decode_phase_split_timed::<Fst4s60>(&cands, skip_llrc, false, offsets, None, None);
+            let (a, _) = decode_rung_major_timed::<Fst4s60>(
+                &cands, skip_llrc, false, offsets, None, 12_000.0,
+            );
+            let (b, _) = decode_phase_split_timed::<Fst4s60>(
+                &cands, skip_llrc, false, offsets, None, None, 12_000.0,
+            );
             assert_eq!(
                 a.len(),
                 b.len(),

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -384,7 +384,7 @@ fn fst4_diag_weak_trials() {
                 eprintln!("skip {path:?}");
                 continue;
             };
-            let cands = coarse_sync::<P>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let cands = coarse_sync::<P>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -491,7 +491,7 @@ fn fst4_diag_nsym4_ladder() {
                 continue;
             };
 
-            let cands = coarse_sync::<P>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let cands = coarse_sync::<P>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
             let Some(cand) = cands
                 .iter()
                 .find(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -676,7 +676,7 @@ fn fst4_diag_zsum_osd() {
                 continue;
             };
 
-            let cands = coarse_sync::<Fst4s120>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let cands = coarse_sync::<Fst4s120>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
             let Some(cand) = cands
                 .iter()
                 .find(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -779,7 +779,7 @@ fn fst4_120_diag_sync_vs_decode_failure() {
                 continue;
             };
             n_total += 1;
-            let cands = coarse_sync::<Fst4s120>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let cands = coarse_sync::<Fst4s120>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -891,7 +891,7 @@ fn fst4_60_diag_candidate_cost_split() {
     };
 
     let t0 = Instant::now();
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50);
+    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
     let coarse_dt = t0.elapsed();
 
     eprintln!(
@@ -1016,7 +1016,7 @@ fn fst4_300_diag_candidate_cost_split() {
     let audio: Vec<i16> = full.iter().take(300 * 12_000).copied().collect();
 
     let t0 = Instant::now();
-    let cands = coarse_sync::<Fst4s300>(&audio, 100.0, 3000.0, 1.0, None, 50);
+    let cands = coarse_sync::<Fst4s300>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
     let coarse_dt = t0.elapsed();
 
     eprintln!(
@@ -1123,7 +1123,7 @@ fn fst4_60_diag_osd_escalation() {
         return;
     };
 
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50);
+    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
     let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
     let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -1282,7 +1282,7 @@ fn fst4_60_diag_npre1_pattern_counts() {
         return;
     };
 
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50);
+    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
     let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
     let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -1402,7 +1402,7 @@ fn fst4_60_diag_osd_depth34_nsync_floor() {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return Vec::new();
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -1712,7 +1712,7 @@ fn recall_tradeoff_for_channel(channel: &str, snr_tags: &'static [(&'static str,
         // call (`decode_wav_fst4` above) — `fst4_60_diag_osd_escalation`'s
         // 1.0 was tuned against the strong real-world golden WAV only,
         // untested against weak AWGN-sweep candidates.
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -2181,7 +2181,7 @@ fn fst4_60_diag_npre_osd_ccir_trial_probe() {
     let path = dir.join("fst4_60_ccir_moderate_m26_02.wav");
     let audio = load_wav_i16_opt(&path).expect("trial 2 must exist");
 
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
     let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
     let verify_info =
@@ -2333,7 +2333,7 @@ fn nsym_depth_sweep_for_channel(channel: &str, snr_tags: &[(&str, u32)]) {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return (snr_idx, [MISS; 5]);
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -2732,7 +2732,7 @@ fn fst4_60_diag_rung_major_scheduling() {
     // far more raw/duplicate candidates on this strong recording and
     // gives a materially different order — not what's being scheduled
     // on real hardware, so not what this diagnostic should model.
-    let raw_candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
+    let raw_candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
     let refined: Vec<_> = raw_candidates
         .iter()
         .map(|c| {
@@ -3082,7 +3082,7 @@ fn stage_ablation_for_channel(channel: &str) {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return (snr_idx, [false; 4]);
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -3230,7 +3230,7 @@ fn fst4_60_diag_decode_rung_major_correctness() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
+    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -3305,7 +3305,7 @@ fn fst4_60_diag_decode_rung_major_correctness() {
                     continue;
                 };
                 let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-                let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+                let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
                 let cands: Vec<RungMajorCandidate> =
                     raw.iter()
                         .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -3366,7 +3366,7 @@ fn fst4_60_diag_rung_major_nsync_gate_count() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
+    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -3569,6 +3569,7 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
                 f32::NEG_INFINITY,
                 Some(t.freq_hz),
                 5000,
+                12_000.0,
             );
 
             // VK3NV's issue #312 cap ladder, plus `SniperRequest`'s real
@@ -3599,6 +3600,7 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
                     SNIPER_SYNC_MIN,
                     Some(t.freq_hz),
                     max_cand,
+                    12_000.0,
                 );
 
                 let t0 = Instant::now();
@@ -3703,7 +3705,7 @@ fn fst4_60_diag_rung_major_stage_timing_probe() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
+    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -3815,7 +3817,7 @@ fn fst4_60_diag_i0_retry_ccir_old_only() {
             eprintln!("trial {trial}: WAV missing, skip");
             continue;
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
 
@@ -3971,7 +3973,7 @@ fn stage_ablation_i0_offsets_for_channel(channel: &str) {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return (snr_idx, [false; 4]);
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -4118,7 +4120,7 @@ fn fst4_60_diag_i0_offset_host_timing() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
+    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -4697,7 +4699,7 @@ fn npre_baseline_for_cell(channel: &str, snr_tag: &str) -> (u32, u32) {
             continue;
         };
         present += 1;
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let mut ok = false;
         'cands: for c in cands
@@ -4915,6 +4917,7 @@ fn fst4_60_diag_sniper_cap_near_threshold() {
                             f32::NEG_INFINITY,
                             Some(GOLDEN_FREQ_HZ),
                             5000,
+                            12_000.0,
                         );
                         let gated = coarse_sync::<Fst4s60>(
                             audio,
@@ -4923,6 +4926,7 @@ fn fst4_60_diag_sniper_cap_near_threshold() {
                             SNIPER_SYNC_MIN,
                             Some(GOLDEN_FREQ_HZ),
                             max_cand,
+                            12_000.0,
                         );
 
                         let fft_cache = build_fft_cache(audio, &FST4_60A_DOWNSAMPLE);
@@ -5082,6 +5086,7 @@ fn fst4_60_diag_sniper_cap_per_trial() {
                         SNIPER_SYNC_MIN,
                         Some(GOLDEN_FREQ_HZ),
                         max_cand,
+                        12_000.0,
                     );
                     let fft_cache = build_fft_cache(audio, &FST4_60A_DOWNSAMPLE);
                     let mut decoded = false;
@@ -5170,7 +5175,7 @@ fn prepare_fst4_60_cell(
         let Some(audio) = load_wav_i16_opt(&path) else {
             continue;
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50);
+        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let mut prep = Vec::new();
         for c in cands
@@ -5613,6 +5618,7 @@ fn fst4_60_diag_dedup_zero_score_readmission() {
                     SNIPER_SYNC_MIN,
                     Some(*hint),
                     cap,
+                    12_000.0,
                 );
                 let zeros = capped.iter().filter(|c| c.score == 0.0).count();
                 let zeros_near = capped
@@ -5738,6 +5744,7 @@ fn fst4_60_diag_dedup_zero_score_recall_effect() {
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
+                12_000.0,
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -5948,6 +5955,7 @@ fn fst4_60_diag_soft_costas_margin_separation() {
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
+                12_000.0,
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -6167,6 +6175,7 @@ fn fst4_60_diag_soft_margin_escalation_priority() {
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
+                12_000.0,
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -6519,6 +6528,7 @@ fn fst4_60_diag_soft_margin_conditional_value() {
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
+                12_000.0,
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -6849,6 +6859,7 @@ fn fst4_60_diag_escalation_budget_curve() {
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
+                12_000.0,
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -7158,6 +7169,7 @@ fn fst4_60_diag_budget_curve_breadth_vs_depth() {
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
+                12_000.0,
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -7389,7 +7401,7 @@ fn fst4_coarse_sync_output_has_no_deduped_candidates() {
         ("wideband", 100.0, 3000.0, None),
     ] {
         for cap in [4usize, 16, 50, 200] {
-            let out = coarse_sync::<Fst4s60>(&audio, lo, hi, 0.8, hint, cap);
+            let out = coarse_sync::<Fst4s60>(&audio, lo, hi, 0.8, hint, cap, 12_000.0);
             let zeros = out.iter().filter(|c| c.score == 0.0).count();
             assert_eq!(
                 zeros,
@@ -7486,7 +7498,7 @@ fn fst4_phase_split_matches_rung_major_without_a_budget() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
+    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
     let cands: Vec<RungMajorCandidate> = raw
         .iter()
         .map(|c| {

--- a/mfsk-core/tests/fst4_wsjtx_samples.rs
+++ b/mfsk-core/tests/fst4_wsjtx_samples.rs
@@ -202,7 +202,7 @@ fn fst4_60_diagnose_golden() {
 
     // Cross-check against `coarse_sync` + the real decode path: is there
     // a candidate inside the golden tolerance window, and does it decode?
-    let candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.0, None, 2000);
+    let candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.0, None, 2000, 12_000.0);
     let mut in_window: Vec<&SyncCandidate> = candidates
         .iter()
         .filter(|c| {
@@ -460,7 +460,7 @@ fn fst4_bake_golden_refined_candidates() {
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
     const SYNC_Q_MIN: u32 = 16;
-    let raw_candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50);
+    let raw_candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
     eprintln!("coarse_sync: {} raw candidates", raw_candidates.len());
 
     // Refine every raw candidate, then apply dedup_refined_candidates'

--- a/mfsk-core/tests/fst4_wsjtx_samples.rs
+++ b/mfsk-core/tests/fst4_wsjtx_samples.rs
@@ -338,11 +338,15 @@ fn fst4_bake_golden_precomputed() {
     // test calls `decode_frame` directly rather than through
     // `DecodeRequest`).
     let reloaded_audio: Vec<i16> = audio_bytes
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|b| i16::from_le_bytes([b[0], b[1]]))
         .collect();
     let reloaded_cache: Vec<num_complex::Complex32> = cache_bytes
-        .chunks_exact(8)
+        .as_chunks::<8>()
+        .0
+        .iter()
         .map(|b| {
             num_complex::Complex32::new(
                 f32::from_le_bytes(b[0..4].try_into().unwrap()),

--- a/mfsk-core/tests/ft4_busy_band_fading_probe.rs
+++ b/mfsk-core/tests/ft4_busy_band_fading_probe.rs
@@ -312,7 +312,7 @@ fn diag_target_score_before_after_subtract() {
     let target_msg = pack("CQ", "DL8YHR", "JO41");
     mix_i16(&mut audio, &tone_pcm(&target_msg, 1600.0, 4_500), pad);
 
-    let d = SyncDims::of::<Ft4>();
+    let d = SyncDims::of::<Ft4>(12_000.0); // only ds_spb/ds_rate read below
     let blocks = <Ft4 as FrameLayout>::SYNC_MODE.blocks();
     let first = &blocks[0];
     let csync = make_costas_ref(first.pattern, d.ds_spb);
@@ -436,7 +436,7 @@ fn diag_seed4_why_still_missing() {
         subtract_signal_lpf(&mut residual, &rr);
     }
 
-    let d = SyncDims::of::<Ft4>();
+    let d = SyncDims::of::<Ft4>(12_000.0); // only ds_spb/ds_rate read below
     let blocks = <Ft4 as FrameLayout>::SYNC_MODE.blocks();
     let first = &blocks[0];
     let csync = make_costas_ref(first.pattern, d.ds_spb);

--- a/mfsk-core/tests/ft4_diag_low_snr.rs
+++ b/mfsk-core/tests/ft4_diag_low_snr.rs
@@ -95,7 +95,7 @@ fn why_does_neg16db_fail() {
         .with_call2("JA1ABC");
 
     let audio = make_slot(&msg, -16.0, 0xCAFE);
-    let cands = coarse_sync::<Ft4>(&audio, 800.0, 1200.0, 0.3, None, 200);
+    let cands = coarse_sync::<Ft4>(&audio, 800.0, 1200.0, 0.3, None, 200, 12_000.0);
     eprintln!("\n-16 dB signal: {} coarse candidates", cands.len());
 
     // Find the truth-proximate candidate

--- a/mfsk-core/tests/ft4_sweep.rs
+++ b/mfsk-core/tests/ft4_sweep.rs
@@ -426,7 +426,7 @@ fn ft4_diag_weak_trials() {
             let Some(audio) = load_wav_i16_opt(&path) else {
                 continue;
             };
-            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -543,7 +543,7 @@ fn ft4_diag_k4_tail_direction() {
             let Some(audio) = load_wav_i16_opt(&path) else {
                 continue;
             };
-            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
             let fft_cache = build_fft_cache(&audio, &FT4_DOWNSAMPLE);
             let ds_rate = 12_000.0 / Ft4::NDOWN as f32;
             let fec = <Ft4 as Protocol>::Fec::default();
@@ -796,7 +796,7 @@ fn ft4_diag_segment_retry() {
             let Some(audio) = load_wav_i16_opt(&path) else {
                 continue;
             };
-            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50);
+            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -953,7 +953,9 @@ fn ft4_diag_candidate_cost_split() {
         let cands = if use_new {
             ft4_coarse_sync(audio, freq_min, freq_max, sync_min, None, max_cand)
         } else {
-            coarse_sync::<Ft4>(audio, freq_min, freq_max, sync_min, None, max_cand)
+            coarse_sync::<Ft4>(
+                audio, freq_min, freq_max, sync_min, None, max_cand, 12_000.0,
+            )
         };
         let coarse_dt = t0.elapsed();
 

--- a/mfsk-core/tests/ft8_decode_block_fixed_point_baseline.rs
+++ b/mfsk-core/tests/ft8_decode_block_fixed_point_baseline.rs
@@ -47,7 +47,9 @@ fn load_wav_i16(path: &str) -> Vec<i16> {
         i += len + if len % 2 == 1 { 1 } else { 0 };
     }
     bytes[data_off..data_off + data_len]
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|b| i16::from_le_bytes([b[0], b[1]]))
         .collect()
 }

--- a/mfsk-core/tests/ft8_decode_block_streaming.rs
+++ b/mfsk-core/tests/ft8_decode_block_streaming.rs
@@ -127,7 +127,9 @@ fn load_wav_i16(path: impl AsRef<Path>) -> Vec<i16> {
         p.display()
     );
     bytes[data_off..data_off + data_len]
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|b| i16::from_le_bytes([b[0], b[1]]))
         .collect()
 }

--- a/mfsk-ffi/tests/builder_options_ffi.rs
+++ b/mfsk-ffi/tests/builder_options_ffi.rs
@@ -246,7 +246,9 @@ fn load_wav_i16(path: &str) -> Vec<i16> {
         offset = body + size + (size % 2);
     }
     let data = data.unwrap_or_else(|| panic!("{path}: missing data chunk"));
-    data.chunks_exact(2)
+    data.as_chunks::<2>()
+        .0
+        .iter()
         .map(|c| i16::from_le_bytes([c[0], c[1]]))
         .collect()
 }


### PR DESCRIPTION
Implements Stage 1 of `docs/notes/FST4_DDC_DESIGN.md`'s plan (§7): *"polyphase.rs + fir_decimate::push_block (host-only, verification 2)"*.

## What's in this PR

Also carries the prep work this stage builds on, previously pushed but never PR'd:

- `refactor(fst4): stop re-deriving ds_rate independently of the real input rate` (#323)
- `refactor(engine): thread sample_rate_hz through SyncDims/coarse_sync` (#309/#323)
- `docs(fst4): DDC design — complex analysis grid parametrized by (center, bandwidth)` — the design doc itself
- **new**: `feat(engine): rational-ratio polyphase resampler + FirStage::push_block`

## The new stage 1 work

`engine::dsp::polyphase::PolyphaseResampler` — a streaming `L`/`M` rational resampler over complex (I, Q). Implements interpolate-by-`L`/filter/decimate-by-`M` without materialising the zero-stuffed intermediate: each output is one dot product against a phase-selected, pre-reversed tap table, reusing `FirStage`'s trailing-window/compact history structure. Per design doc §4.2, a rational stage is unavoidable somewhere in the FST4 DDC chain (`NSPS = 3888 = 2^4·3^5` has no integer divisor landing on a power-of-two `nfft1`); per §4.4, only the refine stage needs it — the coarse-sync cascade stays integer-only.

`FirStage::push_block` — block-mode sibling to `push_one`, behaviourally identical but needed so a later esp-dsp-backed `FirDecimator` (stage 5, `dsps_fird_f32_aes3`) can amortise its FFI hop over a block instead of per sample. `push_one`/`wspr::ddc` unchanged.

## Verification (design doc §6, item 2 — "リサンプラ単体")

- In-band tone amplitude preserved
- Out-of-band/alias rejection (>40 dB)
- `L=1` integer ratio agrees with `FirStage` (up to the two constructors' differing startup-transient offset)
- `push_block` bit-identical to repeated `push_one`, including across a compaction boundary

All host-only; no protocol wiring yet. Merge gate (`MFSK_REQUIRE_CORPUS=1 cargo test --features full,internal-testing --release`), clippy, and the pre-commit hook (fmt/clippy -D warnings/rustdoc) all pass.

## What's next

Stages 2-5 remain (`RxGrid` + complex `compute_spectra`, `ddc.rs` coarse-sync stage, refine-stage rewire, esp-dsp backend + real hardware) — tracked in the design doc itself, stage 2 up next pending this review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)