### PR TITLE
feat(embedded): FST4-60 DDC coarse-sync real-hardware confirmation (CoreS3)

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
@@ -50,7 +50,7 @@ use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candida
 use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
 use mfsk_core::engine::sync2d::fst4_sync_search;
 use mfsk_core::fst4::Fst4s60;
-use mfsk_core::fst4::ddc::{grid_for, sniper_cascade, sniper_refine_recenter};
+use mfsk_core::fst4::ddc::{REFINE_DS_RATE_HZ, grid_for, sniper_cascade, sniper_refine_recenter};
 use mfsk_core::msg::wsjt77::unpack77;
 
 /// Matches `fst4::decode`'s own (private) `SYNC_Q_MIN` — see
@@ -64,11 +64,6 @@ const CENTER_HZ: f32 = 1216.0;
 const SEARCH_HALF_WIDTH_HZ: f32 = 250.0;
 const SYNC_MIN: f32 = 0.8;
 const MAX_CAND: usize = 50;
-/// Same `ds_rate` both `sniper_refine_recenter` configs land on
-/// exactly — see `fst4::ddc::REFINE_DS_RATE_HZ`'s own doc comment
-/// (not reachable from here without importing the const directly,
-/// duplicated as a literal the same way `SYNC_Q_MIN` above is).
-const REFINE_DS_RATE_HZ: f32 = 111.111_11;
 
 fn now_us() -> i64 {
     unsafe { esp_idf_svc::sys::esp_timer_get_time() }
@@ -128,8 +123,14 @@ fn ddc_refine(
     coarse_delay_orig: usize,
 ) -> Vec<Complex32> {
     let mut refine = sniper_refine_recenter(cand.freq_hz, CENTER_HZ);
-    let mut cd0_i = Vec::new();
-    let mut cd0_q = Vec::new();
+    // Sized from the sniper cascade's own fixed L/M=9/64 ratio (plus a
+    // small margin for `flush`'s tail) rather than growing from empty
+    // via repeated reallocation — this runs up to ~90 times per bench
+    // invocation (Stage 2a + 2c), each on a buffer this module's own
+    // doc comment already sizes at up to ~266 KB.
+    let cap = coarse_i.len() * 9 / 64 + 16;
+    let mut cd0_i = Vec::with_capacity(cap);
+    let mut cd0_q = Vec::with_capacity(cap);
     refine.push(coarse_i, coarse_q, &mut cd0_i, &mut cd0_q);
     refine.flush(&mut cd0_i, &mut cd0_q);
     let refine_delay_out = refine.group_delay_output_samples();

--- a/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
@@ -1,0 +1,459 @@
+//! FST4-60 **DDC-fed** coarse-sync + refine + decode bench, real WAV
+//! in, on ESP32-S3 (LX7) — `docs/notes/FST4_DDC_DESIGN.md` stage 5's
+//! first half.
+//!
+//! `apps::fst4_bench` (issue #306/#307) proved the LLR/BP/OSD decoder
+//! fits on-device, but explicitly skipped the front end: `coarse_sync`
+//! and `downsample_cached` both need non-power-of-two FFT lengths
+//! (`nfft1 = 7776`, `fft2_size = 6912` for FST4-60A) the embedded
+//! `fft-extern`/ESP-DSP backend can't serve — that module's own doc
+//! comment calls this "No `coarse_sync` on-device (can't yet — #307)".
+//!
+//! The DDC pipeline (`mfsk_core::engine::dsp::ddc` +
+//! `mfsk_core::fst4::ddc`, `docs/notes/FST4_DDC_DESIGN.md` stages 1-4)
+//! routes around that: its coarse-sync spectrogram is a power-of-two
+//! `nfft1` (512 for the sniper `K=256` grid this bench uses) by
+//! construction, and neither the DDC's own mixer/`FirStage`/
+//! `PolyphaseResampler` cascade nor `fst4_sync_search`'s coherent
+//! block correlator touch an FFT at all — only `compute_spectra`'s
+//! complex path does, and that one fits the ESP-DSP ceiling. So the
+//! **whole** chain — real 12 kHz audio in, decoded message out — has
+//! no FFT this backend can't serve, and this bench is the first
+//! on-device confirmation of that, not just a host claim.
+//!
+//! ## What's *not* yet PIE-accelerated
+//!
+//! `FirStage`/`PolyphaseResampler` are plain portable f32 Rust —
+//! correct on Xtensa, not yet routed through `dsps_fird_f32_aes3`
+//! (design doc §4.5's own remaining stage-5 item). This bench answers
+//! "does it work and what does it cost unaccelerated", the same
+//! starting point `fst4_bench`'s own LLR/BP/OSD measurement was
+//! before its own six-round optimisation pass.
+//!
+//! ## Target window
+//!
+//! Both real signals on the vendored WSJT-X golden (`210115_0058.wav`)
+//! sit within one sniper window: N5TM @ 1101 Hz, K9KFR @ 1331 Hz, 230 Hz
+//! apart — well inside the sniper cascade's own ±250 Hz shape centred
+//! on their midpoint, 1216 Hz. One DDC pass catches both.
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use num_complex::Complex32;
+
+use mfsk_core::engine::dsp::ddc::StreamingComplexDdc;
+use mfsk_core::engine::equalize::EqMode;
+use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_precomputed};
+use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
+use mfsk_core::engine::sync2d::fst4_sync_search;
+use mfsk_core::fst4::Fst4s60;
+use mfsk_core::fst4::ddc::{grid_for, sniper_cascade, sniper_refine_recenter};
+use mfsk_core::msg::wsjt77::unpack77;
+
+/// Matches `fst4::decode`'s own (private) `SYNC_Q_MIN` — see
+/// `fst4_bench`'s identical constant for why it's redeclared here
+/// rather than imported.
+const SYNC_Q_MIN: u32 = 16;
+
+/// Midpoint of N5TM (1101 Hz) / K9KFR (1331 Hz) — see the module doc
+/// comment.
+const CENTER_HZ: f32 = 1216.0;
+const SEARCH_HALF_WIDTH_HZ: f32 = 250.0;
+const SYNC_MIN: f32 = 0.8;
+const MAX_CAND: usize = 50;
+/// Same `ds_rate` both `sniper_refine_recenter` configs land on
+/// exactly — see `fst4::ddc::REFINE_DS_RATE_HZ`'s own doc comment
+/// (not reachable from here without importing the const directly,
+/// duplicated as a literal the same way `SYNC_Q_MIN` above is).
+const REFINE_DS_RATE_HZ: f32 = 111.111_11;
+
+fn now_us() -> i64 {
+    unsafe { esp_idf_svc::sys::esp_timer_get_time() }
+}
+
+fn stack_headroom() -> u32 {
+    unsafe { esp_idf_svc::sys::uxTaskGetStackHighWaterMark(core::ptr::null_mut()) }
+}
+
+const MALLOC_CAP_8BIT: u32 = 1 << 2;
+const MALLOC_CAP_SPIRAM: u32 = 1 << 10;
+const MALLOC_CAP_INTERNAL: u32 = 1 << 11;
+
+fn log_heap(tag: &str) {
+    unsafe {
+        log::info!(
+            "[mem] {tag}: internal {} KB (largest contig {} KB), PSRAM {} KB (largest contig {} KB)",
+            esp_idf_svc::sys::heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT) / 1024,
+            esp_idf_svc::sys::heap_caps_get_largest_free_block(
+                MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT
+            ) / 1024,
+            esp_idf_svc::sys::heap_caps_get_free_size(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT) / 1024,
+            esp_idf_svc::sys::heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)
+                / 1024,
+        );
+    }
+}
+
+pub fn init_logger_once() {
+    static LOGGER_READY: core::sync::atomic::AtomicBool = core::sync::atomic::AtomicBool::new(false);
+    if LOGGER_READY
+        .compare_exchange(
+            false,
+            true,
+            core::sync::atomic::Ordering::AcqRel,
+            core::sync::atomic::Ordering::Acquire,
+        )
+        .is_ok()
+    {
+        esp_idf_svc::log::EspLogger::initialize_default();
+    }
+}
+
+/// Recentre `cand`'s own frequency out of the coarse DDC baseband
+/// down to the refine (`ds_rate`) baseband, trim the best-effort
+/// combined group delay, RMS-normalise (matching `engine::pipeline::
+/// refine_candidate_position_impl`'s own convention, so `process_
+/// candidate_precomputed`'s LLR scaling sees what it would from
+/// `downsample_cached`), then run the real `fst4_sync_search` refine.
+/// Same recipe `tests/fst4_ddc_sniper_full_decode.rs::ddc_refine_and_
+/// decode` verified against `downsample_cached` on host — see that
+/// test for the delay-trim derivation this mirrors.
+fn ddc_refine(
+    cand: &SyncCandidate,
+    coarse_i: &[f32],
+    coarse_q: &[f32],
+    coarse_delay_orig: usize,
+) -> Vec<Complex32> {
+    let mut refine = sniper_refine_recenter(cand.freq_hz, CENTER_HZ);
+    let mut cd0_i = Vec::new();
+    let mut cd0_q = Vec::new();
+    refine.push(coarse_i, coarse_q, &mut cd0_i, &mut cd0_q);
+    refine.flush(&mut cd0_i, &mut cd0_q);
+    let refine_delay_out = refine.group_delay_output_samples();
+
+    let total_delay_out = (coarse_delay_orig as f32 * REFINE_DS_RATE_HZ / 12_000.0).round()
+        as usize
+        + refine_delay_out;
+    let trim = total_delay_out.min(cd0_i.len());
+
+    let mut cd0: Vec<Complex32> = cd0_i[trim..]
+        .iter()
+        .zip(cd0_q[trim..].iter())
+        .map(|(&i, &q)| Complex32::new(i, q))
+        .collect();
+
+    let sum2: f32 = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len().max(1) as f32;
+    if sum2 > f32::EPSILON {
+        let inv = 1.0 / sum2.sqrt();
+        for c in cd0.iter_mut() {
+            *c *= inv;
+        }
+    }
+    cd0
+}
+
+/// `audio_bin` is the raw golden asset (`include_bytes!`,
+/// `i16[720000]` little-endian — same layout `fst4_bench`'s own
+/// `fst4_60_golden_audio.bin` doc comment describes). Byte-wise, not a
+/// transmute: 1-byte `include_bytes!` alignment faults an unaligned
+/// `i16` load on Xtensa.
+pub fn run(audio_bin: &[u8]) {
+    log::info!("mfsk-core {}", mfsk_core::VERSION);
+    log::info!("fst4_ddc_bench: golden asset {} bytes", audio_bin.len());
+    log_heap("boot");
+
+    let audio: Vec<i16> = audio_bin
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|b| i16::from_le_bytes(*b))
+        .collect();
+    log::info!("fst4_ddc_bench: loaded {} samples ({} s @ 12 kHz)", audio.len(), audio.len() / 12_000);
+
+    let r = unsafe { esp_idf_svc::sys::esp_task_wdt_deinit() };
+    log::info!("task watchdog deinit -> {r}");
+
+    // ---- Stage 1: DDC + coarse_sync ----
+    let t0 = now_us();
+    let coarse_cfg = sniper_cascade(CENTER_HZ);
+    let mut coarse = StreamingComplexDdc::new(&coarse_cfg);
+    let mut coarse_i = Vec::new();
+    let mut coarse_q = Vec::new();
+    coarse.push_i16(&audio, &mut coarse_i, &mut coarse_q);
+    coarse.flush(&mut coarse_i, &mut coarse_q);
+    let coarse_delay_orig = coarse.group_delay_input_samples();
+    let t_ddc = now_us() - t0;
+    log::info!(
+        "fst4_ddc_bench: DDC {} -> {} complex samples in {} ms",
+        audio.len(),
+        coarse_i.len(),
+        t_ddc / 1000,
+    );
+    log_heap("post-ddc");
+
+    let t1 = now_us();
+    let grid = grid_for(600.0);
+    let candidates = coarse_sync::<Fst4s60>(
+        AudioSource::Complex(&coarse_i, &coarse_q),
+        CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
+        CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
+        SYNC_MIN,
+        None,
+        MAX_CAND,
+        RxGrid::complex(grid.fs_c, CENTER_HZ),
+    );
+    let t_coarse_sync = now_us() - t1;
+    log::info!(
+        "fst4_ddc_bench: coarse_sync (via DDC, K={}, nfft1={}) -> {} candidates in {} ms",
+        grid.k,
+        grid.nfft1,
+        candidates.len(),
+        t_coarse_sync / 1000,
+    );
+    for c in &candidates {
+        log::info!("    cand {:8.1} Hz  dt {:+.3} s  score {:.2}", c.freq_hz, c.dt_sec, c.score);
+    }
+    log_heap("post-coarse-sync");
+
+    // ---- Stage 2a: refine every raw candidate, metadata only ----
+    //
+    // Mirrors `engine::pipeline::dedup_refined_candidates`'s own first
+    // pass exactly — same near-duplicate rule (§ below), applied
+    // *before* any candidate reaches the expensive nsym=8/OSD stage,
+    // not after. That function isn't `pub` (private to `engine::
+    // pipeline`, same reason `fst4_bake_golden_refined_candidates`'s
+    // own doc comment gives for re-deriving it rather than importing
+    // it: "~20 lines and exposing the private `RefinedSurvivor` type
+    // alias for one caller wasn't worth the extra public surface") —
+    // reproduced here rather than skipped, unlike this bench's first
+    // version, which fed every one of coarse_sync's raw (un-deduped)
+    // candidates straight into LLR/BP/OSD. On real audio, several
+    // near-duplicate coarse-sync cells refine onto the *same* true
+    // position for each real signal (visible in this bench's own
+    // logged candidate list — several entries within a few Hz/lag of
+    // each other), and every one of those duplicates was paying the
+    // full ladder independently — the exact cost issue #244 already
+    // found and fixed for the production real-audio path.
+    //
+    // Unlike the host version, this can't just keep every candidate's
+    // `cd0` (`Vec<Complex32>`) around to reuse post-dedup — PSRAM here
+    // is single-digit MB and `candidates.len()` buffers at ~266 KB
+    // each would exceed it. Stage 2a keeps only the cheap refined
+    // `(freq_hz, i0, score)` triple per candidate and drops each `cd0`
+    // immediately; Stage 2c rebuilds `cd0` for survivors only — a
+    // second DDC-recentre pass, cheap next to LLR/BP/OSD, traded for
+    // the memory this board doesn't have to spare.
+    struct RefineMeta {
+        freq_hz: f32,
+        i0: i32,
+        score: f32,
+    }
+    let t2a = now_us();
+    let refine_meta: Vec<RefineMeta> = candidates
+        .iter()
+        .enumerate()
+        .map(|(i, cand)| {
+            let cd0 = ddc_refine(cand, &coarse_i, &coarse_q, coarse_delay_orig);
+            let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
+            log::info!(
+                "fst4_ddc_bench: refine-all {}/{} done ({:.1} Hz)",
+                i + 1,
+                candidates.len(),
+                cand.freq_hz,
+            );
+            RefineMeta {
+                freq_hz: s2.freq_hz,
+                i0: s2.i0,
+                score: s2.score,
+            }
+        })
+        .collect();
+    let t_refine_all = now_us() - t2a;
+    log::info!(
+        "fst4_ddc_bench: refined {} candidates in {} ms",
+        candidates.len(),
+        t_refine_all / 1000,
+    );
+    log_heap("post-refine-all");
+
+    // ---- Stage 2b: dedup — same rule as engine::pipeline::
+    // dedup_refined_candidates (0.10 * TONE_SPACING_HZ in frequency,
+    // +/-2 downsampled samples in i0, highest-score survivor kept).
+    use mfsk_core::engine::ModulationParams;
+    let freq_tol = 0.10 * <Fst4s60 as ModulationParams>::TONE_SPACING_HZ;
+    const I0_TOL: i32 = 2;
+    let mut order: Vec<usize> = (0..candidates.len()).collect();
+    order.sort_by(|&a, &b| {
+        refine_meta[b]
+            .score
+            .partial_cmp(&refine_meta[a].score)
+            .unwrap_or(core::cmp::Ordering::Equal)
+    });
+    let mut kept_positions: Vec<(f32, i32)> = Vec::new();
+    let mut keep = alloc::vec![false; candidates.len()];
+    for idx in order {
+        let m = &refine_meta[idx];
+        let dup = kept_positions
+            .iter()
+            .any(|&(kf, ki)| (m.freq_hz - kf).abs() < freq_tol && (m.i0 - ki).abs() <= I0_TOL);
+        if !dup {
+            kept_positions.push((m.freq_hz, m.i0));
+            keep[idx] = true;
+        }
+    }
+    let n_survivors = keep.iter().filter(|&&k| k).count();
+    log::info!(
+        "fst4_ddc_bench: dedup {} -> {} survivors",
+        candidates.len(),
+        n_survivors,
+    );
+
+    // ---- Stage 2c: rebuild cd0 for survivors, LLR/BP/OSD ----
+    struct CandidateTiming {
+        freq_hz: f32,
+        refine_us: i64,
+        decode_us: i64,
+        decoded: bool,
+    }
+    let mut timings: Vec<CandidateTiming> = Vec::with_capacity(n_survivors);
+    let mut results: Vec<(f32, f32, Option<String>)> = Vec::new();
+
+    let t2c = now_us();
+    let mut survivor_rank = 0usize;
+    for (idx, cand) in candidates.iter().enumerate() {
+        if !keep[idx] {
+            continue;
+        }
+        survivor_rank += 1;
+        // Incremental, not just the sorted summary after the loop —
+        // this stage has no other progress signal (a slow candidate
+        // pays the same ~7-14s/candidate the un-deduped nsym=8/OSD
+        // tail cost fst4_bench's own doc comment measured, and a
+        // silent multi-minute gap on the UART otherwise looks
+        // indistinguishable from a hang).
+        log::info!(
+            "fst4_ddc_bench: survivor {survivor_rank}/{n_survivors}: {:.1} Hz, dt {:+.3} s ...",
+            cand.freq_hz,
+            cand.dt_sec,
+        );
+        let t_r = now_us();
+        let cd0 = ddc_refine(cand, &coarse_i, &coarse_q, coarse_delay_orig);
+        let refine_us = now_us() - t_r;
+        let m = &refine_meta[idx];
+
+        let t_d = now_us();
+        let precomputed = (cd0, m.freq_hz, m.i0, m.score);
+        let decoded = process_candidate_precomputed::<Fst4s60>(
+            cand,
+            &[],
+            &mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE,
+            DecodeDepth::FULL,
+            DecodeStrictness::Normal,
+            &[],
+            EqMode::Off,
+            SYNC_Q_MIN,
+            precomputed,
+            true, // skip_snr — see fst4_bench's own identical rationale
+            false,
+        );
+        let decode_us = now_us() - t_d;
+        log::info!(
+            "fst4_ddc_bench: survivor {survivor_rank}/{n_survivors} done: refine {} ms, decode {} ms, decoded={}",
+            refine_us / 1000,
+            decode_us / 1000,
+            decoded.is_some(),
+        );
+
+        timings.push(CandidateTiming {
+            freq_hz: cand.freq_hz,
+            refine_us,
+            decode_us,
+            decoded: decoded.is_some(),
+        });
+        if let Some(res) = decoded {
+            let text = res
+                .message77()
+                .try_into()
+                .ok()
+                .and_then(|m77: &[u8; 77]| unpack77(m77));
+            results.push((res.freq_hz, res.dt_sec, text));
+        }
+    }
+    let total_candidate_us = now_us() - t2c;
+
+    timings.sort_by(|a, b| (b.refine_us + b.decode_us).cmp(&(a.refine_us + a.decode_us)));
+    log::info!("fst4_ddc_bench: per-survivor timing, slowest first:");
+    for t in &timings {
+        log::info!(
+            "    {:8.1} Hz  refine {:>6} ms  decode {:>6} ms  decoded={}",
+            t.freq_hz,
+            t.refine_us / 1000,
+            t.decode_us / 1000,
+            t.decoded,
+        );
+    }
+
+    log::info!(
+        "fst4_ddc_bench: TOTALS — ddc {} ms, coarse_sync {} ms, refine-all {} ms, dedup {} -> {} survivors, survivor refine+decode {} ms ({} decodes)",
+        t_ddc / 1000,
+        t_coarse_sync / 1000,
+        t_refine_all / 1000,
+        candidates.len(),
+        n_survivors,
+        total_candidate_us / 1000,
+        results.len(),
+    );
+    for (freq_hz, dt_sec, text) in &results {
+        log::info!("    {text:?} | {freq_hz:.1} Hz | dt {dt_sec:.2} s");
+    }
+    log::info!("fst4_ddc_bench: stack headroom = {} B", stack_headroom());
+    log_heap("post-decode");
+    log::info!("=== fst4_ddc_bench complete ===");
+}
+
+/// Stack for the bench task — same starting-guess rationale as
+/// `fst4_bench::BENCH_STACK` (this bench's own DDC/refine stages add
+/// only heap-allocated `Vec` state, no large stack frames of their
+/// own, so the same order of magnitude is a reasonable starting
+/// point; resize once a real "stack headroom" log line exists).
+pub const BENCH_STACK: u32 = 96 * 1024;
+
+extern "C" fn bench_task(arg: *mut core::ffi::c_void) {
+    // SAFETY: mirrors `fst4_bench::bench_task`'s identical arg-passing
+    // shape.
+    let audio_bin: &'static [u8] = unsafe { *(arg as *const &'static [u8]) };
+    run(audio_bin);
+    loop {
+        unsafe { esp_idf_svc::sys::vTaskDelay(1000) };
+    }
+}
+
+pub fn run_task(audio_bin: &'static [u8]) -> ! {
+    esp_idf_svc::sys::link_patches();
+    init_logger_once();
+
+    let arg: &'static &'static [u8] = alloc::boxed::Box::leak(alloc::boxed::Box::new(audio_bin));
+    let argp = arg as *const _ as *mut core::ffi::c_void;
+
+    let created = unsafe {
+        esp_idf_svc::sys::xTaskCreatePinnedToCore(
+            Some(bench_task),
+            c"fst4_ddc_bench".as_ptr(),
+            BENCH_STACK,
+            argp,
+            5,
+            core::ptr::null_mut(),
+            0,
+        )
+    };
+    if created != 1 {
+        log::error!("failed to create fst4_ddc_bench task ({BENCH_STACK} B stack)");
+    }
+
+    loop {
+        unsafe { esp_idf_svc::sys::vTaskDelay(1000) };
+    }
+}

--- a/embedded-poc/embedded-shared/src/apps/mod.rs
+++ b/embedded-poc/embedded-shared/src/apps/mod.rs
@@ -8,6 +8,8 @@
 pub mod compute_bench;
 #[cfg(feature = "fst4-bench")]
 pub mod fst4_bench;
+#[cfg(feature = "fst4-bench")]
+pub mod fst4_ddc_bench;
 pub mod rx_wavsim;
 pub mod scalar_bench;
 #[cfg(feature = "wspr-bench")]

--- a/embedded-poc/m5stack-cores3-app/Cargo.toml
+++ b/embedded-poc/m5stack-cores3-app/Cargo.toml
@@ -45,6 +45,16 @@ name = "fst4-bench"
 path = "src/bin/fst4_bench.rs"
 harness = false
 
+# FST4-60 DDC-fed coarse-sync + refine + decode bench —
+# docs/notes/FST4_DDC_DESIGN.md stage 5's first half. The whole chain
+# (DDC -> coarse_sync -> refine -> LLR/BP/OSD) on real audio, not just
+# the decoder half `fst4-bench` above measures. See
+# `embedded-shared::apps::fst4_ddc_bench`'s module doc comment.
+[[bin]]
+name = "fst4-ddc-bench"
+path = "src/bin/fst4_ddc_bench.rs"
+harness = false
+
 # LlrScalar (f32 vs Q11i16 vs Q3i8) microbenchmark — issue #198's
 # deprioritized `FecCodec::decode_soft` genericization premise, checked
 # cheaply before committing to that work. See

--- a/embedded-poc/m5stack-cores3-app/src/bin/fst4_ddc_bench.rs
+++ b/embedded-poc/m5stack-cores3-app/src/bin/fst4_ddc_bench.rs
@@ -1,0 +1,25 @@
+//! FST4-60 DDC-fed coarse-sync + refine + decode bench (M5Stack CoreS3
+//! / ESP32-S3 / LX7) — `docs/notes/FST4_DDC_DESIGN.md` stage 5.
+//!
+//! Thin shim — all logic lives in `embedded_shared::apps::fst4_ddc_bench`.
+//! Unlike `fst4-bench` (issue #306/#307, LLR/BP/OSD only, no FFT
+//! anywhere), this one runs the *whole* chain on-device: real 12 kHz
+//! audio in, through the DDC (mixer + FIR cascade + polyphase
+//! resampler, no FFT), `coarse_sync` (one power-of-two FFT, via the
+//! DDC's own complex baseband), `fst4_sync_search` refine (no FFT),
+//! and the same LLR/BP/OSD decoder `fst4-bench` already proved fits.
+//!
+//! Build: `cargo build --release --bin fst4-ddc-bench`.
+//!
+//! The baked asset is the same raw golden audio `fst4-bench` itself
+//! documents generating (`fst4_bake_golden_precomputed` in
+//! `mfsk-core/tests/fst4_wsjtx_samples.rs`) — only the
+//! `fst4_60_golden_audio.bin` half is needed here, not the FFT cache.
+
+const GOLDEN_AUDIO: &[u8] = include_bytes!("../../../assets/fst4_60_golden_audio.bin");
+
+fn main() -> ! {
+    esp_idf_svc::sys::link_patches();
+    embedded_shared::apps::fst4_ddc_bench::init_logger_once();
+    embedded_shared::apps::fst4_ddc_bench::run_task(GOLDEN_AUDIO)
+}

--- a/embedded-poc/scripts/flash-monitor.sh
+++ b/embedded-poc/scripts/flash-monitor.sh
@@ -29,10 +29,20 @@
 # 0x400000` forever, even after a full `espflash erase-flash`. Every
 # app flashed through this script before that issue happened to fit
 # under 4 MB total (factory + littlefs etc.), so this was silently
-# wrong the whole time it just never mattered. `FLASH_SIZE` below
-# defaults to empty (old behaviour, for boards this hasn't been
-# verified safe on yet) — pass it explicitly for any board/partition
-# table that needs more than 4 MB.
+# wrong the whole time it just never mattered — and it recurred for
+# real on a CoreS3 fst4-ddc-bench flash (2026-08-21): board-info
+# correctly reports 16 MB, but the app header still said 4 MB and the
+# board boot-looped on the same partition-table-verification error.
+#
+# **Fixed at the root, not per-board**: when the caller doesn't pass
+# `FLASH_SIZE` explicitly, this script now runs `espflash board-info`
+# first and parses its own "Flash size: NNMB" line to build the
+# `--flash-size` flag automatically — the same value the connected
+# chip already reports, just also handed to the part of espflash that
+# was silently ignoring it. Falls back to the old (unset) behaviour
+# with a warning if `board-info` fails or its output doesn't parse, so
+# a flaky port doesn't turn this into a harder failure than before.
+# Pass `FLASH_SIZE` explicitly to override the detected value.
 #
 # Usage:
 #   embedded-poc/scripts/flash-monitor.sh <ELF> <LOG_FILE> [DURATION_SEC] [PORT] [PARTITIONS] [FLASH_SIZE]
@@ -41,7 +51,7 @@
 #   DURATION_SEC = 90
 #   PORT         = /dev/ttyACM0
 #   PARTITIONS   = ./partitions.csv
-#   FLASH_SIZE   = (unset — espflash's own default, currently 4mb regardless of chip)
+#   FLASH_SIZE   = (unset — auto-detected from the connected chip via `espflash board-info`)
 #
 # Requires `source ~/export-esp.sh` to have been run in the parent shell.
 
@@ -65,6 +75,24 @@ fi
 
 mkdir -p "$(dirname "$LOG")"
 : > "$LOG"
+
+if [[ -z "$FLASH_SIZE" ]]; then
+    # `board-info`'s own line looks like "Flash size:        16MB" —
+    # take the last field, lower-case it (espflash's `--flash-size`
+    # wants e.g. `16mb`, not `16MB`). `|| true`: don't let a flaky
+    # port turn detection failure into a hard script failure under
+    # `set -e`; DETECTED simply stays empty and the fallback below
+    # warns and proceeds exactly as before this fix existed.
+    DETECTED=$(espflash board-info --port "$PORT" 2>/dev/null \
+        | grep -i '^Flash size' \
+        | awk '{print tolower($NF)}') || true
+    if [[ -n "$DETECTED" ]]; then
+        FLASH_SIZE="$DETECTED"
+        echo "[flash-monitor] auto-detected flash size: $FLASH_SIZE"
+    else
+        echo "[flash-monitor] WARNING: could not auto-detect flash size from 'espflash board-info' — falling back to espflash's own default (currently 4mb regardless of chip). Pass FLASH_SIZE explicitly if this board's factory partition exceeds 4 MB." >&2
+    fi
+fi
 
 FLASH_SIZE_FLAG=""
 if [[ -n "$FLASH_SIZE" ]]; then


### PR DESCRIPTION
Stage 5's first half (`docs/notes/FST4_DDC_DESIGN.md`, issue #307/#306), following #324/#325 (stages 1-4, host-only). Interim report posted to #307: https://github.com/jl1nie/mfsk-core/issues/307#issuecomment-5363928040

## New: `fst4-ddc-bench`

Real 12 kHz WSJT-X golden WAV in, decoded message out, entirely on-device on a real CoreS3. Because the DDC's coarse-sync spectrogram is a power-of-two `nfft1` (512, sniper `K=256`) and neither the DDC's own FIR/resampler cascade nor `fst4_sync_search`'s coherent correlator touch an FFT, the whole chain has no FFT the embedded `fft-extern`/ESP-DSP backend can't serve — closing the gap `fst4_bench`'s own doc comment names ("No `coarse_sync` on-device (can't yet — #307)").

Pipeline: DDC → coarse_sync → refine-all (metadata only, `cd0` dropped immediately — storing every candidate's ~266 KB `cd0` at once would exceed this board's single-digit-MB PSRAM) → dedup (`engine::pipeline::dedup_refined_candidates`'s exact near-duplicate rule, re-derived since it isn't `pub`, same reason the existing bake test already had to) → rebuild `cd0` for survivors → LLR/BP/OSD via `process_candidate_precomputed`. Per-candidate progress logging throughout — both the refine-all pass and the decode loop ran for tens of seconds to minutes silently during development, indistinguishable from a hang without it.

**Measured, real CoreS3, sniper window centred on 1216 Hz (covers both known golden signals, 230 Hz apart):**

```
DDC:              2.064 s
coarse_sync:      0.437 s  (50 candidates, top two scoring 38.68/29.79 — next-best 5.85)
refine-all:      35.153 s  (50 candidates)
dedup:           50 -> 38 survivors
survivor loop:  551.117 s  (38 candidates, LLR/BP/OSD)
TOTAL:          ~588.8 s
```

3 decodes, exact match to the golden reference (`CQ K9KFR EN71` @ 1330.6/1330.7 Hz, `CQ N5TM EL29` @ 1100.6 Hz — golden is 1331.0/1101.0 Hz). **No panic anywhere in the chain.**

## Fix: `flash-monitor.sh` auto-detects `--flash-size`

Recurred for real getting this bench flashed: espflash silently writes a 4 MB flash-size into the app image header when `--flash-size` isn't passed, regardless of what it correctly detects from the chip — already documented in this script's own header comment (2026-08-16) but not actually fixed at the time. CoreS3's 9 MB factory partition exceeds that, boot-looping on "Failed to verify partition table" forever. Fixed at the root rather than hardcoding a per-board value: the script now runs `espflash board-info` first and parses the real flash size when the caller doesn't pass one explicitly.

## Scope

`FirStage`/`PolyphaseResampler` are still plain portable f32 Rust, not yet routed through `dsps_fird_f32_aes3` (design doc §4.5's remaining item) — today's numbers are unaccelerated. LLR/BP/OSD remains the dominant cost (551 s of 589 s), same conclusion `fst4_bench`'s own optimisation pass already reached for #306 — dual-core is the next lever under consideration. FST4-120/300 remain out of scope (design doc §8, their `K` exceeds the 8192 ESP-DSP FFT ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)