### PR TITLE
perf(engine,embedded): dual-core the coarse-sync fill, and un-quadratic its dedup — 4123 → 1009 ms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ rather than distributing them across patches.
 
 ### Added
 
+- **`coarse_sync`'s correlation matrix is now a public seam**
+  (issue #327) — `sync2d_shape` / `fill_sync2d_row` /
+  `coarse_sync_from_sync2d`, alongside the existing
+  `coarse_sync_from_spectra`, which is now just those three composed.
+
+  Every row of that matrix is a pure function of the finished
+  spectrogram, and the host has parallelised the fill through rayon
+  since it was written. An embedded caller could not: the loop was
+  buried inside one call. Exposing the seam lets the CoreS3 FST4
+  monitor spread the fill across both cores — measured 1131 → 714 ms on
+  the wideband 100-3000 Hz FST4-60 search — with bit-identical output,
+  since the split decides only which core writes which row.
+
+  This is the same shape as `0.10.0`'s earlier `SpectrogramBuilder`
+  split (#307/#336), which moved the spectrogram *build* out of the
+  post-slot budget: both exist so a receiver can pay a stage somewhere
+  other than "all at once, on one core, after the slot ends".
+
 - **A standalone WSPR receiver application for the CoreS3**
   (`embedded-poc/m5stack-cores3-app/src/bin/wspr_app.rs`). Phase E (#260)
   answered the decoder-level question — `wspr::ddc` exists, the steady-state
@@ -156,6 +174,30 @@ rather than distributing them across patches.
   conceptual and is not addressed by naming the constant. See #307/#309.
 
 ### Fixed
+
+- **`coarse_sync`'s de-duplication is no longer quadratic** (issue #327).
+  It compared every candidate against every earlier one; candidates
+  within 4 Hz are a contiguous run, because the list is
+  frequency-sorted by construction, so it now walks a sliding window
+  instead.
+
+  Output is unchanged — bit-identical, not merely equivalent-in-effect,
+  and that distinction is load-bearing here: the loop zeroes scores as
+  it goes, so which pairs are compared in which order decides the
+  result. Skipped pairs are exactly those that failed the 4 Hz test and
+  mutated nothing, and `dedup_suppress_matches_all_pairs` pins the new
+  loop against a brute-force reference over lists built to stress ties,
+  boundary spacing and suppression chains.
+
+  On a narrow search this was invisible; on a wide one it was most of
+  the search. Real CoreS3 hardware, FST4-60 wideband (1881 bins, ~15k
+  candidates before dedup): the ranking half of `coarse_sync` fell
+  **2989 → 292 ms**, and the whole search 4123 → 1009 ms with the
+  dual-core fill above. It also explains a gap #307 had left open and
+  provisionally attributed to the spectrogram working set — the wideband
+  search cost 2.147 ms/bin against the sniper's 0.671 ms/bin for
+  identical per-bin work. Per-bin *fill* cost is in fact the same for
+  both (0.60 ms/bin); the entire 3.2× was this superlinear stage.
 
 - **`coarse_sync`'s de-duplication decision is now final** (issue #312,
   found by VK3NV). The dedup pass marks the losing near-duplicate (within

--- a/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
@@ -48,8 +48,9 @@ use mfsk_core::engine::dsp::ddc::StreamingComplexDdc;
 use mfsk_core::engine::equalize::EqMode;
 use mfsk_core::engine::pipeline::{process_candidate_precomputed, DecodeDepth, DecodeStrictness};
 use mfsk_core::engine::sync::{
-    coarse_sync, coarse_sync_from_spectra, compute_spectra, spectra_crop_for, AudioSource, RxGrid,
-    SpectrogramBuilder, SyncCandidate, SyncDims,
+    coarse_sync, coarse_sync_from_sync2d, compute_spectra, fill_sync2d_row, spectra_crop_for,
+    sync2d_shape, AudioSource, RxGrid, Spectrogram, SpectrogramBuilder, Sync2dShape, SyncCandidate,
+    SyncDims,
 };
 use mfsk_core::engine::sync2d::fst4_sync_search;
 use mfsk_core::fst4::ddc::{
@@ -423,6 +424,100 @@ fn ddc_refine(
     cd0
 }
 
+/// The correlation matrix, as both cores see it while filling it.
+/// Rows are disjoint by construction — index `fi` owns
+/// `sync2d[fi * n_lag ..][.. n_lag]` and nothing else — which is why
+/// this loop needs no lock.
+struct Sync2dCtx {
+    s: *const Spectrogram,
+    shape: *const Sync2dShape,
+    sync2d: *mut f32,
+    n_lag: usize,
+}
+
+/// One row of the correlation matrix. Returns `Option<()>` rather than
+/// a result type because the output *is* the matrix; `Vec<()>` is a ZST
+/// vector, so `run_split`'s result collection allocates nothing.
+fn sync2d_row(ctx: &Sync2dCtx, fi: usize) -> Option<()> {
+    // SAFETY: `run_split`/`drain_single` block until both cores are
+    // done, so all three pointers outlive this call. The write is to
+    // row `fi` alone, and `NEXT_IDX` hands out each `fi` exactly once,
+    // so no two cores ever hold overlapping slices.
+    let s = unsafe { &*ctx.s };
+    let shape = unsafe { &*ctx.shape };
+    let row = unsafe { core::slice::from_raw_parts_mut(ctx.sync2d.add(fi * ctx.n_lag), ctx.n_lag) };
+    fill_sync2d_row::<Fst4s60>(s, shape, fi, row);
+    Some(())
+}
+
+/// `coarse_sync_from_spectra` with its correlation fill spread across
+/// both cores (issue #327).
+///
+/// The fill is the largest post-slot item left in the wideband monitor
+/// — 4039 ms of the 5207 ms first-decode path, once #336 moved the
+/// spectrogram build into the capture window — and every row of it is a
+/// pure function of the finished spectrogram (the host already fills
+/// them through rayon). So it splits exactly the way the candidate loop
+/// does, over the same worker, and the results are **bit-identical**
+/// either way: the split decides only which core writes which row, and
+/// the ranking stage still sees the whole matrix.
+///
+/// Reports the fill/rank split too, which the single-call form cannot.
+/// Only the fill parallelises, so the rank half is the floor this can
+/// approach.
+fn coarse_search(s: &Spectrogram, rx_grid: RxGrid) -> Vec<SyncCandidate> {
+    let Some(shape) = sync2d_shape::<Fst4s60>(
+        CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
+        CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
+        rx_grid,
+    ) else {
+        return Vec::new();
+    };
+
+    let t_fill0 = now_us();
+    let mut sync2d = alloc::vec![0.0f32; shape.len()];
+    {
+        let ctx = Sync2dCtx {
+            s: s as *const Spectrogram,
+            shape: &shape as *const Sync2dShape,
+            sync2d: sync2d.as_mut_ptr(),
+            n_lag: shape.n_lag,
+        };
+        // No deadline: unlike a candidate, a row is not optional — a
+        // row left unfilled is a hole in the search band, not merely a
+        // decode not attempted.
+        if DUAL_CORE {
+            fst4_dual_core::run_split(&ctx, shape.n_freq, i64::MAX, sync2d_row);
+        } else {
+            fst4_dual_core::drain_single(&ctx, shape.n_freq, i64::MAX, sync2d_row);
+        }
+    }
+    let t_fill = now_us() - t_fill0;
+
+    let t_rank0 = now_us();
+    let cands = coarse_sync_from_sync2d::<Fst4s60>(
+        s,
+        &sync2d,
+        &shape,
+        SYNC_MIN,
+        None,
+        MAX_CAND,
+        rx_grid,
+    );
+    let t_rank = now_us() - t_rank0;
+
+    log::info!(
+        "fst4_ddc_bench: [diag] coarse search split — fill {} ms ({} rows x {} lags, {}), \
+         rank {} ms",
+        t_fill / 1000,
+        shape.n_freq,
+        shape.n_lag,
+        if DUAL_CORE { "dual-core" } else { "single-core" },
+        t_rank / 1000,
+    );
+    cands
+}
+
 /// `audio_bin` is the raw golden asset (`include_bytes!`,
 /// `i16[720000]` little-endian — same layout `fst4_bench`'s own
 /// `fst4_60_golden_audio.bin` doc comment describes). Byte-wise, not a
@@ -459,6 +554,14 @@ pub fn run(audio_bin: &[u8]) {
 
     let r = unsafe { esp_idf_svc::sys::esp_task_wdt_deinit() };
     log::info!("task watchdog deinit -> {r}");
+
+    if DUAL_CORE {
+        // At boot, not per batch: the correlation fill below is the
+        // first thing that wants the second core, and a real app has
+        // to spawn here anyway — before WiFi, per
+        // `fst4_dual_core::init`'s ordering constraint.
+        fst4_dual_core::init();
+    }
 
     // ---- Stage 1: DDC + coarse_sync ----
     let t0 = now_us();
@@ -576,15 +679,7 @@ pub fn run(audio_bin: &[u8]) {
     let candidates = match &prebuilt {
         // Streaming: the spectrogram was finished during capture, so
         // only the correlation search is post-slot work.
-        Some(s) => coarse_sync_from_spectra::<Fst4s60>(
-            s,
-            CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
-            CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
-            SYNC_MIN,
-            None,
-            MAX_CAND,
-            rx_grid,
-        ),
+        Some(s) => coarse_search(s, rx_grid),
         None => coarse_sync::<Fst4s60>(
             AudioSource::Complex(&coarse_i, &coarse_q),
             CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
@@ -896,7 +991,7 @@ const FULL_DEPTH_RANKS: usize = {
 /// `fn` item so [`fst4_dual_core::run_split`] can hand it to the worker
 /// task — a closure's captures cannot cross that boundary, which is why
 /// every input arrives through [`Ctx`].
-fn monitor_candidate(ctx: &fst4_dual_core::Ctx, i: usize) -> Option<MonitorHit> {
+fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
     // SAFETY: `run_split` blocks until both cores are done, so these
     // outlive the call. Shared read-only across cores.
     let candidates: &[SyncCandidate] =
@@ -969,6 +1064,23 @@ fn monitor_candidate(ctx: &fst4_dual_core::Ctx, i: usize) -> Option<MonitorHit> 
     })
 }
 
+/// Everything one candidate needs that does not vary across the batch,
+/// shared read-only by both cores. Raw pointers rather than slices
+/// because this crosses a FreeRTOS task boundary; `run_split`'s
+/// send → work → blocking-recv discipline is what makes them valid for
+/// the whole batch.
+struct MonitorCtx {
+    candidates: *const core::ffi::c_void,
+    n: usize,
+    coarse_i: *const f32,
+    coarse_q: *const f32,
+    coarse_len: usize,
+    coarse_delay_orig: usize,
+    /// When the batch started, so per-candidate results can report a
+    /// loop-relative timestamp that means the same thing on both cores.
+    t0_us: i64,
+}
+
 /// One candidate's outcome. Carries `rank` because [`run_split`] does
 /// not preserve order — two cores complete interleaved.
 ///
@@ -1025,29 +1137,26 @@ fn run_monitor_loop(
     let front_end_all_us = t_ddc_us + t_coarse_sync_us;
     let front_end_streamed_us = t_search_us;
 
-    if DUAL_CORE {
-        // Spawn before the batch, not at boot: this bench brings up no
-        // WiFi, so there is no allocator pressure to race here. A real
-        // app must call it before WiFi — see `fst4_dual_core::init`.
-        fst4_dual_core::init::<MonitorHit>();
-    }
+    // The worker is already up — `run` spawns it at boot so the
+    // correlation fill can use it too.
 
     let t_loop0 = now_us();
-    let ctx = fst4_dual_core::Ctx {
+    let n = candidates.len();
+    let deadline_us = t_loop0 + MONITOR_DEADLINE_MS * 1000;
+    let ctx = MonitorCtx {
         candidates: candidates.as_ptr() as *const core::ffi::c_void,
-        n: candidates.len(),
+        n,
         coarse_i: coarse_i.as_ptr(),
         coarse_q: coarse_q.as_ptr(),
         coarse_len: coarse_i.len(),
         coarse_delay_orig,
-        deadline_us: t_loop0 + MONITOR_DEADLINE_MS * 1000,
         t0_us: t_loop0,
     };
 
     let mut hits = if DUAL_CORE {
-        fst4_dual_core::run_split(&ctx, monitor_candidate)
+        fst4_dual_core::run_split(&ctx, n, deadline_us, monitor_candidate)
     } else {
-        fst4_dual_core::drain_single(&ctx, monitor_candidate)
+        fst4_dual_core::drain_single(&ctx, n, deadline_us, monitor_candidate)
     };
     hits.sort_by_key(|h| h.rank);
 

--- a/embedded-poc/embedded-shared/src/fst4_dual_core.rs
+++ b/embedded-poc/embedded-shared/src/fst4_dual_core.rs
@@ -39,16 +39,23 @@
 //!
 //! ## Shape of the work
 //!
-//! The unit is one candidate index. Everything a candidate needs —
-//! the coarse-sync list, the DDC baseband, the group delay — is shared
-//! read-only for the whole batch, so it lives in [`Ctx`] behind a
-//! raw pointer rather than being copied per job. The per-candidate
-//! function is a plain `fn` item, not a closure: it has to be callable
-//! from the worker task, and a closure's captures cannot cross that
-//! boundary. Context reaches it through [`ctx`], the same
-//! global-plus-`fn`-item idiom `wspr_dual_core`'s `DeadlineCell` uses
-//! for its budget check (and for the same underlying reason — Xtensa's
-//! `max_atomic_width` is 32, so several of these cannot be atomics).
+//! The unit is one index of a batch — a candidate for the decode loop,
+//! a frequency row for `coarse_sync`'s correlation fill. Everything an
+//! item needs that does not vary across the batch (the coarse-sync
+//! list and DDC baseband; or the spectrogram and its `Sync2dShape`)
+//! lives in a caller-owned context `C`, shared read-only behind one
+//! raw pointer rather than copied per item. The per-item function is a
+//! plain `fn` item, not a closure: it has to be callable from the
+//! worker task, and a closure's captures cannot cross that boundary.
+//!
+//! **The job the worker receives is type-erased**, which is what lets
+//! one persistent worker serve both loops. `C` and `R` appear only in
+//! [`run_split`]'s signature and in the monomorphised `worker_body` it
+//! hands over as a plain `fn(*const c_void)`; the queues themselves
+//! carry an untyped pointer pair. The alternative — `init::<R>()`
+//! fixing one result type for the life of the worker, as the first
+//! version did — would need a second 48 KiB `.bss` stack and a second
+//! queue pair for every additional kind of batch.
 
 use core::cell::UnsafeCell;
 use core::ptr;
@@ -146,37 +153,39 @@ unsafe fn queue_recv_ptr<T>(q: QueueHandle_t) -> *mut T {
     out
 }
 
-/// Everything one candidate needs that does not vary across the batch.
-/// Raw pointers rather than slices because this crosses a FreeRTOS task
-/// boundary; the send → work → blocking-recv discipline in
-/// [`run_split`] is what makes them valid for the whole batch.
-pub struct Ctx {
-    pub candidates: *const core::ffi::c_void,
-    pub n: usize,
-    pub coarse_i: *const f32,
-    pub coarse_q: *const f32,
-    pub coarse_len: usize,
-    pub coarse_delay_orig: usize,
+/// A batch's per-item function: a plain `fn` item, not a closure — see
+/// the module doc comment. `C` is the caller's read-only context, `i`
+/// the item index, and `None` means "nothing to report for this one".
+pub type WorkFn<C, R> = fn(&C, usize) -> Option<R>;
+
+/// One batch, as both cores see it. Lives on [`run_split`]'s stack;
+/// the send → do-my-share → blocking-recv discipline there is what
+/// makes the `ctx` pointer valid for the worker's whole run.
+struct Split<C, R> {
+    ctx: *const C,
+    n: usize,
     /// Absolute `esp_timer` deadline for the whole batch; a core that
-    /// reaches it stops claiming new candidates.
-    pub deadline_us: i64,
-    /// When the batch started, so per-candidate results can report a
-    /// loop-relative timestamp that means the same thing on both cores.
-    pub t0_us: i64,
+    /// reaches it stops claiming new items.
+    deadline_us: i64,
+    work: WorkFn<C, R>,
+    /// The worker's results. Written by the worker exactly once,
+    /// before it posts to `RESULT_Q`; read by the main core only after
+    /// that message arrives, which is the happens-before edge.
+    worker_out: UnsafeCell<Vec<R>>,
 }
 
-/// The per-candidate worker function. A `fn` item, not a closure —
-/// see the module doc comment.
-pub type CandidateFn<R> = fn(&Ctx, usize) -> Option<R>;
-
-struct Job<R: 'static> {
-    ctx: *const Ctx,
-    work: CandidateFn<R>,
+/// A type-erased batch for the worker task. `state` is a
+/// `*const Split<C, R>` and `run` the [`worker_body`] monomorphised
+/// for that same pair, so the types are recovered by construction
+/// rather than by a cast the receiver has to get right.
+struct Job {
+    state: *const core::ffi::c_void,
+    run: fn(*const core::ffi::c_void),
 }
-// SAFETY: `ctx` outlives the job — `run_split` blocks on the result
-// queue before returning, so the borrow cannot dangle. `work` is a
-// plain function pointer.
-unsafe impl<R> Send for Job<R> {}
+// SAFETY: `state` outlives the job — `run_split` blocks on the result
+// queue before returning, so the borrow cannot dangle. `run` is a plain
+// function pointer.
+unsafe impl Send for Job {}
 
 static NEXT_IDX: AtomicUsize = AtomicUsize::new(0);
 
@@ -202,51 +211,70 @@ fn log_worker_stack(who: &str, reserved: usize) {
     );
 }
 
-/// Claim candidate indices until the list or the deadline runs out.
+/// Claim item indices until the batch or the deadline runs out.
 /// Both cores run this identical loop; `fetch_add` is what grants one
 /// of them exclusive ownership of each index.
-fn drain<R>(ctx: &Ctx, work: CandidateFn<R>) -> Vec<R> {
+fn drain<C, R>(split: &Split<C, R>) -> Vec<R> {
+    // SAFETY: the caller's context outlives the batch — see `Split`.
+    let ctx = unsafe { &*split.ctx };
     let mut out = Vec::new();
     loop {
         let i = NEXT_IDX.fetch_add(1, Ordering::AcqRel);
-        if i >= ctx.n {
+        if i >= split.n {
             break;
         }
-        if now_us() >= ctx.deadline_us {
+        if now_us() >= split.deadline_us {
             break;
         }
-        if let Some(r) = work(ctx, i) {
+        if let Some(r) = (split.work)(ctx, i) {
             out.push(r);
         }
     }
     out
 }
 
+/// The worker's half of a batch, monomorphised per `(C, R)` pair and
+/// handed to the worker task as a plain `fn(*const c_void)`.
+fn worker_body<C, R>(state: *const core::ffi::c_void) {
+    // SAFETY: `run_split` built this `Job` with `state` pointing at its
+    // own `Split<C, R>` and `run` set to this instantiation, and blocks
+    // until we post our result.
+    let split = unsafe { &*(state as *const Split<C, R>) };
+    let out = drain(split);
+    log_worker_stack("worker", WORKER_STACK_BYTES);
+    // SAFETY: the main core does not touch `worker_out` until it
+    // receives from `RESULT_Q`, which happens after this write.
+    unsafe { *split.worker_out.get() = out };
+}
+
 /// Single-core equivalent of [`run_split`] — same `work`, same
 /// deadline, same claim loop, just without the second core. Exists so
 /// the dual-core comparison is one build switch over one code path
 /// rather than two separate loops that could drift apart.
-pub fn drain_single<R>(ctx: &Ctx, work: CandidateFn<R>) -> Vec<R> {
+pub fn drain_single<C, R>(ctx: &C, n: usize, deadline_us: i64, work: WorkFn<C, R>) -> Vec<R> {
     NEXT_IDX.store(0, Ordering::Release);
-    let out = drain(ctx, work);
+    let split = Split {
+        ctx: ctx as *const C,
+        n,
+        deadline_us,
+        work,
+        worker_out: UnsafeCell::new(Vec::new()),
+    };
+    let out = drain(&split);
     log_worker_stack("main(single)", 0);
     out
 }
 
-/// The generic worker body, monomorphised per result type `R` by
-/// [`spawn_worker_for`].
-extern "C" fn worker_main<R: 'static>(_arg: *mut core::ffi::c_void) {
+/// The worker task body: take type-erased jobs forever, run each one's
+/// share of the batch, and post a completion token.
+extern "C" fn worker_main(_arg: *mut core::ffi::c_void) {
     log::info!("fst4_dual_core: worker started on core {}", current_core());
     loop {
-        let job_ptr = unsafe { queue_recv_ptr::<Job<R>>(JOB_Q.get()) };
+        let job_ptr = unsafe { queue_recv_ptr::<Job>(JOB_Q.get()) };
         // SAFETY: sender boxed this and transferred ownership.
         let job = unsafe { Box::from_raw(job_ptr) };
-        // SAFETY: `run_split` blocks until it has received our result,
-        // so `ctx` is alive for the whole of this call.
-        let ctx = unsafe { &*job.ctx };
-        let out = drain(ctx, job.work);
-        log_worker_stack("worker", WORKER_STACK_BYTES);
-        unsafe { queue_send_ptr(RESULT_Q.get(), Box::into_raw(Box::new(out))) };
+        (job.run)(job.state);
+        unsafe { queue_send_ptr(RESULT_Q.get(), ptr::null_mut::<()>()) };
     }
 }
 
@@ -260,19 +288,19 @@ static INIT_DONE: AtomicUsize = AtomicUsize::new(0);
 /// stack here sidesteps that for the stack itself, but the TCB and
 /// queues are still allocations).
 ///
-/// `R` fixes the result type this worker will handle; one call site,
-/// one `R`. A second `init` with a different `R` would spawn a second
-/// worker against the same queues and is rejected.
-pub fn init<R: 'static>() {
+/// Not generic: the worker takes type-erased jobs, so one call serves
+/// every kind of batch [`run_split`] is later asked to run. A second
+/// call is a no-op rather than a second worker.
+pub fn init() {
     if INIT_DONE.swap(1, Ordering::AcqRel) != 0 {
         log::warn!("fst4_dual_core: init called twice — ignoring");
         return;
     }
     unsafe {
-        JOB_Q.set(queue_create(core::mem::size_of::<*mut Job<R>>()));
-        RESULT_Q.set(queue_create(core::mem::size_of::<*mut Vec<R>>()));
+        JOB_Q.set(queue_create(core::mem::size_of::<*mut Job>()));
+        RESULT_Q.set(queue_create(core::mem::size_of::<*mut ()>()));
         let h = xTaskCreateStaticPinnedToCore(
-            Some(worker_main::<R>),
+            Some(worker_main),
             c"fst4_worker".as_ptr(),
             WORKER_STACK_BYTES as u32,
             ptr::null_mut(),
@@ -289,32 +317,38 @@ pub fn init<R: 'static>() {
     );
 }
 
-/// Run `work` over `0..ctx.n` across both cores, returning every
-/// `Some` result. Order is **not** preserved — two cores complete
-/// interleaved, and the caller is expected to sort or key the results
-/// itself.
+/// Run `work` over `0..n` across both cores, returning every `Some`
+/// result. Order is **not** preserved — two cores complete interleaved,
+/// and the caller is expected to sort or key the results itself.
 ///
 /// Strictly send → do-my-own-share → blocking recv, which is the entire
-/// safety argument for the raw pointers in [`Ctx`]: this function
-/// cannot return while the worker still holds them.
-pub fn run_split<R: 'static>(ctx: &Ctx, work: CandidateFn<R>) -> Vec<R> {
+/// safety argument for the raw pointer in `Split`: this function cannot
+/// return while the worker still holds it.
+pub fn run_split<C, R>(ctx: &C, n: usize, deadline_us: i64, work: WorkFn<C, R>) -> Vec<R> {
     NEXT_IDX.store(0, Ordering::Release);
 
-    let job = Box::new(Job {
-        ctx: ctx as *const Ctx,
+    let split = Split {
+        ctx: ctx as *const C,
+        n,
+        deadline_us,
         work,
+        worker_out: UnsafeCell::new(Vec::new()),
+    };
+    let job = Box::new(Job {
+        state: (&split as *const Split<C, R>) as *const core::ffi::c_void,
+        run: worker_body::<C, R>,
     });
     unsafe { queue_send_ptr(JOB_Q.get(), Box::into_raw(job)) };
 
-    let mut mine = drain(ctx, work);
+    let mut mine = drain(&split);
     log_worker_stack("main", 0);
 
-    let theirs_ptr = unsafe { queue_recv_ptr::<Vec<R>>(RESULT_Q.get()) };
-    // SAFETY: the worker boxed this and transferred ownership.
-    let theirs = unsafe { Box::from_raw(theirs_ptr) };
+    // Blocks until the worker has finished writing `worker_out`.
+    let _token = unsafe { queue_recv_ptr::<()>(RESULT_Q.get()) };
+    let theirs = split.worker_out.into_inner();
 
     let n_worker = theirs.len();
-    mine.extend(*theirs);
+    mine.extend(theirs);
     log::info!(
         "fst4_dual_core: batch done — {} results ({} from worker)",
         mine.len(),

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -760,6 +760,173 @@ pub fn spectra_crop_for<P: Protocol>(
     Some((ia, (ib + headroom).min(usable.saturating_sub(1))))
 }
 
+/// Upper bound on any protocol's sync-block count (FT8=3, FT4=4,
+/// FST4=5 — see each protocol's `SYNC_MODE`/`mod.rs` sync-block table)
+/// with headroom. Stack arrays sized to this bound let
+/// [`fill_sync2d_row`]'s `t_blocks`/`t0_blocks` be reused across every
+/// lag of a row instead of heap-allocated per cell — that loop runs
+/// `n_freq × (2·jz+1)` times per candidate search (thousands of cells),
+/// so a fresh `Vec` per cell was thousands of small allocations, and an
+/// opaque allocator call is also an optimization barrier LLVM can't see
+/// through.
+const MAX_SYNC_BLOCKS: usize = 8;
+
+/// Shape of the (freq-bin × lag) correlation matrix
+/// [`coarse_sync_from_spectra`] fills, plus the per-row parameters
+/// [`fill_sync2d_row`] reads.
+///
+/// Exposed so a caller can fill that matrix itself — one row at a time,
+/// on whichever core it likes — and hand the finished matrix to
+/// [`coarse_sync_from_sync2d`]. Rows are fully independent (the host
+/// already fills them through rayon), which is the whole reason this
+/// seam exists: on CoreS3's wideband FST4-60 search the fill is the
+/// largest post-slot item while the second core sits idle (#327).
+///
+/// Build one with [`sync2d_shape`]; the fields are read-only geometry.
+#[derive(Copy, Clone, Debug)]
+pub struct Sync2dShape {
+    /// Protocol/grid dimensions every row read goes through.
+    pub d: SyncDims,
+    /// Absolute spectrogram bin of row 0.
+    pub ia: usize,
+    /// Rows — one per candidate bin `ia..=ib`.
+    pub n_freq: usize,
+    /// Columns per row, lags `-jz..=jz`; also the row stride.
+    pub n_lag: usize,
+    /// `grid.usable_bins(&d)`, the clamp every tone read applies.
+    usable: usize,
+}
+
+impl Sync2dShape {
+    /// `f32`s in the whole matrix — `n_freq * n_lag`.
+    pub fn len(&self) -> usize {
+        self.n_freq * self.n_lag
+    }
+
+    /// Whether the band produced no candidate bins at all.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+/// The correlation matrix's shape for a band, or `None` when the band
+/// holds no candidate bin.
+///
+/// Derives `ia`/`ib` exactly as [`coarse_sync_from_spectra`] does —
+/// which is the point: a caller filling rows itself must index the same
+/// grid the ranking stage will. Note this is the *candidate* bin range,
+/// narrower than the spectrogram crop [`spectra_crop_for`] returns by
+/// the `headroom` bins the reference tones read above `ib`.
+pub fn sync2d_shape<P: Protocol>(
+    freq_min: f32,
+    freq_max: f32,
+    grid: RxGrid,
+) -> Option<Sync2dShape> {
+    let d = SyncDims::of::<P>(grid.sample_rate_hz);
+    let ntones = P::NTONES as usize;
+    let usable = grid.usable_bins(&d);
+
+    // Leave room for NTONES-1 tones above the candidate bin.
+    let ia = grid.bin_of(&d, freq_min);
+    let headroom = d.nfos * (ntones - 1) + 1;
+    let ib = grid
+        .bin_of(&d, freq_max)
+        .min(usable.saturating_sub(headroom));
+    if ib < ia {
+        return None;
+    }
+
+    Some(Sync2dShape {
+        d,
+        ia,
+        n_freq: ib - ia + 1,
+        n_lag: (2 * d.jz + 1) as usize,
+        usable,
+    })
+}
+
+/// Fill row `fi` of the correlation matrix: the Costas-grid score at
+/// every lag for candidate bin `shape.ia + fi`.
+///
+/// `row.len()` must be `shape.n_lag`. Every cell is a pure function of
+/// the spectrogram, so rows may be filled in any order, concurrently,
+/// by any number of threads or cores.
+#[inline]
+pub fn fill_sync2d_row<P: Protocol>(
+    s: &Spectrogram,
+    shape: &Sync2dShape,
+    fi: usize,
+    row: &mut [f32],
+) {
+    debug_assert_eq!(row.len(), shape.n_lag);
+    let d = &shape.d;
+    let ntones = P::NTONES as usize;
+    let usable = shape.usable;
+    let num_blocks = P::SYNC_MODE.blocks().len();
+    debug_assert!(
+        num_blocks <= MAX_SYNC_BLOCKS,
+        "protocol has more sync blocks than MAX_SYNC_BLOCKS accounts for"
+    );
+
+    let i = shape.ia + fi;
+    let mut t_blocks = [0.0f32; MAX_SYNC_BLOCKS];
+    let mut t0_blocks = [0.0f32; MAX_SYNC_BLOCKS];
+    for (jlag, lag) in (-d.jz..=d.jz).enumerate() {
+        t_blocks[..num_blocks].fill(0.0);
+        t0_blocks[..num_blocks].fill(0.0);
+
+        for (bk, block) in P::SYNC_MODE.blocks().iter().enumerate() {
+            let block_offset = d.nssy as i32 * block.start_symbol as i32;
+            for (n, &costas_n) in block.pattern.iter().enumerate() {
+                let m = lag + d.jstrt + block_offset + (d.nssy * n) as i32;
+                let tone_bin = i + d.nfos * costas_n as usize;
+                if m >= 0 && (m as usize) < d.nhsym && tone_bin < usable {
+                    let m = m as usize;
+                    t_blocks[bk] += s.get(tone_bin, m);
+                    // Reference: sum over all NTONES tones at this time slot.
+                    t0_blocks[bk] += (0..ntones)
+                        .map(|k| s.get((i + d.nfos * k).min(usable - 1), m))
+                        .sum::<f32>();
+                }
+            }
+        }
+
+        // All blocks combined.
+        let t_all: f32 = t_blocks[..num_blocks].iter().sum();
+        let t0_all: f32 = t0_blocks[..num_blocks].iter().sum();
+        // Zero-denominator: clean synthetic signal lies entirely on
+        // Costas tones (t0_all == t_all).  Report t_all directly so
+        // round-trip tests score above noise-floor candidates.
+        let t0_ref = (t0_all - t_all) / (ntones as f32 - 1.0);
+        let sync_all = if t0_ref > f32::EPSILON {
+            t_all / t0_ref
+        } else if t_all > 0.0 {
+            t_all
+        } else {
+            0.0
+        };
+
+        // Trailing N-1 blocks (drop block 0) tolerate an early-block loss.
+        let score = if num_blocks > 1 {
+            let t_tail: f32 = t_blocks[1..num_blocks].iter().sum();
+            let t0_tail: f32 = t0_blocks[1..num_blocks].iter().sum();
+            let t0_tail_ref = (t0_tail - t_tail) / (ntones as f32 - 1.0);
+            let sync_tail = if t0_tail_ref > f32::EPSILON {
+                t_tail / t0_tail_ref
+            } else if t_tail > 0.0 {
+                t_tail
+            } else {
+                0.0
+            };
+            sync_all.max(sync_tail)
+        } else {
+            sync_all
+        };
+
+        row[jlag] = score;
+    }
+}
+
 /// [`coarse_sync`]'s second half: everything from a finished
 /// spectrogram to a ranked candidate list.
 ///
@@ -770,6 +937,10 @@ pub fn spectra_crop_for<P: Protocol>(
 ///
 /// `s` must have been produced with the same `P`/`grid` and the crop
 /// [`spectra_crop_for`] returns; anything else indexes wrongly.
+///
+/// Itself two stages — [`fill_sync2d_row`] across every row, then
+/// [`coarse_sync_from_sync2d`] — split apart for callers that want to
+/// spread the fill across cores; see [`Sync2dShape`].
 #[allow(clippy::too_many_arguments)]
 pub fn coarse_sync_from_spectra<P: Protocol>(
     s: &Spectrogram,
@@ -780,120 +951,53 @@ pub fn coarse_sync_from_spectra<P: Protocol>(
     max_cand: usize,
     grid: RxGrid,
 ) -> Vec<SyncCandidate> {
-    let d = SyncDims::of::<P>(grid.sample_rate_hz);
-    let ntones = P::NTONES as usize;
-    let pattern_len = P::SYNC_MODE.blocks()[0].pattern.len();
-    let usable = grid.usable_bins(&d);
-
-    // Leave room for NTONES-1 tones above the candidate bin.
-    let ia = grid.bin_of(&d, freq_min);
-    let headroom = d.nfos * (ntones - 1) + 1;
-    let ib = grid
-        .bin_of(&d, freq_max)
-        .min(usable.saturating_sub(headroom));
-    if ib < ia {
+    let Some(shape) = sync2d_shape::<P>(freq_min, freq_max, grid) else {
         return Vec::new();
-    }
-
-    let n_freq = ib - ia + 1;
-    let n_lag = (2 * d.jz + 1) as usize;
-    let mut sync2d = vec![0.0f32; n_freq * n_lag];
-    let idx = |fi: usize, lag: i32| fi * n_lag + (lag + d.jz) as usize;
-
-    // Per-block (t_block_k, t0_block_k) accumulators. All-blocks score =
-    // Σ t/Σ t0_mean. Trailing-(N-1)-blocks score excludes block 0 (the
-    // FT8 heuristic that a late start can still sync on blocks 1..).
-    let num_blocks = P::SYNC_MODE.blocks().len();
-    // Upper bound on any protocol's block count (FT8=3, FT4=4, FST4=5 —
-    // see each protocol's `SYNC_MODE`/`mod.rs` sync-block table) with
-    // headroom. Stack arrays sized to this bound let `t_blocks`/
-    // `t0_blocks` below be reused across every (freq-bin, lag) cell
-    // instead of heap-allocated per cell — this loop runs `n_freq ×
-    // (2·d.jz+1)` times per candidate search (thousands of cells), so a
-    // fresh `Vec` per cell was thousands of small allocations, and an
-    // opaque allocator call is also an optimization barrier LLVM can't
-    // see through.
-    const MAX_SYNC_BLOCKS: usize = 8;
-    debug_assert!(
-        num_blocks <= MAX_SYNC_BLOCKS,
-        "protocol has more sync blocks than MAX_SYNC_BLOCKS accounts for"
-    );
+    };
 
     // Compute correlation scores for every (freq-bin, lag) cell.
     // Each cell is fully independent, so the outer fi loop is safe to parallelise.
-    macro_rules! fill_sync2d_row {
-        ($fi:expr, $row:expr) => {{
-            let i = ia + $fi;
-            let mut t_blocks = [0.0f32; MAX_SYNC_BLOCKS];
-            let mut t0_blocks = [0.0f32; MAX_SYNC_BLOCKS];
-            for (jlag, lag) in (-d.jz..=d.jz).enumerate() {
-                t_blocks[..num_blocks].fill(0.0);
-                t0_blocks[..num_blocks].fill(0.0);
-
-                for (bk, block) in P::SYNC_MODE.blocks().iter().enumerate() {
-                    let block_offset = d.nssy as i32 * block.start_symbol as i32;
-                    for (n, &costas_n) in block.pattern.iter().enumerate() {
-                        let m = lag + d.jstrt + block_offset + (d.nssy * n) as i32;
-                        let tone_bin = i + d.nfos * costas_n as usize;
-                        if m >= 0 && (m as usize) < d.nhsym && tone_bin < usable {
-                            let m = m as usize;
-                            t_blocks[bk] += s.get(tone_bin, m);
-                            // Reference: sum over all NTONES tones at this time slot.
-                            t0_blocks[bk] += (0..ntones)
-                                .map(|k| s.get((i + d.nfos * k).min(usable - 1), m))
-                                .sum::<f32>();
-                        }
-                    }
-                }
-
-                // All blocks combined.
-                let t_all: f32 = t_blocks[..num_blocks].iter().sum();
-                let t0_all: f32 = t0_blocks[..num_blocks].iter().sum();
-                // Zero-denominator: clean synthetic signal lies entirely on
-                // Costas tones (t0_all == t_all).  Report t_all directly so
-                // round-trip tests score above noise-floor candidates.
-                let t0_ref = (t0_all - t_all) / (ntones as f32 - 1.0);
-                let sync_all = if t0_ref > f32::EPSILON {
-                    t_all / t0_ref
-                } else if t_all > 0.0 {
-                    t_all
-                } else {
-                    0.0
-                };
-
-                // Trailing N-1 blocks (drop block 0) tolerate an early-block loss.
-                let score = if num_blocks > 1 {
-                    let t_tail: f32 = t_blocks[1..num_blocks].iter().sum();
-                    let t0_tail: f32 = t0_blocks[1..num_blocks].iter().sum();
-                    let t0_tail_ref = (t0_tail - t_tail) / (ntones as f32 - 1.0);
-                    let sync_tail = if t0_tail_ref > f32::EPSILON {
-                        t_tail / t0_tail_ref
-                    } else if t_tail > 0.0 {
-                        t_tail
-                    } else {
-                        0.0
-                    };
-                    sync_all.max(sync_tail)
-                } else {
-                    sync_all
-                };
-
-                $row[jlag] = score;
-            }
-        }};
-    }
+    let mut sync2d = alloc::vec![0.0f32; shape.len()];
 
     #[cfg(feature = "parallel")]
     sync2d
-        .par_chunks_mut(n_lag)
+        .par_chunks_mut(shape.n_lag)
         .enumerate()
-        .for_each(|(fi, row)| fill_sync2d_row!(fi, row));
+        .for_each(|(fi, row)| fill_sync2d_row::<P>(s, &shape, fi, row));
 
     #[cfg(not(feature = "parallel"))]
-    for fi in 0..n_freq {
-        let start = fi * n_lag;
-        fill_sync2d_row!(fi, sync2d[start..start + n_lag]);
+    for (fi, row) in sync2d.chunks_mut(shape.n_lag).enumerate() {
+        fill_sync2d_row::<P>(s, &shape, fi, row);
     }
+
+    coarse_sync_from_sync2d::<P>(s, &sync2d, &shape, sync_min, freq_hint, max_cand, grid)
+}
+
+/// [`coarse_sync_from_spectra`]'s ranking half: peak detection,
+/// noise-floor normalisation, the FST4 stage-1 OR-gate, dedup and
+/// ranking, over an already-filled correlation matrix.
+///
+/// `sync2d` must be `shape.len()` long and row-major with stride
+/// `shape.n_lag` — i.e. exactly what [`fill_sync2d_row`] writes, and
+/// `s`/`shape` must be the same pair those rows were filled from.
+#[allow(clippy::too_many_arguments)]
+pub fn coarse_sync_from_sync2d<P: Protocol>(
+    s: &Spectrogram,
+    sync2d: &[f32],
+    shape: &Sync2dShape,
+    sync_min: f32,
+    freq_hint: Option<f32>,
+    max_cand: usize,
+    grid: RxGrid,
+) -> Vec<SyncCandidate> {
+    debug_assert_eq!(sync2d.len(), shape.len());
+    let d = shape.d;
+    let ntones = P::NTONES as usize;
+    let usable = shape.usable;
+    let ia = shape.ia;
+    let n_freq = shape.n_freq;
+    let n_lag = shape.n_lag;
+    let idx = |fi: usize, lag: i32| fi * n_lag + (lag + d.jz) as usize;
 
     // Per-frequency peak detection — non-maximum suppression.
     //
@@ -1056,8 +1160,6 @@ pub fn coarse_sync_from_spectra<P: Protocol>(
     #[cfg(not(feature = "parallel"))]
     let mut cands: Vec<SyncCandidate> = (0..n_freq).flat_map(fi_cands).collect();
 
-    let _ = pattern_len; // currently unused; kept for future scoring weights
-
     // De-duplicate: within 4 Hz and 40 ms, keep highest score.
     //
     // `suppressed` records the decision separately from the score
@@ -1080,22 +1182,7 @@ pub fn coarse_sync_from_spectra<P: Protocol>(
     // score gate but fail stage 1, which is what the #146 OR-gate exists
     // to keep. The defect is only that a rejected duplicate comes back,
     // so only that is fixed.
-    let mut suppressed = alloc::vec![false; cands.len()];
-    for i in 1..cands.len() {
-        for j in 0..i {
-            let fdiff = (cands[i].freq_hz - cands[j].freq_hz).abs();
-            let tdiff = (cands[i].dt_sec - cands[j].dt_sec).abs();
-            if fdiff < 4.0 && tdiff < 0.04 {
-                if cands[i].score >= cands[j].score {
-                    cands[j].score = 0.0;
-                    suppressed[j] = true;
-                } else {
-                    cands[i].score = 0.0;
-                    suppressed[i] = true;
-                }
-            }
-        }
-    }
+    let suppressed = dedup_suppress(&mut cands);
     let mut keep = suppressed.iter().map(|s| !s);
     cands.retain(|c| {
         if !keep.next().unwrap_or(true) {
@@ -1109,6 +1196,66 @@ pub fn coarse_sync_from_spectra<P: Protocol>(
     });
 
     rank_candidates(cands, freq_hint, max_cand)
+}
+
+/// Frequency half-window the dedup below treats as "the same signal".
+const DEDUP_HZ: f32 = 4.0;
+/// Time half-window, likewise.
+const DEDUP_SEC: f32 = 0.04;
+
+/// Mark, per candidate, whether a near-duplicate beat it — same signal
+/// within [`DEDUP_HZ`] and [`DEDUP_SEC`], loser's score zeroed.
+///
+/// A sliding window, not the O(n^2) all-pairs loop this used to be.
+/// `cands` is frequency-sorted by construction — built `fi`-major over
+/// `0..n_freq`, every candidate of one `fi` sharing that bin's
+/// `freq_hz`, and `hz_of` monotonic in the bin (rayon's `collect`
+/// preserves order, so the parallel path is sorted too) — so the
+/// partners of `cands[i]` are the contiguous run ending at `i - 1`
+/// whose frequency is within [`DEDUP_HZ`]. Every pair outside that run
+/// fails the `fdiff` test and mutates nothing, so skipping them leaves
+/// both the visitation order and the result **exactly** as the
+/// all-pairs loop had them. That equivalence is load-bearing rather
+/// than incidental: the loop mutates scores as it goes, so which pairs
+/// are compared in which order decides the outcome
+/// (`dedup_suppress_matches_all_pairs` pins it against a brute-force
+/// reference).
+///
+/// The quadratic term was not academic. On the wideband FST4-60
+/// monitor search (issue #327, real CoreS3) this ranking half cost
+/// 2989 ms against 1130 ms for the correlation fill it ranks — ~15k
+/// candidates from 1881 bins x up to 8 lag peaks each, i.e. ~112M pair
+/// tests. It is also the whole of the otherwise-unexplained 3.2x
+/// per-bin gap between the wideband search (2.147 ms/bin) and the
+/// sniper's (0.671 ms/bin), which #307 had provisionally attributed to
+/// the spectrogram working set: per-bin *fill* cost is in fact the same
+/// for both (0.60 ms/bin), and only this superlinear stage differed.
+fn dedup_suppress(cands: &mut [SyncCandidate]) -> Vec<bool> {
+    let mut suppressed = alloc::vec![false; cands.len()];
+    let mut lo = 0usize;
+    for i in 1..cands.len() {
+        debug_assert!(
+            cands[i].freq_hz >= cands[i - 1].freq_hz,
+            "dedup window assumes frequency-sorted candidates"
+        );
+        while cands[i].freq_hz - cands[lo].freq_hz >= DEDUP_HZ {
+            lo += 1;
+        }
+        for j in lo..i {
+            let fdiff = (cands[i].freq_hz - cands[j].freq_hz).abs();
+            let tdiff = (cands[i].dt_sec - cands[j].dt_sec).abs();
+            if fdiff < DEDUP_HZ && tdiff < DEDUP_SEC {
+                if cands[i].score >= cands[j].score {
+                    cands[j].score = 0.0;
+                    suppressed[j] = true;
+                } else {
+                    cands[i].score = 0.0;
+                    suppressed[i] = true;
+                }
+            }
+        }
+    }
+    suppressed
 }
 
 /// A candidate this far (Hz) from `freq_hint` counts as "at the aim
@@ -1434,10 +1581,14 @@ pub fn refine_candidate<P: Protocol>(
 
 #[cfg(all(test, feature = "fst4", feature = "ft4"))]
 mod tests {
-    use super::{AudioSource, PI, Protocol, RxGrid, SyncDims, compute_spectra};
+    use super::{
+        AudioSource, DEDUP_HZ, DEDUP_SEC, PI, Protocol, RxGrid, SyncCandidate, SyncDims,
+        compute_spectra, dedup_suppress,
+    };
     use crate::engine::protocol::ModulationParams;
     use crate::fst4::{Fst4s15, Fst4s30, Fst4s60, Fst4s120, Fst4s300};
     use crate::ft4::Ft4;
+    use alloc::vec::Vec;
 
     /// `SyncDims::of::<P>(12_000.0)`'s `nsps` is derived from
     /// `P::SYMBOL_DT * sample_rate_hz` (issue #309/#323), not read
@@ -1522,6 +1673,71 @@ mod tests {
                 peak_bin.abs_diff(want) <= 1,
                 "offset={offset_hz}: peak_bin={peak_bin}, RxGrid predicted {want}"
             );
+        }
+    }
+
+    /// The windowed dedup must reproduce the all-pairs loop it
+    /// replaced *exactly*, not merely "keep the same winners": the loop
+    /// zeroes scores as it goes, so a different visitation order can
+    /// flip later comparisons. Brute-force reference, over lists built
+    /// to stress the parts that matter — dense ties (`>=` decides
+    /// those, and it decides them in favour of the later candidate),
+    /// candidates exactly on the 4 Hz boundary, and chains where a
+    /// suppressed candidate is itself compared again afterwards.
+    #[test]
+    fn dedup_suppress_matches_all_pairs() {
+        fn reference(cands: &mut [SyncCandidate]) -> Vec<bool> {
+            let mut suppressed = alloc::vec![false; cands.len()];
+            for i in 1..cands.len() {
+                for j in 0..i {
+                    let fdiff = (cands[i].freq_hz - cands[j].freq_hz).abs();
+                    let tdiff = (cands[i].dt_sec - cands[j].dt_sec).abs();
+                    if fdiff < DEDUP_HZ && tdiff < DEDUP_SEC {
+                        if cands[i].score >= cands[j].score {
+                            cands[j].score = 0.0;
+                            suppressed[j] = true;
+                        } else {
+                            cands[i].score = 0.0;
+                            suppressed[i] = true;
+                        }
+                    }
+                }
+            }
+            suppressed
+        }
+
+        // Deterministic pseudo-random lists, frequency-sorted the way
+        // `coarse_sync_from_sync2d` builds them: `df`-spaced bins, up
+        // to 8 lag peaks per bin.
+        let mut state = 0x1234_5678u32;
+        let mut next = move || {
+            state = state.wrapping_mul(1_103_515_245).wrapping_add(12_345);
+            (state >> 16) as f32 / 65_536.0
+        };
+        for df in [0.5f32, 1.54, 4.0, 13.0] {
+            let mut cands: Vec<SyncCandidate> = Vec::new();
+            for bin in 0..40 {
+                let freq_hz = 100.0 + bin as f32 * df;
+                for _ in 0..(1 + (next() * 8.0) as usize) {
+                    cands.push(SyncCandidate {
+                        freq_hz,
+                        // Spread lags across and around the 40 ms
+                        // window so both arms of `tdiff` are exercised.
+                        dt_sec: (next() * 0.4 - 0.2 + (next() * 4.0).floor() * 0.01),
+                        // Coarse quantisation so exact ties are common.
+                        score: (next() * 5.0).floor(),
+                    });
+                }
+            }
+            let mut want = cands.clone();
+            let want_flags = reference(&mut want);
+            let mut got = cands.clone();
+            let got_flags = dedup_suppress(&mut got);
+
+            assert_eq!(want_flags, got_flags, "df={df}: suppression flags differ");
+            for (i, (w, g)) in want.iter().zip(got.iter()).enumerate() {
+                assert_eq!(w.score, g.score, "df={df}: candidate {i} score differs");
+            }
         }
     }
 }


### PR DESCRIPTION
Continues #327's dual-core work into `coarse_sync`, the largest post-slot item left in the CoreS3 FST4-60 wideband monitor (#307: 4039 ms of a 5207 ms first decode, once #336 moved the spectrogram build into the capture window).

Two changes. The one that mattered is not the one this set out to make.

## 1. The seam (the dual-core part)

`coarse_sync_from_spectra` is now `sync2d_shape` + `fill_sync2d_row` (per row) + `coarse_sync_from_sync2d` (ranking), composed — the same shape as #336's `SpectrogramBuilder` split, and for the same reason: so a receiver can pay a stage somewhere other than "all at once, on one core, after the slot ends".

Rows of the correlation matrix are pure functions of the finished spectrogram; the host has filled them through rayon since they were written, but an embedded caller could not reach them. The bench now fills them across both cores through the same worker. `fst4_dual_core`'s job became type-erased so one persistent worker serves both batches — the previous `init::<R>()` fixed one result type for the worker's life, which would have cost a second 48 KiB `.bss` stack and queue pair.

**Fill: 1131 → 714 ms**, work-steal split 941/940. Not 2×: the spectrogram is 2.76 MB in PSRAM and both cores stream it.

## 2. What the split actually measured

The search was never fill-bound. Filling is 1131 ms of it; **ranking was 2989 ms** — the dedup pass comparing all ~15k candidates pairwise, ~112M tests.

The candidate list is frequency-sorted by construction (built `fi`-major, `hz_of` monotonic in the bin, rayon's `collect` order-preserving), so a sliding window over the 4 Hz neighbourhood visits exactly the pairs that can suppress anything and skips only no-ops. **2989 → 292 ms.**

Bit-identical is the claim, not "equivalent in effect" — the loop zeroes scores as it goes, so which pairs are compared in which order decides the result. `dedup_suppress_matches_all_pairs` pins the new loop against a brute-force reference over lists built to stress ties, boundary spacing and suppression chains (and it fails if the window is narrowed by 1 Hz — checked). On hardware all 50 candidates match the pre-change list exactly, as do both decodes.

This also closes a question #307 left open. It measured wideband at 2.147 ms/bin against the sniper's 0.671 ms/bin for identical per-bin work, and provisionally blamed the spectrogram working set (477 KB vs 2.76 MB) while flagging it as "a hypothesis to test, not to act on". Per-bin *fill* cost is in fact 0.60 ms/bin for both. The whole 3.2× was this superlinear stage, which a 325-bin sniper search never notices.

## Measured — real CoreS3, wideband 100–3000 Hz, production `sync_min = 0.8`

| | fill | rank | search | first decode (post-slot) |
|---|---:|---:|---:|---:|
| before, single-core | 1130 | 2989 | 4123 | 5207 ms |
| dual-core fill only | 714 | 2978 | 3696 | 4870 ms |
| + windowed dedup, single-core | 1131 | 303 | 1437 | — |
| **both** | **714** | **292** | **1009** | **2183 ms** |

Against the 7200 ms TX-guard budget the first decode now lands at 2183 ms rather than 5207. The candidate loop is unchanged (33.1 s for all 50, inside the 60 s slot period).

Sniper regression build (no env switches) unmoved: 1300/402/1358/299 ms vs the 1300/394/1358/300 baseline, 2/2 decodes.

## Host

669 tests pass, including a full run with `-C debug-assertions=on` so the new frequency-sortedness assert is exercised against every golden recording.

Refs #327, #307.