### PR TITLE
fix(embedded): fst4-ddc-bench sniper sync_min 0.8 -> 8.0, real-hw 551s -> 363ms survivor loop

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
@@ -62,7 +62,21 @@ const SYNC_Q_MIN: u32 = 16;
 /// comment.
 const CENTER_HZ: f32 = 1216.0;
 const SEARCH_HALF_WIDTH_HZ: f32 = 250.0;
-const SYNC_MIN: f32 = 0.8;
+/// Production default is 0.8 (real weak-signal candidates near FST4-60's
+/// -28 dB threshold score as low as ~1.4-4.5, per the DDC recall
+/// measurement in `fst4::ddc`'s own doc comment) -- **not** what this
+/// bench uses. Raised here, sniper-bench-scoped only: a host-side sweep
+/// against this exact golden recording (issue #307, 2026-08-21) found
+/// the real signals' raw coarse_sync scores (N5TM 38.68, K9KFR 29.79)
+/// sit ~5x above the recording's own noise-floor ceiling (5.85, the
+/// next-highest of 48 false alarms scattered across the whole ±250 Hz/
+/// ±2.5 s search grid -- confirmed *not* near-duplicates of each other
+/// or of the real signals, so `coarse_sync`'s own ±4 Hz/40 ms NMS
+/// legitimately has nothing to collapse there). 8.0 clears that ceiling
+/// with margin while staying ~4x under both real signals' scores. This
+/// is a strong-signal demo recording, not a sensitivity measurement --
+/// do not carry this value into any production/general-search path.
+const SYNC_MIN: f32 = 8.0;
 const MAX_CAND: usize = 50;
 
 fn now_us() -> i64 {


### PR DESCRIPTION
## Summary

Issue #307's real-hardware DDC bench (PR #326) measured a 551.117 s LLR/BP/OSD survivor loop against FST4-60's ~7 s slot budget, with 4 expensive false candidates (129.3 s of it) attributed to a near-duplicate noise cluster near N5TM.

**dedup-tolerance widening (the issue's own proposed low-risk fix) was tried first and measured ineffective**: sweeping `freq_tol` 0.10x–4x `TONE_SPACING_HZ` against the real golden WAV only dropped survivors 38→36, because the "cluster" candidates' refined `i0` (timing) is scattered across hundreds of downsampled samples — not close at all — and the dedup rule ANDs frequency and timing proximity.

**Root cause was upstream of dedup.** `coarse_sync`'s raw candidate list at this bench's `sync_min=0.8` is 50 candidates: the 2 real signals (N5TM 38.68, K9KFR 29.79) plus **48 independent noise-floor false alarms** (≤5.85, scattered across the entire ±250 Hz / ±2.5 s search grid, not clustered near either real signal). `coarse_sync`'s own ±4 Hz/40 ms NMS was already working correctly — these aren't near-duplicates of anything, so there was nothing for it to collapse.

## Fix

Raise this bench's own `SYNC_MIN` from 0.8 to 8.0 — clears the 5.85 noise ceiling with margin, stays ~4x under both real signals' scores.

## Measured on real CoreS3 hardware (2026-08-21)

| stage | sync_min=0.8 | sync_min=8.0 |
|---|---:|---:|
| coarse_sync candidates | 50 | **2** |
| dedup survivors | 38 | **2** |
| refine-all | 35153 ms | **1419 ms** |
| survivor refine+decode | 551117 ms | **363 ms** |
| **TOTAL** | **~588.8 s** | **~6.3 s** |

Both real signals still decode correctly (`CQ N5TM EL29`, `CQ K9KFR EN71`) — zero recall cost on this recording. Total time now comfortably fits FST4-60's ~7 s post-slot budget for this known-strong-signal sniper scenario.

## Scope

**Bench-only.** Production `coarse_sync` callers keep `sync_min=0.8`. This is a strong-signal demo recording, not a sensitivity measurement — a value calibrated against real weak-signal scores (~1.4–4.5 near FST4-60A's -28 dB threshold, per `fst4::ddc`'s own recall measurement) would need a different, much smaller margin if this is ever generalized past this specific bench. Doc comment on the constant spells this out.

## Testing

- Host-side scratch probes (not committed) confirmed the sync_min sweep and ruled out dedup-tolerance widening against the real golden WAV before implementing.
- `cargo +esp build --release --bin fst4-ddc-bench` on `xtensa-esp32s3-espidf` — builds clean.
- Flashed + captured via `embedded-poc/scripts/flash-monitor.sh` on real CoreS3 hardware.
- Pre-commit hook (`cargo fmt`, `clippy --workspace --all-targets --features full,internal-testing -D warnings`, `cargo doc`) passed on push.

Refs: #306, #307, #312

🤖 Generated with [Claude Code](https://claude.com/claude-code)