### PR TITLE
test(fst4): timing diversity × OSD pruning under fading — #311's ablation at n=100

### DIFF
--- a/mfsk-core/tests/fst4_rung_major_recall_gap.rs
+++ b/mfsk-core/tests/fst4_rung_major_recall_gap.rs
@@ -262,3 +262,281 @@ fn fst4_60_rung_major_vs_production_ladder_at_threshold() {
         );
     }
 }
+
+/// One trial, four arms, on one shared DDC candidate list: the
+/// production baseline on real 12 kHz audio, `rung_major` at
+/// `offsets = &[0]` (what every embedded caller runs) and at
+/// `&[0, 1, -1]`, and the production ladder on the same candidates.
+///
+/// Extracted so
+/// [`fst4_60_ccir_moderate_timing_x_pruning`] can run it twice per
+/// cell, once per OSD search.
+fn trial_arms(audio: &[i16]) -> (bool, bool, bool, bool) {
+    let baseline = DecodeRequest::<Fst4s60>::new(audio, 100.0, 3000.0, SYNC_MIN, MAX_CAND)
+        .decode()
+        .results
+        .iter()
+        .any(|r| is_golden(r.message77()));
+
+    let cfg = wideband_cascade(CENTER_HZ);
+    let mut ddc = mfsk_core::engine::dsp::ddc::StreamingComplexDdc::new(&cfg);
+    let (mut ci, mut cq) = (Vec::new(), Vec::new());
+    ddc.push_i16(audio, &mut ci, &mut cq);
+    ddc.flush(&mut ci, &mut cq);
+    let delay = ddc.group_delay_input_samples();
+    let grid = grid_for(2900.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Complex(&ci, &cq),
+        CENTER_HZ - HALF,
+        CENTER_HZ + HALF,
+        SYNC_MIN,
+        None,
+        MAX_CAND,
+        RxGrid::complex(grid.fs_c, CENTER_HZ),
+    );
+
+    let (mut via_rung, mut via_prod, mut via_rung_off) = (false, false, false);
+    for c in cands.iter() {
+        let cd0 = ddc_refine(c, &ci, &cq, delay);
+        let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+        let mk = || RungMajorCandidate {
+            cand: c.clone(),
+            cd0: cd0.clone(),
+            refined_freq_hz: s2.freq_hz,
+            i0: s2.i0,
+        };
+
+        if !via_rung {
+            let (o, _) = decode_phase_split_timed::<Fst4s60>(
+                &[mk()],
+                false,
+                false,
+                &[0],
+                None,
+                None,
+                12_000.0,
+            );
+            via_rung = o
+                .first()
+                .and_then(|x| x.as_ref())
+                .is_some_and(|r| is_golden(r.message77()));
+        }
+        if !via_rung_off {
+            let (o, _) = decode_phase_split_timed::<Fst4s60>(
+                &[mk()],
+                false,
+                false,
+                &[0, 1, -1],
+                None,
+                None,
+                12_000.0,
+            );
+            via_rung_off = o
+                .first()
+                .and_then(|x| x.as_ref())
+                .is_some_and(|r| is_golden(r.message77()));
+        }
+        if !via_prod {
+            let pre = (cd0.clone(), s2.freq_hz, s2.i0, s2.score);
+            via_prod = process_candidate_precomputed::<Fst4s60>(
+                c,
+                &[],
+                &FST4_60A_DOWNSAMPLE,
+                DecodeDepth::FULL,
+                DecodeStrictness::Normal,
+                &[],
+                EqMode::Off,
+                SYNC_Q_MIN,
+                pre,
+                true,
+                false,
+            )
+            .is_some_and(|r| is_golden(r.message77()));
+        }
+        if via_rung && via_prod && via_rung_off {
+            break;
+        }
+    }
+    (baseline, via_rung, via_rung_off, via_prod)
+}
+
+/// Do the monitor's fading recall gap and #311's unexplained
+/// `npre2`-pruning misses share a mechanism? — issue #311/#343.
+///
+/// The two are different by construction — #311's residual 3 of 5 is
+/// *defined* as what timing diversity failed to explain, and the
+/// monitor's `&[0]` gap is timing diversity — but that only rules out
+/// identity, not a common cause. The version worth testing is whether
+/// they interact: if fading works by making success depend on getting
+/// enough independent tries, then every mechanism that removes tries
+/// (one `i0`, a pruned OSD pattern set) should cost more here than on
+/// AWGN, and the two should partly substitute for each other.
+///
+/// So: the 2x2, on the monitor's own DDC path, at 100 trials per cell.
+/// `fst4_osd_diag_force_old` is a process-global toggle, so each cell
+/// runs as two rayon-parallel passes with the flag set *between* them
+/// rather than per trial — which is also why this cannot share a
+/// process with another FST4-decoding test.
+///
+/// This is #311's own ablation at the n it asked for. That one ran at
+/// n=20 ("the n=100 run that would settle it needs `fst4sim`, which
+/// isn't installed on the machine this ran on") and reported
+/// single-digit rescue counts it called directional only; the
+/// CCIR-moderate corpus here carries 100 trials at every cell of this
+/// channel's threshold region.
+///
+/// ## Measured (100 trials/cell, paired)
+///
+/// | cell | arm | npre | unpruned | npre-only | unpruned-only |
+/// |---|---|---:|---:|---:|---:|
+/// | m26 | baseline | 20 | 26 | 0 | 6 |
+/// | m26 | `[0]` | 12 | 14 | 0 | 2 |
+/// | m26 | `[0,1,-1]` | 20 | 23 | 1 | 4 |
+/// | m25 | baseline | 56 | 57 | 1 | 2 |
+/// | m25 | `[0]` | 43 | 46 | 2 | 5 |
+/// | m25 | `[0,1,-1]` | 56 | 58 | 3 | 5 |
+/// | m24 | baseline | 85 | 88 | 1 | 4 |
+/// | m24 | `[0]` | 75 | 84 | 0 | 9 |
+/// | m24 | `[0,1,-1]` | 84 | 89 | 0 | 5 |
+///
+/// **The two are separate mechanisms, and the monitor's gap is
+/// entirely the first one.** Timing diversity takes `rung_major` from
+/// 12/43/75 to 20/56/84 with **zero** trials lost, matching the real
+/// 12 kHz baseline exactly at m26 and m25 (20/20, 56/56) and within one
+/// at m24 — so under fading the monitor path is timing-limited and
+/// nothing else. On AWGN a residual 5 remained at −27 dB and was
+/// attributed to the DDC front end; here not even that shows.
+///
+/// The `npre` pruning cost is real, independent and much smaller:
+/// 2 npre-only against 12 unpruned-only pooled across cells on the
+/// production baseline (McNemar exact, two-sided, p = 0.013), i.e.
+/// 1–6 trials per 100. That is #311's floor, quantified at n=100 —
+/// with the caveat that its n=20 claim "`npre` never decodes a trial
+/// the unpruned search misses" is *nearly* but not exactly right here:
+/// npre-only is 1 at both m25 and m24.
+///
+/// **Substitutable or additive is cell-dependent, and the trend runs
+/// with SNR.** From the shared `[0]`+npre floor: m26 12 → timing 20,
+/// pruning 14, both 23 where additivity predicts 22 (super-additive —
+/// #311's "rescues trials neither rescues alone", reproduced at n=100);
+/// m25 43 → 56 / 46 / 58 against 59 (additive); m24 75 → 84 / 84 / 89
+/// against 93 (strongly overlapping — 4 of 9 rescued by either alone).
+/// Near threshold the two fix different failures; higher up the
+/// marginal trials just need one more try, whichever kind.
+///
+/// One consequence for the embedded ladder (#310): the pruning cost is
+/// nearly twice as large without timing diversity as with it (9 vs 5
+/// unpruned-only at m24), so the two are not independent knobs, and
+/// restoring timing is the one that pays.
+#[test]
+#[ignore = "tier C — needs the fst4_60_ccir_moderate_* corpus; process-global OSD toggle, run alone"]
+fn fst4_60_ccir_moderate_timing_x_pruning() {
+    use mfsk_core::fec::ldpc240_101::fst4_osd_diag_force_old;
+    use rayon::prelude::*;
+
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let dir: PathBuf = Path::new(&manifest)
+        .join("../embedded-poc/assets/fst4_sweep")
+        .to_path_buf();
+
+    eprintln!("\nFST4-60 CCIR-moderate — timing diversity x OSD search, DDC monitor path");
+    eprintln!("npre = production npre1/npre2; unpruned = pre-#198 combinatorial search");
+    eprintln!("trials are paired (same waveform both passes), so the discordant counts");
+    eprintln!("are what the aggregate difference is actually made of.\n");
+
+    /// Discordant pair counts for one arm across the two OSD passes:
+    /// (both, npre-only, unpruned-only, neither).
+    fn pairs(
+        a: &[(bool, bool, bool, bool)],
+        b: &[(bool, bool, bool, bool)],
+        f: fn(&(bool, bool, bool, bool)) -> bool,
+    ) -> (usize, usize, usize, usize) {
+        let mut c = (0, 0, 0, 0);
+        for (x, y) in a.iter().zip(b.iter()) {
+            match (f(x), f(y)) {
+                (true, true) => c.0 += 1,
+                (true, false) => c.1 += 1,
+                (false, true) => c.2 += 1,
+                (false, false) => c.3 += 1,
+            }
+        }
+        c
+    }
+
+    for snr in ["m26", "m25", "m24"] {
+        let mut paths: Vec<PathBuf> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_stem()
+                    .and_then(|s| s.to_str())
+                    .is_some_and(|s| s.starts_with(&format!("fst4_60_ccir_moderate_{snr}_")))
+            })
+            .collect();
+        paths.sort();
+
+        let mut passes: Vec<Vec<(bool, bool, bool, bool)>> = Vec::new();
+        for force_old in [false, true] {
+            fst4_osd_diag_force_old(force_old);
+            passes.push(
+                paths
+                    .par_iter()
+                    .filter_map(|p| load_wav_i16_opt(p).map(|a| trial_arms(&a)))
+                    .collect(),
+            );
+            fst4_osd_diag_force_old(false);
+        }
+        let (np, un) = (&passes[0], &passes[1]);
+        let n = np.len();
+
+        eprintln!("{snr} (n={n})");
+        eprintln!(
+            "  {:<22} {:>6} {:>9}   {:>9} {:>13}",
+            "arm", "npre", "unpruned", "npre-only", "unpruned-only"
+        );
+        for (name, f) in [
+            (
+                "baseline (real 12k)",
+                (|r: &(bool, bool, bool, bool)| r.0) as fn(&(bool, bool, bool, bool)) -> bool,
+            ),
+            ("rung_major [0]", |r| r.1),
+            ("rung_major [0,1,-1]", |r| r.2),
+            ("production ladder", |r| r.3),
+        ] {
+            let (_, npre_only, unpruned_only, _) = pairs(np, un, f);
+            eprintln!(
+                "  {name:<22} {:>6} {:>9}   {:>9} {:>13}",
+                np.iter().filter(|r| f(r)).count(),
+                un.iter().filter(|r| f(r)).count(),
+                npre_only,
+                unpruned_only,
+            );
+        }
+
+        // The timing factor is within-trial in both passes, so its
+        // discordance comes straight out of one pass's tuples.
+        for (label, pass) in [("npre", np), ("unpruned", un)] {
+            let gained = pass.iter().filter(|r| !r.1 && r.2).count();
+            let lost = pass.iter().filter(|r| r.1 && !r.2).count();
+            eprintln!(
+                "  timing [0] -> [0,1,-1] under {label:<9}: +{gained} -{lost}  \
+                 (rescued by timing alone: {})",
+                pass.iter().filter(|r| !r.1 && r.2).count(),
+            );
+        }
+        // Substitutable or additive: what each factor rescues from the
+        // shared [0]+npre floor, and whether the two sets overlap.
+        let floor = np.iter().filter(|r| r.1).count();
+        let timing_only = np.iter().filter(|r| r.2).count();
+        let pruning_only = un.iter().filter(|r| r.1).count();
+        let both = un.iter().filter(|r| r.2).count();
+        eprintln!(
+            "  factorial: floor([0],npre)={floor}  timing={timing_only}  \
+             pruning={pruning_only}  both={both}  \
+             (additive would predict {})",
+            floor + (timing_only - floor) + (pruning_only - floor),
+        );
+        eprintln!();
+    }
+}


### PR DESCRIPTION
Answers a question raised by #343: is the wideband monitor's CCIR-moderate recall gap the same root as #311's three unexplained `npre2`-pruning misses?

**No — and the 2×2 separates them cleanly.** They are different mechanisms of very different size, they interact, and only one of them matters for the embedded monitor.

The experiment is #311's own substitutable-vs-additive ablation, run on the monitor's DDC path at 100 trials per cell — the `n` #311 said it needed ("the n=100 run that would settle it needs `fst4sim`, which isn't installed on the machine this ran on"). Trials are paired across the two OSD searches, toggled with `fst4_osd_diag_force_old`, so the discordant counts show what each aggregate difference is actually made of. The toggle is process-global, so each cell runs as two rayon-parallel passes with the flag set between them rather than per trial.

## Measured — FST4-60 CCIR-moderate, DDC monitor path, n=100/cell

| cell | arm | npre | unpruned | npre-only | unpruned-only |
|---|---|---:|---:|---:|---:|
| m26 | baseline (real 12 kHz) | 20 | 26 | 0 | **6** |
| m26 | `rung_major [0]` | 12 | 14 | 0 | 2 |
| m26 | `rung_major [0,1,-1]` | 20 | 23 | 1 | 4 |
| m25 | baseline | 56 | 57 | 1 | 2 |
| m25 | `rung_major [0]` | 43 | 46 | 2 | 5 |
| m25 | `rung_major [0,1,-1]` | 56 | 58 | 3 | 5 |
| m24 | baseline | 85 | 88 | 1 | 4 |
| m24 | `rung_major [0]` | 75 | 84 | 0 | **9** |
| m24 | `rung_major [0,1,-1]` | 84 | 89 | 0 | 5 |

`rung_major [0,1,-1]` and the production ladder are identical in every row, as on AWGN.

## 1. The monitor's fading gap is entirely timing diversity

| cell | `[0]` | `[0,1,-1]` | gained | lost | real-12 kHz baseline |
|---|---:|---:|---:|---:|---:|
| m26 | 12 | **20** | +8 | 0 | 20 |
| m25 | 43 | **56** | +13 | 0 | 56 |
| m24 | 75 | **84** | +9 | 0 | 85 |

Zero trials lost in any cell, and it lands exactly on the baseline at m26 and m25. On AWGN a residual ~5 remained at −27 dB and was attributed to the DDC front end; under fading not even that shows. So the 12/43/75-vs-20/56/85 gap reported in #343 is 100% the `offsets = &[0]` choice — #308's mechanism, simply never wired into the embedded caller — and nothing is left over for #311's residual to explain.

## 2. The `npre` pruning cost is real, independent, and much smaller

On the production baseline: **2 npre-only against 12 unpruned-only** pooled across the three cells (McNemar exact, two-sided, **p = 0.013**), i.e. 1–6 trials per 100. That is #311's "known floor of 3 trials with no mechanism attached", quantified at n=100 on this channel.

One correction to the n=20 run: its finding that "`npre` never decodes a trial the unpruned search misses" is nearly but not exactly right at n=100 — npre-only is 1 at m25 and 1 at m24. Small enough to be tie-breaking rather than an advantage, but it means the relationship is not strictly a subset.

## 3. Substitutable or additive: cell-dependent, and the trend runs with SNR

From the shared `[0]`+npre floor:

| cell | floor | timing alone | pruning alone | both | additive would predict |
|---|---:|---:|---:|---:|---:|
| m26 | 12 | 20 | 14 | **23** | 22 |
| m25 | 43 | 56 | 46 | **58** | 59 |
| m24 | 75 | 84 | 84 | **89** | 93 |

- **m26 is super-additive** — the combination rescues one trial neither factor rescues alone. That is exactly the shape #311's n=20 run saw in 2 of 4 cells, now reproduced at n=100.
- **m25 is additive** (one overlap).
- **m24 overlaps strongly** — each factor alone reaches 84, both reach 89, so 4 of the 9 are rescued either way.

Near threshold the two fix different failures (timing produces better LLRs; the unpruned search reaches patterns `npre2`'s hash table never surfaces); higher up the marginal trials just need one more try of any kind. #311's "the verdict is cell-dependent, so it has to be cited with the cell" holds, and now has a direction attached.

## What this means for the embedded ladder (#310)

The two are not independent knobs: the pruning cost is nearly **twice as large without timing diversity as with it** (9 vs 5 unpruned-only at m24). Restoring timing on the ranks that matter — #341's tier — is what pays; chasing the pruning residual afterwards is worth 1–6 trials per 100 and costs the WSJT-X-faithful architecture plus the 1.25–1.5× it bought on hardware.

Refs #311, #343, #308, #310.