### PR TITLE
feat(engine,embedded): capture-time spectrogram — front end leaves the post-slot budget

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
@@ -48,7 +48,8 @@ use mfsk_core::engine::dsp::ddc::StreamingComplexDdc;
 use mfsk_core::engine::equalize::EqMode;
 use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_precomputed};
 use mfsk_core::engine::sync::{
-    AudioSource, RxGrid, SyncCandidate, SyncDims, coarse_sync, compute_spectra,
+    AudioSource, RxGrid, SpectrogramBuilder, SyncCandidate, SyncDims, coarse_sync,
+    coarse_sync_from_spectra, compute_spectra, spectra_crop_for,
 };
 use mfsk_core::engine::sync2d::fst4_sync_search;
 use mfsk_core::fst4::Fst4s60;
@@ -286,6 +287,31 @@ fn budget_ok() -> bool {
 /// both cores (issue #327). Same per-candidate function either way.
 const DUAL_CORE: bool = is_one(option_env!("MFSK_FST4_DDC_BENCH_DUAL"));
 
+/// `MFSK_FST4_DDC_BENCH_STREAM=1` — run the DDC and the spectrogram
+/// **incrementally, block by block**, the way a receiver processes
+/// audio as it arrives, instead of batching both after the slot ends.
+///
+/// This does not make the front end cheaper; it moves it. A receiver
+/// has the whole 60 s capture window to do this work, so what it costs
+/// against is a *duty cycle*, not the post-slot guard budget. WSPR
+/// already ships exactly this shape (`wspr_app`'s `ddc_loop` ->
+/// `DDC_READY_IDX` -> `scan_loop`), measured there at 18.5-24.1 s of
+/// DDC running beside an 82.8-90.1 s decode inside a 110 s deadline.
+///
+/// Measured motivation (2026-08-22, FST4-60 wideband): DDC 1976 ms +
+/// spectrogram 2842 ms = 4818 ms, against a first decode that otherwise
+/// lands at 10 060 ms post-slot versus a 7.2 s guard. Moving both out
+/// is the difference between "over" and "fits".
+const STREAM_FRONTEND: bool = is_one(option_env!("MFSK_FST4_DDC_BENCH_STREAM"));
+
+/// Block size the streaming front end is fed in. 12 000 samples = 1 s
+/// of 12 kHz audio, a plausible unit for a real capture path and large
+/// enough that per-block overhead is irrelevant. The spectrogram is
+/// bit-identical at any block size (pinned by
+/// `fst4_spectrogram_builder`), so this is a pacing choice, not a
+/// numerical one.
+const STREAM_BLOCK: usize = 12_000;
+
 const fn is_one(v: Option<&str>) -> bool {
     match v {
         Some(s) => {
@@ -435,8 +461,47 @@ pub fn run(audio_bin: &[u8]) {
     let mut coarse = StreamingComplexDdc::new(&coarse_cfg);
     let mut coarse_i = Vec::new();
     let mut coarse_q = Vec::new();
-    coarse.push_i16(&audio, &mut coarse_i, &mut coarse_q);
-    coarse.flush(&mut coarse_i, &mut coarse_q);
+    let grid = grid_for(GRID_BANDWIDTH_HZ);
+    let rx_grid = RxGrid::complex(grid.fs_c, CENTER_HZ);
+
+    // In streaming mode the spectrogram is built alongside the DDC, one
+    // block at a time, so both finish with the capture rather than
+    // after it. `prebuilt` is what `coarse_sync_from_spectra` then
+    // consumes post-slot.
+    let mut prebuilt = None;
+    if STREAM_FRONTEND {
+        let crop = spectra_crop_for::<Fst4s60>(
+            CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
+            CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
+            rx_grid,
+        );
+        let mut builder =
+            crop.map(|(lo, hi)| SpectrogramBuilder::new::<Fst4s60>(lo, hi, rx_grid));
+        let mut blk_i = Vec::new();
+        let mut blk_q = Vec::new();
+        for chunk in audio.chunks(STREAM_BLOCK) {
+            blk_i.clear();
+            blk_q.clear();
+            coarse.push_i16(chunk, &mut blk_i, &mut blk_q);
+            if let Some(b) = builder.as_mut() {
+                b.push(&blk_i, &blk_q);
+            }
+            coarse_i.extend_from_slice(&blk_i);
+            coarse_q.extend_from_slice(&blk_q);
+        }
+        blk_i.clear();
+        blk_q.clear();
+        coarse.flush(&mut blk_i, &mut blk_q);
+        if let Some(b) = builder.as_mut() {
+            b.push(&blk_i, &blk_q);
+        }
+        coarse_i.extend_from_slice(&blk_i);
+        coarse_q.extend_from_slice(&blk_q);
+        prebuilt = builder.map(|b| b.finish());
+    } else {
+        coarse.push_i16(&audio, &mut coarse_i, &mut coarse_q);
+        coarse.flush(&mut coarse_i, &mut coarse_q);
+    }
     let coarse_delay_orig = coarse.group_delay_input_samples();
     let t_ddc = now_us() - t0;
     log::info!(
@@ -446,8 +511,6 @@ pub fn run(audio_bin: &[u8]) {
         t_ddc / 1000,
     );
     log_heap("post-ddc");
-
-    let grid = grid_for(GRID_BANDWIDTH_HZ);
 
     // Diagnostic split of `coarse_sync`'s cost into its spectrogram
     // build vs its correlation search — the two have completely
@@ -467,9 +530,8 @@ pub fn run(audio_bin: &[u8]) {
     // replicates `coarse_sync`'s own `ia`/`ib`/`headroom` derivation
     // (`engine/sync.rs:566-586`) so the timed call crops identically
     // rather than over-reporting on a wider band.
-    let rx_grid = RxGrid::complex(grid.fs_c, CENTER_HZ);
     let mut t_spectra_us = 0i64;
-    {
+    if !STREAM_FRONTEND {
         let d = SyncDims::of::<Fst4s60>(rx_grid.sample_rate_hz);
         let ntones = <Fst4s60 as mfsk_core::engine::ModulationParams>::NTONES as usize;
         let usable = rx_grid.usable_bins(&d);
@@ -503,15 +565,28 @@ pub fn run(audio_bin: &[u8]) {
     log_heap("post-diag-spectra");
 
     let t1 = now_us();
-    let candidates = coarse_sync::<Fst4s60>(
-        AudioSource::Complex(&coarse_i, &coarse_q),
-        CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
-        CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
-        SYNC_MIN,
-        None,
-        MAX_CAND,
-        rx_grid,
-    );
+    let candidates = match &prebuilt {
+        // Streaming: the spectrogram was finished during capture, so
+        // only the correlation search is post-slot work.
+        Some(s) => coarse_sync_from_spectra::<Fst4s60>(
+            s,
+            CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
+            CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
+            SYNC_MIN,
+            None,
+            MAX_CAND,
+            rx_grid,
+        ),
+        None => coarse_sync::<Fst4s60>(
+            AudioSource::Complex(&coarse_i, &coarse_q),
+            CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
+            CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
+            SYNC_MIN,
+            None,
+            MAX_CAND,
+            rx_grid,
+        ),
+    };
     let t_coarse_sync = now_us() - t1;
     log::info!(
         "fst4_ddc_bench: coarse_sync (via DDC, K={}, nfft1={}) -> {} candidates in {} ms",
@@ -949,14 +1024,29 @@ fn run_monitor_loop(
         decoded.len(),
         t_loop_ms,
     );
-    log::info!(
-        "fst4_ddc_bench: front end — ddc {} ms + spectra {} ms (both streamable during capture) \
-         + search {} ms = {} ms total",
-        t_ddc_us / 1000,
-        t_spectra_us / 1000,
-        t_search_us / 1000,
-        front_end_all_us / 1000,
-    );
+    if STREAM_FRONTEND {
+        // `t_ddc_us` here is DDC *and* spectrogram: the builder was fed
+        // inside the same block loop, so the two are one capture-time
+        // cost and cannot be separated after the fact.
+        let capture_ms = t_ddc_us / 1000;
+        log::info!(
+            "fst4_ddc_bench: front end (STREAMING) — ddc+spectrogram {} ms done during capture \
+             ({}% duty of a 60 s slot) + search {} ms post-slot = {} ms total",
+            capture_ms,
+            capture_ms * 100 / 60_000,
+            t_search_us / 1000,
+            front_end_all_us / 1000,
+        );
+    } else {
+        log::info!(
+            "fst4_ddc_bench: front end (BATCH) — ddc {} ms + spectra {} ms \
+             (both streamable during capture) + search {} ms = {} ms total",
+            t_ddc_us / 1000,
+            t_spectra_us / 1000,
+            t_search_us / 1000,
+            front_end_all_us / 1000,
+        );
+    }
     for (msg, hz, t_ms) in &decoded {
         let strict = front_end_streamed_us / 1000 + t_ms;
         let naive = front_end_all_us / 1000 + t_ms;

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -509,6 +509,173 @@ pub fn compute_spectra<P: Protocol>(
     }
 }
 
+/// Incremental, capture-time counterpart to [`compute_spectra`] for the
+/// complex (DDC-fed) path.
+///
+/// [`compute_spectra`] needs the whole slot before it can start, which
+/// puts its cost squarely in the post-slot decode budget. But its row
+/// loop only ever reads `xi[j·nstep .. j·nstep + nsps]` — row `j` is
+/// computable the moment those samples exist, and rows are otherwise
+/// independent. A receiver therefore does not have to wait: it can
+/// complete each row as audio arrives and have the finished
+/// spectrogram ready at slot end, exactly as WSPR already runs its
+/// down-converter (`wspr_app`'s `ddc_loop` → `DDC_READY_IDX` →
+/// `scan_loop`).
+///
+/// Measured motivation (issue #307, FST4-60 wideband on CoreS3): the
+/// spectrogram is 2842 ms of `coarse_sync`'s 6934 ms, and the DDC ahead
+/// of it another 1976 ms. Moving both off the post-slot budget is the
+/// difference between a first decode at 10 060 ms and one at 5242 ms,
+/// against a 7.2 s guard.
+///
+/// Output is **bit-identical** to [`compute_spectra`] on the same
+/// input — same FFT, same window, same fftshift, same zero-fill past
+/// the end of the stream — which
+/// `spectrogram_builder_matches_compute_spectra` pins.
+///
+/// Complex input only: this exists for the DDC path, and the real-PCM
+/// path has no streaming caller today.
+pub struct SpectrogramBuilder {
+    d: SyncDims,
+    grid: RxGrid,
+    bin_lo: usize,
+    bin_hi_incl: usize,
+    n_freq: usize,
+    window: Option<Vec<f32>>,
+    fft: alloc::boxed::Box<dyn crate::engine::fft::Fft>,
+    /// Retained tail: samples from `abs_base` onwards that a future row
+    /// still needs. Rows overlap by `nsps - nstep`, so this stays
+    /// bounded at `nsps` regardless of how long the stream runs.
+    hist_i: Vec<f32>,
+    hist_q: Vec<f32>,
+    /// Absolute stream index of `hist_*[0]`.
+    abs_base: usize,
+    /// Next row to emit.
+    j: usize,
+    data: Vec<f32>,
+    buf: Vec<Complex<f32>>,
+}
+
+impl SpectrogramBuilder {
+    pub fn new<P: Protocol>(bin_lo: usize, bin_hi_incl: usize, grid: RxGrid) -> Self {
+        let d = SyncDims::of::<P>(grid.sample_rate_hz);
+        let window: Option<Vec<f32>> = match P::SPECTRUM_WINDOW {
+            SpectrumWindow::Rectangular => None,
+            SpectrumWindow::Nuttall4 => Some(nuttall_window(d.nsps)),
+        };
+        let usable = grid.usable_bins(&d);
+        let bin_lo = bin_lo.min(usable.saturating_sub(1));
+        let bin_hi_incl = bin_hi_incl.min(usable.saturating_sub(1)).max(bin_lo);
+        let n_freq = bin_hi_incl - bin_lo + 1;
+        let mut planner = default_planner();
+        let fft = planner.plan_forward(d.nfft1);
+        let nfft1 = d.nfft1;
+        let nhsym = d.nhsym;
+        Self {
+            d,
+            grid,
+            bin_lo,
+            bin_hi_incl,
+            n_freq,
+            window,
+            fft,
+            hist_i: Vec::new(),
+            hist_q: Vec::new(),
+            abs_base: 0,
+            j: 0,
+            data: vec![0.0f32; n_freq * nhsym],
+            buf: vec![Complex::new(0.0f32, 0.0); nfft1],
+        }
+    }
+
+    /// Feed the next contiguous block of complex baseband, completing
+    /// every row it makes available. Block boundaries are irrelevant to
+    /// the result — one `push` of the whole slot and many small pushes
+    /// produce the same spectrogram.
+    pub fn push(&mut self, xi: &[f32], xq: &[f32]) {
+        debug_assert_eq!(xi.len(), xq.len());
+        self.hist_i.extend_from_slice(xi);
+        self.hist_q.extend_from_slice(xq);
+        self.drain_ready(false);
+    }
+
+    /// Finish the slot: emit every remaining row, zero-filling past the
+    /// end of the stream the way [`compute_spectra`] does.
+    pub fn finish(mut self) -> Spectrogram {
+        self.drain_ready(true);
+        Spectrogram {
+            n_freq: self.n_freq,
+            n_time: self.d.nhsym,
+            freq_offset: self.bin_lo,
+            data: self.data,
+        }
+    }
+
+    fn drain_ready(&mut self, flush: bool) {
+        while self.j < self.d.nhsym {
+            let ia = self.j * self.d.nstep;
+            let need_end = ia + self.d.nsps;
+            let have_end = self.abs_base + self.hist_i.len();
+            if !flush && have_end < need_end {
+                break;
+            }
+            self.emit_row(ia);
+            self.j += 1;
+        }
+        // Drop history no future row can reach. `saturating_sub` covers
+        // the flush case, where `j` has run past the last row.
+        if self.j < self.d.nhsym {
+            let keep_from = self.j * self.d.nstep;
+            let drop = keep_from
+                .saturating_sub(self.abs_base)
+                .min(self.hist_i.len());
+            if drop > 0 {
+                self.hist_i.drain(..drop);
+                self.hist_q.drain(..drop);
+                self.abs_base += drop;
+            }
+        }
+    }
+
+    fn emit_row(&mut self, ia: usize) {
+        let d = &self.d;
+        for (k, c) in self.buf.iter_mut().enumerate() {
+            *c = if k < d.nsps {
+                let abs = ia + k;
+                // Same zero-fill past end-of-stream `compute_spectra`
+                // applies for `ia + k >= xi.len()`.
+                if abs >= self.abs_base && abs - self.abs_base < self.hist_i.len() {
+                    let idx = abs - self.abs_base;
+                    let (mut si, mut sq) = (self.hist_i[idx], self.hist_q[idx]);
+                    if let Some(w) = &self.window {
+                        si *= w[k];
+                        sq *= w[k];
+                    }
+                    Complex::new(si, sq)
+                } else {
+                    Complex::new(0.0, 0.0)
+                }
+            } else {
+                Complex::new(0.0, 0.0)
+            };
+        }
+        self.fft.process(&mut self.buf);
+        let j = self.j;
+        let nhsym = d.nhsym;
+        let nfft1 = d.nfft1;
+        if self.grid.complex_input {
+            for shifted in self.bin_lo..=self.bin_hi_incl {
+                let k = (shifted + nfft1 / 2) % nfft1;
+                self.data[(shifted - self.bin_lo) * nhsym + j] = self.buf[k].norm_sqr();
+            }
+        } else {
+            for i in self.bin_lo..=self.bin_hi_incl {
+                self.data[(i - self.bin_lo) * nhsym + j] = self.buf[i].norm_sqr();
+            }
+        }
+    }
+}
+
 /// Coarse sync: search audio for candidate frames.
 ///
 /// Matches the sync shape of the protocol's `SYNC_BLOCKS`. Returns up to
@@ -558,6 +725,61 @@ pub fn coarse_sync<P: Protocol>(
     max_cand: usize,
     grid: RxGrid,
 ) -> Vec<SyncCandidate> {
+    let Some((bin_lo, bin_hi)) = spectra_crop_for::<P>(freq_min, freq_max, grid) else {
+        return Vec::new();
+    };
+    // Crop to exactly the range the correlation loop and the FST4
+    // stage1 augmentation ever read: candidate bins `ia..=ib` plus
+    // `headroom` bins above `ib` for their reference tones.
+    // `Spectrogram::get` stays absolute-bin-indexed (subtracts
+    // `freq_offset` internally) so nothing downstream needs to change.
+    let s = compute_spectra::<P>(audio, bin_lo, bin_hi, grid);
+    coarse_sync_from_spectra::<P>(&s, freq_min, freq_max, sync_min, freq_hint, max_cand, grid)
+}
+
+/// The bin range [`coarse_sync`] crops its spectrogram to, or `None`
+/// when the requested band is empty. Exposed so a caller building the
+/// spectrogram itself — incrementally, via [`SpectrogramBuilder`] —
+/// crops identically instead of re-deriving this and drifting.
+pub fn spectra_crop_for<P: Protocol>(
+    freq_min: f32,
+    freq_max: f32,
+    grid: RxGrid,
+) -> Option<(usize, usize)> {
+    let d = SyncDims::of::<P>(grid.sample_rate_hz);
+    let ntones = P::NTONES as usize;
+    let usable = grid.usable_bins(&d);
+    let ia = grid.bin_of(&d, freq_min);
+    let headroom = d.nfos * (ntones - 1) + 1;
+    let ib = grid
+        .bin_of(&d, freq_max)
+        .min(usable.saturating_sub(headroom));
+    if ib < ia {
+        return None;
+    }
+    Some((ia, (ib + headroom).min(usable.saturating_sub(1))))
+}
+
+/// [`coarse_sync`]'s second half: everything from a finished
+/// spectrogram to a ranked candidate list.
+///
+/// Split out so a receiver can build the spectrogram **during capture**
+/// with [`SpectrogramBuilder`] and pay only this part after the slot
+/// ends. On FST4-60 wideband that moves 2842 ms of a 6934 ms
+/// `coarse_sync` off the post-slot decode budget (issue #307).
+///
+/// `s` must have been produced with the same `P`/`grid` and the crop
+/// [`spectra_crop_for`] returns; anything else indexes wrongly.
+#[allow(clippy::too_many_arguments)]
+pub fn coarse_sync_from_spectra<P: Protocol>(
+    s: &Spectrogram,
+    freq_min: f32,
+    freq_max: f32,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    max_cand: usize,
+    grid: RxGrid,
+) -> Vec<SyncCandidate> {
     let d = SyncDims::of::<P>(grid.sample_rate_hz);
     let ntones = P::NTONES as usize;
     let pattern_len = P::SYNC_MODE.blocks()[0].pattern.len();
@@ -572,18 +794,6 @@ pub fn coarse_sync<P: Protocol>(
     if ib < ia {
         return Vec::new();
     }
-
-    // Crop to exactly the range the correlation loop below and the
-    // FST4 stage1 augmentation ever read: candidate bins `ia..=ib`
-    // plus `headroom` bins above `ib` for their reference tones.
-    // `Spectrogram::get` stays absolute-bin-indexed (subtracts
-    // `freq_offset` internally) so nothing below needs to change.
-    let s = compute_spectra::<P>(
-        audio,
-        ia,
-        (ib + headroom).min(usable.saturating_sub(1)),
-        grid,
-    );
 
     let n_freq = ib - ia + 1;
     let n_lag = (2 * d.jz + 1) as usize;

--- a/mfsk-core/tests/fst4_spectrogram_builder.rs
+++ b/mfsk-core/tests/fst4_spectrogram_builder.rs
@@ -1,0 +1,110 @@
+//! `SpectrogramBuilder` must be bit-identical to `compute_spectra`.
+//!
+//! The builder exists so a receiver can complete spectrogram rows as
+//! audio arrives instead of waiting for the whole slot (issue #307 —
+//! on FST4-60 wideband that is 2842 ms moved off the post-slot decode
+//! budget). That is only sound if the streaming result is *exactly*
+//! what the batch path would have produced, so this pins equality of
+//! the raw f32 bins rather than a tolerance: same FFT, same window,
+//! same fftshift, same zero-fill past end-of-stream.
+//!
+//! Block boundaries must also be irrelevant — a receiver's block size
+//! is set by its audio transport, not by the DSP — so the same input is
+//! fed at several chunk sizes, including ones that deliberately fall
+//! mid-row and mid-overlap.
+
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use mfsk_core::engine::sync::{AudioSource, RxGrid, SpectrogramBuilder, compute_spectra};
+use mfsk_core::fst4::Fst4s60;
+use mfsk_core::fst4::ddc::grid_for;
+
+/// Deterministic complex baseband with structure at several rates, so a
+/// row-indexing or overlap-retention bug shows up as a real difference
+/// rather than being hidden by a flat signal.
+fn synth(n: usize) -> (Vec<f32>, Vec<f32>) {
+    let mut xi = Vec::with_capacity(n);
+    let mut xq = Vec::with_capacity(n);
+    for k in 0..n {
+        let t = k as f32;
+        let re = (t * 0.017).sin() * 0.6 + (t * 0.31).cos() * 0.25 + (t * 0.0031).sin() * 0.4;
+        let im = (t * 0.019).cos() * 0.55 + (t * 0.29).sin() * 0.2 + (t * 0.0027).cos() * 0.35;
+        xi.push(re);
+        xq.push(im);
+    }
+    (xi, xq)
+}
+
+#[test]
+fn spectrogram_builder_matches_compute_spectra() {
+    let grid_desc = grid_for(2900.0);
+    let grid = RxGrid::complex(grid_desc.fs_c, 1550.0);
+
+    // Roughly a 60 s FST4-60 slot at the wideband DDC's own output rate,
+    // which is the case this was built for.
+    let n = (grid_desc.fs_c * 60.0) as usize;
+    let (xi, xq) = synth(n);
+
+    let bin_lo = 84usize;
+    let bin_hi = 1964usize;
+
+    let want = compute_spectra::<Fst4s60>(AudioSource::Complex(&xi, &xq), bin_lo, bin_hi, grid);
+
+    // Chunk sizes chosen to land badly on purpose: 1 (pathological),
+    // a prime, one just under and one just over `nstep`, one that is a
+    // whole number of rows, and the whole slot in one push.
+    for chunk in [1usize, 7, 511, 512, 513, 1024, 4096, n] {
+        let mut b = SpectrogramBuilder::new::<Fst4s60>(bin_lo, bin_hi, grid);
+        let mut off = 0usize;
+        while off < n {
+            let end = (off + chunk).min(n);
+            b.push(&xi[off..end], &xq[off..end]);
+            off = end;
+        }
+        let got = b.finish();
+
+        assert_eq!(got.n_freq, want.n_freq, "chunk {chunk}: n_freq");
+        assert_eq!(got.n_time, want.n_time, "chunk {chunk}: n_time");
+        assert_eq!(
+            got.freq_offset(),
+            want.freq_offset(),
+            "chunk {chunk}: freq_offset"
+        );
+
+        // Bit-identical, not approximate — see the module doc comment.
+        let a = want.avg_power_per_bin();
+        let c = got.avg_power_per_bin();
+        assert_eq!(a.len(), c.len(), "chunk {chunk}: avg_power len");
+        for (i, (x, y)) in a.iter().zip(c.iter()).enumerate() {
+            assert_eq!(
+                x.to_bits(),
+                y.to_bits(),
+                "chunk {chunk}: avg_power_per_bin[{i}] {x} != {y}"
+            );
+        }
+    }
+}
+
+/// A stream that stops short of the full slot must zero-fill the
+/// remaining rows exactly as `compute_spectra` does for a short input —
+/// the case a real receiver hits when capture is cut off.
+#[test]
+fn spectrogram_builder_zero_fills_a_short_stream() {
+    let grid_desc = grid_for(2900.0);
+    let grid = RxGrid::complex(grid_desc.fs_c, 1550.0);
+    let n = (grid_desc.fs_c * 12.0) as usize; // deliberately far short
+    let (xi, xq) = synth(n);
+    let (bin_lo, bin_hi) = (100usize, 400usize);
+
+    let want = compute_spectra::<Fst4s60>(AudioSource::Complex(&xi, &xq), bin_lo, bin_hi, grid);
+
+    let mut b = SpectrogramBuilder::new::<Fst4s60>(bin_lo, bin_hi, grid);
+    b.push(&xi, &xq);
+    let got = b.finish();
+
+    let a = want.avg_power_per_bin();
+    let c = got.avg_power_per_bin();
+    for (i, (x, y)) in a.iter().zip(c.iter()).enumerate() {
+        assert_eq!(x.to_bits(), y.to_bits(), "avg_power_per_bin[{i}]");
+    }
+}


### PR DESCRIPTION
## Summary

`compute_spectra` needs the whole slot before it can start, which puts its cost in the post-slot decode budget. But its row loop only ever reads `xi[j*nstep .. j*nstep + nsps]` — row `j` is computable the moment those samples exist, and rows are otherwise independent. A receiver doesn't have to wait.

Adds:

- **`engine::sync::SpectrogramBuilder`** — incremental, complex-input (DDC path) counterpart to `compute_spectra`.
- **`engine::sync::coarse_sync_from_spectra`** — `coarse_sync`'s second half, from a finished spectrogram to a ranked candidate list. `coarse_sync` is now `compute_spectra` + this, behaviour unchanged.
- **`engine::sync::spectra_crop_for`** — the bin crop `coarse_sync` uses, exposed so a streaming caller crops identically instead of re-deriving it and drifting.
- `MFSK_FST4_DDC_BENCH_STREAM=1` in the bench, feeding DDC and spectrogram together in 1 s blocks.

## Bit-identical, not approximate

`fst4_spectrogram_builder` pins `to_bits()` equality against `compute_spectra` across chunk sizes **1, 7, 511, 512, 513, 1024, 4096 and whole-slot** — deliberately including sizes that land mid-row and mid-overlap — plus a short-stream zero-fill case. Block size is a pacing choice, not a numerical one.

## Measured — real CoreS3, FST4-60 wideband 100–3000 Hz, `sync_min=0.8`, dual-core, cap 150 ms

| | batch | streaming |
|---|---:|---:|
| DDC + spectrogram | 4818 ms post-slot | **5839 ms during capture** |
| duty cycle of a 60 s slot | — | **9%** |
| `coarse_sync` post-slot | 6934 ms | **4039 ms** (search only) |
| **first decode, post-slot** | 11045 ms | **5206 ms — FITS 7.2 s** |

**This is the change that makes the earlier "fits the guard budget" claims real rather than conditional** — every previous such number in #330/#331/#332/#335 assumed a streamed front end that did not exist yet.

Streaming costs ~21% more total front-end work (5839 vs 4818 ms) from block-wise processing and the extra copies. That's the right trade: it's spent against a 60 s capture window at 9% duty rather than against a 7.2 s guard.

## Testing

- Host merge gate green (0 failures).
- Batch paths verified unchanged on hardware: sniper TOTALS 1300/394/1358/300 ms, both decodes identical.
- All five build-flag combinations compile.
- Pre-commit hook passed.

Refs: #306, #307, #309, #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)