### PR TITLE
test(fst4): the monitor's design decisions under CCIR-moderate fading

### DIFF
--- a/mfsk-core/tests/fst4_monitor_cap_sensitivity.rs
+++ b/mfsk-core/tests/fst4_monitor_cap_sensitivity.rs
@@ -114,7 +114,12 @@ struct WavMeta {
     path: PathBuf,
 }
 
-fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
+/// `fst4_60_<channel>_m<snr>_<trial>.wav`. Matching on the whole
+/// `fst4_60_<channel>_m` prefix rather than splitting on `_` is what
+/// lets one parser serve both `awgn` and the two-word fading channels
+/// (`ccir_moderate`).
+fn collect_wavs(dir: &Path, channel: &str) -> Vec<WavMeta> {
+    let prefix = format!("fst4_60_{channel}_m");
     let mut out = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
         return out;
@@ -126,14 +131,13 @@ fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
             .and_then(|s| s.to_str())
             .unwrap_or("")
             .to_string();
-        let parts: Vec<&str> = stem.split('_').collect();
-        if parts.len() != 5 || parts[0] != "fst4" || parts[1] != "60" || parts[2] != "awgn" {
-            continue;
-        }
-        let Some(rest) = parts[3].strip_prefix('m') else {
+        let Some(rest) = stem.strip_prefix(&prefix) else {
             continue;
         };
-        let Ok(v) = rest.parse::<i32>() else { continue };
+        let Some((snr, _trial)) = rest.split_once('_') else {
+            continue;
+        };
+        let Ok(v) = snr.parse::<i32>() else { continue };
         out.push(WavMeta { snr_db: -v, path });
     }
     out.sort_by_key(|m| -m.snr_db);
@@ -274,14 +278,40 @@ fn run_trial(audio: &[i16]) -> TrialOutcome {
     }
 }
 
+/// AWGN, the channel every monitor design decision was taken on.
 #[test]
 #[ignore = "tier C — needs the fst4_60_awgn_* sweep corpus; run with --ignored --nocapture"]
 fn fst4_60_monitor_cap_recall_vs_stage_budget() {
+    // Threshold region only — above -24 dB everything decodes at every
+    // budget and the rows carry no information.
+    run_budget_sweep("awgn", i32::MIN, -23);
+}
+
+/// The same measurement under CCIR-moderate fading (0.5 Hz Doppler
+/// spread, 1.0 ms delay spread), which is where a real HF path lives
+/// and where none of the monitor work had been measured.
+///
+/// Its threshold sits ~2.5 dB above AWGN's, so the SNR window differs.
+/// Measured production recall on this corpus (`fst4_sweep`,
+/// `MFSK_FST4_SWEEP_CHANNELS=ccir_moderate`, 100 trials/cell): -27 dB
+/// 1%, -26 dB 20%, -25 dB 56%, -24 dB 85%, -23 dB 96%. So -26..-24 is
+/// this channel's threshold region, the way -28..-26 is AWGN's; at
+/// -27 dB every row would read zero.
+#[test]
+#[ignore = "tier C — needs the fst4_60_ccir_moderate_* sweep corpus; run with --ignored --nocapture"]
+fn fst4_60_monitor_cap_recall_vs_stage_budget_ccir_moderate() {
+    run_budget_sweep("ccir_moderate", -26, -24);
+}
+
+/// `snr_lo`/`snr_hi` are inclusive dB bounds on which corpus cells to
+/// run — the threshold region for that channel, since above it every
+/// budget decodes everything and below it none of them decode anything.
+fn run_budget_sweep(channel: &str, snr_lo: i32, snr_hi: i32) {
     let dir = sweep_dir();
-    let wavs = collect_wavs(&dir);
+    let wavs = collect_wavs(&dir, channel);
     if wavs.is_empty() {
         eprintln!(
-            "No fst4_60_awgn_*.wav in {dir:?}\n\
+            "No fst4_60_{channel}_*.wav in {dir:?}\n\
              Run: scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh"
         );
         return;
@@ -293,14 +323,15 @@ fn fst4_60_monitor_cap_recall_vs_stage_budget() {
 
     let mut groups: BTreeMap<i32, Vec<&WavMeta>> = BTreeMap::new();
     for w in &wavs {
-        // Threshold region only — above -24 dB everything decodes at
-        // every budget and the rows carry no information.
-        if w.snr_db <= -23 {
+        if (snr_lo..=snr_hi).contains(&w.snr_db) {
             groups.entry(w.snr_db).or_default().push(w);
         }
     }
 
-    eprintln!("\nFST4-60 AWGN — monitor recall vs per-candidate stage budget");
+    eprintln!(
+        "\nFST4-60 {} — monitor recall vs per-candidate stage budget",
+        channel.to_uppercase()
+    );
     eprintln!("budget 4 = uncapped reference; 0 = llra only\n");
     eprintln!(
         "  {:>7}  {:>5}  {:>9}  {:>7} {:>7} {:>7} {:>7} {:>7}  {:>10}",

--- a/mfsk-core/tests/fst4_wideband_max_cand.rs
+++ b/mfsk-core/tests/fst4_wideband_max_cand.rs
@@ -81,7 +81,11 @@ struct WavMeta {
     path: PathBuf,
 }
 
-fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
+/// `fst4_60_<channel>_m<snr>_<trial>.wav` — see the identical parser in
+/// `fst4_monitor_cap_sensitivity` for why it matches on the prefix
+/// rather than splitting on `_`.
+fn collect_wavs(dir: &Path, channel: &str) -> Vec<WavMeta> {
+    let prefix = format!("fst4_60_{channel}_m");
     let mut out = Vec::new();
     let Ok(entries) = std::fs::read_dir(dir) else {
         return out;
@@ -93,14 +97,13 @@ fn collect_wavs(dir: &Path) -> Vec<WavMeta> {
             .and_then(|s| s.to_str())
             .unwrap_or("")
             .to_string();
-        let parts: Vec<&str> = stem.split('_').collect();
-        if parts.len() != 5 || parts[0] != "fst4" || parts[1] != "60" || parts[2] != "awgn" {
-            continue;
-        }
-        let Some(rest) = parts[3].strip_prefix('m') else {
+        let Some(rest) = stem.strip_prefix(&prefix) else {
             continue;
         };
-        let Ok(v) = rest.parse::<i32>() else { continue };
+        let Some((snr, _trial)) = rest.split_once('_') else {
+            continue;
+        };
+        let Ok(v) = snr.parse::<i32>() else { continue };
         out.push(WavMeta { snr_db: -v, path });
     }
     out.sort_by_key(|m| -m.snr_db);
@@ -214,14 +217,39 @@ fn run_trial(audio: &[i16]) -> Trial {
     }
 }
 
+/// AWGN, the channel the rank distribution was first measured on.
 #[test]
 #[ignore = "tier C — needs the fst4_60_awgn_* sweep corpus; run with --ignored --nocapture"]
 fn fst4_60_wideband_recall_vs_max_cand() {
+    // Threshold region only — the question is about weak signals losing
+    // slot competitions.
+    run_rank_sweep("awgn", -28, -26);
+}
+
+/// The same rank distribution under CCIR-moderate fading. Ordering, the
+/// per-candidate cap and the rank-tiered decode depth (#341) all rest
+/// on the AWGN finding that the signal sits at median rank 1 and that
+/// 88% of achievable decodes are inside rank 8 — neither of which is
+/// guaranteed to survive a fading channel, where the coarse score is
+/// integrated over a slot the signal fades within.
+///
+/// Window shifted up ~2.5 dB from AWGN's, to this channel's own
+/// threshold region — measured production recall here is 20% at -26 dB,
+/// 56% at -25, 85% at -24 (`fst4_sweep`, 100 trials/cell).
+#[test]
+#[ignore = "tier C — needs the fst4_60_ccir_moderate_* sweep corpus; run with --ignored --nocapture"]
+fn fst4_60_wideband_recall_vs_max_cand_ccir_moderate() {
+    run_rank_sweep("ccir_moderate", -26, -24);
+}
+
+/// `snr_lo`/`snr_hi` are inclusive dB bounds on which corpus cells to
+/// run — that channel's threshold region.
+fn run_rank_sweep(channel: &str, snr_lo: i32, snr_hi: i32) {
     let dir = sweep_dir();
-    let wavs = collect_wavs(&dir);
+    let wavs = collect_wavs(&dir, channel);
     if wavs.is_empty() {
         eprintln!(
-            "No fst4_60_awgn_*.wav in {dir:?}\n\
+            "No fst4_60_{channel}_*.wav in {dir:?}\n\
              Run: scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh"
         );
         return;
@@ -233,14 +261,15 @@ fn fst4_60_wideband_recall_vs_max_cand() {
 
     let mut groups: BTreeMap<i32, Vec<&WavMeta>> = BTreeMap::new();
     for w in &wavs {
-        // Threshold region only — the question is about weak signals
-        // losing slot competitions.
-        if (-28..=-26).contains(&w.snr_db) {
+        if (snr_lo..=snr_hi).contains(&w.snr_db) {
             groups.entry(w.snr_db).or_default().push(w);
         }
     }
 
-    eprintln!("\nFST4-60 AWGN wideband — recall vs max_cand truncation point");
+    eprintln!(
+        "\nFST4-60 {} wideband — recall vs max_cand truncation point",
+        channel.to_uppercase()
+    );
     eprintln!("walking a {PROBE_MAX_CAND}-deep list; production is {PROD_MAX_CAND}\n");
     eprintln!(
         "  {:>7}  {:>5}  {:>9}  {:>6} {:>6} {:>6} {:>6} {:>6} {:>6}  {:>12}  {:>9}",


### PR DESCRIPTION
Closes the last item on #307's list: every monitor-mode decision — candidate ordering (#331), the per-candidate cap (#332), rank-tiered decode depth (#341), dual-core dispatch (#327) — was taken on AWGN alone, on a channel where the existing ablation already showed the same corpus cell going 74/100 (AWGN) to 1/100 (CCIR-moderate).

## What changed in the harnesses

`fst4_monitor_cap_sensitivity` and `fst4_wideband_max_cand` now take a channel. Their `split('_')` arity check could only ever match `awgn` — a two-word channel name makes six parts, not five — so both now match on the `fst4_60_<channel>_m` prefix instead, and each grows a `_ccir_moderate` sibling test.

The SNR window differs per channel because the threshold does. Measured production recall on this corpus (`fst4_sweep`, `MFSK_FST4_SWEEP_CHANNELS=ccir_moderate`, 100 trials/cell):

| SNR | -27 | -26 | -25 | -24 | -23 | -22 |
|---|---:|---:|---:|---:|---:|---:|
| recall | 1% | 20% | 56% | 85% | 96% | 99% |

50% crossing ≈ -24.8 dB, so -26..-24 is this channel's threshold region against AWGN's -28..-26.

## Ordering and rank-tiering survive — and fit better under fading

Rank distribution, walking a 200-deep candidate list (`fst4_wideband_max_cand`):

| channel | SNR | n | baseline | ≤10 | ≤25 | ≤50 | ≤100 | ≤200 | median rank |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| AWGN | -27 | 100 | 80 | 41 | 48 | 55 | 65 | 68 | **1** |
| AWGN | -26 | 100 | 99 | 86 | 92 | 95 | 96 | 96 | **1** |
| CCIR-mod | -26 | 100 | 20 | 10 | 10 | 11 | 12 | 13 | **1** |
| CCIR-mod | -25 | 100 | 56 | 38 | 39 | 40 | 43 | 44 | **1** |
| CCIR-mod | -24 | 100 | 85 | 70 | 72 | 74 | 75 | 76 | **1** |

- **Median rank is 1 at every fading SNR**, exactly as on AWGN. The coarse score still ranks the real signal first even when it is integrated over a slot the signal fades within, so #331's ordering change holds.
- Recall is *more* concentrated in the top ranks under fading: at -25 dB, rank ≤10 captures 38 of the 40 decodes rank ≤50 finds (95%), where AWGN at -27 dB captures 41 of 55 (75%). **`FULL_DEPTH_RANKS = 8` fits this channel better than the one it was tuned on.**
- `max_cand = 50` is not the gap on either channel — 200 slots buy 4 more decodes at -25 dB.

## The cap is worse here than "costs 2/3 of threshold recall"

Stage-budget ladder (`fst4_monitor_cap_sensitivity`; b=3 is the full ladder minus OSD, b=4 uncapped):

| channel | SNR | baseline | b=0 | b=1 | b=2 | b=3 | b=4 |
|---|---:|---:|---:|---:|---:|---:|---:|
| CCIR-mod | -26 | 20/100 | 0 | 0 | 0 | **0** | 12/100 |
| CCIR-mod | -25 | 56/100 | 0 | 0 | 3 | **3** | 43/100 |
| CCIR-mod | -24 | 85/100 | 1 | 18 | 26 | **27** | 75/100 |
| AWGN | -27 | 80/100 | — | — | — | **22** | 65/100 |
| AWGN | -26 | 99/100 | — | — | — | **77** | 96/100 |

At -25 dB the OSD rung supplies **93%** of the monitor's decodes (AWGN at -27 dB: 66%). At -26 dB, without OSD the monitor decodes nothing at all.

So on a real HF path a wall-clock cap that stops short of OSD does not degrade threshold recall — it removes it. Two consequences:

1. **#341's rank tiering is load-bearing, not an optimisation.** Under AWGN it recovered 88% of achievable recall for +4.3% time; under fading the uniform-cap alternative it replaced would decode nothing at threshold.
2. It reinforces what #307 already recorded: wall-clock is the wrong quantity to bound, because it cannot separate an expensive noise candidate from a weak signal that needs OSD — they are the same work. A bound that works has to look at something visible *before* OSD is entered (BP convergence, `nsync`, LLR distribution).

## One more thing the tables show

Uncapped monitor (b=4) vs production baseline: 12/20, 43/56, 75/85 — a 40%/23%/12% relative deficit that grows as the signal weakens. Both harnesses run `rung_major` with `offsets = &[0]`, so this is the `i0 ± 1` timing-diversity gap #308/#310 identified and #341 addressed for ranks inside the tier. That it widens under fading is consistent with #311's unexplained CCIR-moderate `npre2` misses, and is the natural next thread to pull.

Refs #307, #341, #311.