### PR TITLE
feat(engine,fst4): FST4 DDC stages 2-4 — RxGrid, complex coarse-sync DDC, refine recentre

### DIFF
--- a/mfsk-core/src/engine/dsp/ddc.rs
+++ b/mfsk-core/src/engine/dsp/ddc.rs
@@ -1,0 +1,295 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! Generic complex digital down-converter: real PCM at an arbitrary
+//! centre frequency → complex baseband, streaming.
+//!
+//! `docs/notes/FST4_DDC_DESIGN.md` §4.3. Composes three pieces this
+//! crate already has, none of them protocol-specific:
+//!
+//! ```text
+//! real i16 @ input_rate
+//!   → Mixer (exp(-j2π·center·n/Fs))                    → complex @ input_rate
+//!   → FirStage cascade (loose filter, integer decimate)  → complex @ input_rate/D
+//!   → PolyphaseResampler (sharp filter, final stage)      → complex @ Fs_c
+//! ```
+//!
+//! The sharp filter sits last (lowest rate), same reasoning
+//! `wspr::ddc`'s own two-stage cascade documents: a single-stage filter's
+//! MAC count is set by the transition-band ratio alone, independent of
+//! how much decimation happens, so pushing the narrow-transition work
+//! to the cheapest (lowest) rate is what makes a cascade pay for
+//! itself. Unlike `wspr::ddc` (fixed 1500 Hz centre, `Fs/32` target,
+//! integer-only), this module's centre frequency and target rate are
+//! both caller-supplied — `fst4::ddc` is the first caller, picking
+//! `(center_hz, K)` per search shape (sniper vs. wideband) and
+//! deriving the cascade split from it.
+//!
+//! [`wspr::ddc`]: crate::wspr::ddc
+
+use alloc::vec::Vec;
+
+use num_complex::Complex;
+#[cfg(not(feature = "std"))]
+use num_traits::Float;
+
+use super::fir_decimate::FirStage;
+use super::polyphase::PolyphaseResampler;
+
+/// Samples between phasor renormalisations — see [`Mixer`]'s doc
+/// comment.
+const RENORM_PERIOD: u32 = 4096;
+
+/// Streaming complex mixer, `exp(-j2π·center_hz·n/Fs)`.
+///
+/// A rotating-phasor NCO (`cur *= step` each sample) rather than a
+/// per-sample `sin`/`cos` call — `wspr::ddc`'s own mixer avoids that
+/// too, but does it with a period-8 lookup table because its centre
+/// frequency (1500 Hz) is always exactly `Fs/8`. This module's centre
+/// is caller-supplied and generally irrational relative to `Fs`, so no
+/// finite table applies; the rotation recurrence is the general form
+/// of the same idea. Rotation error accumulates every multiply, so
+/// `cur` is renormalised to unit magnitude every [`RENORM_PERIOD`]
+/// samples — cheap (one `sqrt` per period) and bounds the drift a long
+/// FST4 slot (thousands of samples) would otherwise accumulate.
+struct Mixer {
+    step: Complex<f32>,
+    cur: Complex<f32>,
+    since_renorm: u32,
+}
+
+impl Mixer {
+    fn new(center_hz: f32, sample_rate_hz: f32) -> Self {
+        let dphi = -2.0 * core::f32::consts::PI * center_hz / sample_rate_hz;
+        Self {
+            step: Complex::new(dphi.cos(), dphi.sin()),
+            cur: Complex::new(1.0, 0.0),
+            since_renorm: 0,
+        }
+    }
+
+    #[inline]
+    fn mix(&mut self, x: f32) -> (f32, f32) {
+        let out = (x * self.cur.re, x * self.cur.im);
+        self.cur *= self.step;
+        self.since_renorm += 1;
+        if self.since_renorm >= RENORM_PERIOD {
+            let mag = (self.cur.re * self.cur.re + self.cur.im * self.cur.im).sqrt();
+            if mag > 0.0 {
+                self.cur.re /= mag;
+                self.cur.im /= mag;
+            }
+            self.since_renorm = 0;
+        }
+        out
+    }
+}
+
+/// One integer FirStage cascade link: `(ntaps, decim, fc_norm)` —
+/// `fc_norm` normalised to *this stage's own input rate*, matching
+/// [`FirStage::new`]'s own parameter.
+pub type IntStageSpec = (usize, usize, f32);
+
+/// Cascade recipe: mixer centre/rate, an integer `FirStage` chain
+/// (loose filters, cheap — may be empty, e.g. `fst4::ddc`'s wideband
+/// config), and a final rational [`PolyphaseResampler`] stage
+/// (`(l, m, ntaps)`) carrying the real passband/stopband requirement.
+#[derive(Clone)]
+pub struct DdcCascadeConfig {
+    pub center_hz: f32,
+    pub input_rate_hz: f32,
+    pub int_stages: Vec<IntStageSpec>,
+    pub resampler: (u32, u32, usize),
+    /// `hist_margin` passed to every stage's constructor (both
+    /// `FirStage` and `PolyphaseResampler` take one).
+    pub hist_margin: usize,
+}
+
+/// Streaming instance built from a [`DdcCascadeConfig`].
+pub struct StreamingComplexDdc {
+    mixer: Mixer,
+    int_stages: Vec<FirStage>,
+    resampler: PolyphaseResampler,
+    /// Conservative total group delay, in *original* (mixer-input-rate)
+    /// samples — see [`Self::flush`].
+    flush_zeros: usize,
+}
+
+impl StreamingComplexDdc {
+    pub fn new(cfg: &DdcCascadeConfig) -> Self {
+        let mixer = Mixer::new(cfg.center_hz, cfg.input_rate_hz);
+        let int_stages = cfg
+            .int_stages
+            .iter()
+            .map(|&(ntaps, decim, fc_norm)| FirStage::new(ntaps, decim, fc_norm, cfg.hist_margin))
+            .collect();
+        let (l, m, ntaps) = cfg.resampler;
+        let resampler = PolyphaseResampler::new(l, m, ntaps, cfg.hist_margin);
+
+        // Total group delay, converted to original-input-rate samples
+        // one stage at a time: a stage's own `(ntaps-1)/2` is in its
+        // *own* input samples, so it's scaled up by every upstream
+        // decimation factor before accumulating (mirrors
+        // `wspr::ddc::StreamingDdcCascade::flush`'s single-stage
+        // version of the same idea, generalised to N stages plus a
+        // rational tail). The resampler's own delay uses `l` in place
+        // of an integer `decim` — `(ntaps-1)/2` there is measured at
+        // the *upsampled* (`L`×) domain, so dividing by `l` converts
+        // it back to the resampler's own input-rate samples, same
+        // derivation as [`PolyphaseResampler::group_delay_output`]
+        // but stopping one conversion step earlier (input-rate, not
+        // output-rate). Truncating (not rounding) integer division
+        // makes this an underestimate by at most a handful of
+        // samples per stage — harmless for `flush`'s purpose (letting
+        // transients clear before `compute_spectra` reads the tail),
+        // not a precision the caller should rely on for exact timing.
+        let mut scale = 1usize;
+        let mut delay = 0usize;
+        for &(stage_ntaps, decim, _) in &cfg.int_stages {
+            delay += ((stage_ntaps - 1) / 2) * scale;
+            scale *= decim;
+        }
+        delay += (((ntaps - 1) / 2) / l as usize) * scale;
+
+        Self {
+            mixer,
+            int_stages,
+            resampler,
+            flush_zeros: delay + 1,
+        }
+    }
+
+    /// Push one real sample through mixer → integer cascade → final
+    /// resampler, appending any complex baseband samples this push
+    /// completes.
+    pub fn push_one(&mut self, x: f32, out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
+        let (mut i, mut q) = self.mixer.mix(x);
+        for stage in &mut self.int_stages {
+            match stage.push_one(i, q) {
+                Some((si, sq)) => {
+                    i = si;
+                    q = sq;
+                }
+                None => return,
+            }
+        }
+        self.resampler.push(i, q, out_i, out_q);
+    }
+
+    /// Push a block of `i16` PCM.
+    pub fn push_i16(&mut self, audio: &[i16], out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
+        for &s in audio {
+            self.push_one(s as f32, out_i, out_q);
+        }
+    }
+
+    /// Flush the tail: feed `flush_zeros`-worth of zero input samples
+    /// through the whole cascade so the last real input reaches the
+    /// centre of every filter — see that field's doc comment in
+    /// [`Self::new`] for the delay derivation.
+    pub fn flush(&mut self, out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
+        for _ in 0..self.flush_zeros {
+            self.push_one(0.0, out_i, out_q);
+        }
+    }
+}
+
+/// Block-mode convenience: run a whole buffer through a fresh
+/// [`StreamingComplexDdc`] and return `(i, q)`. For host tests and
+/// non-streaming callers — the streaming `push_one`/`push_i16` API is
+/// what an embedded, capture-time-interleaved caller would use.
+pub fn ddc_block(audio: &[i16], cfg: &DdcCascadeConfig) -> (Vec<f32>, Vec<f32>) {
+    let mut ddc = StreamingComplexDdc::new(cfg);
+    let mut out_i = Vec::new();
+    let mut out_q = Vec::new();
+    ddc.push_i16(audio, &mut out_i, &mut out_q);
+    ddc.flush(&mut out_i, &mut out_q);
+    (out_i, out_q)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tone(freq_hz: f32, fs_hz: f32, amp: f32, n: usize) -> Vec<i16> {
+        let w = 2.0 * core::f64::consts::PI * freq_hz as f64 / fs_hz as f64;
+        (0..n)
+            .map(|k| (amp as f64 * 32767.0 * (w * k as f64).cos()) as i16)
+            .collect()
+    }
+
+    /// A single-stage cascade (no integer pre-decimation) centred on a
+    /// tone: the tone lands at DC in the complex output, positive
+    /// audio offset giving positive baseband frequency (same
+    /// convention `wspr::ddc`'s own equivalent test documents).
+    #[test]
+    fn centre_tone_lands_near_dc() {
+        let fs_in = 12_000.0f32;
+        let center = 1500.0f32;
+        let cfg = DdcCascadeConfig {
+            center_hz: center,
+            input_rate_hz: fs_in,
+            int_stages: Vec::new(),
+            resampler: (64, 243, 4001), // matches fst4::ddc's wideband shape
+            hist_margin: 512,
+        };
+        let n = 96_000;
+        let audio = tone(center, fs_in, 0.5, n);
+        let (i, q) = ddc_block(&audio, &cfg);
+
+        let settle = i.len() / 4;
+        let span = settle..(i.len() - settle);
+        let (mut si, mut sq, mut cnt) = (0.0f64, 0.0f64, 0usize);
+        for k in span {
+            si += i[k] as f64;
+            sq += q[k] as f64;
+            cnt += 1;
+        }
+        let (mi, mq) = (si / cnt as f64, sq / cnt as f64);
+        let mag = (mi * mi + mq * mq).sqrt();
+        assert!(mag > 0.05, "centre tone magnitude too small: {mag}");
+        // DC in the complex output means the phase barely rotates
+        // sample to sample over the settled span — check the first
+        // and last sample in the span keep the same phase sign
+        // structure rather than asserting an exact ratio (amplitude
+        // scale isn't calibrated here, unlike `wspr::ddc::
+        // REFERENCE_GAIN` — this cascade has no reference to match).
+        assert!(mi.abs() > mag * 0.3 || mq.abs() > mag * 0.3);
+    }
+
+    /// An offset tone becomes a rotating phasor at the offset,
+    /// measured the same way `wspr::ddc`'s own offset-tone test does.
+    #[test]
+    fn offset_tone_rotates_at_the_offset() {
+        let fs_in = 12_000.0f32;
+        let center = 1500.0f32;
+        let offset = 40.0f32;
+        let cfg = DdcCascadeConfig {
+            center_hz: center,
+            input_rate_hz: fs_in,
+            int_stages: Vec::new(),
+            resampler: (64, 243, 4001),
+            hist_margin: 512,
+        };
+        let n = 96_000;
+        let audio = tone(center + offset, fs_in, 0.5, n);
+        let (i, q) = ddc_block(&audio, &cfg);
+        let fs_out = fs_in * 64.0 / 243.0;
+
+        let settle = i.len() / 4;
+        let a = settle;
+        let b = i.len() - settle;
+        let ph = |k: usize| q[k].atan2(i[k]);
+        let mut d = ph(b) - ph(a);
+        let expect_total = 2.0 * core::f32::consts::PI * offset * (b - a) as f32 / fs_out;
+        while d - expect_total > core::f32::consts::PI {
+            d -= 2.0 * core::f32::consts::PI;
+        }
+        while expect_total - d > core::f32::consts::PI {
+            d += 2.0 * core::f32::consts::PI;
+        }
+        let measured_hz = d / (2.0 * core::f32::consts::PI) * fs_out / (b - a) as f32;
+        assert!(
+            (measured_hz - offset).abs() < 1.0,
+            "measured {measured_hz} Hz, expected {offset}"
+        );
+    }
+}

--- a/mfsk-core/src/engine/dsp/ddc.rs
+++ b/mfsk-core/src/engine/dsp/ddc.rs
@@ -50,14 +50,14 @@ const RENORM_PERIOD: u32 = 4096;
 /// `cur` is renormalised to unit magnitude every [`RENORM_PERIOD`]
 /// samples — cheap (one `sqrt` per period) and bounds the drift a long
 /// FST4 slot (thousands of samples) would otherwise accumulate.
-struct Mixer {
+pub(crate) struct Mixer {
     step: Complex<f32>,
     cur: Complex<f32>,
     since_renorm: u32,
 }
 
 impl Mixer {
-    fn new(center_hz: f32, sample_rate_hz: f32) -> Self {
+    pub(crate) fn new(center_hz: f32, sample_rate_hz: f32) -> Self {
         let dphi = -2.0 * core::f32::consts::PI * center_hz / sample_rate_hz;
         Self {
             step: Complex::new(dphi.cos(), dphi.sin()),
@@ -66,9 +66,10 @@ impl Mixer {
         }
     }
 
+    /// Advance the phasor one sample and renormalise on schedule —
+    /// the part [`Self::mix`]/[`Self::mix_complex`] share.
     #[inline]
-    fn mix(&mut self, x: f32) -> (f32, f32) {
-        let out = (x * self.cur.re, x * self.cur.im);
+    fn advance(&mut self) {
         self.cur *= self.step;
         self.since_renorm += 1;
         if self.since_renorm >= RENORM_PERIOD {
@@ -79,6 +80,30 @@ impl Mixer {
             }
             self.since_renorm = 0;
         }
+    }
+
+    /// Mix one real input sample.
+    #[inline]
+    pub(crate) fn mix(&mut self, x: f32) -> (f32, f32) {
+        let out = (x * self.cur.re, x * self.cur.im);
+        self.advance();
+        out
+    }
+
+    /// Mix one complex input sample — for re-centring an
+    /// already-complex baseband (`fst4::ddc`'s refine stage: the
+    /// coarse DDC baseband still spans a whole search window around
+    /// one `center_hz`, and pulling a specific candidate's own
+    /// zero-frequency baseband out of it needs a second,
+    /// per-candidate complex mix). `(i+jq)·cur`, same phasor as
+    /// [`Self::mix`].
+    #[inline]
+    pub(crate) fn mix_complex(&mut self, i: f32, q: f32) -> (f32, f32) {
+        let out = (
+            i * self.cur.re - q * self.cur.im,
+            i * self.cur.im + q * self.cur.re,
+        );
+        self.advance();
         out
     }
 }
@@ -157,6 +182,19 @@ impl StreamingComplexDdc {
         }
     }
 
+    /// This cascade's own estimated group delay, in *original*
+    /// (mixer-input-rate) samples — the same conservative estimate
+    /// [`Self::flush`] uses, exposed so a caller chaining more DSP
+    /// after this cascade's output (e.g. `fst4::ddc`'s refine-stage
+    /// resampler) can account for it rather than treating this
+    /// cascade's sample 0 as if it carried no delay at all. Per
+    /// [`Self::new`]'s derivation this is an *underestimate* by up to
+    /// a handful of samples per stage — not a precision to build exact
+    /// timing on without a dedicated alignment pass.
+    pub fn group_delay_input_samples(&self) -> usize {
+        self.flush_zeros.saturating_sub(1)
+    }
+
     /// Push one real sample through mixer → integer cascade → final
     /// resampler, appending any complex baseband samples this push
     /// completes.
@@ -188,6 +226,77 @@ impl StreamingComplexDdc {
     pub fn flush(&mut self, out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
         for _ in 0..self.flush_zeros {
             self.push_one(0.0, out_i, out_q);
+        }
+    }
+}
+
+/// Re-centre and further decimate an already-complex baseband —
+/// [`StreamingComplexDdc`]'s sibling for a second, per-candidate
+/// down-conversion stage on top of a first cascade's output (`fst4::
+/// ddc`'s refine stage: the coarse DDC baseband still spans a whole
+/// search window around one `center_hz`; recovering a specific
+/// candidate's own zero-frequency baseband — what a Costas correlator
+/// like [`crate::engine::sync::fine_sync_power`] assumes — needs this).
+/// Same shape as `StreamingComplexDdc` minus the real-input step
+/// (input is already complex) and the integer-cascade support (no
+/// caller needs one yet).
+pub struct StreamingComplexRecenter {
+    mixer: Mixer,
+    resampler: PolyphaseResampler,
+    flush_zeros: usize,
+}
+
+impl StreamingComplexRecenter {
+    /// `center_hz` here is relative to the *input* baseband's own
+    /// zero (i.e. the offset still present after the first DDC stage,
+    /// not an absolute audio frequency) — the candidate frequency
+    /// this stage should pull down to DC.
+    pub fn new(
+        center_hz: f32,
+        input_rate_hz: f32,
+        l: u32,
+        m: u32,
+        ntaps: usize,
+        hist_margin: usize,
+    ) -> Self {
+        let mixer = Mixer::new(center_hz, input_rate_hz);
+        let resampler = PolyphaseResampler::new(l, m, ntaps, hist_margin);
+        let delay = ((ntaps - 1) / 2) / l as usize;
+        Self {
+            mixer,
+            resampler,
+            flush_zeros: delay + 1,
+        }
+    }
+
+    /// This stage's own estimated group delay, in its *input*
+    /// (already-complex-baseband-rate) samples — same caveat as
+    /// [`StreamingComplexDdc::group_delay_input_samples`].
+    pub fn group_delay_input_samples(&self) -> usize {
+        self.flush_zeros.saturating_sub(1)
+    }
+
+    /// This stage's own group delay in its *output* samples — see
+    /// [`PolyphaseResampler::group_delay_output`], which this
+    /// forwards.
+    pub fn group_delay_output_samples(&self) -> usize {
+        self.resampler.group_delay_output()
+    }
+
+    pub fn push_one(&mut self, i: f32, q: f32, out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
+        let (mi, mq) = self.mixer.mix_complex(i, q);
+        self.resampler.push(mi, mq, out_i, out_q);
+    }
+
+    pub fn push(&mut self, xi: &[f32], xq: &[f32], out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
+        for (&i, &q) in xi.iter().zip(xq.iter()) {
+            self.push_one(i, q, out_i, out_q);
+        }
+    }
+
+    pub fn flush(&mut self, out_i: &mut Vec<f32>, out_q: &mut Vec<f32>) {
+        for _ in 0..self.flush_zeros {
+            self.push_one(0.0, 0.0, out_i, out_q);
         }
     }
 }

--- a/mfsk-core/src/engine/dsp/mod.rs
+++ b/mfsk-core/src/engine/dsp/mod.rs
@@ -10,6 +10,7 @@
 // once we have alloc.
 #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub mod analytic;
+pub mod ddc;
 #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub mod downsample;
 pub mod envelope;

--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -24,7 +24,7 @@ use super::llr::{
     sync_quality,
 };
 use super::protocol::BpPooledFec;
-use super::sync::{SyncCandidate, coarse_sync, fine_sync_power_per_block};
+use super::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync, fine_sync_power_per_block};
 use super::tx::codeword_to_itone;
 use super::{FecCodec, FecOpts, MessageCodec, Protocol};
 
@@ -1710,7 +1710,13 @@ where
         super::ft4_coarse::ft4_coarse_sync(audio, freq_min, freq_max, sync_min, freq_hint, max_cand)
     } else {
         coarse_sync::<P>(
-            audio, freq_min, freq_max, sync_min, freq_hint, max_cand, 12_000.0,
+            AudioSource::Real(audio),
+            freq_min,
+            freq_max,
+            sync_min,
+            freq_hint,
+            max_cand,
+            RxGrid::real(12_000.0),
         )
     };
     #[cfg(feature = "std")]
@@ -1987,13 +1993,13 @@ where
             )
         } else {
             coarse_sync::<P>(
-                &residual,
+                AudioSource::Real(&residual),
                 freq_min,
                 freq_max,
                 sync_min * factor,
                 freq_hint,
                 max_cand,
-                12_000.0,
+                RxGrid::real(12_000.0),
             )
         };
         #[cfg(feature = "std")]

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -180,6 +180,110 @@ impl SyncDims {
     }
 }
 
+/// Analysis-grid descriptor: the bin↔Hz mapping [`compute_spectra`] and
+/// [`coarse_sync`] use, in one place.
+///
+/// `docs/notes/FST4_DDC_DESIGN.md` §4.1 — VK3NV's `RxAnalysisDescriptor`.
+/// Two grids exist:
+///
+/// - **Real** (`center_hz: 0.0, complex_input: false`): today's 12 kHz
+///   real-PCM path. `bin_of` is a plain `hz/df`; `usable_bins` is
+///   [`SyncDims::nh1`], the positive-frequency half a real FFT gives.
+///   Every existing caller uses this grid, and its numbers are
+///   unchanged bit-for-bit from before `RxGrid` existed — the
+///   non-regression bar `docs/notes/FST4_DDC_DESIGN.md` §6 item 1 sets.
+/// - **Complex** (`complex_input: true`): a DDC-fed complex baseband
+///   grid parametrised by `(center_hz, sample_rate_hz)`, covering both
+///   the wideband scan and the sniper shape with one mechanism.
+///   `compute_spectra` stores this grid's spectrogram **fftshifted**,
+///   so `bin_of` stays a monotonic affine map (`(hz-center)/df +
+///   nfft1/2`) and [`coarse_sync`]'s correlation loop — which only
+///   ever adds an offset to a bin index — needs no change to consume
+///   it; see that fftshift-on-store reasoning in this type's own
+///   `bin_of`/`usable_bins` doc comments.
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub struct RxGrid {
+    /// The rate `audio` fed to [`compute_spectra`]/[`coarse_sync`] is
+    /// actually at.
+    pub sample_rate_hz: f32,
+    /// Down-conversion centre frequency, Hz. `0.0` for the real path
+    /// (DC-referenced, matching today's 12 kHz real-PCM ingest).
+    pub center_hz: f32,
+    /// `false`: real PCM, positive-frequency-only spectrum (today's
+    /// path). `true`: complex I/Q baseband, full fftshifted spectrum
+    /// centred on `center_hz`.
+    pub complex_input: bool,
+}
+
+impl RxGrid {
+    /// The real, DC-referenced grid every caller uses today.
+    pub fn real(sample_rate_hz: f32) -> Self {
+        Self {
+            sample_rate_hz,
+            center_hz: 0.0,
+            complex_input: false,
+        }
+    }
+
+    /// A DDC-fed complex baseband grid centred on `center_hz`.
+    pub fn complex(sample_rate_hz: f32, center_hz: f32) -> Self {
+        Self {
+            sample_rate_hz,
+            center_hz,
+            complex_input: true,
+        }
+    }
+
+    /// Absolute FFT bin index a frequency `hz` maps to in this grid's
+    /// spectrogram, given `d`'s `nfft1`/`df` (from
+    /// `SyncDims::of::<P>(self.sample_rate_hz)`).
+    ///
+    /// Real grid: `hz/df`, unmodified from `coarse_sync`'s pre-`RxGrid`
+    /// arithmetic. Complex grid: `(hz-center)/df + nfft1/2` — the
+    /// fftshifted bin `compute_spectra`'s complex path actually stores
+    /// at, so this and `usable_bins` are the only two call sites
+    /// `coarse_sync` needs to change to consume either grid; its
+    /// correlation loop body (`abs_bin = i + nfos*k`) stays untouched.
+    #[inline]
+    pub fn bin_of(&self, d: &SyncDims, hz: f32) -> usize {
+        if self.complex_input {
+            (((hz - self.center_hz) / d.df) + d.nfft1 as f32 / 2.0).round() as usize
+        } else {
+            (hz / d.df).round() as usize
+        }
+    }
+
+    /// Number of usable bins in this grid's spectrogram — the bound
+    /// every `coarse_sync`/`compute_spectra` clamp against `d.nh1`
+    /// used before `RxGrid` existed.
+    ///
+    /// Real grid: `d.nh1` (`nfft1/2`, the positive-frequency half a
+    /// real-input FFT gives — anything above is the mirrored negative
+    /// half and never valid to read). Complex grid: `d.nfft1` (the
+    /// full fftshifted spectrum is meaningful, since a complex FFT's
+    /// negative-frequency bins carry real information — content below
+    /// `center_hz`).
+    #[inline]
+    pub fn usable_bins(&self, d: &SyncDims) -> usize {
+        if self.complex_input { d.nfft1 } else { d.nh1 }
+    }
+}
+
+/// The samples [`compute_spectra`]/[`coarse_sync`] analyse: real 12 kHz
+/// PCM (today's path) or a DDC-fed complex baseband I/Q pair.
+///
+/// `Copy`/`Clone` (both variants are just slice references) so callers
+/// can pass one value into `coarse_sync`, which forwards it into
+/// `compute_spectra` unchanged.
+#[derive(Copy, Clone)]
+pub enum AudioSource<'a> {
+    /// Real PCM, paired with [`RxGrid::real`].
+    Real(&'a [i16]),
+    /// Complex baseband (I, Q), paired with [`RxGrid::complex`]. Both
+    /// slices must be the same length.
+    Complex(&'a [f32], &'a [f32]),
+}
+
 // ──────────────────────────────────────────────────────────────────────────
 // Coarse sync
 // ──────────────────────────────────────────────────────────────────────────
@@ -292,18 +396,31 @@ pub(crate) fn nuttall_window(n: usize) -> Vec<f32> {
 /// mask weak signals); FT8 stays on `Rectangular` (its synth-roundtrip
 /// path is calibrated against rectangular).
 ///
-/// `sample_rate_hz`: the rate `audio` is actually sampled at —
-/// `12_000.0` for every caller today (issue #323/#309; see
-/// [`SyncDims::of`]'s doc). Not yet reachable from a DDC-fed front end;
-/// threaded through now so wiring one up later is a call-site change,
-/// not a rediscovery of this function's own rate assumption.
+/// `grid`: the rate and (for a complex `audio`) down-conversion centre
+/// [`AudioSource`] is actually at — [`RxGrid::real`] for every caller
+/// today (issue #323/#309; see [`SyncDims::of`]'s doc). The complex
+/// path isn't yet reachable from a real DDC front end (that's
+/// `docs/notes/FST4_DDC_DESIGN.md` stage 3); wiring one up later is a
+/// call-site change, not a rediscovery of this function's rate/centre
+/// assumptions.
+///
+/// [`AudioSource::Real`] behaves exactly as before `RxGrid`/
+/// `AudioSource` existed: bins are read straight off the FFT output,
+/// no shift. [`AudioSource::Complex`] stores **fftshifted** — raw FFT
+/// bin `k` (standard convention: `k < nfft1/2` positive frequencies,
+/// `k >= nfft1/2` negative, wrapped) is written to
+/// `(k + nfft1/2) % nfft1`, which is exactly [`RxGrid::bin_of`]'s
+/// complex-grid formula inverted. That keeps the stored frequency axis
+/// monotonic, which is the whole reason `coarse_sync`'s correlation
+/// loop needs no change to read either grid — see `RxGrid`'s own doc
+/// comment.
 pub fn compute_spectra<P: Protocol>(
-    audio: &[i16],
+    audio: AudioSource,
     bin_lo: usize,
     bin_hi_incl: usize,
-    sample_rate_hz: f32,
+    grid: RxGrid,
 ) -> Spectrogram {
-    let d = SyncDims::of::<P>(sample_rate_hz);
+    let d = SyncDims::of::<P>(grid.sample_rate_hz);
     let fac = 1.0f32 / 300.0;
     let mut planner = default_planner();
     let fft = planner.plan_forward(d.nfft1);
@@ -313,8 +430,9 @@ pub fn compute_spectra<P: Protocol>(
         SpectrumWindow::Nuttall4 => Some(nuttall_window(d.nsps)),
     };
 
-    let bin_lo = bin_lo.min(d.nh1.saturating_sub(1));
-    let bin_hi_incl = bin_hi_incl.min(d.nh1.saturating_sub(1)).max(bin_lo);
+    let usable = grid.usable_bins(&d);
+    let bin_lo = bin_lo.min(usable.saturating_sub(1));
+    let bin_hi_incl = bin_hi_incl.min(usable.saturating_sub(1)).max(bin_lo);
     let n_freq = bin_hi_incl - bin_lo + 1;
 
     let mut data = vec![0.0f32; n_freq * d.nhsym];
@@ -324,23 +442,46 @@ pub fn compute_spectra<P: Protocol>(
         let ia = j * d.nstep;
         for (k, c) in buf.iter_mut().enumerate() {
             *c = if k < d.nsps {
-                let sample = if ia + k < audio.len() {
-                    let raw = audio[ia + k] as f32 * fac;
-                    match &window {
-                        Some(w) => raw * w[k],
-                        None => raw,
+                match audio {
+                    AudioSource::Real(pcm) => {
+                        let sample = if ia + k < pcm.len() {
+                            let raw = pcm[ia + k] as f32 * fac;
+                            match &window {
+                                Some(w) => raw * w[k],
+                                None => raw,
+                            }
+                        } else {
+                            0.0
+                        };
+                        Complex::new(sample, 0.0)
                     }
-                } else {
-                    0.0
-                };
-                Complex::new(sample, 0.0)
+                    AudioSource::Complex(xi, xq) => {
+                        if ia + k < xi.len() {
+                            let (mut si, mut sq) = (xi[ia + k], xq[ia + k]);
+                            if let Some(w) = &window {
+                                si *= w[k];
+                                sq *= w[k];
+                            }
+                            Complex::new(si, sq)
+                        } else {
+                            Complex::new(0.0, 0.0)
+                        }
+                    }
+                }
             } else {
                 Complex::new(0.0, 0.0)
             };
         }
         fft.process(&mut buf);
-        for i in bin_lo..=bin_hi_incl {
-            data[(i - bin_lo) * d.nhsym + j] = buf[i].norm_sqr();
+        if grid.complex_input {
+            for shifted in bin_lo..=bin_hi_incl {
+                let k = (shifted + d.nfft1 / 2) % d.nfft1;
+                data[(shifted - bin_lo) * d.nhsym + j] = buf[k].norm_sqr();
+            }
+        } else {
+            for i in bin_lo..=bin_hi_incl {
+                data[(i - bin_lo) * d.nhsym + j] = buf[i].norm_sqr();
+            }
         }
     }
 
@@ -379,28 +520,39 @@ pub fn compute_spectra<P: Protocol>(
 /// `engine/pipeline.rs` and `msg/pipeline_ap.rs` calls this generic
 /// function with a non-FST4/FT4 protocol).
 ///
-/// `sample_rate_hz`: the rate `audio` is actually sampled at —
-/// `12_000.0` for every caller today (issue #323/#309; see
-/// [`SyncDims::of`]'s doc). Not yet reachable from a DDC-fed front end;
-/// threaded through now so wiring one up later is a call-site change,
-/// not a rediscovery of this function's own rate assumption.
+/// `grid`: the rate and (for a complex `audio`) down-conversion centre
+/// [`AudioSource`] is actually at — [`RxGrid::real`] for every caller
+/// today (issue #323/#309; see [`SyncDims::of`]'s doc). The complex
+/// path isn't yet reachable from a real DDC front end (that's
+/// `docs/notes/FST4_DDC_DESIGN.md` stage 3); wiring one up later is a
+/// call-site change, not a rediscovery of this function's rate/centre
+/// assumptions. `ia`/`ib` and every `nh1`-shaped clamp below go
+/// through [`RxGrid::bin_of`]/[`RxGrid::usable_bins`] — the only two
+/// places this function's logic depends on which grid it's reading;
+/// the correlation loop itself (`abs_bin = i + nfos*k`) is unchanged
+/// either way, since [`compute_spectra`]'s complex path already
+/// stores its spectrogram on a monotonic bin axis (see that function's
+/// own doc comment).
 pub fn coarse_sync<P: Protocol>(
-    audio: &[i16],
+    audio: AudioSource,
     freq_min: f32,
     freq_max: f32,
     sync_min: f32,
     freq_hint: Option<f32>,
     max_cand: usize,
-    sample_rate_hz: f32,
+    grid: RxGrid,
 ) -> Vec<SyncCandidate> {
-    let d = SyncDims::of::<P>(sample_rate_hz);
+    let d = SyncDims::of::<P>(grid.sample_rate_hz);
     let ntones = P::NTONES as usize;
     let pattern_len = P::SYNC_MODE.blocks()[0].pattern.len();
+    let usable = grid.usable_bins(&d);
 
     // Leave room for NTONES-1 tones above the candidate bin.
-    let ia = (freq_min / d.df).round() as usize;
+    let ia = grid.bin_of(&d, freq_min);
     let headroom = d.nfos * (ntones - 1) + 1;
-    let ib = ((freq_max / d.df).round() as usize).min(d.nh1.saturating_sub(headroom));
+    let ib = grid
+        .bin_of(&d, freq_max)
+        .min(usable.saturating_sub(headroom));
     if ib < ia {
         return Vec::new();
     }
@@ -413,8 +565,8 @@ pub fn coarse_sync<P: Protocol>(
     let s = compute_spectra::<P>(
         audio,
         ia,
-        (ib + headroom).min(d.nh1.saturating_sub(1)),
-        sample_rate_hz,
+        (ib + headroom).min(usable.saturating_sub(1)),
+        grid,
     );
 
     let n_freq = ib - ia + 1;
@@ -457,12 +609,12 @@ pub fn coarse_sync<P: Protocol>(
                     for (n, &costas_n) in block.pattern.iter().enumerate() {
                         let m = lag + d.jstrt + block_offset + (d.nssy * n) as i32;
                         let tone_bin = i + d.nfos * costas_n as usize;
-                        if m >= 0 && (m as usize) < d.nhsym && tone_bin < d.nh1 {
+                        if m >= 0 && (m as usize) < d.nhsym && tone_bin < usable {
                             let m = m as usize;
                             t_blocks[bk] += s.get(tone_bin, m);
                             // Reference: sum over all NTONES tones at this time slot.
                             t0_blocks[bk] += (0..ntones)
-                                .map(|k| s.get((i + d.nfos * k).min(d.nh1 - 1), m))
+                                .map(|k| s.get((i + d.nfos * k).min(usable - 1), m))
                                 .sum::<f32>();
                         }
                     }
@@ -601,7 +753,7 @@ pub fn coarse_sync<P: Protocol>(
         let avg_power = s.avg_power_per_bin();
         // `avg_power` is offset-relative (indexed from `s.freq_offset()`,
         // not an absolute bin) — see `Spectrogram::avg_power_per_bin`'s
-        // doc comment. The `.min(d.nh1 - 1)` clamp is still against the
+        // doc comment. The `.min(usable - 1)` clamp is still against the
         // *absolute* full-band bound (matches `coarse_sync`'s own
         // `headroom` derivation, which sizes the crop to always cover
         // this read), so the offset subtraction happens last.
@@ -610,7 +762,7 @@ pub fn coarse_sync<P: Protocol>(
                 let i = ia + fi;
                 (0..ntones)
                     .map(|k| {
-                        let abs_bin = (i + d.nfos * k).min(d.nh1 - 1);
+                        let abs_bin = (i + d.nfos * k).min(usable - 1);
                         avg_power[(abs_bin - s.freq_offset()).min(avg_power.len() - 1)]
                     })
                     .sum()
@@ -1056,7 +1208,7 @@ pub fn refine_candidate<P: Protocol>(
 
 #[cfg(all(test, feature = "fst4", feature = "ft4"))]
 mod tests {
-    use super::{Protocol, SyncDims};
+    use super::{AudioSource, PI, Protocol, RxGrid, SyncDims, compute_spectra};
     use crate::engine::protocol::ModulationParams;
     use crate::fst4::{Fst4s15, Fst4s30, Fst4s60, Fst4s120, Fst4s300};
     use crate::ft4::Ft4;
@@ -1086,5 +1238,64 @@ mod tests {
         check::<Fst4s120>("Fst4s120");
         check::<Fst4s300>("Fst4s300");
         check::<Ft4>("Ft4");
+    }
+
+    /// `RxGrid::real`'s `bin_of`/`usable_bins` must reproduce, bit for
+    /// bit, the inline `(hz/df).round() as usize` / `d.nh1` arithmetic
+    /// `coarse_sync`/`compute_spectra` used before `RxGrid` existed —
+    /// `docs/notes/FST4_DDC_DESIGN.md` §6 item 1's non-regression bar,
+    /// pinned the same way `sync_dims_of_matches_nsps_at_12khz` pins
+    /// `SyncDims::of`'s own refactor.
+    #[test]
+    fn rx_grid_real_matches_pre_rxgrid_bin_math() {
+        let d = SyncDims::of::<Fst4s60>(12_000.0);
+        let grid = RxGrid::real(12_000.0);
+        for hz in [0.0f32, 100.0, 1500.0, 2963.34, 3000.0] {
+            let want = (hz / d.df).round() as usize;
+            assert_eq!(grid.bin_of(&d, hz), want, "hz={hz}");
+        }
+        assert_eq!(grid.usable_bins(&d), d.nh1);
+    }
+
+    /// A complex DDC-fed grid's `compute_spectra` path stores its
+    /// spectrogram fftshifted so `RxGrid::bin_of`'s complex formula
+    /// predicts where a tone lands — including a tone *below*
+    /// `center_hz` (negative baseband frequency), which is the half
+    /// the fftshift-on-store scheme exists to keep monotonic (see
+    /// `RxGrid`'s and `compute_spectra`'s own doc comments).
+    #[test]
+    fn rx_grid_complex_bin_of_predicts_compute_spectra_peak() {
+        let sample_rate_hz = 12_000.0f32;
+        let center_hz = 1500.0f32;
+        let d = SyncDims::of::<Fst4s60>(sample_rate_hz);
+        let grid = RxGrid::complex(sample_rate_hz, center_hz);
+
+        for offset_hz in [200.0f32, -200.0] {
+            let f_signal = center_hz + offset_hz;
+            let f_baseband = offset_hz; // e^{j 2*pi*f_baseband*n/Fs}
+            let n = d.nmax;
+            let w = 2.0 * PI * f_baseband / sample_rate_hz;
+            let audio_i: Vec<f32> = (0..n).map(|k| (w * k as f32).cos()).collect();
+            let audio_q: Vec<f32> = (0..n).map(|k| (w * k as f32).sin()).collect();
+
+            let s = compute_spectra::<Fst4s60>(
+                AudioSource::Complex(&audio_i, &audio_q),
+                0,
+                d.nfft1 - 1,
+                grid,
+            );
+            let avg = s.avg_power_per_bin();
+            let (peak_bin, _) = avg
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                .unwrap();
+
+            let want = grid.bin_of(&d, f_signal);
+            assert!(
+                peak_bin.abs_diff(want) <= 1,
+                "offset={offset_hz}: peak_bin={peak_bin}, RxGrid predicted {want}"
+            );
+        }
     }
 }

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -253,6 +253,22 @@ impl RxGrid {
         }
     }
 
+    /// Exact inverse of [`Self::bin_of`]: the frequency (Hz) an
+    /// absolute FFT bin index represents in this grid. `coarse_sync`
+    /// needs this the same way it needs `bin_of` — reporting a
+    /// candidate's `freq_hz` back from the bin its correlation peak
+    /// landed on is the same bin↔Hz mapping in the other direction,
+    /// so it goes through `RxGrid` too rather than the real grid's
+    /// `bin*df` shortcut alone.
+    #[inline]
+    pub fn hz_of(&self, d: &SyncDims, bin: usize) -> f32 {
+        if self.complex_input {
+            self.center_hz + (bin as f32 - d.nfft1 as f32 / 2.0) * d.df
+        } else {
+            bin as f32 * d.df
+        }
+    }
+
     /// Number of usable bins in this grid's spectrogram — the bound
     /// every `coarse_sync`/`compute_spectra` clamp against `d.nh1`
     /// used before `RxGrid` existed.
@@ -779,7 +795,7 @@ pub fn coarse_sync<P: Protocol>(
     // Extract into a closure so both serial and parallel paths share the logic.
     let fi_cands = |fi: usize| -> Vec<SyncCandidate> {
         let i = ia + fi;
-        let freq_hz = i as f32 * d.df;
+        let freq_hz = grid.hz_of(&d, i);
         let local_base = sbase[fi];
         let bin_stage1_pass = stage1_pass(fi);
 

--- a/mfsk-core/src/fst4/ddc.rs
+++ b/mfsk-core/src/fst4/ddc.rs
@@ -154,6 +154,82 @@ pub fn wideband_cascade(center_hz: f32) -> DdcCascadeConfig {
     }
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+// Refine stage — per-candidate re-centre on top of the coarse DDC baseband
+// ─────────────────────────────────────────────────────────────────────────
+//
+// `docs/notes/FST4_DDC_DESIGN.md` §4.4, §7 stage 4. `sniper_cascade`/
+// `wideband_cascade`'s baseband still spans a whole search window
+// around one `center_hz` — a specific candidate's own zero-frequency
+// baseband (what `engine::sync::fine_sync_power`'s Costas correlator
+// assumes `cd0` already is, the same convention `downsample_cached`'s
+// per-`f0` cyclic shift provides) needs a second, per-candidate
+// down-conversion: `StreamingComplexRecenter` re-centres on the
+// candidate's own offset from `center_hz` and decimates on to the
+// existing refine rate, `ds_rate = 111.11 Hz` (`ds_spb = 36`, kept for
+// WSJT-X fidelity — see the module doc comment's "Cascade split"
+// section for why this needs a small rational stage, `L=9`, rather
+// than the pure-integer stage §4.4's own heading might suggest).
+
+/// Refine re-centre ratio numerator, both configs — `Fs_c × 9/M` lands
+/// exactly on `ds_rate = 111.11 Hz` for either `K` (see
+/// `tests::refine_ratio_hits_ds_rate`).
+const REFINE_L: u32 = 9;
+const REFINE_M_SNIPER: u32 = 64;
+const REFINE_M_WIDEBAND: u32 = 256;
+
+/// Refine filter tap counts. Refine's own occupied bandwidth is small
+/// — 4 tones + 1.5+1.5 tone-spacing pad = 7×`TONE_SPACING_HZ` ≈ 21.6 Hz
+/// (design doc §4.4) — against a 111.11 Hz baseband (55.5 Hz Nyquist),
+/// so a generous 30 Hz transition still leaves the filter loose:
+/// `ntaps = ⌈4×9×Fs_c/30⌉` rounded up to odd, `Fs_c` from
+/// [`grid_for`]'s sniper/wideband values respectively.
+const REFINE_NTAPS_SNIPER: usize = 949;
+const REFINE_NTAPS_WIDEBAND: usize = 3793;
+
+/// Build the refine-stage recentre/decimate for a candidate found in
+/// the sniper coarse baseband. `candidate_freq_hz`/`coarse_center_hz`
+/// are absolute Hz (same space `RxGrid::complex`'s `center_hz` and a
+/// `SyncCandidate::freq_hz` are both in) — the mixer offset is their
+/// difference.
+pub fn sniper_refine_recenter(
+    candidate_freq_hz: f32,
+    coarse_center_hz: f32,
+) -> crate::engine::dsp::ddc::StreamingComplexRecenter {
+    let fs_c = grid_for(600.0).fs_c;
+    crate::engine::dsp::ddc::StreamingComplexRecenter::new(
+        candidate_freq_hz - coarse_center_hz,
+        fs_c,
+        REFINE_L,
+        REFINE_M_SNIPER,
+        REFINE_NTAPS_SNIPER,
+        HIST_MARGIN,
+    )
+}
+
+/// Wideband counterpart of [`sniper_refine_recenter`].
+pub fn wideband_refine_recenter(
+    candidate_freq_hz: f32,
+    coarse_center_hz: f32,
+) -> crate::engine::dsp::ddc::StreamingComplexRecenter {
+    let fs_c = grid_for(2900.0).fs_c;
+    crate::engine::dsp::ddc::StreamingComplexRecenter::new(
+        candidate_freq_hz - coarse_center_hz,
+        fs_c,
+        REFINE_L,
+        REFINE_M_WIDEBAND,
+        REFINE_NTAPS_WIDEBAND,
+        HIST_MARGIN,
+    )
+}
+
+/// `ds_rate` the existing refine pipeline (`SyncDims::ds_rate`,
+/// `NDOWN`-derived) already uses — both refine configs' `L/M` ratio
+/// lands here exactly (`tests::refine_ratio_hits_ds_rate`), which is
+/// what lets `fine_sync_power`/`refine_candidate` read this stage's
+/// output with no change to their own `ds_rate`-indexed arithmetic.
+pub const REFINE_DS_RATE_HZ: f32 = 111.111_11;
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -363,5 +439,145 @@ mod tests {
             .map(|k| (i[k] * i[k] + q[k] * q[k]).sqrt())
             .fold(0.0f32, f32::max);
         assert!(peak > 500.0, "centre tone peak magnitude too small: {peak}");
+    }
+
+    /// Both refine configs' `L=9/M` ratio must land exactly on
+    /// `REFINE_DS_RATE_HZ` — the invariant that lets
+    /// `fine_sync_power`/`refine_candidate` read this stage's output
+    /// with no change to their own `ds_rate`-indexed arithmetic.
+    #[test]
+    fn refine_ratio_hits_ds_rate() {
+        let sniper_out = grid_for(600.0).fs_c * REFINE_L as f32 / REFINE_M_SNIPER as f32;
+        assert!(
+            (sniper_out - REFINE_DS_RATE_HZ).abs() < 0.01,
+            "sniper refine out = {sniper_out}"
+        );
+        let wideband_out = grid_for(2900.0).fs_c * REFINE_L as f32 / REFINE_M_WIDEBAND as f32;
+        assert!(
+            (wideband_out - REFINE_DS_RATE_HZ).abs() < 0.01,
+            "wideband refine out = {wideband_out}"
+        );
+    }
+
+    /// End-to-end (design doc §6 items 3+4 combined, refine's own
+    /// half): the refine stage built on top of the coarse DDC baseband
+    /// finds the same timing `downsample_cached` + `fine_sync_power`
+    /// (the existing reference path) finds, on the same clean
+    /// synthetic FST4-60 signal `ddc_coarse_sync_matches_real_path_on_
+    /// synth_signal` uses.
+    ///
+    /// Both `StreamingComplexDdc` and `StreamingComplexRecenter`
+    /// leave their own group delay untrimmed at push/flush time (see
+    /// each's own doc comment) — this test does that trim itself,
+    /// using `group_delay_input_samples`/`group_delay_output_samples`
+    /// as a *best-effort* estimate (both are documented
+    /// underestimates), then widens the search window well past what
+    /// that estimation error should plausibly leave outstanding
+    /// (`SEARCH_STEPS`, vs. production's `REFINE_STEPS = 40`) so the
+    /// comparison doesn't depend on the trim being exact — only on the
+    /// true peak being somewhere inside the searched window.
+    #[test]
+    fn ddc_refine_matches_downsample_cached_reference() {
+        use crate::engine::dsp::ddc::StreamingComplexDdc;
+        use crate::engine::dsp::downsample::{build_fft_cache, downsample_cached};
+        use crate::engine::sync::{SyncCandidate, refine_candidate};
+        use crate::fst4::Fst4s60;
+        use crate::fst4::decode::FST4_60A_DOWNSAMPLE;
+        use crate::fst4::encode::{message_to_tones, tones_to_i16};
+        use crate::msg::wsjt77::pack77;
+
+        let msg77 = pack77("CQ", "JA1ABC", "PM95").expect("pack77");
+        let tones = message_to_tones(&msg77);
+        let target_freq = 1500.0f32;
+        let audio = tones_to_i16(&tones, target_freq, 10_000);
+
+        let mut slot = alloc::vec![0i16; 60 * 12_000];
+        let offset = 12_000; // matches TX_START_OFFSET_S = 1.0 s
+        let copy_len = audio.len().min(slot.len() - offset);
+        slot[offset..offset + copy_len].copy_from_slice(&audio[..copy_len]);
+
+        // Reference: downsample_cached + refine_candidate.
+        let fft_cache = build_fft_cache(&slot, &FST4_60A_DOWNSAMPLE);
+        let cd0_ref = downsample_cached(&fft_cache, target_freq, &FST4_60A_DOWNSAMPLE);
+        const SEARCH_STEPS: i32 = 200;
+        let ref_refined = refine_candidate::<Fst4s60>(
+            &cd0_ref,
+            &SyncCandidate {
+                freq_hz: target_freq,
+                dt_sec: 0.0,
+                score: 0.0,
+            },
+            SEARCH_STEPS,
+        );
+
+        // DDC path: coarse DDC -> refine recentre -> ds_rate baseband,
+        // with a best-effort delay trim (see the test's own doc
+        // comment).
+        let coarse_cfg = sniper_cascade(target_freq);
+        let mut coarse = StreamingComplexDdc::new(&coarse_cfg);
+        let mut coarse_i = Vec::new();
+        let mut coarse_q = Vec::new();
+        coarse.push_i16(&slot, &mut coarse_i, &mut coarse_q);
+        coarse.flush(&mut coarse_i, &mut coarse_q);
+        let coarse_delay_orig = coarse.group_delay_input_samples();
+
+        let mut refine = sniper_refine_recenter(target_freq, target_freq);
+        let mut cd0_ddc_i = Vec::new();
+        let mut cd0_ddc_q = Vec::new();
+        refine.push(&coarse_i, &coarse_q, &mut cd0_ddc_i, &mut cd0_ddc_q);
+        refine.flush(&mut cd0_ddc_i, &mut cd0_ddc_q);
+        let refine_delay_out = refine.group_delay_output_samples();
+
+        let total_delay_out = (coarse_delay_orig as f32 * REFINE_DS_RATE_HZ / 12_000.0).round()
+            as usize
+            + refine_delay_out;
+        let trim = total_delay_out.min(cd0_ddc_i.len());
+        let cd0_ddc: Vec<num_complex::Complex<f32>> = cd0_ddc_i[trim..]
+            .iter()
+            .zip(cd0_ddc_q[trim..].iter())
+            .map(|(&i, &q)| num_complex::Complex::new(i, q))
+            .collect();
+
+        let ddc_refined = refine_candidate::<Fst4s60>(
+            &cd0_ddc,
+            &SyncCandidate {
+                freq_hz: target_freq,
+                dt_sec: 0.0,
+                score: 0.0,
+            },
+            SEARCH_STEPS,
+        );
+
+        assert!(
+            (ddc_refined.dt_sec - ref_refined.dt_sec).abs() < 0.1,
+            "reference dt_sec={}, DDC dt_sec={} (trim={trim} samples)",
+            ref_refined.dt_sec,
+            ddc_refined.dt_sec
+        );
+        // Not a cross-pipeline score comparison: `downsample_cached`
+        // applies its own `1/sqrt(fft1*fft2)` normalisation
+        // (`downsample_cached`'s own doc comment, step 6) and this
+        // DDC path applies none, so the two `.score`s sit on entirely
+        // different absolute scales — `fine_sync_power` is a raw
+        // correlation *power*, not the ratio-normalised score
+        // `coarse_sync` reports (that comparison is what the sibling
+        // `ddc_coarse_sync_matches_real_path_on_synth_signal` test
+        // already does, correctly, since `coarse_sync`'s score is
+        // scale-invariant). What this checks instead: the DDC path's
+        // own peak, at the timing `ddc_refined` found, is a real
+        // correlation peak — comfortably above its own score 30 steps
+        // away — not noise the search happened to land on.
+        use crate::engine::sync::{SyncDims, fine_sync_power};
+        let ds_rate = SyncDims::of::<Fst4s60>(12_000.0).ds_rate;
+        let peak_i0 = ((ddc_refined.dt_sec
+            + <Fst4s60 as crate::engine::FrameLayout>::TX_START_OFFSET_S)
+            * ds_rate)
+            .round() as i32;
+        let off_peak = fine_sync_power::<Fst4s60>(&cd0_ddc, peak_i0 + 30);
+        assert!(
+            ddc_refined.score > off_peak * 3.0,
+            "DDC peak score={} not distinguishable from off-peak score={off_peak}",
+            ddc_refined.score
+        );
     }
 }

--- a/mfsk-core/src/fst4/ddc.rs
+++ b/mfsk-core/src/fst4/ddc.rs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! FST4-60 coarse-sync DDC: `K`-selection and cascade decomposition.
+//!
+//! `docs/notes/FST4_DDC_DESIGN.md` §4.3, §7 stage 3. Scope matches the
+//! design doc's own (§3): FST4-60 only, and only the two search shapes
+//! `coarse_sync` actually uses today — a narrow sniper window (±250 Hz
+//! around a frequency hint) and the wideband scan (100-3000 Hz).
+//!
+//! ## `K`-selection
+//!
+//! §2's invariants force `Fs_c = K/SYMBOL_DT` once `nfft1 = 2K` is
+//! chosen (both `df = Fs_c/nfft1` and `nfft1` fixed simultaneously
+//! pins `Fs_c`) — so picking `K` *is* picking the analysis rate, not a
+//! free parameter alongside it. [`choose_k`] picks the smallest power
+//! of two whose `Fs_c` covers a target bandwidth: `K ≥ bandwidth_hz ×
+//! SYMBOL_DT` (this falls out of `Fs_c = K/SYMBOL_DT ≥ bandwidth_hz`).
+//! Reproduces the design doc's own worked table exactly: `600 Hz →
+//! K=256` (sniper), `2900 Hz → K=1024` (wideband) — see this module's
+//! own `choose_k_matches_design_doc_table` test.
+//!
+//! ## Cascade split
+//!
+//! `Fs_c/12_000 = K/NSPS` always reduces to `(K/16)/243` for FST4-60
+//! (`NSPS = 3888 = 2^4·3^5`; a power-of-two `K ≥ 16` always has
+//! `gcd(K, 3888) = 16`) — the `243 = 3^5` denominator is exactly the
+//! irreducible part §1 says a DDC exists to route around, and it's
+//! fixed regardless of `K`. The two configs below split that ratio
+//! differently, both taken from the design doc's own worked table
+//! rather than re-derived here: sniper pre-decimates by an integer 3
+//! (`FirStage`, loose filter, cheap) before the final rational
+//! `16/81` stage; wideband skips the integer stage entirely (`1/1`)
+//! and does the whole `64/243` in one rational stage. Tap counts are
+//! this module's own Crochiere-Rabiner-style derivation (§4.3's own
+//! `~84`/`~184` taps/phase are explicitly estimates, not a spec to
+//! reproduce exactly) — see the `SNIPER_*`/`WIDEBAND_*` constants
+//! below for the transition-width choices, and
+//! `tests::cascade_configs_hit_their_target_fs_c` for the
+//! self-consistency check that the two integer/rational splits
+//! actually multiply out to `Fs_c`.
+
+use crate::engine::dsp::ddc::DdcCascadeConfig;
+
+/// `SYMBOL_DT` for FST4-60, `NSPS/12_000 = 3888/12000`. A plain `f32`
+/// literal rather than reaching through
+/// `<Fst4s60 as ModulationParams>::SYMBOL_DT` — this module fixes the
+/// sub-mode in scope by construction (see the module doc comment), so
+/// there's no generic `P` to derive it from; keeping this as the one
+/// named constant (used by every derivation below and pinned against
+/// the trait value in `tests::symbol_dt_matches_fst4s60`) is cheaper
+/// than adding a `P: ModulationParams` bound this module doesn't
+/// otherwise need.
+const SYMBOL_DT_S: f32 = 0.324;
+
+/// Smallest power-of-two `K` whose `Fs_c = K/SYMBOL_DT_S` covers
+/// `bandwidth_hz` — see the module doc comment's `K`-selection
+/// derivation.
+pub fn choose_k(bandwidth_hz: f32) -> u32 {
+    let raw = (bandwidth_hz * SYMBOL_DT_S).ceil() as u32;
+    raw.max(1).next_power_of_two()
+}
+
+/// The complex analysis grid `choose_k` implies: `K`, `Fs_c` (Hz),
+/// `nfft1 = 2K`.
+#[derive(Copy, Clone, Debug)]
+pub struct Fst4DdcGrid {
+    pub k: u32,
+    pub fs_c: f32,
+    pub nfft1: usize,
+}
+
+pub fn grid_for(bandwidth_hz: f32) -> Fst4DdcGrid {
+    let k = choose_k(bandwidth_hz);
+    Fst4DdcGrid {
+        k,
+        fs_c: k as f32 / SYMBOL_DT_S,
+        nfft1: 2 * k as usize,
+    }
+}
+
+/// Sniper stage-1 (integer, decimate-by-3) tap count. `fc_norm`
+/// cutoff 300 Hz (comfortably above the ±250 Hz search window, which
+/// is all this loose pre-filter needs to protect — the final
+/// resampler carries the real passband/stopband requirement, same
+/// "stage 1 only needs to keep stage 2 honest" logic
+/// `wspr::ddc`'s own cascade doc comment uses), 1000 Hz transition
+/// (`4/ntaps` rule, `design_lowpass`'s own convention) — a
+/// deliberately loose, cheap filter: `ntaps = ⌈4×12000/1000⌉` rounded
+/// up to odd.
+const SNIPER_STAGE1_NTAPS: usize = 49;
+const SNIPER_STAGE1_DECIM: usize = 3;
+const SNIPER_STAGE1_FC_NORM: f32 = 300.0 / 12_000.0;
+
+/// Sniper final resampler: `L=16, M=81` (see the module doc comment's
+/// cascade-split derivation), 150 Hz transition around the output
+/// Nyquist (`Fs_c/2 ≈ 395 Hz`) — flat through the ±250 Hz search
+/// window with room to spare before the ~395 Hz edge.
+/// `ntaps = ⌈4×L×F1/150⌉` rounded up to odd, `F1 = 12000/3 = 4000 Hz`
+/// (stage 1's output rate).
+const SNIPER_RESAMPLER_L: u32 = 16;
+const SNIPER_RESAMPLER_M: u32 = 81;
+const SNIPER_RESAMPLER_NTAPS: usize = 1707;
+
+/// Wideband final (only) resampler: `L=64, M=243`, 300 Hz transition
+/// around the output Nyquist (`Fs_c/2 ≈ 1580 Hz`) — flat through the
+/// ±1450 Hz half-width the 2900 Hz search band needs.
+/// `ntaps = ⌈4×L×12000/300⌉` rounded up to odd (no integer stage, so
+/// `F_in = 12000` directly).
+const WIDEBAND_RESAMPLER_L: u32 = 64;
+const WIDEBAND_RESAMPLER_M: u32 = 243;
+const WIDEBAND_RESAMPLER_NTAPS: usize = 10_241;
+
+/// History margin every stage in both configs uses — both cascades'
+/// stages are small (see the tap-count constants above), so a
+/// generous fixed margin costs little and keeps compaction well
+/// amortised (same tradeoff `wspr::ddc`'s own cascade documents).
+const HIST_MARGIN: usize = 512;
+
+/// FST4-60 sniper DDC: ±250 Hz search window centred on `center_hz`,
+/// `K=256`. Matches `SniperRequest`'s own search shape
+/// (`docs/notes/FST4_DDC_DESIGN.md` §4.3's "スナイパー ±250 Hz" row).
+pub fn sniper_cascade(center_hz: f32) -> DdcCascadeConfig {
+    DdcCascadeConfig {
+        center_hz,
+        input_rate_hz: 12_000.0,
+        int_stages: alloc::vec![(
+            SNIPER_STAGE1_NTAPS,
+            SNIPER_STAGE1_DECIM,
+            SNIPER_STAGE1_FC_NORM
+        )],
+        resampler: (
+            SNIPER_RESAMPLER_L,
+            SNIPER_RESAMPLER_M,
+            SNIPER_RESAMPLER_NTAPS,
+        ),
+        hist_margin: HIST_MARGIN,
+    }
+}
+
+/// FST4-60 wideband DDC: `center_hz` should be the mid-point of the
+/// 100-3000 Hz scan (matching `K=1024`'s ≈3160 Hz `Fs_c` against the
+/// 2900 Hz band — `docs/notes/FST4_DDC_DESIGN.md` §4.3's "広帯域
+/// 100-3000 Hz" row).
+pub fn wideband_cascade(center_hz: f32) -> DdcCascadeConfig {
+    DdcCascadeConfig {
+        center_hz,
+        input_rate_hz: 12_000.0,
+        int_stages: alloc::vec::Vec::new(),
+        resampler: (
+            WIDEBAND_RESAMPLER_L,
+            WIDEBAND_RESAMPLER_M,
+            WIDEBAND_RESAMPLER_NTAPS,
+        ),
+        hist_margin: HIST_MARGIN,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn symbol_dt_matches_fst4s60() {
+        use crate::engine::protocol::ModulationParams;
+        assert!(
+            (SYMBOL_DT_S - <super::super::Fst4s60 as ModulationParams>::SYMBOL_DT).abs() < 1e-6
+        );
+    }
+
+    /// Reproduces `docs/notes/FST4_DDC_DESIGN.md` §4.3's worked table:
+    /// `600 Hz -> K=256` (sniper), `2900 Hz -> K=1024` (wideband).
+    /// These are exact invariants (§2), not estimates — unlike the
+    /// tap-count constants, which the doc itself marks with `~`.
+    #[test]
+    fn choose_k_matches_design_doc_table() {
+        assert_eq!(choose_k(600.0), 256, "sniper");
+        assert_eq!(choose_k(2900.0), 1024, "wideband");
+    }
+
+    #[test]
+    fn grid_for_matches_design_doc_table() {
+        let sniper = grid_for(600.0);
+        assert_eq!(sniper.k, 256);
+        assert_eq!(sniper.nfft1, 512);
+        assert!((sniper.fs_c - 790.123).abs() < 0.01, "{}", sniper.fs_c);
+
+        let wideband = grid_for(2900.0);
+        assert_eq!(wideband.k, 1024);
+        assert_eq!(wideband.nfft1, 2048);
+        assert!((wideband.fs_c - 3160.494).abs() < 0.01, "{}", wideband.fs_c);
+    }
+
+    /// Self-consistency: each cascade's integer-stage decimation times
+    /// its final resampler's `L/M` must land on exactly the `Fs_c`
+    /// `grid_for` predicts for that config's bandwidth — the check the
+    /// module doc comment's cascade-split section promises.
+    #[test]
+    fn cascade_configs_hit_their_target_fs_c() {
+        let sniper = sniper_cascade(1500.0);
+        let sniper_grid = grid_for(600.0);
+        let sniper_decim: usize = sniper.int_stages.iter().map(|&(_, d, _)| d).product();
+        let sniper_fs_c = sniper.input_rate_hz / sniper_decim as f32 * SNIPER_RESAMPLER_L as f32
+            / SNIPER_RESAMPLER_M as f32;
+        assert!(
+            (sniper_fs_c - sniper_grid.fs_c).abs() < 0.01,
+            "sniper cascade Fs_c {sniper_fs_c} != grid Fs_c {}",
+            sniper_grid.fs_c
+        );
+
+        let wideband = wideband_cascade(1500.0);
+        assert!(wideband.int_stages.is_empty());
+        let wideband_grid = grid_for(2900.0);
+        let wideband_fs_c =
+            wideband.input_rate_hz * WIDEBAND_RESAMPLER_L as f32 / WIDEBAND_RESAMPLER_M as f32;
+        assert!(
+            (wideband_fs_c - wideband_grid.fs_c).abs() < 0.01,
+            "wideband cascade Fs_c {wideband_fs_c} != grid Fs_c {}",
+            wideband_grid.fs_c
+        );
+    }
+
+    /// End-to-end equivalence (design doc §6 item 3): the DDC-fed
+    /// complex `coarse_sync` path finds the same candidate — same
+    /// frequency, comparable score — the real 12 kHz path finds, on a
+    /// clean synthetic FST4-60 signal. Not the WSJT-X golden WAV the
+    /// design doc's own item 3 names (`210115_0058.wav`); a
+    /// self-consistency check on this crate's own encoder, same
+    /// caveat `fst4::decode::tests::synth_roundtrip_for`'s doc comment
+    /// already carries for the same reason (encode/decode share
+    /// `NSPS`/`NDOWN` — this can't catch a wrong-vs-WSJT-X parameter).
+    /// Sufficient here: this test's job is confirming the *DDC
+    /// pipeline* reproduces what the real-input path already computes
+    /// correctly, not re-verifying `coarse_sync` itself against
+    /// WSJT-X, which the existing FST4-60 golden tests already do on
+    /// the real path.
+    #[test]
+    fn ddc_coarse_sync_matches_real_path_on_synth_signal() {
+        use crate::engine::dsp::ddc::ddc_block;
+        use crate::engine::sync::{AudioSource, RxGrid, coarse_sync};
+        use crate::fst4::Fst4s60;
+        use crate::fst4::encode::{message_to_tones, tones_to_i16};
+        use crate::msg::wsjt77::pack77;
+
+        let msg77 = pack77("CQ", "JA1ABC", "PM95").expect("pack77");
+        let tones = message_to_tones(&msg77);
+        let target_freq = 1500.0f32;
+        let audio = tones_to_i16(&tones, target_freq, 10_000);
+
+        let mut slot = alloc::vec![0i16; 60 * 12_000];
+        let offset = 12_000;
+        let copy_len = audio.len().min(slot.len() - offset);
+        slot[offset..offset + copy_len].copy_from_slice(&audio[..copy_len]);
+
+        let real_cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&slot),
+            target_freq - 250.0,
+            target_freq + 250.0,
+            0.0,
+            None,
+            10,
+            RxGrid::real(12_000.0),
+        );
+        let real_best = real_cands
+            .iter()
+            .max_by(|a, b| a.score.partial_cmp(&b.score).unwrap())
+            .expect("real path found no candidate at all");
+
+        let cfg = sniper_cascade(target_freq);
+        let (audio_i, audio_q) = ddc_block(&slot, &cfg);
+        let grid = grid_for(600.0);
+        let ddc_cands = coarse_sync::<Fst4s60>(
+            AudioSource::Complex(&audio_i, &audio_q),
+            target_freq - 250.0,
+            target_freq + 250.0,
+            0.0,
+            None,
+            10,
+            RxGrid::complex(grid.fs_c, target_freq),
+        );
+        let ddc_best = ddc_cands
+            .iter()
+            .max_by(|a, b| a.score.partial_cmp(&b.score).unwrap())
+            .expect("DDC path found no candidate at all");
+
+        assert!(
+            (ddc_best.freq_hz - real_best.freq_hz).abs() < 2.0,
+            "real best freq={} Hz, DDC best freq={} Hz",
+            real_best.freq_hz,
+            ddc_best.freq_hz
+        );
+        // Score comparison, not dt_sec: the DDC cascade's own group
+        // delay isn't trimmed from its output (`StreamingComplexDdc::
+        // flush`'s own doc comment — a conservative, not exact,
+        // estimate), so `dt_sec` carries an unremoved, unknown-but-
+        // bounded offset. `coarse_sync`'s ±2.5 s lag search already
+        // absorbs that (it exists to tolerate unknown timing), so
+        // candidate *detection* doesn't depend on it — only reporting
+        // a precise `dt_sec` does, which is refine's job (stage 4),
+        // not coarse search's.
+        //
+        // Not a tight ratio: measured on this synth signal, the DDC
+        // path's score lands at roughly 1/3 of the real path's
+        // (~115 vs. ~355) — a real processing-margin cost from
+        // routing through a mixer + 2-stage filter cascade instead of
+        // one direct 7776-point FFT, not a bug (this is still a
+        // factor of ~30+ above the ~1-5 noise-floor scores
+        // `coarse_sync`'s own normalisation produces — see e.g.
+        // `stage1_pass`'s `sync_min` gate). Whether that margin cost
+        // is acceptable for real (non-synthetic, noisy) signals is a
+        // sensitivity-sweep question (design doc §6 item 4), and
+        // whether the `SNIPER_*`/`WIDEBAND_*` tap counts above are
+        // the right cost/margin tradeoff is open for that sweep to
+        // answer — this assertion only guards against the DDC path
+        // going *dark* (a real bug), not against it costing SNR
+        // margin, which some cost is expected to.
+        let noise_floor_headroom = 20.0;
+        assert!(
+            ddc_best.score > noise_floor_headroom,
+            "DDC best score={} looks noise-floor-scale, not a detected signal",
+            ddc_best.score
+        );
+        assert!(
+            ddc_best.score > real_best.score * 0.2,
+            "real best score={}, DDC best score={} — margin cost far past what §4.3's \
+             estimated tap counts should plausibly produce",
+            real_best.score,
+            ddc_best.score
+        );
+    }
+
+    /// `wideband_cascade` isn't exercised by the sniper-focused
+    /// end-to-end test above (its `~10K`-tap resampler is the more
+    /// expensive of the two configs) — this pins that its own
+    /// construction and single-tone response are sane: a centre tone
+    /// lands with non-trivial magnitude and the output length roughly
+    /// matches the `K/NSPS` decimation ratio `grid_for` predicts.
+    /// Cheaper than another full `coarse_sync` round-trip and still
+    /// catches an `L`/`M` swap or ntaps-parity mistake specific to
+    /// this config.
+    #[test]
+    fn wideband_cascade_single_tone_lands_near_dc() {
+        use crate::engine::dsp::ddc::ddc_block;
+
+        let center = 1550.0f32;
+        let cfg = wideband_cascade(center);
+        let n = 240_000; // 20 s @ 12 kHz — enough to clear the ~10K-tap resampler's settling
+        let w = 2.0 * core::f64::consts::PI * center as f64 / 12_000.0;
+        let audio: Vec<i16> = (0..n)
+            .map(|k| (8000.0 * (w * k as f64).cos()) as i16)
+            .collect();
+
+        let (i, q) = ddc_block(&audio, &cfg);
+        let grid = grid_for(2900.0);
+        let expected_len = (n as f32 * grid.fs_c / 12_000.0) as usize;
+        assert!(
+            i.len().abs_diff(expected_len) < expected_len / 4,
+            "got {} outputs, expected ~{expected_len}",
+            i.len()
+        );
+
+        let settle = i.len() / 3;
+        let span = settle..(i.len() - settle);
+        let peak = span
+            .map(|k| (i[k] * i[k] + q[k] * q[k]).sqrt())
+            .fold(0.0f32, f32::max);
+        assert!(peak > 500.0, "centre tone peak magnitude too small: {peak}");
+    }
+}

--- a/mfsk-core/src/fst4/ddc.rs
+++ b/mfsk-core/src/fst4/ddc.rs
@@ -373,21 +373,27 @@ mod tests {
         // a precise `dt_sec` does, which is refine's job (stage 4),
         // not coarse search's.
         //
-        // Not a tight ratio: measured on this synth signal, the DDC
-        // path's score lands at roughly 1/3 of the real path's
-        // (~115 vs. ~355) — a real processing-margin cost from
-        // routing through a mixer + 2-stage filter cascade instead of
-        // one direct 7776-point FFT, not a bug (this is still a
-        // factor of ~30+ above the ~1-5 noise-floor scores
-        // `coarse_sync`'s own normalisation produces — see e.g.
-        // `stage1_pass`'s `sync_min` gate). Whether that margin cost
-        // is acceptable for real (non-synthetic, noisy) signals is a
-        // sensitivity-sweep question (design doc §6 item 4), and
-        // whether the `SNIPER_*`/`WIDEBAND_*` tap counts above are
-        // the right cost/margin tradeoff is open for that sweep to
-        // answer — this assertion only guards against the DDC path
-        // going *dark* (a real bug), not against it costing SNR
-        // margin, which some cost is expected to.
+        // Not a tight ratio: measured on this *clean* (noiseless)
+        // synth signal, the DDC path's score lands at roughly 1/3 of
+        // the real path's (~115 vs. ~355) — but that ratio is
+        // misleading as a sensitivity estimate, and turned out not to
+        // generalise. `tests/fst4_ddc_sniper_sensitivity.rs` (real
+        // `fst4sim` AWGN corpus, per-SNR-bucket mean score) found the
+        // ratio *depends heavily on SNR*: DDC/real is 0.92-0.97 across
+        // -30..-22 dB (bracketing FST4-60A's actual ~-28 dB threshold)
+        // and only degrades toward this test's ~0.33 as SNR climbs
+        // toward the noiseless end (-5 dB: 0.54; noiseless: ~0.33).
+        // The likely reason: at low SNR, `t0_ref` (coarse_sync's
+        // score denominator) is dominated by *real* injected noise,
+        // which both pipelines see identically; at high/no-noise SNR
+        // it's dominated by whatever residual leakage this DDC
+        // cascade's own filtering introduces, which the direct-FFT
+        // real path doesn't have — so the ratio is worst exactly where
+        // it matters least. Near the actual sensitivity floor, the
+        // measured cost is a few percent, not 3x. This assertion only
+        // guards against the DDC path going *dark* (a real bug), not
+        // against it costing SNR margin — see the sensitivity test
+        // above for the actual measured number.
         let noise_floor_headroom = 20.0;
         assert!(
             ddc_best.score > noise_floor_headroom,

--- a/mfsk-core/src/fst4/mod.rs
+++ b/mfsk-core/src/fst4/mod.rs
@@ -65,6 +65,8 @@ use crate::msg::Wsjt77Message;
 #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub(crate) mod baseline;
 #[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
+pub mod ddc;
+#[cfg(any(feature = "fft-rustfft", feature = "fft-extern"))]
 pub mod decode;
 pub mod encode;
 #[cfg(all(

--- a/mfsk-core/src/msg/pipeline_ap.rs
+++ b/mfsk-core/src/msg/pipeline_ap.rs
@@ -25,7 +25,9 @@ use crate::engine::pipeline::{
     DecodeDepth, DecodeResult, DecodeStrictness, GenericPipelineProtocol, SnrCtx,
     refine_candidate_position,
 };
-use crate::engine::sync::{SyncCandidate, coarse_sync, fine_sync_power_per_block};
+use crate::engine::sync::{
+    AudioSource, RxGrid, SyncCandidate, coarse_sync, fine_sync_power_per_block,
+};
 use crate::engine::tx::codeword_to_itone;
 use crate::engine::{FecCodec, FecOpts, Protocol};
 
@@ -450,13 +452,13 @@ where
     let freq_min = (target_freq - search_hz).max(100.0);
     let freq_max = (target_freq + search_hz).min(5_900.0);
     let candidates = coarse_sync::<P>(
-        audio,
+        AudioSource::Real(audio),
         freq_min,
         freq_max,
         sync_min,
         Some(target_freq),
         max_cand,
-        12_000.0,
+        RxGrid::real(12_000.0),
     );
     if candidates.is_empty() {
         return Vec::new();

--- a/mfsk-core/tests/fst4_ddc_sniper_full_decode.rs
+++ b/mfsk-core/tests/fst4_ddc_sniper_full_decode.rs
@@ -1,0 +1,343 @@
+//! FST4-60 sniper: real-path vs. DDC-path **full decode** recall, by SNR.
+//!
+//! `tests/fst4_ddc_sniper_sensitivity.rs` measured coarse_sync's own
+//! score, which is only half the story — this crate's real
+//! signal/noise selectivity happens downstream, in the LDPC/CRC
+//! decode itself (see that file's own doc comment on why binary
+//! coarse_sync detection isn't informative). This test goes all the
+//! way through: coarse_sync -> refine (`fst4_sync_search`, the *real*
+//! production refine algorithm, not the simpler `fine_sync_power` the
+//! stage 4 unit test used) -> LLR -> BP/OSD -> CRC -> message unpack,
+//! for both the real 12 kHz path and the DDC path, and compares
+//! whether the corpus's golden message actually comes out.
+//!
+//! The DDC side reuses `engine::pipeline::process_candidate_precomputed`
+//! — an `internal-testing`-gated hook built exactly for this: feed a
+//! precomputed `(cd0, freq_hz, i0, score)` refine result in directly,
+//! skipping `downsample_cached` entirely (its own doc comment: "how
+//! the LLR/BP/OSD stage alone gets measured... without waiting on
+//! [non-power-of-two FFT support]"). So the DDC path here is genuinely
+//! coarse_sync + refine fed by the DDC baseband, then the *unmodified*
+//! production LLR/BP/OSD/CRC/unpack — no separate reimplementation of
+//! the hard part.
+//!
+//! `#[ignore]` — tier C, needs the generated corpus:
+//!
+//! ```sh
+//! scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh
+//! cargo test --test fst4_ddc_sniper_full_decode --release \
+//!   --features fst4,fft-rustfft,parallel,internal-testing \
+//!   -- --ignored --nocapture
+//! ```
+//!
+//! Measured 2026-08-21 (~120 s): at the 50%-crossing region the two
+//! paths are statistically indistinguishable — `-27 dB: real 80/100,
+//! ddc 77/100` (binomial σ ≈ 4 at n=100, so a 3-hit gap is well under
+//! 1σ), `-28 dB: 7/20 both`, `-29 dB: 1/20 both`, `-30 dB: 0/20 both`;
+//! both saturate at/near 100% from -26 dB up. This is the number that
+//! actually answers the sensitivity question the stage 3 test's own
+//! ~1/3 score ratio raised, and it says the DDC coarse-sync + refine
+//! pipeline costs no measurable full-decode recall at FST4-60A's real
+//! operating point.
+
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+
+use num_complex::Complex;
+
+use mfsk_core::engine::dsp::ddc::ddc_block;
+use mfsk_core::engine::dsp::downsample::build_fft_cache;
+use mfsk_core::engine::equalize::EqMode;
+use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_precomputed};
+use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
+use mfsk_core::engine::sync2d::fst4_sync_search;
+use mfsk_core::fst4::Fst4s60;
+use mfsk_core::fst4::ddc::{grid_for, sniper_cascade, sniper_refine_recenter};
+use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+// Matches `tests/fst4_sweep.rs`'s own `GOLDEN_MSG` — the message the
+// `fst4_60_awgn_*.wav` corpus actually encodes (not this file's own
+// earlier synthetic tests' "CQ JA1ABC PM95", a different message used
+// only in `fst4::ddc`'s unit tests).
+const GOLDEN_MSG: &str = "CQ JL1NIE PM95";
+const GOLDEN_FREQ_HZ: f32 = 1500.0;
+const SEARCH_HALF_WIDTH_HZ: f32 = 250.0;
+const SYNC_MIN: f32 = 0.8;
+const MAX_CAND: usize = 50;
+/// `fst4::decode::SYNC_Q_MIN` — private to that module, reproduced
+/// here as a literal (both call `pipeline::decode_frame`/
+/// `process_candidate_precomputed` with the same value, so this stays
+/// an apples-to-apples comparison against the real path's own
+/// `DecodeRequest`).
+const SYNC_Q_MIN: u32 = 16;
+/// Cap on how many DDC-path candidates get refined+decoded per trial
+/// — coarse_sync can return up to `MAX_CAND`, and refine+decode is the
+/// expensive step; the real path's own `decode_frame` tries every
+/// candidate; this caps it to keep a multi-SNR sweep tractable while
+/// still trying enough candidates that a truncation artifact would
+/// show up as a gap between the two paths' recall at the *same* SNR
+/// coarse_sync returns the golden candidate at (which the companion
+/// sensitivity test already confirms is at rank 1 in the clean case).
+const MAX_CAND_TRIED: usize = 8;
+
+fn sweep_dir() -> PathBuf {
+    if let Ok(d) = std::env::var("MFSK_FST4_SWEEP_DIR") {
+        return PathBuf::from(d);
+    }
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    Path::new(&manifest)
+        .join("../embedded-poc/assets/fst4_sweep")
+        .to_path_buf()
+}
+
+fn parse_snr_tag(tag: &str) -> Option<i32> {
+    if let Some(rest) = tag.strip_prefix('m') {
+        rest.parse::<i32>().ok().map(|v| -v)
+    } else if let Some(rest) = tag.strip_prefix('p') {
+        rest.parse::<i32>().ok()
+    } else {
+        None
+    }
+}
+
+struct WavMeta {
+    snr_db: i32,
+    trial: u32,
+    path: PathBuf,
+}
+
+fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        let parts: Vec<&str> = stem.split('_').collect();
+        if parts.len() != 5 || parts[0] != "fst4" || parts[1] != "60" || parts[2] != "awgn" {
+            continue;
+        }
+        let trial: u32 = match parts[4].parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let snr_db = match parse_snr_tag(parts[3]) {
+            Some(v) => v,
+            None => continue,
+        };
+        out.push(WavMeta {
+            snr_db,
+            trial,
+            path,
+        });
+    }
+    out.sort_by_key(|m| (-m.snr_db, m.trial));
+    out
+}
+
+fn is_golden(msg77: &[u8]) -> bool {
+    let arr: &[u8; 77] = match msg77.try_into() {
+        Ok(a) => a,
+        Err(_) => return false,
+    };
+    unpack77(arr).as_deref() == Some(GOLDEN_MSG)
+}
+
+fn real_path_decodes(audio: &[i16]) -> bool {
+    DecodeRequest::<Fst4s60>::new(
+        audio,
+        GOLDEN_FREQ_HZ - SEARCH_HALF_WIDTH_HZ,
+        GOLDEN_FREQ_HZ + SEARCH_HALF_WIDTH_HZ,
+        SYNC_MIN,
+        MAX_CAND,
+    )
+    .decode()
+    .results
+    .iter()
+    .any(|r| is_golden(r.message77()))
+}
+
+/// Recentre-and-decimate `cand`'s own frequency out of the coarse DDC
+/// baseband, trim the (best-effort) combined group delay, RMS-
+/// normalise (matching `refine_candidate_position_impl`'s own
+/// normalisation, so `process_candidate_precomputed`'s LLR scaling
+/// sees the same convention it would from `downsample_cached`), then
+/// run the *real* refine algorithm and hand the result to production
+/// LLR/BP/OSD/CRC/unpack.
+fn ddc_refine_and_decode(
+    cand: &SyncCandidate,
+    coarse_i: &[f32],
+    coarse_q: &[f32],
+    coarse_delay_orig: usize,
+    fft_cache: &[Complex<f32>],
+) -> Option<String> {
+    let mut refine = sniper_refine_recenter(cand.freq_hz, GOLDEN_FREQ_HZ);
+    let mut cd0_i = Vec::new();
+    let mut cd0_q = Vec::new();
+    refine.push(coarse_i, coarse_q, &mut cd0_i, &mut cd0_q);
+    refine.flush(&mut cd0_i, &mut cd0_q);
+    let refine_delay_out = refine.group_delay_output_samples();
+
+    const REFINE_DS_RATE_HZ: f32 = 111.111_11;
+    let total_delay_out = (coarse_delay_orig as f32 * REFINE_DS_RATE_HZ / 12_000.0).round()
+        as usize
+        + refine_delay_out;
+    let trim = total_delay_out.min(cd0_i.len());
+
+    let mut cd0: Vec<Complex<f32>> = cd0_i[trim..]
+        .iter()
+        .zip(cd0_q[trim..].iter())
+        .map(|(&i, &q)| Complex::new(i, q))
+        .collect();
+
+    // Same RMS-normalisation `refine_candidate_position_impl` applies.
+    let sum2: f32 = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len().max(1) as f32;
+    if sum2 > f32::EPSILON {
+        let inv = 1.0 / sum2.sqrt();
+        for c in cd0.iter_mut() {
+            *c *= inv;
+        }
+    }
+
+    let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
+    let precomputed = (cd0, s2.freq_hz, s2.i0, s2.score);
+
+    let result = process_candidate_precomputed::<Fst4s60>(
+        cand,
+        fft_cache,
+        &FST4_60A_DOWNSAMPLE,
+        DecodeDepth::FULL,
+        DecodeStrictness::Normal,
+        &[],
+        EqMode::Off,
+        SYNC_Q_MIN,
+        precomputed,
+        true, // skip_snr — snr_db not needed for this recall comparison
+        false,
+    )?;
+    let mut m77 = [0u8; 77];
+    m77.copy_from_slice(result.message77());
+    unpack77(&m77)
+}
+
+fn ddc_path_decodes(audio: &[i16]) -> bool {
+    let coarse_cfg = sniper_cascade(GOLDEN_FREQ_HZ);
+    let (coarse_i, coarse_q) = ddc_block(audio, &coarse_cfg);
+    // Recompute the same delay estimate `ddc_block` doesn't expose —
+    // matches `fst4::ddc::tests::ddc_refine_matches_downsample_cached_
+    // reference`'s own derivation.
+    let coarse_delay_orig = {
+        use mfsk_core::engine::dsp::ddc::StreamingComplexDdc;
+        StreamingComplexDdc::new(&coarse_cfg).group_delay_input_samples()
+    };
+
+    let grid = grid_for(600.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Complex(&coarse_i, &coarse_q),
+        GOLDEN_FREQ_HZ - SEARCH_HALF_WIDTH_HZ,
+        GOLDEN_FREQ_HZ + SEARCH_HALF_WIDTH_HZ,
+        SYNC_MIN,
+        Some(GOLDEN_FREQ_HZ),
+        MAX_CAND,
+        RxGrid::complex(grid.fs_c, GOLDEN_FREQ_HZ),
+    );
+    if cands.is_empty() {
+        return false;
+    }
+
+    let fft_cache = build_fft_cache(audio, &FST4_60A_DOWNSAMPLE);
+    for cand in cands.iter().take(MAX_CAND_TRIED) {
+        if let Some(msg) =
+            ddc_refine_and_decode(cand, &coarse_i, &coarse_q, coarse_delay_orig, &fft_cache)
+            && msg == GOLDEN_MSG
+        {
+            return true;
+        }
+    }
+    false
+}
+
+#[test]
+#[ignore = "tier C — needs the fst4_60_awgn_* sweep corpus; run with --ignored --nocapture"]
+fn fst4_60_sniper_ddc_vs_real_full_decode() {
+    let dir = sweep_dir();
+    let wavs = collect_wavs(&dir);
+    if wavs.is_empty() {
+        eprintln!(
+            "No fst4_60_awgn_*.wav found in {dir:?}\n\
+             Run: scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh"
+        );
+        return;
+    }
+
+    #[cfg(feature = "parallel")]
+    use rayon::prelude::*;
+    use std::collections::BTreeMap;
+    use std::io::Write;
+
+    let mut groups: BTreeMap<i32, Vec<&WavMeta>> = BTreeMap::new();
+    for w in &wavs {
+        groups.entry(w.snr_db).or_default().push(w);
+    }
+
+    let mut csv = common::sweep_csv_writer(
+        "MFSK_FST4_DDC_SNIPER_DECODE_CSV",
+        "snr_db,trial,real_pass,ddc_pass",
+    );
+
+    eprintln!("\n{:-<56}", "");
+    eprintln!(
+        "  {:>7}  {:>6}  {:>10}  {:>10}",
+        "SNR(dB)", "n", "real", "ddc"
+    );
+    eprintln!("{:-<56}", "");
+
+    for (snr, group) in &groups {
+        #[cfg(feature = "parallel")]
+        let results: Vec<(u32, bool, bool)> = group
+            .par_iter()
+            .filter_map(|w| {
+                load_wav_i16_opt(&w.path)
+                    .map(|audio| (w.trial, real_path_decodes(&audio), ddc_path_decodes(&audio)))
+            })
+            .collect();
+
+        #[cfg(not(feature = "parallel"))]
+        let results: Vec<(u32, bool, bool)> = group
+            .iter()
+            .filter_map(|w| {
+                load_wav_i16_opt(&w.path)
+                    .map(|audio| (w.trial, real_path_decodes(&audio), ddc_path_decodes(&audio)))
+            })
+            .collect();
+
+        let n = results.len() as u32;
+        if n == 0 {
+            continue;
+        }
+        let real_hits = results.iter().filter(|&&(_, r, _)| r).count() as u32;
+        let ddc_hits = results.iter().filter(|&&(_, _, d)| d).count() as u32;
+
+        if let Some(f) = csv.as_mut() {
+            for &(trial, r, d) in &results {
+                writeln!(f, "{snr},{trial},{},{}", r as u8, d as u8).unwrap();
+            }
+        }
+
+        eprintln!("  {snr:>7}  {n:>6}  {real_hits:>3}/{n:<3}    {ddc_hits:>3}/{n:<3}");
+    }
+    eprintln!("{:-<56}", "");
+}

--- a/mfsk-core/tests/fst4_ddc_sniper_sensitivity.rs
+++ b/mfsk-core/tests/fst4_ddc_sniper_sensitivity.rs
@@ -1,0 +1,274 @@
+//! FST4-60 sniper coarse-sync: real-path vs. DDC-path score, by SNR.
+//!
+//! Answers the question `docs/notes/FST4_DDC_DESIGN.md`'s own stage 3
+//! end-to-end test left open (see its doc comment): the DDC path's
+//! `coarse_sync` score measured ~1/3 of the real path's on a single
+//! *clean* synthetic signal — plausible extra processing-margin cost
+//! from routing through a mixer + 2-stage filter cascade instead of
+//! one direct FFT, but that test cannot say how many dB of real
+//! sensitivity that margin costs, because a noiseless fixture can't
+//! (`feedback_noiseless_synth_fixture_trap`). This one uses the real
+//! `fst4sim`-generated AWGN corpus instead.
+//!
+//! **Not a detection-recall sweep** — an earlier version of this file
+//! was, and the result was uninformative: `coarse_sync`'s own
+//! admission gate (`sync_min = 0.8`, plus the FST4 full-slot OR-gate)
+//! is loose *by design* — this decoder's real signal/noise selectivity
+//! happens downstream, in LDPC/CRC, not at the coarse-sync layer.
+//! "Was a candidate found near the golden position" turned out to be
+//! ~100% for both paths from -5 dB all the way down to synthetic
+//! -60 dB, which is not a real result, just evidence that binary
+//! detection isn't a useful metric for this decoder's architecture.
+//! What *does* move with SNR, meaningfully, is the golden candidate's
+//! own `.score` — this measures that instead, and reports it as a
+//! ratio (DDC/real) per SNR bucket, which is the number that
+//! generalises the single-clean-signal ~1/3 figure the stage 3 test
+//! measured.
+//!
+//! `#[ignore]` — tier C, needs the generated corpus:
+//!
+//! ```sh
+//! scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh
+//! cargo test --test fst4_ddc_sniper_sensitivity --release \
+//!   --features fst4,fft-rustfft,parallel,internal-testing \
+//!   -- --ignored --nocapture
+//! ```
+//!
+//! Both paths search the same ±250 Hz sniper window around the known
+//! golden frequency (a real `SniperRequest` would do the same once it
+//! had a target hint), so this is specifically the sniper cascade's
+//! cost — the wideband cascade (heavier, ~10K taps) is not measured
+//! here.
+
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+
+use mfsk_core::engine::dsp::ddc::ddc_block;
+use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
+use mfsk_core::fst4::Fst4s60;
+use mfsk_core::fst4::ddc::{grid_for, sniper_cascade};
+
+const GOLDEN_FREQ_HZ: f32 = 1500.0;
+const FREQ_TOL_HZ: f32 = 5.0;
+const DT_TOL_SEC: f32 = 0.6;
+const SEARCH_HALF_WIDTH_HZ: f32 = 250.0; // matches sniper_cascade's own ±250 Hz shape
+
+fn sweep_dir() -> PathBuf {
+    if let Ok(d) = std::env::var("MFSK_FST4_SWEEP_DIR") {
+        return PathBuf::from(d);
+    }
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    Path::new(&manifest)
+        .join("../embedded-poc/assets/fst4_sweep")
+        .to_path_buf()
+}
+
+fn parse_snr_tag(tag: &str) -> Option<i32> {
+    if let Some(rest) = tag.strip_prefix('m') {
+        rest.parse::<i32>().ok().map(|v| -v)
+    } else if let Some(rest) = tag.strip_prefix('p') {
+        rest.parse::<i32>().ok()
+    } else {
+        None
+    }
+}
+
+struct WavMeta {
+    snr_db: i32,
+    trial: u32,
+    path: PathBuf,
+}
+
+/// Collects only `fst4_60_awgn_*` — the channel/mode this test scopes
+/// to (see the module doc comment).
+fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
+    let mut out = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let stem = path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or("")
+            .to_string();
+        // fst4_60_awgn_m26_01
+        let parts: Vec<&str> = stem.split('_').collect();
+        if parts.len() != 5 || parts[0] != "fst4" || parts[1] != "60" || parts[2] != "awgn" {
+            continue;
+        }
+        let trial: u32 = match parts[4].parse() {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+        let snr_db = match parse_snr_tag(parts[3]) {
+            Some(v) => v,
+            None => continue,
+        };
+        out.push(WavMeta {
+            snr_db,
+            trial,
+            path,
+        });
+    }
+    out.sort_by_key(|m| (-m.snr_db, m.trial));
+    out
+}
+
+/// The golden candidate's own `.score` if `coarse_sync` returned one
+/// near the known position, `None` otherwise (rare at these SNRs —
+/// see the module doc comment on why binary detection isn't the
+/// metric here; `None` trials are excluded from the mean rather than
+/// counted as 0, so a handful of misses don't silently pull the mean
+/// toward a number that looks like "signal" when it's actually "no
+/// candidate returned at all").
+fn golden_score(cands: &[mfsk_core::engine::sync::SyncCandidate]) -> Option<f32> {
+    cands
+        .iter()
+        .find(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ && c.dt_sec.abs() <= DT_TOL_SEC)
+        .map(|c| c.score)
+}
+
+fn real_path_score(audio: &[i16]) -> Option<f32> {
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Real(audio),
+        GOLDEN_FREQ_HZ - SEARCH_HALF_WIDTH_HZ,
+        GOLDEN_FREQ_HZ + SEARCH_HALF_WIDTH_HZ,
+        // f32::NEG_INFINITY, not the production 0.8 — this test wants
+        // the golden candidate's raw score whether or not it would
+        // have cleared the admission gate (see module doc comment),
+        // not to replicate the gate itself.
+        f32::NEG_INFINITY,
+        Some(GOLDEN_FREQ_HZ),
+        50,
+        RxGrid::real(12_000.0),
+    );
+    golden_score(&cands)
+}
+
+fn ddc_path_score(audio: &[i16]) -> Option<f32> {
+    let cfg = sniper_cascade(GOLDEN_FREQ_HZ);
+    let (ai, aq) = ddc_block(audio, &cfg);
+    // `sniper_cascade` hardcodes the 600 Hz / K=256 grid internally
+    // (design doc §4.3's sniper row) — reproduced here since it
+    // doesn't expose K/Fs_c itself.
+    let grid = grid_for(600.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Complex(&ai, &aq),
+        GOLDEN_FREQ_HZ - SEARCH_HALF_WIDTH_HZ,
+        GOLDEN_FREQ_HZ + SEARCH_HALF_WIDTH_HZ,
+        f32::NEG_INFINITY,
+        Some(GOLDEN_FREQ_HZ),
+        50,
+        RxGrid::complex(grid.fs_c, GOLDEN_FREQ_HZ),
+    );
+    golden_score(&cands)
+}
+
+#[test]
+#[ignore = "tier C — needs the fst4_60_awgn_* sweep corpus; run with --ignored --nocapture"]
+fn fst4_60_sniper_ddc_vs_real_score_by_snr() {
+    let dir = sweep_dir();
+    let wavs = collect_wavs(&dir);
+    if wavs.is_empty() {
+        eprintln!(
+            "No fst4_60_awgn_*.wav found in {dir:?}\n\
+             Run: scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh"
+        );
+        return;
+    }
+
+    #[cfg(feature = "parallel")]
+    use rayon::prelude::*;
+    use std::collections::BTreeMap;
+    use std::io::Write;
+
+    let mut groups: BTreeMap<i32, Vec<&WavMeta>> = BTreeMap::new();
+    for w in &wavs {
+        groups.entry(w.snr_db).or_default().push(w);
+    }
+
+    let mut csv = common::sweep_csv_writer(
+        "MFSK_FST4_DDC_SNIPER_SWEEP_CSV",
+        "snr_db,trial,real_score,ddc_score",
+    );
+
+    eprintln!("\n{:-<78}", "");
+    eprintln!(
+        "  {:>7}  {:>6}  {:>12}  {:>12}  {:>10}",
+        "SNR(dB)", "n", "real (mean)", "ddc (mean)", "ddc/real"
+    );
+    eprintln!("{:-<78}", "");
+
+    for (snr, group) in &groups {
+        #[cfg(feature = "parallel")]
+        let results: Vec<(u32, Option<f32>, Option<f32>)> = group
+            .par_iter()
+            .filter_map(|w| {
+                load_wav_i16_opt(&w.path)
+                    .map(|audio| (w.trial, real_path_score(&audio), ddc_path_score(&audio)))
+            })
+            .collect();
+
+        #[cfg(not(feature = "parallel"))]
+        let results: Vec<(u32, Option<f32>, Option<f32>)> = group
+            .iter()
+            .filter_map(|w| {
+                load_wav_i16_opt(&w.path)
+                    .map(|audio| (w.trial, real_path_score(&audio), ddc_path_score(&audio)))
+            })
+            .collect();
+
+        let n = results.len() as u32;
+        if n == 0 {
+            continue;
+        }
+
+        if let Some(f) = csv.as_mut() {
+            for &(trial, r, d) in &results {
+                writeln!(
+                    f,
+                    "{snr},{trial},{},{}",
+                    r.map(|v| v.to_string()).unwrap_or_default(),
+                    d.map(|v| v.to_string()).unwrap_or_default()
+                )
+                .unwrap();
+            }
+        }
+
+        let real_vals: Vec<f32> = results.iter().filter_map(|&(_, r, _)| r).collect();
+        let ddc_vals: Vec<f32> = results.iter().filter_map(|&(_, _, d)| d).collect();
+        let mean = |v: &[f32]| -> Option<f32> {
+            if v.is_empty() {
+                None
+            } else {
+                Some(v.iter().sum::<f32>() / v.len() as f32)
+            }
+        };
+        let real_mean = mean(&real_vals);
+        let ddc_mean = mean(&ddc_vals);
+
+        let fmt = |v: Option<f32>, hit_n: usize| match v {
+            Some(m) => format!("{m:>8.2} ({hit_n}/{n})"),
+            None => format!("{:>8}", "n/a"),
+        };
+        let ratio = match (real_mean, ddc_mean) {
+            (Some(r), Some(d)) if r > 0.0 => format!("{:.2}", d / r),
+            _ => "n/a".to_string(),
+        };
+
+        eprintln!(
+            "  {snr:>7}  {n:>6}  {}  {}  {ratio:>10}",
+            fmt(real_mean, real_vals.len()),
+            fmt(ddc_mean, ddc_vals.len()),
+        );
+    }
+    eprintln!("{:-<78}", "");
+}

--- a/mfsk-core/tests/fst4_sweep.rs
+++ b/mfsk-core/tests/fst4_sweep.rs
@@ -367,7 +367,7 @@ fn fst4_snr_sweep() {
 fn fst4_diag_weak_trials() {
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::decode::{FST4_30_DOWNSAMPLE, FST4_300_DOWNSAMPLE};
     use mfsk_core::fst4::{Fst4s30, Fst4s300};
 
@@ -384,7 +384,15 @@ fn fst4_diag_weak_trials() {
                 eprintln!("skip {path:?}");
                 continue;
             };
-            let cands = coarse_sync::<P>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+            let cands = coarse_sync::<P>(
+                AudioSource::Real(&audio),
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                50,
+                RxGrid::real(12_000.0),
+            );
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -453,7 +461,7 @@ fn fst4_diag_nsym4_ladder() {
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::llr::{compute_llr_generic, symbol_spectra, sync_quality};
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec};
     use mfsk_core::fst4::decode::{FST4_30_DOWNSAMPLE, FST4_300_DOWNSAMPLE};
@@ -491,7 +499,15 @@ fn fst4_diag_nsym4_ladder() {
                 continue;
             };
 
-            let cands = coarse_sync::<P>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+            let cands = coarse_sync::<P>(
+                AudioSource::Real(&audio),
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                50,
+                RxGrid::real(12_000.0),
+            );
             let Some(cand) = cands
                 .iter()
                 .find(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -640,7 +656,7 @@ fn fst4_diag_nsym4_ladder() {
 fn fst4_diag_zsum_osd() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{MessageCodec, ModulationParams, Protocol};
     use mfsk_core::fec::ldpc::bp::{bp_decode_generic, bp_llr_zsum};
@@ -676,7 +692,15 @@ fn fst4_diag_zsum_osd() {
                 continue;
             };
 
-            let cands = coarse_sync::<Fst4s120>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+            let cands = coarse_sync::<Fst4s120>(
+                AudioSource::Real(&audio),
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                50,
+                RxGrid::real(12_000.0),
+            );
             let Some(cand) = cands
                 .iter()
                 .find(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -763,7 +787,7 @@ fn fst4_diag_zsum_osd() {
 fn fst4_120_diag_sync_vs_decode_failure() {
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s120;
     use mfsk_core::fst4::decode::FST4_120_DOWNSAMPLE;
 
@@ -779,7 +803,15 @@ fn fst4_120_diag_sync_vs_decode_failure() {
                 continue;
             };
             n_total += 1;
-            let cands = coarse_sync::<Fst4s120>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+            let cands = coarse_sync::<Fst4s120>(
+                AudioSource::Real(&audio),
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                50,
+                RxGrid::real(12_000.0),
+            );
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -852,7 +884,7 @@ fn fst4_60_diag_candidate_cost_split() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
     use mfsk_core::engine::sync2d::fst4_sync_search;
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
@@ -891,7 +923,15 @@ fn fst4_60_diag_candidate_cost_split() {
     };
 
     let t0 = Instant::now();
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.0,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let coarse_dt = t0.elapsed();
 
     eprintln!(
@@ -976,7 +1016,7 @@ fn fst4_300_diag_candidate_cost_split() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
     use mfsk_core::engine::sync2d::fst4_sync_search;
     use mfsk_core::fst4::Fst4s300;
     use mfsk_core::fst4::decode::FST4_300_DOWNSAMPLE;
@@ -1016,7 +1056,15 @@ fn fst4_300_diag_candidate_cost_split() {
     let audio: Vec<i16> = full.iter().take(300 * 12_000).copied().collect();
 
     let t0 = Instant::now();
-    let cands = coarse_sync::<Fst4s300>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
+    let cands = coarse_sync::<Fst4s300>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.0,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let coarse_dt = t0.elapsed();
 
     eprintln!(
@@ -1104,7 +1152,7 @@ fn fst4_60_diag_osd_escalation() {
 
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -1123,7 +1171,15 @@ fn fst4_60_diag_osd_escalation() {
         return;
     };
 
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.0,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
     let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
     let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -1258,7 +1314,7 @@ fn fst4_60_diag_osd_escalation() {
 fn fst4_60_diag_npre1_pattern_counts() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fec::ldpc::osd::npre1_pattern_counts;
@@ -1282,7 +1338,15 @@ fn fst4_60_diag_npre1_pattern_counts() {
         return;
     };
 
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.0,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
     let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
     let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -1379,7 +1443,7 @@ fn fst4_60_diag_npre1_pattern_counts() {
 fn fst4_60_diag_osd_depth34_nsync_floor() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -1402,7 +1466,15 @@ fn fst4_60_diag_osd_depth34_nsync_floor() {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return Vec::new();
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.0, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            1.0,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -1664,7 +1736,7 @@ fn fst4_60_diag_recall_tradeoff_ccir_moderate_old_osd() {
 fn recall_tradeoff_for_channel(channel: &str, snr_tags: &'static [(&'static str, u32)]) {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -1712,7 +1784,15 @@ fn recall_tradeoff_for_channel(channel: &str, snr_tags: &'static [(&'static str,
         // call (`decode_wav_fst4` above) — `fst4_60_diag_osd_escalation`'s
         // 1.0 was tuned against the strong real-world golden WAV only,
         // untested against weak AWGN-sweep candidates.
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -2169,7 +2249,7 @@ fn fst4_60_diag_npre_osd_bug_hunt() {
 fn fst4_60_diag_npre_osd_ccir_trial_probe() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{MessageCodec, Protocol};
     use mfsk_core::fec::ldpc::osd::{osd_decode_generic, osd_decode_npre_generic};
@@ -2181,7 +2261,15 @@ fn fst4_60_diag_npre_osd_ccir_trial_probe() {
     let path = dir.join("fst4_60_ccir_moderate_m26_02.wav");
     let audio = load_wav_i16_opt(&path).expect("trial 2 must exist");
 
-    let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        0.8,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
     let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
     let verify_info =
@@ -2288,7 +2376,7 @@ fn nsym_depth_sweep_for_channel(channel: &str, snr_tags: &[(&str, u32)]) {
     use mfsk_core::engine::llr::{
         compute_llr_fast, compute_llr_partial, symbol_spectra, sync_quality,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -2333,7 +2421,15 @@ fn nsym_depth_sweep_for_channel(channel: &str, snr_tags: &[(&str, u32)]) {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return (snr_idx, [MISS; 5]);
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -2700,7 +2796,7 @@ fn fst4_60_diag_rung_major_scheduling() {
     use mfsk_core::engine::llr::{
         compute_llr_fast, compute_llr_partial, symbol_spectra, sync_quality,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -2732,7 +2828,15 @@ fn fst4_60_diag_rung_major_scheduling() {
     // far more raw/duplicate candidates on this strong recording and
     // gives a materially different order — not what's being scheduled
     // on real hardware, so not what this diagnostic should model.
-    let raw_candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
+    let raw_candidates = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.2,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let refined: Vec<_> = raw_candidates
         .iter()
         .map(|c| {
@@ -3045,7 +3149,7 @@ fn fst4_60_diag_stage_ablation_ccir_moderate() {
 fn stage_ablation_for_channel(channel: &str) {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -3082,7 +3186,15 @@ fn stage_ablation_for_channel(channel: &str) {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return (snr_idx, [false; 4]);
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -3214,7 +3326,7 @@ fn stage_ablation_for_channel(channel: &str) {
 fn fst4_60_diag_decode_rung_major_correctness() {
     use mfsk_core::engine::dsp::downsample::build_fft_cache;
     use mfsk_core::engine::pipeline::refine_candidate_position;
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
     use mfsk_core::fst4::rung_major::{RungMajorCandidate, decode_rung_major};
@@ -3230,7 +3342,15 @@ fn fst4_60_diag_decode_rung_major_correctness() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
+    let raw = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.2,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -3305,7 +3425,15 @@ fn fst4_60_diag_decode_rung_major_correctness() {
                     continue;
                 };
                 let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-                let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+                let raw = coarse_sync::<Fst4s60>(
+                    AudioSource::Real(&audio),
+                    100.0,
+                    3000.0,
+                    0.8,
+                    None,
+                    50,
+                    RxGrid::real(12_000.0),
+                );
                 let cands: Vec<RungMajorCandidate> =
                     raw.iter()
                         .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -3353,7 +3481,7 @@ fn fst4_60_diag_rung_major_nsync_gate_count() {
     use mfsk_core::engine::dsp::downsample::build_fft_cache;
     use mfsk_core::engine::llr::{symbol_spectra, sync_quality};
     use mfsk_core::engine::pipeline::refine_candidate_position;
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -3366,7 +3494,15 @@ fn fst4_60_diag_rung_major_nsync_gate_count() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
+    let raw = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.2,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -3505,7 +3641,7 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
     use mfsk_core::engine::pipeline::{
         DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -3563,13 +3699,13 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
             let freq_max = (t.freq_hz + width).min(3000.0);
 
             let raw = coarse_sync::<Fst4s60>(
-                &audio,
+                AudioSource::Real(&audio),
                 freq_min,
                 freq_max,
                 f32::NEG_INFINITY,
                 Some(t.freq_hz),
                 5000,
-                12_000.0,
+                RxGrid::real(12_000.0),
             );
 
             // VK3NV's issue #312 cap ladder, plus `SniperRequest`'s real
@@ -3594,13 +3730,13 @@ fn fst4_60_diag_sniper_gate_width_sweep() {
             // score-based or distribution-adaptive criterion instead.
             for max_cand in [4usize, 8, 10, 16, 32, 50, 5000] {
                 let gated = coarse_sync::<Fst4s60>(
-                    &audio,
+                    AudioSource::Real(&audio),
                     freq_min,
                     freq_max,
                     SNIPER_SYNC_MIN,
                     Some(t.freq_hz),
                     max_cand,
-                    12_000.0,
+                    RxGrid::real(12_000.0),
                 );
 
                 let t0 = Instant::now();
@@ -3691,7 +3827,7 @@ fn host_clock_us() -> i64 {
 fn fst4_60_diag_rung_major_stage_timing_probe() {
     use mfsk_core::engine::dsp::downsample::build_fft_cache;
     use mfsk_core::engine::pipeline::refine_candidate_position;
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
     use mfsk_core::fst4::rung_major::{RungMajorCandidate, decode_rung_major_timed};
@@ -3705,7 +3841,15 @@ fn fst4_60_diag_rung_major_stage_timing_probe() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
+    let raw = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.2,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -3796,7 +3940,7 @@ fn fst4_60_diag_rung_major_stage_timing_probe() {
 fn fst4_60_diag_i0_retry_ccir_old_only() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -3817,7 +3961,15 @@ fn fst4_60_diag_i0_retry_ccir_old_only() {
             eprintln!("trial {trial}: WAV missing, skip");
             continue;
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
 
@@ -3938,7 +4090,7 @@ fn fst4_60_diag_i0_offset_ablation() {
 fn stage_ablation_i0_offsets_for_channel(channel: &str) {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -3973,7 +4125,15 @@ fn stage_ablation_i0_offsets_for_channel(channel: &str) {
         let Some(audio) = load_wav_i16_opt(&path) else {
             return (snr_idx, [false; 4]);
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let ds_rate = 12_000.0 / <Fst4s60 as mfsk_core::ModulationParams>::NDOWN as f32;
         let fec = <Fst4s60 as Protocol>::Fec::default();
@@ -4104,7 +4264,7 @@ fn fst4_60_diag_i0_offset_host_timing() {
     use mfsk_core::engine::dsp::downsample::build_fft_cache;
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
     use mfsk_core::engine::pipeline::refine_candidate_position;
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::freq_shift_cd0;
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -4120,7 +4280,15 @@ fn fst4_60_diag_i0_offset_host_timing() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
+    let raw = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.2,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let refined: Vec<_> = raw
         .iter()
         .map(|c| refine_candidate_position::<Fst4s60>(c, &fft_cache, &FST4_60A_DOWNSAMPLE))
@@ -4671,7 +4839,7 @@ fn npre_timing_grid_for_cell(channel: &str, snr_tag: &str) {
 fn npre_baseline_for_cell(channel: &str, snr_tag: &str) -> (u32, u32) {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fec::ldpc240_101::fst4_osd_diag_force_old;
@@ -4699,7 +4867,15 @@ fn npre_baseline_for_cell(channel: &str, snr_tag: &str) -> (u32, u32) {
             continue;
         };
         present += 1;
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let mut ok = false;
         'cands: for c in cands
@@ -4824,7 +5000,7 @@ fn fst4_60_diag_sniper_cap_near_threshold() {
     use mfsk_core::engine::pipeline::{
         DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -4911,22 +5087,22 @@ fn fst4_60_diag_sniper_cap_near_threshold() {
                         // retained-fraction denominator — the same shape
                         // `fst4_60_diag_sniper_gate_width_sweep` uses.
                         let raw = coarse_sync::<Fst4s60>(
-                            audio,
+                            AudioSource::Real(audio),
                             freq_min,
                             freq_max,
                             f32::NEG_INFINITY,
                             Some(GOLDEN_FREQ_HZ),
                             5000,
-                            12_000.0,
+                            RxGrid::real(12_000.0),
                         );
                         let gated = coarse_sync::<Fst4s60>(
-                            audio,
+                            AudioSource::Real(audio),
                             freq_min,
                             freq_max,
                             SNIPER_SYNC_MIN,
                             Some(GOLDEN_FREQ_HZ),
                             max_cand,
-                            12_000.0,
+                            RxGrid::real(12_000.0),
                         );
 
                         let fft_cache = build_fft_cache(audio, &FST4_60A_DOWNSAMPLE);
@@ -5026,7 +5202,7 @@ fn fst4_60_diag_sniper_cap_per_trial() {
     use mfsk_core::engine::pipeline::{
         DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -5080,13 +5256,13 @@ fn fst4_60_diag_sniper_cap_per_trial() {
                 // in trial order since `par_map` preserves input order.
                 let results: Vec<(u32, bool)> = common::par_map(&trials, |(trial, audio)| {
                     let gated = coarse_sync::<Fst4s60>(
-                        audio,
+                        AudioSource::Real(audio),
                         freq_min,
                         freq_max,
                         SNIPER_SYNC_MIN,
                         Some(GOLDEN_FREQ_HZ),
                         max_cand,
-                        12_000.0,
+                        RxGrid::real(12_000.0),
                     );
                     let fft_cache = build_fft_cache(audio, &FST4_60A_DOWNSAMPLE);
                     let mut decoded = false;
@@ -5161,7 +5337,7 @@ fn prepare_fst4_60_cell(
     max_trial: u32,
 ) -> Vec<(u32, Vec<Fst4PreparedCand>)> {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
@@ -5175,7 +5351,15 @@ fn prepare_fst4_60_cell(
         let Some(audio) = load_wav_i16_opt(&path) else {
             continue;
         };
-        let cands = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+        let cands = coarse_sync::<Fst4s60>(
+            AudioSource::Real(&audio),
+            100.0,
+            3000.0,
+            0.8,
+            None,
+            50,
+            RxGrid::real(12_000.0),
+        );
         let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
         let mut prep = Vec::new();
         for c in cands
@@ -5560,7 +5744,7 @@ fn fst4_60_diag_i0_cheap_rank_vs_exhaustive() {
 #[test]
 #[ignore = "manual audit — dedup-suppressed candidates re-admitted past the cap (issue #312, VK3NV)"]
 fn fst4_60_diag_dedup_zero_score_readmission() {
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
 
     // `engine::sync::FREQ_HINT_NEAR_HZ` is pub(crate); mirrored here.
@@ -5612,13 +5796,13 @@ fn fst4_60_diag_dedup_zero_score_readmission() {
             let freq_max = (hint + width).min(3000.0);
             for &cap in CAPS {
                 let capped = coarse_sync::<Fst4s60>(
-                    audio,
+                    AudioSource::Real(audio),
                     freq_min,
                     freq_max,
                     SNIPER_SYNC_MIN,
                     Some(*hint),
                     cap,
-                    12_000.0,
+                    RxGrid::real(12_000.0),
                 );
                 let zeros = capped.iter().filter(|c| c.score == 0.0).count();
                 let zeros_near = capped
@@ -5702,7 +5886,7 @@ fn fst4_60_diag_dedup_zero_score_recall_effect() {
     use mfsk_core::engine::pipeline::{
         DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -5738,13 +5922,13 @@ fn fst4_60_diag_dedup_zero_score_recall_effect() {
             n += 1;
 
             let cands = coarse_sync::<Fst4s60>(
-                &audio,
+                AudioSource::Real(&audio),
                 (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
                 (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
-                12_000.0,
+                RxGrid::real(12_000.0),
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -5883,7 +6067,7 @@ fn fst4_60_diag_soft_costas_margin_separation() {
     use mfsk_core::engine::pipeline::{
         DecodeDepth, DecodeStrictness, process_candidate_basic, refine_candidate_position,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -5949,13 +6133,13 @@ fn fst4_60_diag_soft_costas_margin_separation() {
                 continue;
             };
             let cands = coarse_sync::<Fst4s60>(
-                &audio,
+                AudioSource::Real(&audio),
                 (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
                 (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
-                12_000.0,
+                RxGrid::real(12_000.0),
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -6101,7 +6285,7 @@ fn fst4_60_diag_soft_margin_escalation_priority() {
     use mfsk_core::engine::llr::{
         compute_llr, symbol_spectra, sync_quality, sync_quality_soft_generic, sync_symbol_count,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -6169,13 +6353,13 @@ fn fst4_60_diag_soft_margin_escalation_priority() {
                 continue;
             };
             let cands = coarse_sync::<Fst4s60>(
-                &audio,
+                AudioSource::Real(&audio),
                 (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
                 (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
-                12_000.0,
+                RxGrid::real(12_000.0),
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -6377,7 +6561,7 @@ fn fst4_60_diag_soft_margin_conditional_value() {
     use mfsk_core::engine::llr::{
         compute_llr, symbol_spectra, sync_quality, sync_quality_soft_generic, sync_symbol_count,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -6522,13 +6706,13 @@ fn fst4_60_diag_soft_margin_conditional_value() {
                 continue;
             };
             let cands = coarse_sync::<Fst4s60>(
-                &audio,
+                AudioSource::Real(&audio),
                 (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
                 (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
-                12_000.0,
+                RxGrid::real(12_000.0),
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -6808,7 +6992,7 @@ fn fst4_60_diag_escalation_budget_curve() {
     use mfsk_core::engine::llr::{
         compute_llr, symbol_spectra, sync_quality, sync_quality_soft_generic, sync_symbol_count,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -6853,13 +7037,13 @@ fn fst4_60_diag_escalation_budget_curve() {
                 continue;
             };
             let cands = coarse_sync::<Fst4s60>(
-                &audio,
+                AudioSource::Real(&audio),
                 (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
                 (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
-                12_000.0,
+                RxGrid::real(12_000.0),
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -7106,7 +7290,7 @@ fn fst4_60_diag_escalation_budget_curve() {
 fn fst4_60_diag_budget_curve_breadth_vs_depth() {
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, fst4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fst4::Fst4s60;
@@ -7163,13 +7347,13 @@ fn fst4_60_diag_budget_curve_breadth_vs_depth() {
                 continue;
             };
             let cands = coarse_sync::<Fst4s60>(
-                &audio,
+                AudioSource::Real(&audio),
                 (GOLDEN_FREQ_HZ - WIDTH_HZ).max(100.0),
                 (GOLDEN_FREQ_HZ + WIDTH_HZ).min(3000.0),
                 SNIPER_SYNC_MIN,
                 Some(GOLDEN_FREQ_HZ),
                 MAX_CAND,
-                12_000.0,
+                RxGrid::real(12_000.0),
             );
             let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
@@ -7382,7 +7566,7 @@ fn fst4_60_diag_budget_curve_breadth_vs_depth() {
 /// so this asserts the observable property directly.
 #[test]
 fn fst4_coarse_sync_output_has_no_deduped_candidates() {
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
 
     let Some(path) = common::corpus::golden_path_or_upstream(
@@ -7401,7 +7585,15 @@ fn fst4_coarse_sync_output_has_no_deduped_candidates() {
         ("wideband", 100.0, 3000.0, None),
     ] {
         for cap in [4usize, 16, 50, 200] {
-            let out = coarse_sync::<Fst4s60>(&audio, lo, hi, 0.8, hint, cap, 12_000.0);
+            let out = coarse_sync::<Fst4s60>(
+                AudioSource::Real(&audio),
+                lo,
+                hi,
+                0.8,
+                hint,
+                cap,
+                RxGrid::real(12_000.0),
+            );
             let zeros = out.iter().filter(|c| c.score == 0.0).count();
             assert_eq!(
                 zeros,
@@ -7482,7 +7674,7 @@ fn fst4_60_diag_wideband_band_recall() {
 fn fst4_phase_split_matches_rung_major_without_a_budget() {
     use mfsk_core::engine::dsp::downsample::build_fft_cache;
     use mfsk_core::engine::pipeline::refine_candidate_position;
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
     use mfsk_core::fst4::rung_major::{
@@ -7498,7 +7690,15 @@ fn fst4_phase_split_matches_rung_major_without_a_budget() {
     };
     let audio = load_wav_i16_opt(&path).expect("golden WAV must load");
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
-    let raw = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
+    let raw = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.2,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     let cands: Vec<RungMajorCandidate> = raw
         .iter()
         .map(|c| {

--- a/mfsk-core/tests/fst4_wsjtx_samples.rs
+++ b/mfsk-core/tests/fst4_wsjtx_samples.rs
@@ -152,7 +152,7 @@ fn fst4_60_diagnose_golden() {
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::llr::{symbol_spectra, sync_quality};
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
     use mfsk_core::engine::{FrameLayout, ModulationParams};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
@@ -202,7 +202,15 @@ fn fst4_60_diagnose_golden() {
 
     // Cross-check against `coarse_sync` + the real decode path: is there
     // a candidate inside the golden tolerance window, and does it decode?
-    let candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 0.0, None, 2000, 12_000.0);
+    let candidates = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        0.0,
+        None,
+        2000,
+        RxGrid::real(12_000.0),
+    );
     let mut in_window: Vec<&SyncCandidate> = candidates
         .iter()
         .filter(|c| {
@@ -453,7 +461,7 @@ fn fst4_bake_golden_refined_candidates() {
     use mfsk_core::engine::pipeline::{
         DecodeDepth, DecodeStrictness, process_candidate_precomputed, refine_candidate_position,
     };
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::fst4::Fst4s60;
     use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
 
@@ -464,7 +472,15 @@ fn fst4_bake_golden_refined_candidates() {
     let fft_cache = build_fft_cache(&audio, &FST4_60A_DOWNSAMPLE);
 
     const SYNC_Q_MIN: u32 = 16;
-    let raw_candidates = coarse_sync::<Fst4s60>(&audio, 100.0, 3000.0, 1.2, None, 50, 12_000.0);
+    let raw_candidates = coarse_sync::<Fst4s60>(
+        AudioSource::Real(&audio),
+        100.0,
+        3000.0,
+        1.2,
+        None,
+        50,
+        RxGrid::real(12_000.0),
+    );
     eprintln!("coarse_sync: {} raw candidates", raw_candidates.len());
 
     // Refine every raw candidate, then apply dedup_refined_candidates'

--- a/mfsk-core/tests/ft4_diag_low_snr.rs
+++ b/mfsk-core/tests/ft4_diag_low_snr.rs
@@ -8,7 +8,7 @@ use std::f32::consts::PI;
 
 use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
 use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
-use mfsk_core::engine::sync::{coarse_sync, refine_candidate};
+use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync, refine_candidate};
 use mfsk_core::engine::{
     FecCodec, FecOpts, FrameLayout, MessageCodec, MessageFields, ModulationParams, Protocol,
 };
@@ -95,7 +95,15 @@ fn why_does_neg16db_fail() {
         .with_call2("JA1ABC");
 
     let audio = make_slot(&msg, -16.0, 0xCAFE);
-    let cands = coarse_sync::<Ft4>(&audio, 800.0, 1200.0, 0.3, None, 200, 12_000.0);
+    let cands = coarse_sync::<Ft4>(
+        AudioSource::Real(&audio),
+        800.0,
+        1200.0,
+        0.3,
+        None,
+        200,
+        RxGrid::real(12_000.0),
+    );
     eprintln!("\n-16 dB signal: {} coarse candidates", cands.len());
 
     // Find the truth-proximate candidate

--- a/mfsk-core/tests/ft4_sweep.rs
+++ b/mfsk-core/tests/ft4_sweep.rs
@@ -384,7 +384,7 @@ fn ft4_diag_weak_trials() {
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::llr::{symbol_spectra, sync_quality};
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
     use mfsk_core::engine::sync2d::ft4_sync_search;
     use mfsk_core::ft4::Ft4;
     use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
@@ -426,7 +426,15 @@ fn ft4_diag_weak_trials() {
             let Some(audio) = load_wav_i16_opt(&path) else {
                 continue;
             };
-            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+            let cands = coarse_sync::<Ft4>(
+                AudioSource::Real(&audio),
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                50,
+                RxGrid::real(12_000.0),
+            );
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -509,7 +517,7 @@ fn ft4_diag_k4_tail_direction() {
     use mfsk_core::ModulationParams;
     use mfsk_core::engine::dsp::downsample::{build_fft_cache, downsample_cached};
     use mfsk_core::engine::llr::{compute_llr, descramble_info, symbol_spectra, sync_quality};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, ft4_sync_search};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::fec::ldpc::osd::osd_decode_generic;
@@ -543,7 +551,15 @@ fn ft4_diag_k4_tail_direction() {
             let Some(audio) = load_wav_i16_opt(&path) else {
                 continue;
             };
-            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+            let cands = coarse_sync::<Ft4>(
+                AudioSource::Real(&audio),
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                50,
+                RxGrid::real(12_000.0),
+            );
             let fft_cache = build_fft_cache(&audio, &FT4_DOWNSAMPLE);
             let ds_rate = 12_000.0 / Ft4::NDOWN as f32;
             let fec = <Ft4 as Protocol>::Fec::default();
@@ -684,7 +700,7 @@ fn ft4_diag_segment_retry() {
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::llr::{compute_llr, symbol_spectra, sync_quality};
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::coarse_sync;
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, coarse_sync};
     use mfsk_core::engine::sync2d::{freq_shift_cd0, ft4_sync_search_window};
     use mfsk_core::engine::{FecCodec, FecOpts, MessageCodec, Protocol};
     use mfsk_core::ft4::Ft4;
@@ -796,7 +812,15 @@ fn ft4_diag_segment_retry() {
             let Some(audio) = load_wav_i16_opt(&path) else {
                 continue;
             };
-            let cands = coarse_sync::<Ft4>(&audio, 100.0, 3000.0, 0.8, None, 50, 12_000.0);
+            let cands = coarse_sync::<Ft4>(
+                AudioSource::Real(&audio),
+                100.0,
+                3000.0,
+                0.8,
+                None,
+                50,
+                RxGrid::real(12_000.0),
+            );
             let near: Vec<_> = cands
                 .iter()
                 .filter(|c| (c.freq_hz - GOLDEN_FREQ_HZ).abs() <= FREQ_TOL_HZ)
@@ -909,7 +933,7 @@ fn ft4_diag_candidate_cost_split() {
     use mfsk_core::engine::equalize::EqMode;
     use mfsk_core::engine::ft4_coarse::ft4_coarse_sync;
     use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_basic};
-    use mfsk_core::engine::sync::{SyncCandidate, coarse_sync};
+    use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
     use mfsk_core::engine::sync2d::ft4_sync_search;
     use mfsk_core::ft4::Ft4;
     use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
@@ -954,7 +978,13 @@ fn ft4_diag_candidate_cost_split() {
             ft4_coarse_sync(audio, freq_min, freq_max, sync_min, None, max_cand)
         } else {
             coarse_sync::<Ft4>(
-                audio, freq_min, freq_max, sync_min, None, max_cand, 12_000.0,
+                AudioSource::Real(audio),
+                freq_min,
+                freq_max,
+                sync_min,
+                None,
+                max_cand,
+                RxGrid::real(12_000.0),
             )
         };
         let coarse_dt = t0.elapsed();


### PR DESCRIPTION
Stacked on #324 (stage 1). Implements stages 2-4 of `docs/notes/FST4_DDC_DESIGN.md`'s plan (§7):

- **Stage 2** — `RxGrid` + complex-input `compute_spectra`
- **Stage 3** — `engine::dsp::ddc` (generic complex DDC) + `fst4::ddc`'s coarse-sync cascade
- **Stage 4** — refine-stage re-centre on the DDC baseband

## Stage 2: `RxGrid` + complex `compute_spectra`

`engine::sync::RxGrid` consolidates the bin↔Hz mapping `compute_spectra`/`coarse_sync` need: `RxGrid::real` reproduces today's positive-frequency-only 12 kHz real-PCM path bit-for-bit; `RxGrid::complex` adds a DDC-fed complex-baseband grid centred on an arbitrary `center_hz`, stored **fftshifted-on-store** so `coarse_sync`'s correlation loop body needs zero changes to read either grid — only the `ia`/`ib` derivation and every `nh1`-shaped clamp move to `RxGrid::bin_of`/`usable_bins` calls.

`compute_spectra`/`coarse_sync` signatures change (`sample_rate_hz: f32 → grid: RxGrid`, `audio: &[i16] → AudioSource`); every real call site (3 in `src/`, ~45 in `tests/`) now passes `AudioSource::Real(audio)` / `RxGrid::real(12_000.0)` — same numbers, new types.

**Verification** (design doc §6 item 1, non-regression): full merge gate green (444 passed) — every FST4/FT4 golden test's numbers are provably unchanged on the real path. New unit tests pin `RxGrid::real`'s bin math against the pre-`RxGrid` formulas, and a synthetic complex-tone test confirms the fftshift lands where `RxGrid::complex::bin_of` predicts, both above and below `center_hz`.

## Stage 3: complex DDC + FST4-60 coarse-sync cascade

`engine::dsp::ddc` is the generic complex down-converter §4.3 describes: a rotating-phasor mixer feeding an integer `FirStage` cascade into a final `PolyphaseResampler`. `fst4::ddc` is FST4-60's own `K`-selection (`choose_k` reproduces the design doc's worked table exactly: 600 Hz → K=256 sniper, 2900 Hz → K=1024 wideband) and cascade split (sniper: integer /3 → rational 16/81; wideband: rational 64/243 direct).

Also fixes a real bug: `coarse_sync`'s candidate `freq_hz` reporting still used the real-grid-only `i as f32 * d.df` instead of going through `RxGrid` — added `RxGrid::hz_of` (`bin_of`'s exact inverse) and wired it in. Caught by this stage's own end-to-end test (initially reported a candidate 1100+ Hz off).

**Verification** (§6 item 3): a clean synthetic FST4-60 signal run through both the real 12 kHz path and the DDC-complex path finds the same candidate frequency (<2 Hz), with the DDC path's score at roughly 1/3 of the real path's — a real, documented processing-margin cost from routing through more filter stages than one direct FFT, not a bug. Full merge gate green (452 passed).

## Stage 4: refine-stage re-centre

The coarse DDC baseband still spans a whole search window around one `center_hz`; a Costas correlator (`fine_sync_power`) assumes tone 0 sits exactly at DC, so a second per-candidate re-centring stage is needed — `StreamingComplexRecenter` (`Mixer::mix_complex` + `PolyphaseResampler`, no integer cascade needed at this bandwidth). Both refine configs' `L=9/M` ratio lands exactly on the existing `ds_rate = 111.11 Hz` (`NDOWN=108`, kept for WSJT-X fidelity).

**Verification** (§6 items 3+4): `refine_candidate` run on the DDC-derived baseband finds the same `dt_sec` (within 0.1 s) that `downsample_cached` + `refine_candidate` finds on the same synthetic signal — the timing-alignment derivation this stage's difficulty was in getting right. Full merge gate green (454 passed).

## Scope

All four stages are **additive and host-only** — no live decode caller (`pipeline.rs`) is rewired yet. Every new type/function is exercised only by its own tests. Stage 5 (esp-dsp backend + real hardware) remains, along with tightening the group-delay estimates (currently documented as conservative, not exact) before any production wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)