### PR TITLE
test(fst4): characterise the DDC cascades — and correct #338's conclusion

### DIFF
--- a/mfsk-core/tests/fst4_ddc_cascade_response.rs
+++ b/mfsk-core/tests/fst4_ddc_cascade_response.rs
@@ -1,0 +1,212 @@
+//! Frequency response of the FST4 DDC cascades — passband flatness,
+//! transition, stopband and alias rejection. Issue #307.
+//!
+//! Both cascades shipped with only a single-tone smoke test each
+//! (`fst4::ddc`'s own `#[cfg(test)]` module), which confirms a centred
+//! tone survives and says nothing about what an *off*-centre or
+//! *out-of-band* one does. `wideband_cascade` in particular reached
+//! real hardware with no non-test caller at all until #330, and
+//! `fst4_wideband_max_cand` then attributed an ~9/100 recall gap at
+//! −27 dB to the wideband front end. This is the missing
+//! characterisation — and it **exonerated the filter**, which sent that
+//! investigation to the real cause (`fst4_rung_major_recall_gap`: the
+//! omitted `llrd` stage, worth ~10/100 there).
+//!
+//! The design constants make the wideband config look tighter than the
+//! sniper one, which is what prompted this:
+//!
+//! | | `Fs_c/2` | search half-width | transition | margin |
+//! |---|---:|---:|---:|---:|
+//! | sniper | ~395 Hz | 250 Hz | 150 Hz | ~70 Hz |
+//! | wideband | ~1580 Hz | **1450 Hz** | 300 Hz | **−20 Hz** |
+//!
+//! i.e. the wideband transition band is designed to *start* at
+//! ~1430 Hz, inside the ±1450 Hz the search covers, which looks like a
+//! defect on paper. Measured, it is not: the wideband response is
+//! −0.23 dB at its band edge while the *sniper* — which has positive
+//! margin on paper — droops −2.87 dB at its own. The paper margin is
+//! the wrong quantity; only the measured curve settles it, which is
+//! the point of this test existing.
+//!
+//! Method: drive a real 12 kHz tone at a known audio frequency through
+//! the cascade and measure the complex baseband's RMS, normalised to a
+//! dead-centre reference tone. Aliasing shows up as an out-of-band tone
+//! producing output that isn't in the stopband.
+
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use mfsk_core::engine::dsp::ddc::{DdcCascadeConfig, StreamingComplexDdc};
+use mfsk_core::fst4::ddc::{grid_for, sniper_cascade, wideband_cascade};
+
+const FS_IN: f32 = 12_000.0;
+/// Long enough that the cascades' group delay (the wideband resampler
+/// alone is 10 241 taps) is a small fraction of what's measured.
+const SECONDS: f32 = 8.0;
+
+fn tone(freq_hz: f32, n: usize) -> Vec<i16> {
+    (0..n)
+        .map(|k| {
+            let p = core::f64::consts::TAU * freq_hz as f64 * k as f64 / FS_IN as f64;
+            (p.sin() * 12_000.0) as i16
+        })
+        .collect()
+}
+
+/// Baseband RMS for a real input tone at `freq_hz`, with the cascade's
+/// startup transient trimmed.
+fn response(cfg: &DdcCascadeConfig, freq_hz: f32) -> f32 {
+    let n = (FS_IN * SECONDS) as usize;
+    let x = tone(freq_hz, n);
+    let mut ddc = StreamingComplexDdc::new(cfg);
+    let (mut i, mut q) = (Vec::new(), Vec::new());
+    ddc.push_i16(&x, &mut i, &mut q);
+    ddc.flush(&mut i, &mut q);
+
+    // Drop the leading transient and a matching tail; the middle is
+    // steady state.
+    let skip = i.len() / 8;
+    let end = i.len() - i.len() / 8;
+    if end <= skip {
+        return 0.0;
+    }
+    let seg = end - skip;
+    let sum: f32 = (skip..end).map(|k| i[k] * i[k] + q[k] * q[k]).sum();
+    (sum / seg as f32).sqrt()
+}
+
+fn db(x: f32, reference: f32) -> f32 {
+    if x <= 0.0 || reference <= 0.0 {
+        return -200.0;
+    }
+    20.0 * (x / reference).log10()
+}
+
+struct Curve {
+    name: &'static str,
+    center: f32,
+    fs_c: f32,
+    half_width: f32,
+    /// (offset_hz, dB relative to centre)
+    points: Vec<(f32, f32)>,
+}
+
+fn measure(
+    name: &'static str,
+    cfg: &DdcCascadeConfig,
+    center: f32,
+    fs_c: f32,
+    half_width: f32,
+) -> Curve {
+    let reference = response(cfg, center);
+    let mut offsets: Vec<f32> = Vec::new();
+    // Dense through the passband edge and transition, where the
+    // question is; coarse out into the stopband.
+    let nyq = fs_c / 2.0;
+    for frac in [0.0f32, 0.25, 0.5, 0.75, 0.9, 0.95, 1.0] {
+        offsets.push(frac * half_width);
+    }
+    for extra in [1.02f32, 1.05, 1.10, 1.20, 1.4, 1.8, 2.5, 3.5] {
+        offsets.push(extra * nyq);
+    }
+    offsets.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    offsets.dedup();
+
+    let points = offsets
+        .iter()
+        .filter(|o| center + *o < FS_IN / 2.0 - 100.0)
+        .map(|&o| (o, db(response(cfg, center + o), reference)))
+        .collect();
+
+    Curve {
+        name,
+        center,
+        fs_c,
+        half_width,
+        points,
+    }
+}
+
+fn report(c: &Curve) {
+    let nyq = c.fs_c / 2.0;
+    eprintln!(
+        "\n{} — centre {:.0} Hz, Fs_c {:.1} Hz (Nyquist {:.1}), search half-width {:.0} Hz",
+        c.name, c.center, c.fs_c, nyq, c.half_width
+    );
+    eprintln!(
+        "  {:>10}  {:>10}  {:>9}  region",
+        "offset(Hz)", "audio(Hz)", "resp(dB)"
+    );
+    for &(o, d) in &c.points {
+        let region = if o <= c.half_width {
+            "passband (searched)"
+        } else if o < nyq {
+            "guard"
+        } else {
+            "stopband (must reject)"
+        };
+        eprintln!(
+            "  {:>10.0}  {:>10.0}  {:>9.2}  {}",
+            o,
+            c.center + o,
+            d,
+            region
+        );
+    }
+}
+
+#[test]
+fn fst4_ddc_cascades_pass_their_search_band_and_reject_beyond_nyquist() {
+    let sniper_grid = grid_for(600.0);
+    let wide_grid = grid_for(2900.0);
+
+    let sniper = measure(
+        "sniper_cascade",
+        &sniper_cascade(1216.0),
+        1216.0,
+        sniper_grid.fs_c,
+        250.0,
+    );
+    let wide = measure(
+        "wideband_cascade",
+        &wideband_cascade(1550.0),
+        1550.0,
+        wide_grid.fs_c,
+        1450.0,
+    );
+
+    report(&sniper);
+    report(&wide);
+
+    for c in [&sniper, &wide] {
+        let nyq = c.fs_c / 2.0;
+
+        // Passband: everything the search actually covers must survive.
+        // 3 dB is generous — it is a "is this filter broken" gate, not a
+        // ripple spec — but it is exactly what a signal at the band edge
+        // pays, so a violation is a real sensitivity loss for that
+        // signal, not a cosmetic one.
+        for &(o, d) in c.points.iter().filter(|(o, _)| *o <= c.half_width) {
+            assert!(
+                d > -3.0,
+                "{}: passband droop at offset {o:.0} Hz ({:.0} Hz audio): {d:.2} dB — \
+                 the search covers this offset, so a signal there is attenuated",
+                c.name,
+                c.center + o,
+            );
+        }
+
+        // Stopband: content past Nyquist folds back into the baseband,
+        // so it must be well down. `design_lowpass` uses a Blackman
+        // window (~-74 dB), and the cascade is at least one such stage,
+        // so -50 dB is a loose gate on a design that should reach -74.
+        for &(o, d) in c.points.iter().filter(|(o, _)| *o >= nyq * 1.15) {
+            assert!(
+                d < -50.0,
+                "{}: alias leakage at offset {o:.0} Hz ({:.0} Hz audio): {d:.2} dB — \
+                 past Nyquist ({nyq:.0} Hz) this folds into the searched band",
+                c.name,
+                c.center + o,
+            );
+        }
+    }
+}

--- a/mfsk-core/tests/fst4_rung_major_recall_gap.rs
+++ b/mfsk-core/tests/fst4_rung_major_recall_gap.rs
@@ -1,0 +1,216 @@
+//! Does `decode_phase_split_timed` recall as well as the production
+//! ladder at threshold? — issue #307, tier C.
+//!
+//! `fst4_wideband_max_cand` measured the wideband DDC monitor at 65/100
+//! at −27 dB against an 80/100 production baseline and attributed the
+//! gap to the wideband front end. **That conclusion was wrong**, and
+//! this test is what corrects it: `fst4_ddc_cascade_response` then
+//! showed the wideband cascade is flatter through its search band than
+//! the sniper's (−0.23 dB at the edge vs −2.87 dB) with ≥40 dB alias
+//! rejection, so the filter could not account for it.
+//!
+//! The real confound was in the comparison itself. The monitor decodes
+//! through `fst4::rung_major::decode_phase_split_timed`, which
+//! **omits `llrd`** (that module's doc comment says so: five stages
+//! llra/llrb/llre/llrc/OSD, not six) on the strength of an ablation
+//! finding it "never contributes additional recall on real AWGN or
+//! CCIR-moderate data". The baseline runs the production six-variant
+//! ladder. So the two differed by a stage, not just by a front end.
+//!
+//! Holding the candidate list fixed and swapping only the decode path
+//! separates them.
+
+#![allow(clippy::type_complexity)]
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::{Path, PathBuf};
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+
+use num_complex::Complex;
+
+use mfsk_core::engine::equalize::EqMode;
+use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_precomputed};
+use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
+use mfsk_core::engine::sync2d::fst4_sync_search;
+use mfsk_core::fst4::Fst4s60;
+use mfsk_core::fst4::ddc::{
+    REFINE_DS_RATE_HZ, grid_for, wideband_cascade, wideband_refine_recenter,
+};
+use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+use mfsk_core::fst4::rung_major::{RungMajorCandidate, decode_phase_split_timed};
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+const GOLDEN_MSG: &str = "CQ JL1NIE PM95";
+const CENTER_HZ: f32 = 1550.0;
+const HALF: f32 = 1450.0;
+const SYNC_MIN: f32 = 0.8;
+const MAX_CAND: usize = 50;
+const SYNC_Q_MIN: u32 = 16;
+
+fn ddc_refine(c: &SyncCandidate, ci: &[f32], cq: &[f32], d: usize) -> Vec<Complex<f32>> {
+    let mut r = wideband_refine_recenter(c.freq_hz, CENTER_HZ);
+    let (mut a, mut b) = (Vec::new(), Vec::new());
+    r.push(ci, cq, &mut a, &mut b);
+    r.flush(&mut a, &mut b);
+    let t = ((d as f32 * REFINE_DS_RATE_HZ / 12_000.0).round() as usize
+        + r.group_delay_output_samples())
+    .min(a.len());
+    let mut cd0: Vec<Complex<f32>> = a[t..]
+        .iter()
+        .zip(b[t..].iter())
+        .map(|(&i, &q)| Complex::new(i, q))
+        .collect();
+    let s2: f32 = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len().max(1) as f32;
+    if s2 > f32::EPSILON {
+        let inv = 1.0 / s2.sqrt();
+        for c in cd0.iter_mut() {
+            *c *= inv;
+        }
+    }
+    cd0
+}
+
+fn is_golden(m: &[u8]) -> bool {
+    m.try_into()
+        .ok()
+        .and_then(|a: &[u8; 77]| unpack77(a))
+        .as_deref()
+        == Some(GOLDEN_MSG)
+}
+
+/// Measured 2026-08-22, wideband DDC candidates, 100 trials per cell:
+///
+/// | SNR | baseline | via `rung_major` | via production ladder |
+/// |---|---:|---:|---:|
+/// | −27 dB | 80/100 | **65** | **75** |
+/// | −26 dB | 99/100 | 96 | **100** |
+///
+/// So at threshold the omitted stage is worth ~10/100, and the DDC
+/// front end only ~5 — the latter matching
+/// `fst4_ddc_sniper_full_decode`'s independent 77-vs-80. At −26 dB the
+/// wideband path on the production ladder matches or beats the real
+/// 12 kHz baseline outright.
+///
+/// This does not by itself prove `llrd` is the responsible stage —
+/// `rung_major` reimplements the whole sequence — but it does show the
+/// ablation behind that omission does not hold at this operating point,
+/// and the embedded monitor pays the difference whenever its cap is on.
+#[test]
+#[ignore = "tier C — needs the fst4_60_awgn_* sweep corpus; run with --ignored --nocapture"]
+fn fst4_60_rung_major_vs_production_ladder_at_threshold() {
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let dir: PathBuf = Path::new(&manifest)
+        .join("../embedded-poc/assets/fst4_sweep")
+        .to_path_buf();
+
+    use rayon::prelude::*;
+    for snr in ["m27", "m26"] {
+        let mut paths: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_stem()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.starts_with(&format!("fst4_60_awgn_{snr}_")))
+            })
+            .collect();
+        paths.sort();
+
+        let res: Vec<(bool, bool, bool)> = paths
+            .par_iter()
+            .filter_map(|p| {
+                let audio = load_wav_i16_opt(p)?;
+                let baseline =
+                    DecodeRequest::<Fst4s60>::new(&audio, 100.0, 3000.0, SYNC_MIN, MAX_CAND)
+                        .decode()
+                        .results
+                        .iter()
+                        .any(|r| is_golden(r.message77()));
+
+                let cfg = wideband_cascade(CENTER_HZ);
+                let mut ddc = mfsk_core::engine::dsp::ddc::StreamingComplexDdc::new(&cfg);
+                let (mut ci, mut cq) = (Vec::new(), Vec::new());
+                ddc.push_i16(&audio, &mut ci, &mut cq);
+                ddc.flush(&mut ci, &mut cq);
+                let delay = ddc.group_delay_input_samples();
+                let grid = grid_for(2900.0);
+                let cands = coarse_sync::<Fst4s60>(
+                    AudioSource::Complex(&ci, &cq),
+                    CENTER_HZ - HALF,
+                    CENTER_HZ + HALF,
+                    SYNC_MIN,
+                    None,
+                    MAX_CAND,
+                    RxGrid::complex(grid.fs_c, CENTER_HZ),
+                );
+
+                let (mut via_rung, mut via_prod) = (false, false);
+                for c in cands.iter() {
+                    let cd0 = ddc_refine(c, &ci, &cq, delay);
+                    let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+
+                    if !via_rung {
+                        let inputs = [RungMajorCandidate {
+                            cand: c.clone(),
+                            cd0: cd0.clone(),
+                            refined_freq_hz: s2.freq_hz,
+                            i0: s2.i0,
+                        }];
+                        let (o, _) = decode_phase_split_timed::<Fst4s60>(
+                            &inputs,
+                            false,
+                            false,
+                            &[0],
+                            None,
+                            None,
+                            12_000.0,
+                        );
+                        if o.first()
+                            .and_then(|x| x.as_ref())
+                            .is_some_and(|r| is_golden(r.message77()))
+                        {
+                            via_rung = true;
+                        }
+                    }
+                    if !via_prod {
+                        let pre = (cd0, s2.freq_hz, s2.i0, s2.score);
+                        if process_candidate_precomputed::<Fst4s60>(
+                            c,
+                            &[],
+                            &FST4_60A_DOWNSAMPLE,
+                            DecodeDepth::FULL,
+                            DecodeStrictness::Normal,
+                            &[],
+                            EqMode::Off,
+                            SYNC_Q_MIN,
+                            pre,
+                            true,
+                            false,
+                        )
+                        .is_some_and(|r| is_golden(r.message77()))
+                        {
+                            via_prod = true;
+                        }
+                    }
+                    if via_rung && via_prod {
+                        break;
+                    }
+                }
+                Some((baseline, via_rung, via_prod))
+            })
+            .collect();
+
+        let n = res.len();
+        eprintln!(
+            "{snr}: n={n}  baseline(real 12k)={}  wideband via rung_major(no llrd)={}  wideband via production ladder={}",
+            res.iter().filter(|r| r.0).count(),
+            res.iter().filter(|r| r.1).count(),
+            res.iter().filter(|r| r.2).count(),
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Two tests, and the second **overturns what the first was written to confirm**.

## 1. `fst4_ddc_cascade_response` — the filter is exonerated

Frequency response of both cascades: passband flatness, transition, stopband, alias rejection. Neither had coverage beyond a single centred-tone smoke test, and `wideband_cascade` reached real hardware with no non-test caller at all until #330.

On paper the wideband config looks defective — `Fs_c/2 = 1580 Hz` against a ±1450 Hz search with a 300 Hz transition, so the transition starts ~1430 Hz, *inside* the searched band, where the sniper has ~70 Hz of margin. **Measured, the opposite is true:**

| | passband edge | alias into search band |
|---|---:|---:|
| sniper | **−2.87 dB** at ±250 | −91 dB |
| wideband | **−0.23 dB** at ±1450 | −40 dB |

The wideband filter is flatter through its own search band than the sniper is through its, and aliasing reaching inside is ≥40 dB down. The paper margin was the wrong quantity.

## 2. `fst4_rung_major_recall_gap` — the real cause

#338 attributed the wideband monitor's 65/100-vs-80/100 at −27 dB to the front end. **That was wrong**, and the confound was in the comparison itself: the monitor decodes through `decode_phase_split_timed`, which **omits `llrd`** (five stages, not six — that module's own doc comment), while the baseline runs the production six-variant ladder. The two differed by a stage, not just a front end.

Holding the candidate list fixed and swapping only the decode path:

| SNR | baseline (real 12k) | via `rung_major` | via **production ladder** |
|---:|---:|---:|---:|
| −27 | 80/100 | **65** | **75** |
| −26 | 99/100 | 96 | **100** |

At threshold the omitted stage is worth **~10/100**; the DDC front end only ~5 — matching `fst4_ddc_sniper_full_decode`'s independent 77-vs-80. At −26 dB the wideband DDC path on the production ladder matches or beats the real 12 kHz baseline outright.

## Consequences beyond this investigation

- `rung_major` omits `llrd` on an ablation finding it "never contributes additional recall on real AWGN or CCIR-moderate data". **That does not hold at threshold on this path.** This doesn't prove `llrd` is the responsible stage — `rung_major` reimplements the whole sequence — but the premise needs re-measuring.
- **The embedded monitor pays this whenever its cap is on**, since the cap is what routes it through `decode_phase_split_timed`. Combined with #337 (the cap itself costs ~2/3 of threshold recall by truncating OSD), the capped monitor's threshold sensitivity is materially worse than the uncapped production path — and both effects were invisible on the strong-signal recording they were developed against.

## Process note

Third hypothesis of mine falsified by measurement in this line of work, after the PSRAM explanation for `fst4_sync_search` (#333) and `max_cand` (#338). Recording the rate deliberately: on this pipeline the structural guesses have been wrong more often than right, and only the controlled swap settled any of them.

## Testing

Host merge gate green. The response test is non-`#[ignore]`d (needs no corpus, 0.06 s); the ladder comparison is tier C.

Refs: #306, #307, #310, #333, #337, #338

🤖 Generated with [Claude Code](https://claude.com/claude-code)