### PR TITLE
feat(embedded): FST4 dual-core candidate loop — 1.67×, full band inside the deadline

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
@@ -59,6 +59,8 @@ use mfsk_core::fst4::ddc::{
 };
 use mfsk_core::msg::wsjt77::unpack77;
 
+use crate::fst4_dual_core;
+
 /// Matches `fst4::decode`'s own (private) `SYNC_Q_MIN` — see
 /// `fst4_bench`'s identical constant for why it's redeclared here
 /// rather than imported.
@@ -258,14 +260,40 @@ const fn parse_dec(v: Option<&str>) -> i64 {
 /// `wspr_dual_core`'s `DeadlineCell` exactly, including why it is an
 /// `UnsafeCell` rather than an atomic. Single-threaded here (one bench
 /// task), written only between candidates.
-struct DeadlineCell(core::cell::UnsafeCell<i64>);
-// SAFETY: written only by the bench task between candidates, read only
-// by `budget_ok` on that same task. No other task touches it.
-unsafe impl Sync for DeadlineCell {}
-static DEADLINE_US: DeadlineCell = DeadlineCell(core::cell::UnsafeCell::new(i64::MAX));
+/// **Per core**, not one shared cell: under `MFSK_FST4_DDC_BENCH_DUAL=1`
+/// both cores sit inside `monitor_candidate` on *different* candidates
+/// at once, so a single cell would let one core's arming truncate the
+/// other's ladder. Indexed by `xTaskGetCoreID`.
+struct DeadlineCells(core::cell::UnsafeCell<[i64; 2]>);
+// SAFETY: each core writes and reads only its own slot, and only
+// between its own candidates. No slot is ever touched by two cores.
+unsafe impl Sync for DeadlineCells {}
+static DEADLINE_US: DeadlineCells = DeadlineCells(core::cell::UnsafeCell::new([i64::MAX; 2]));
+
+fn core_slot() -> usize {
+    (unsafe { esp_idf_svc::sys::xTaskGetCoreID(core::ptr::null_mut()) } as usize) & 1
+}
+
+fn set_deadline(abs_us: i64) {
+    unsafe { (*DEADLINE_US.0.get())[core_slot()] = abs_us };
+}
 
 fn budget_ok() -> bool {
-    now_us() < unsafe { *DEADLINE_US.0.get() }
+    now_us() < unsafe { (*DEADLINE_US.0.get())[core_slot()] }
+}
+
+/// `MFSK_FST4_DDC_BENCH_DUAL=1` — run the monitor candidate loop across
+/// both cores (issue #327). Same per-candidate function either way.
+const DUAL_CORE: bool = is_one(option_env!("MFSK_FST4_DDC_BENCH_DUAL"));
+
+const fn is_one(v: Option<&str>) -> bool {
+    match v {
+        Some(s) => {
+            let b = s.as_bytes();
+            b.len() == 1 && b[0] == b'1'
+        }
+        None => false,
+    }
 }
 
 fn now_us() -> i64 {
@@ -712,6 +740,109 @@ pub fn run(audio_bin: &[u8]) {
 /// total, because that is the number a monitoring receiver is actually
 /// judged on.
 #[allow(clippy::too_many_arguments)]
+/// One candidate's full work: refine, sync-search, decode. A plain
+/// `fn` item so [`fst4_dual_core::run_split`] can hand it to the worker
+/// task — a closure's captures cannot cross that boundary, which is why
+/// every input arrives through [`Ctx`].
+fn monitor_candidate(ctx: &fst4_dual_core::Ctx, i: usize) -> Option<MonitorHit> {
+    // SAFETY: `run_split` blocks until both cores are done, so these
+    // outlive the call. Shared read-only across cores.
+    let candidates: &[SyncCandidate] =
+        unsafe { core::slice::from_raw_parts(ctx.candidates as *const SyncCandidate, ctx.n) };
+    let coarse_i: &[f32] = unsafe { core::slice::from_raw_parts(ctx.coarse_i, ctx.coarse_len) };
+    let coarse_q: &[f32] = unsafe { core::slice::from_raw_parts(ctx.coarse_q, ctx.coarse_len) };
+    let cand = &candidates[i];
+
+    let t_r = now_us();
+    let cd0 = ddc_refine(cand, coarse_i, coarse_q, ctx.coarse_delay_orig);
+    let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
+    let refine_us = now_us() - t_r;
+
+    let t_d = now_us();
+    let result = if MONITOR_CAP_MS > 0 {
+        // Per-candidate cap. The deadline cell is **per core** — with
+        // both cores in this function at once on different candidates,
+        // a single shared cell would have one core's arming truncate
+        // the other's ladder.
+        set_deadline(now_us() + MONITOR_CAP_MS * 1000);
+        let inputs = [RungMajorCandidate {
+            cand: cand.clone(),
+            cd0,
+            refined_freq_hz: s2.freq_hz,
+            i0: s2.i0,
+        }];
+        let (mut out, _) = decode_phase_split_timed::<Fst4s60>(
+            &inputs,
+            false,
+            false,
+            &[0],
+            None,
+            Some(budget_ok),
+            12_000.0,
+        );
+        set_deadline(i64::MAX);
+        out.pop().flatten()
+    } else {
+        let precomputed = (cd0, s2.freq_hz, s2.i0, s2.score);
+        process_candidate_precomputed::<Fst4s60>(
+            cand,
+            &[],
+            &mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE,
+            DecodeDepth::FULL,
+            DecodeStrictness::Normal,
+            &[],
+            EqMode::Off,
+            SYNC_Q_MIN,
+            precomputed,
+            true,
+            false,
+        )
+    };
+    let decode_us = now_us() - t_d;
+
+    let msg = result.and_then(|r| {
+        let m: &[u8; 77] = r.message77().try_into().ok()?;
+        unpack77(m)
+    });
+
+    Some(MonitorHit {
+        rank: i,
+        freq_hz: cand.freq_hz,
+        refined_hz: s2.freq_hz,
+        cscore: cand.score,
+        refine_us,
+        decode_us,
+        t_ms: (now_us() - ctx.t0_us) / 1000,
+        msg,
+    })
+}
+
+/// One candidate's outcome. Carries `rank` because [`run_split`] does
+/// not preserve order — two cores complete interleaved.
+///
+/// [`run_split`]: fst4_dual_core::run_split
+struct MonitorHit {
+    rank: usize,
+    freq_hz: f32,
+    refined_hz: f32,
+    cscore: f32,
+    refine_us: i64,
+    decode_us: i64,
+    t_ms: i64,
+    msg: Option<String>,
+}
+
+/// `MFSK_FST4_DDC_BENCH_MODE=monitor` — see [`MONITOR`] for why this
+/// exists and what it measures. Streaming, coarse-score-ordered,
+/// deadline-bounded; reports **time-to-first-decode** rather than a
+/// total, because that is the number a monitoring receiver is actually
+/// judged on.
+///
+/// `MFSK_FST4_DDC_BENCH_DUAL=1` runs the same candidate list across
+/// both cores via [`fst4_dual_core`] (issue #327). Identical work and
+/// identical per-candidate function either way — only who runs it
+/// differs — so the two are directly comparable on one build pair.
+#[allow(clippy::too_many_arguments)]
 fn run_monitor_loop(
     candidates: &[SyncCandidate],
     coarse_i: &[f32],
@@ -722,9 +853,12 @@ fn run_monitor_loop(
     t_coarse_sync_us: i64,
 ) {
     log::info!(
-        "fst4_ddc_bench: MONITOR mode — {} candidates, coarse-score order, no dedup, deadline {} ms",
+        "fst4_ddc_bench: MONITOR mode — {} candidates, coarse-score order, no dedup, \
+         deadline {} ms, cap {} ms, {}",
         candidates.len(),
         MONITOR_DEADLINE_MS,
+        MONITOR_CAP_MS,
+        if DUAL_CORE { "DUAL-CORE" } else { "single-core" },
     );
 
     // `coarse_sync`'s spectrogram build and the DDC ahead of it are
@@ -738,192 +872,77 @@ fn run_monitor_loop(
     let front_end_all_us = t_ddc_us + t_coarse_sync_us;
     let front_end_streamed_us = t_search_us;
 
-    let mut decoded: Vec<(String, f32, i64)> = Vec::new();
+    if DUAL_CORE {
+        // Spawn before the batch, not at boot: this bench brings up no
+        // WiFi, so there is no allocator pressure to race here. A real
+        // app must call it before WiFi — see `fst4_dual_core::init`.
+        fst4_dual_core::init::<MonitorHit>();
+    }
+
     let t_loop0 = now_us();
-    let mut n_tried = 0usize;
+    let ctx = fst4_dual_core::Ctx {
+        candidates: candidates.as_ptr() as *const core::ffi::c_void,
+        n: candidates.len(),
+        coarse_i: coarse_i.as_ptr(),
+        coarse_q: coarse_q.as_ptr(),
+        coarse_len: coarse_i.len(),
+        coarse_delay_orig,
+        deadline_us: t_loop0 + MONITOR_DEADLINE_MS * 1000,
+        t0_us: t_loop0,
+    };
 
-    for (rank, cand) in candidates.iter().enumerate() {
-        let elapsed_ms = (now_us() - t_loop0) / 1000;
-        if elapsed_ms >= MONITOR_DEADLINE_MS {
-            log::info!(
-                "fst4_ddc_bench: monitor deadline hit after {} candidates ({} ms)",
-                n_tried,
-                elapsed_ms,
-            );
-            break;
-        }
-        n_tried += 1;
+    let mut hits = if DUAL_CORE {
+        fst4_dual_core::run_split(&ctx, monitor_candidate)
+    } else {
+        fst4_dual_core::drain_single(&ctx, monitor_candidate)
+    };
+    hits.sort_by_key(|h| h.rank);
 
-        let t_r = now_us();
-        let t_ddcref0 = now_us();
-        let cd0 = ddc_refine(cand, coarse_i, coarse_q, coarse_delay_orig);
-        let t_ddcref = now_us() - t_ddcref0;
-        let t_sync0 = now_us();
-        let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
-        let t_sync = now_us() - t_sync0;
-        let refine_us = now_us() - t_r;
+    let t_loop_ms = (now_us() - t_loop0) / 1000;
+    let n_tried = hits.len();
 
-        // One-shot A/B: is `fst4_sync_search` compute-bound or bound by
-        // PSRAM reads of `cd0`?
-        //
-        // **Measured 2026-08-22: PSRAM 590 ms vs INTERNAL 589 ms —
-        // the memory hypothesis is falsified.** Kept as a standing
-        // check rather than deleted, because the hypothesis was
-        // plausible enough to be worth stating and is the kind of thing
-        // that gets re-proposed: `fst4_sync_search` does ~3.22M complex
-        // MAC (2235 grid cells x 5 Costas blocks x 288 samples) ~=
-        // 107 ms of arithmetic at 240 MHz but measures ~590 ms, `cd0`
-        // is ~53 KB, and `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096`
-        // puts it in PSRAM — and this repo had already found exactly
-        // that shape once, in WSPR's `refine_alignment_top_k`
-        // ("97.5% PSRAM re-reads, not FFTs"). It is simply not what is
-        // happening here.
-        //
-        // The ~5.5x gap over the arithmetic floor is therefore in the
-        // scalar kernel itself, which makes it addressable by esp-dsp
-        // PIE (`dsps_dotprod_f32_aes3`, 4-wide f32) rather than by
-        // placement. Note that kernel needs planar I/Q — `cd0` is
-        // interleaved `Complex32` today — whereas
-        // `PolyphaseResampler::dot` is already in the right layout.
-        //
-        // The copy is timed separately and is not part of the
-        // comparison.
-        if n_tried == 1 {
-            const MALLOC_CAP_8BIT_L: u32 = 1 << 2;
-            const MALLOC_CAP_INTERNAL_L: u32 = 1 << 11;
-            let bytes = core::mem::size_of_val(&cd0[..]);
-            let p = unsafe {
-                esp_idf_svc::sys::heap_caps_malloc(
-                    bytes,
-                    MALLOC_CAP_INTERNAL_L | MALLOC_CAP_8BIT_L,
-                ) as *mut Complex32
-            };
-            if p.is_null() {
-                log::info!(
-                    "fst4_ddc_bench: [diag] internal alloc of {} B failed — cd0 stays in PSRAM",
-                    bytes
-                );
-            } else {
-                let t_cp0 = now_us();
-                unsafe { core::ptr::copy_nonoverlapping(cd0.as_ptr(), p, cd0.len()) };
-                let t_cp = now_us() - t_cp0;
-                let internal_cd0: &[Complex32] = unsafe { core::slice::from_raw_parts(p, cd0.len()) };
-                let t_i0 = now_us();
-                let s_int = fst4_sync_search::<Fst4s60>(internal_cd0, cand);
-                let t_int = now_us() - t_i0;
-                log::info!(
-                    "fst4_ddc_bench: [diag] fst4_sync_search cd0 placement — PSRAM {} ms vs \
-                     INTERNAL {} ms ({} KB, copy {} ms) — score {:.1} vs {:.1}",
-                    t_sync / 1000,
-                    t_int / 1000,
-                    bytes / 1024,
-                    t_cp / 1000,
-                    s2.score,
-                    s_int.score,
-                );
-                unsafe { esp_idf_svc::sys::heap_caps_free(p as *mut core::ffi::c_void) };
-            }
-            log::info!(
-                "fst4_ddc_bench: [diag] refine split — ddc_refine {} ms + fst4_sync_search {} ms",
-                t_ddcref / 1000,
-                t_sync / 1000,
-            );
-        }
-
-        let t_d = now_us();
-        let result = if MONITOR_CAP_MS > 0 {
-            // Per-candidate cap: arm the deadline, then let
-            // `decode_phase_split_timed` poll it before every Phase B/C
-            // stage. One candidate per call — passing all 50 at once
-            // would be the "proper" PhaseSplit shape, but it needs every
-            // candidate's `cd0` resident simultaneously (~266 KB each,
-            // ~13 MB for 50) which this board's PSRAM cannot hold; that
-            // is the same constraint the batch path's Stage 2a/2c split
-            // exists for.
-            unsafe { *DEADLINE_US.0.get() = now_us() + MONITOR_CAP_MS * 1000 };
-            let inputs = [RungMajorCandidate {
-                cand: cand.clone(),
-                cd0,
-                refined_freq_hz: s2.freq_hz,
-                i0: s2.i0,
-            }];
-            let (mut out, _) = decode_phase_split_timed::<Fst4s60>(
-                &inputs,
-                false, // skip_llrc — keep the full ladder; the cap, not
-                // a fixed ablation, is what bounds cost here
-                false,
-                &[0],
-                None,
-                Some(budget_ok),
-                12_000.0,
-            );
-            unsafe { *DEADLINE_US.0.get() = i64::MAX };
-            out.pop().flatten()
-        } else {
-            let precomputed = (cd0, s2.freq_hz, s2.i0, s2.score);
-            process_candidate_precomputed::<Fst4s60>(
-                cand,
-                &[],
-                &mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE,
-                DecodeDepth::FULL,
-                DecodeStrictness::Normal,
-                &[],
-                EqMode::Off,
-                SYNC_Q_MIN,
-                precomputed,
-                true,
-                false,
-            )
-        };
-        let decode_us = now_us() - t_d;
-        let since_loop_ms = (now_us() - t_loop0) / 1000;
-
-        let msg = result.and_then(|r| {
-            let m: &[u8; 77] = r.message77().try_into().ok()?;
-            unpack77(m)
-        });
-
-        match &msg {
+    // Collapse by decoded *message*, not by position — a monitor
+    // reports stations, and two coarse cells for one signal are the
+    // same station. Cheaper than a dedup barrier ahead of the loop and
+    // it cannot delay a first decode.
+    let mut decoded: Vec<(String, f32, i64)> = Vec::new();
+    for h in &hits {
+        match &h.msg {
             Some(text) => {
-                // Collapse by message, not by position — a monitor
-                // reports stations, and two coarse cells for one signal
-                // are the same station. Cheaper than a dedup barrier
-                // ahead of the loop and it cannot delay a first decode.
                 let dup = decoded.iter().any(|(m, _, _)| m == text);
                 log::info!(
                     "fst4_ddc_bench: [monitor] rank {:2}/{} {:8.1} Hz cscore {:5.2} \
                      refine {:4} ms decode {:5} ms  t+{:5} ms  DECODED {:?}{}",
-                    rank + 1,
+                    h.rank + 1,
                     candidates.len(),
-                    cand.freq_hz,
-                    cand.score,
-                    refine_us / 1000,
-                    decode_us / 1000,
-                    since_loop_ms,
+                    h.freq_hz,
+                    h.cscore,
+                    h.refine_us / 1000,
+                    h.decode_us / 1000,
+                    h.t_ms,
                     text,
                     if dup { " (dup)" } else { "" },
                 );
                 if !dup {
-                    decoded.push((text.clone(), s2.freq_hz, since_loop_ms));
+                    decoded.push((text.clone(), h.refined_hz, h.t_ms));
                 }
             }
             None => {
                 log::info!(
                     "fst4_ddc_bench: [monitor] rank {:2}/{} {:8.1} Hz cscore {:5.2} \
                      refine {:4} ms decode {:5} ms  t+{:5} ms",
-                    rank + 1,
+                    h.rank + 1,
                     candidates.len(),
-                    cand.freq_hz,
-                    cand.score,
-                    refine_us / 1000,
-                    decode_us / 1000,
-                    since_loop_ms,
+                    h.freq_hz,
+                    h.cscore,
+                    h.refine_us / 1000,
+                    h.decode_us / 1000,
+                    h.t_ms,
                 );
             }
         }
     }
 
-    let t_loop_ms = (now_us() - t_loop0) / 1000;
     log::info!(
         "fst4_ddc_bench: MONITOR done — {} candidates tried, {} distinct decodes, loop {} ms",
         n_tried,

--- a/embedded-poc/embedded-shared/src/esp_dsp_dotprod.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_dotprod.rs
@@ -42,10 +42,35 @@
 //! The misaligned column is the one that applies today:
 //! `PolyphaseResampler`'s window start advances by a Bresenham carry,
 //! so the history pointer lands on an arbitrary 4-byte offset.
-//! Capturing the remaining ~2.5x needs aligned history buffers and a
-//! tap depth padded to a multiple of 4, which is a separate change —
-//! deliberately not bundled here, so the cheap win lands first and the
-//! alignment work can be measured on its own.
+//!
+//! ## Why the remaining ~2.5x was costed and declined (2026-08-22)
+//!
+//! Measured the non-dot floor of each stage directly, by stubbing this
+//! function to return without computing:
+//!
+//! - wideband DDC: **905 ms** of its 1976 ms is *not* dot product. So
+//!   the dots went 2496 ms (portable) -> 1071 ms here, an in-situ 2.33x
+//!   — and aligning them would give 1976 -> ~1330 ms, **1.49x**.
+//! - per-candidate `ddc_refine`: the same accounting puts its non-dot
+//!   floor near 240 ms of 314 ms, so alignment is worth ~**1.17x**
+//!   there.
+//!
+//! The 1.49x lands on the DDC, which is the one stage that can run
+//! *during* capture (WSPR ships exactly this: `wspr_app`'s `ddc_loop`
+//! -> `DDC_READY_IDX` -> `scan_loop`), so it does not come out of the
+//! post-slot budget at all — at 1976 ms per 60 s slot it is a 3% duty
+//! cycle. The stage that actually binds the monitor deadline is
+//! per-candidate refine, where alignment is worth ~5% (905 -> 860 ms
+//! per candidate, 43 -> ~45 candidates in a 45 s deadline).
+//!
+//! Against that: the fast path needs *both* pointers 16-byte aligned,
+//! and the moving window start means fixing it requires four
+//! pre-shifted tap tables per phase — **168 KB for the wideband coarse
+//! cascade** (L=64) against ~190 KB of free internal DRAM. Copying each
+//! window into an aligned scratch instead gives back roughly a third of
+//! the gain. Neither is worth 5% on the binding stage, so dual-core
+//! (#327) was taken first. Revisit if the DDC's duty cycle ever becomes
+//! the constraint.
 
 /// Below this length the FFI hop costs more than it saves; the portable
 /// loop wins. `dotprod-bench`'s shortest measured depth is 107, where

--- a/embedded-poc/embedded-shared/src/fst4_dual_core.rs
+++ b/embedded-poc/embedded-shared/src/fst4_dual_core.rs
@@ -1,0 +1,324 @@
+//! Dual-core work-steal for FST4's candidate loop — issue #327.
+//!
+//! A third sibling to [`dual_core`](crate::dual_core) (FT8) and
+//! [`wspr_dual_core`](crate::wspr_dual_core) (WSPR), not a shared
+//! abstraction over them. `embedded-poc/CLAUDE.md` states that
+//! convention for the existing pair, and it holds again here: FT8's
+//! `Job` enum, its four typed result queues and its `CS_SCRATCH_*`
+//! buffers are all sized and shaped for FT8's 79-symbol geometry, so
+//! adding FST4 variants would drag FST4 types into that module and
+//! inflate its 16 KB worker's frame for work it never runs.
+//!
+//! ## What it borrows from each
+//!
+//! | | source | why |
+//! |---|---|---|
+//! | persistent single worker | FT8 | FST4 has no phase-dependent stack-size split, so WSPR's spawn/teardown lifecycle buys nothing |
+//! | static `.bss` stack | WSPR | see below |
+//! | work-steal via one `AtomicUsize` | both | per-candidate cost is bimodal |
+//! | send → do-my-share → blocking recv | both | the whole safety argument |
+//!
+//! **Static `.bss` stack, not FT8's heap spawn.** FT8 gets away with
+//! `xTaskCreatePinnedToCore` because its single spawn happens at boot,
+//! before WiFi. WSPR measured the failure mode when that isn't true: a
+//! worker spawn was silently lost to heap fragmentation with the radio
+//! associated, costing that pass its split (17 583 → 28 246 ms) and the
+//! scan 11 s, with nothing in the log. A `.bss` reservation is made by
+//! the linker and cannot be lost, which turns "did we get the second
+//! core this time?" from a runtime lottery into a build-time fact.
+//! FST4's stack need is small enough (see [`WORKER_STACK_BYTES`]) that
+//! this costs almost nothing.
+//!
+//! **Work-steal, not a static split.** Per-candidate cost is strongly
+//! bimodal: on the wideband run that motivated this, real signals
+//! decoded in 53 ms while individual noise candidates ran the OSD
+//! escalation for ~19 s. A static half/half split strands whichever
+//! core draws the slow one — the same reasoning `wspr_dual_core`
+//! documents for its pass 0/1, and precisely why WSPR's *pass 2* static
+//! 1-1 split is the weakest number in its whole table (1.10x).
+//!
+//! ## Shape of the work
+//!
+//! The unit is one candidate index. Everything a candidate needs —
+//! the coarse-sync list, the DDC baseband, the group delay — is shared
+//! read-only for the whole batch, so it lives in [`Ctx`] behind a
+//! raw pointer rather than being copied per job. The per-candidate
+//! function is a plain `fn` item, not a closure: it has to be callable
+//! from the worker task, and a closure's captures cannot cross that
+//! boundary. Context reaches it through [`ctx`], the same
+//! global-plus-`fn`-item idiom `wspr_dual_core`'s `DeadlineCell` uses
+//! for its budget check (and for the same underlying reason — Xtensa's
+//! `max_atomic_width` is 32, so several of these cannot be atomics).
+
+use core::cell::UnsafeCell;
+use core::ptr;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use esp_idf_svc::sys::{
+    QueueHandle_t, xQueueGenericCreate, xQueueGenericSend, xQueueReceive,
+    xTaskCreateStaticPinnedToCore, xTaskGetCoreID,
+};
+
+// Not re-exported by esp-idf-svc; same local declarations
+// `wspr_dual_core` makes.
+const PD_PASS: i32 = 1;
+const QUEUE_SEND_TO_BACK: i32 = 0;
+const QUEUE_TYPE_BASE: u8 = 0;
+const PORT_MAX_DELAY: u32 = u32::MAX;
+const APP_CPU: i32 = 1;
+
+/// Measured, not guessed — but sized with margin because the number it
+/// has to cover is a *peak*, not an average.
+///
+/// `fst4_ddc_bench` reserves 96 KiB for its own task and reports
+/// ~81.7 KiB still untouched after a full wideband monitor run, i.e.
+/// ~14 KiB actually used across `ddc_refine` + `fst4_sync_search` +
+/// the LLR/BP/OSD ladder including its ~8 KiB `g_packed` OSD scratch.
+/// 48 KiB is ~3.4x that.
+///
+/// Two orders of magnitude below WSPR's 81 920 B, which it needs
+/// because its per-candidate Fano state is genuinely ~63 KiB. FST4
+/// shares FT8's `BpPooledFec` machinery (`Ldpc240_101` vs
+/// `Ldpc174_91`), so it sits near FT8's 16 KB rather than WSPR's.
+///
+/// [`log_worker_stack`] reports the real high-water mark every batch so
+/// this stays measured rather than reverting to a guess.
+pub const WORKER_STACK_BYTES: usize = 48 * 1024;
+
+#[repr(align(16))]
+struct WorkerStack([u8; WORKER_STACK_BYTES]);
+static mut WORKER_STACK: WorkerStack = WorkerStack([0; WORKER_STACK_BYTES]);
+static mut WORKER_TCB: core::mem::MaybeUninit<esp_idf_svc::sys::StaticTask_t> =
+    core::mem::MaybeUninit::uninit();
+
+struct QueueCell(UnsafeCell<QueueHandle_t>);
+// SAFETY: written once in `init()` before any other access.
+unsafe impl Sync for QueueCell {}
+impl QueueCell {
+    const fn new() -> Self {
+        Self(UnsafeCell::new(ptr::null_mut()))
+    }
+    fn get(&self) -> QueueHandle_t {
+        unsafe { *self.0.get() }
+    }
+    /// SAFETY: only call from `init()` before any other access.
+    unsafe fn set(&self, q: QueueHandle_t) {
+        unsafe { *self.0.get() = q };
+    }
+}
+
+static JOB_Q: QueueCell = QueueCell::new();
+static RESULT_Q: QueueCell = QueueCell::new();
+
+unsafe fn queue_create(item_size: usize) -> QueueHandle_t {
+    let q = unsafe { xQueueGenericCreate(1, item_size as u32, QUEUE_TYPE_BASE) };
+    assert!(!q.is_null(), "xQueueGenericCreate failed");
+    q
+}
+
+/// SAFETY: caller transfers ownership of `p` to the receiver.
+unsafe fn queue_send_ptr<T>(q: QueueHandle_t, p: *mut T) {
+    let r = unsafe {
+        xQueueGenericSend(
+            q,
+            (&p as *const *mut T) as *const core::ffi::c_void,
+            PORT_MAX_DELAY,
+            QUEUE_SEND_TO_BACK,
+        )
+    };
+    debug_assert_eq!(r, PD_PASS, "xQueueGenericSend failed: {r}");
+}
+
+/// SAFETY: receiver takes ownership of the returned pointer.
+unsafe fn queue_recv_ptr<T>(q: QueueHandle_t) -> *mut T {
+    let mut out: *mut T = ptr::null_mut();
+    let r = unsafe {
+        xQueueReceive(
+            q,
+            (&mut out as *mut *mut T) as *mut core::ffi::c_void,
+            PORT_MAX_DELAY,
+        )
+    };
+    debug_assert_eq!(r, PD_PASS, "xQueueReceive failed: {r}");
+    out
+}
+
+/// Everything one candidate needs that does not vary across the batch.
+/// Raw pointers rather than slices because this crosses a FreeRTOS task
+/// boundary; the send → work → blocking-recv discipline in
+/// [`run_split`] is what makes them valid for the whole batch.
+pub struct Ctx {
+    pub candidates: *const core::ffi::c_void,
+    pub n: usize,
+    pub coarse_i: *const f32,
+    pub coarse_q: *const f32,
+    pub coarse_len: usize,
+    pub coarse_delay_orig: usize,
+    /// Absolute `esp_timer` deadline for the whole batch; a core that
+    /// reaches it stops claiming new candidates.
+    pub deadline_us: i64,
+    /// When the batch started, so per-candidate results can report a
+    /// loop-relative timestamp that means the same thing on both cores.
+    pub t0_us: i64,
+}
+
+/// The per-candidate worker function. A `fn` item, not a closure —
+/// see the module doc comment.
+pub type CandidateFn<R> = fn(&Ctx, usize) -> Option<R>;
+
+struct Job<R: 'static> {
+    ctx: *const Ctx,
+    work: CandidateFn<R>,
+}
+// SAFETY: `ctx` outlives the job — `run_split` blocks on the result
+// queue before returning, so the borrow cannot dangle. `work` is a
+// plain function pointer.
+unsafe impl<R> Send for Job<R> {}
+
+static NEXT_IDX: AtomicUsize = AtomicUsize::new(0);
+
+fn now_us() -> i64 {
+    unsafe { esp_idf_svc::sys::esp_timer_get_time() }
+}
+
+fn current_core() -> i32 {
+    unsafe { xTaskGetCoreID(ptr::null_mut()) }
+}
+
+/// Report this task's stack high-water mark against what it reserved —
+/// lifted from `wspr_dual_core`, and worth keeping for the same reason:
+/// it is what turns [`WORKER_STACK_BYTES`] from a guess into a
+/// measurement.
+fn log_worker_stack(who: &str, reserved: usize) {
+    let free = unsafe { esp_idf_svc::sys::uxTaskGetStackHighWaterMark(ptr::null_mut()) } as usize;
+    log::info!(
+        "fst4_dual_core: {who} stack — {} B free of {} B reserved (peak use {} B)",
+        free,
+        reserved,
+        reserved.saturating_sub(free),
+    );
+}
+
+/// Claim candidate indices until the list or the deadline runs out.
+/// Both cores run this identical loop; `fetch_add` is what grants one
+/// of them exclusive ownership of each index.
+fn drain<R>(ctx: &Ctx, work: CandidateFn<R>) -> Vec<R> {
+    let mut out = Vec::new();
+    loop {
+        let i = NEXT_IDX.fetch_add(1, Ordering::AcqRel);
+        if i >= ctx.n {
+            break;
+        }
+        if now_us() >= ctx.deadline_us {
+            break;
+        }
+        if let Some(r) = work(ctx, i) {
+            out.push(r);
+        }
+    }
+    out
+}
+
+/// Single-core equivalent of [`run_split`] — same `work`, same
+/// deadline, same claim loop, just without the second core. Exists so
+/// the dual-core comparison is one build switch over one code path
+/// rather than two separate loops that could drift apart.
+pub fn drain_single<R>(ctx: &Ctx, work: CandidateFn<R>) -> Vec<R> {
+    NEXT_IDX.store(0, Ordering::Release);
+    let out = drain(ctx, work);
+    log_worker_stack("main(single)", 0);
+    out
+}
+
+/// The generic worker body, monomorphised per result type `R` by
+/// [`spawn_worker_for`].
+extern "C" fn worker_main<R: 'static>(_arg: *mut core::ffi::c_void) {
+    log::info!("fst4_dual_core: worker started on core {}", current_core());
+    loop {
+        let job_ptr = unsafe { queue_recv_ptr::<Job<R>>(JOB_Q.get()) };
+        // SAFETY: sender boxed this and transferred ownership.
+        let job = unsafe { Box::from_raw(job_ptr) };
+        // SAFETY: `run_split` blocks until it has received our result,
+        // so `ctx` is alive for the whole of this call.
+        let ctx = unsafe { &*job.ctx };
+        let out = drain(ctx, job.work);
+        log_worker_stack("worker", WORKER_STACK_BYTES);
+        unsafe { queue_send_ptr(RESULT_Q.get(), Box::into_raw(Box::new(out))) };
+    }
+}
+
+static INIT_DONE: AtomicUsize = AtomicUsize::new(0);
+
+/// Create the dispatch queues and spawn the persistent worker on
+/// APP_CPU. Call once at startup — **before** WiFi or any other
+/// large allocator activity, matching `wspr_app`'s ordering constraint
+/// (real hardware saw `xTaskCreatePinnedToCore` fail outright when task
+/// stacks were reserved after WiFi brought its buffers up; the `.bss`
+/// stack here sidesteps that for the stack itself, but the TCB and
+/// queues are still allocations).
+///
+/// `R` fixes the result type this worker will handle; one call site,
+/// one `R`. A second `init` with a different `R` would spawn a second
+/// worker against the same queues and is rejected.
+pub fn init<R: 'static>() {
+    if INIT_DONE.swap(1, Ordering::AcqRel) != 0 {
+        log::warn!("fst4_dual_core: init called twice — ignoring");
+        return;
+    }
+    unsafe {
+        JOB_Q.set(queue_create(core::mem::size_of::<*mut Job<R>>()));
+        RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<R>>()));
+        let h = xTaskCreateStaticPinnedToCore(
+            Some(worker_main::<R>),
+            c"fst4_worker".as_ptr(),
+            WORKER_STACK_BYTES as u32,
+            ptr::null_mut(),
+            5,
+            ptr::addr_of_mut!(WORKER_STACK) as *mut u8,
+            ptr::addr_of_mut!(WORKER_TCB) as *mut esp_idf_svc::sys::StaticTask_t,
+            APP_CPU,
+        );
+        assert!(!h.is_null(), "fst4_dual_core: worker spawn failed");
+    }
+    log::info!(
+        "fst4_dual_core: worker spawned on core {APP_CPU} with {} B static stack",
+        WORKER_STACK_BYTES
+    );
+}
+
+/// Run `work` over `0..ctx.n` across both cores, returning every
+/// `Some` result. Order is **not** preserved — two cores complete
+/// interleaved, and the caller is expected to sort or key the results
+/// itself.
+///
+/// Strictly send → do-my-own-share → blocking recv, which is the entire
+/// safety argument for the raw pointers in [`Ctx`]: this function
+/// cannot return while the worker still holds them.
+pub fn run_split<R: 'static>(ctx: &Ctx, work: CandidateFn<R>) -> Vec<R> {
+    NEXT_IDX.store(0, Ordering::Release);
+
+    let job = Box::new(Job {
+        ctx: ctx as *const Ctx,
+        work,
+    });
+    unsafe { queue_send_ptr(JOB_Q.get(), Box::into_raw(job)) };
+
+    let mut mine = drain(ctx, work);
+    log_worker_stack("main", 0);
+
+    let theirs_ptr = unsafe { queue_recv_ptr::<Vec<R>>(RESULT_Q.get()) };
+    // SAFETY: the worker boxed this and transferred ownership.
+    let theirs = unsafe { Box::from_raw(theirs_ptr) };
+
+    let n_worker = theirs.len();
+    mine.extend(*theirs);
+    log::info!(
+        "fst4_dual_core: batch done — {} results ({} from worker)",
+        mine.len(),
+        n_worker,
+    );
+    mine
+}

--- a/embedded-poc/embedded-shared/src/lib.rs
+++ b/embedded-poc/embedded-shared/src/lib.rs
@@ -8,6 +8,7 @@ extern crate alloc;
 pub mod apps;
 pub mod dual_core;
 pub mod esp_dsp_dotprod;
+pub mod fst4_dual_core;
 pub mod esp_dsp_fft;
 pub mod internal_pool;
 pub mod pipeline;


### PR DESCRIPTION
## Summary

Adds `embedded-shared::fst4_dual_core` — a third sibling to FT8's `dual_core` and WSPR's `wspr_dual_core` rather than an abstraction over them, per the convention `embedded-poc/CLAUDE.md` already states. It holds again here: FT8's `Job` enum, its four typed result queues and its `CS_SCRATCH_*` buffers are all shaped for FT8's 79-symbol geometry.

Composition follows #327's own design note:

| piece | from | why |
|---|---|---|
| persistent single worker | FT8 | FST4 has no phase-dependent stack-size split |
| static `.bss` stack | WSPR | spawn can't be lost to heap fragmentation — WSPR measured that failing silently for 11 s |
| work-steal via one `AtomicUsize` | both | per-candidate cost is bimodal |
| send → own share → blocking recv | both | the whole safety argument for the raw pointers |

## Measured — real CoreS3, wideband 100–3000 Hz, `sync_min=0.8`, cap 150 ms, 45 s deadline

Identical build, only the dispatch switched (`MFSK_FST4_DDC_BENCH_DUAL=1`):

| | single-core | dual-core |
|---|---:|---:|
| candidates tried | 43 (deadline hit) | **50 (all)** |
| loop time | 45019 ms (truncated) | **31351 ms** |
| per candidate | 1047 ms | **627 ms** |
| both signals decoded by | t+1921 ms | **t+1162 ms** |

**1.67×** — above WSPR's measured 1.35–1.47×, and the reason is worth recording: **the per-candidate decode cap (#332) didn't only cut cost, it made the workload nearly uniform** (~1.1 s refine + ≤0.25 s decode), which removes the straggler effect that bounded WSPR's yield. The two changes compose better than either alone.

**The deadline is no longer binding.** All 50 candidates complete in 31.4 s — full band coverage inside one 45 s budget and comfortably inside a 60 s slot period. Time-to-both-decodes improves 1.65× because the two real signals land on different cores and decode in parallel.

Work split 25/25, perfectly balanced.

## Worker stack

48 KiB reserved, **measured peak 2704 B**. Deliberately *not* shrunk yet — the cap truncates the OSD ladder early, so an uncapped run should be measured before trusting that as the peak. `log_worker_stack` reports it every batch, keeping this measured rather than guessed.

## Per-core deadline cells

The per-candidate cap's deadline is now **per core**. With both cores inside `monitor_candidate` on different candidates, a single shared cell would let one core's arming truncate the other's ladder.

## Also in this PR: why dot-product alignment was declined

Recorded in `esp_dsp_dotprod`'s doc comment rather than left to be rediscovered. Measured against a stubbed dot, the wideband DDC's **non-dot floor is 905 ms of its 1976 ms**, so aligning would be worth 1.49× there but only **~1.17× on the per-candidate refine that actually binds** — and it needs 168 KB of pre-shifted tap tables against ~190 KB free internal DRAM. The DDC is also the one stage that can run *during* capture, so its cost doesn't enter the post-slot budget at all.

## Testing

- Both dispatch modes flashed and captured on real CoreS3; decodes identical.
- `drain_single` runs the same claim loop on one core, so the comparison is one build switch over one code path rather than two loops that could drift.
- Pre-commit hook passed; `mfsk-core` untouched.

Refs: #306, #307, #327, #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)