### PR TITLE
feat(embedded): FST4-60 monitor receiver app, on an extracted monitor pipeline

### DIFF
--- a/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
+++ b/embedded-poc/embedded-shared/src/apps/fst4_ddc_bench.rs
@@ -42,26 +42,19 @@ extern crate alloc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use num_complex::Complex32;
 
-use mfsk_core::engine::dsp::ddc::StreamingComplexDdc;
 use mfsk_core::engine::equalize::EqMode;
 use mfsk_core::engine::pipeline::{process_candidate_precomputed, DecodeDepth, DecodeStrictness};
 use mfsk_core::engine::sync::{
-    coarse_sync, coarse_sync_from_sync2d, compute_spectra, fill_sync2d_row, spectra_crop_for,
-    sync2d_shape, AudioSource, RxGrid, Spectrogram, SpectrogramBuilder, Sync2dShape, SyncCandidate,
-    SyncDims,
+    coarse_sync, compute_spectra, AudioSource, SyncCandidate, SyncDims,
 };
 use mfsk_core::engine::sync2d::fst4_sync_search;
-use mfsk_core::fst4::ddc::{
-    grid_for, sniper_cascade, sniper_refine_recenter, wideband_cascade, wideband_refine_recenter,
-    REFINE_DS_RATE_HZ,
-};
-use mfsk_core::fst4::rung_major::{decode_phase_split_timed, RungMajorCandidate};
+use mfsk_core::fst4::ddc::grid_for;
 use mfsk_core::fst4::Fst4s60;
 use mfsk_core::msg::wsjt77::unpack77;
 
 use crate::fst4_dual_core;
+use crate::fst4_monitor::{self, Band, CapturedSlot, MonitorConfig, SlotCapture, now_us};
 
 /// Matches `fst4::decode`'s own (private) `SYNC_Q_MIN` — see
 /// `fst4_bench`'s identical constant for why it's redeclared here
@@ -253,37 +246,6 @@ const fn parse_dec(v: Option<&str>) -> i64 {
     }
 }
 
-/// Absolute `esp_timer` deadline (µs) the [`budget_ok`] `fn` item reads.
-///
-/// `decode_phase_split_timed` takes `Option<fn() -> bool>` — a plain
-/// function pointer, not a closure — so the deadline cannot be captured
-/// and has to travel through a global. Xtensa's `max_atomic_width` is
-/// 32, so there is no `AtomicI64` to use; this mirrors
-/// `wspr_dual_core`'s `DeadlineCell` exactly, including why it is an
-/// `UnsafeCell` rather than an atomic. Single-threaded here (one bench
-/// task), written only between candidates.
-/// **Per core**, not one shared cell: under `MFSK_FST4_DDC_BENCH_DUAL=1`
-/// both cores sit inside `monitor_candidate` on *different* candidates
-/// at once, so a single cell would let one core's arming truncate the
-/// other's ladder. Indexed by `xTaskGetCoreID`.
-struct DeadlineCells(core::cell::UnsafeCell<[i64; 2]>);
-// SAFETY: each core writes and reads only its own slot, and only
-// between its own candidates. No slot is ever touched by two cores.
-unsafe impl Sync for DeadlineCells {}
-static DEADLINE_US: DeadlineCells = DeadlineCells(core::cell::UnsafeCell::new([i64::MAX; 2]));
-
-fn core_slot() -> usize {
-    (unsafe { esp_idf_svc::sys::xTaskGetCoreID(core::ptr::null_mut()) } as usize) & 1
-}
-
-fn set_deadline(abs_us: i64) {
-    unsafe { (*DEADLINE_US.0.get())[core_slot()] = abs_us };
-}
-
-fn budget_ok() -> bool {
-    now_us() < unsafe { (*DEADLINE_US.0.get())[core_slot()] }
-}
-
 /// `MFSK_FST4_DDC_BENCH_DUAL=1` — run the monitor candidate loop across
 /// both cores (issue #327). Same per-candidate function either way.
 const DUAL_CORE: bool = is_one(option_env!("MFSK_FST4_DDC_BENCH_DUAL"));
@@ -323,10 +285,6 @@ const fn is_one(v: Option<&str>) -> bool {
     }
 }
 
-fn now_us() -> i64 {
-    unsafe { esp_idf_svc::sys::esp_timer_get_time() }
-}
-
 fn stack_headroom() -> u32 {
     unsafe { esp_idf_svc::sys::uxTaskGetStackHighWaterMark(core::ptr::null_mut()) }
 }
@@ -364,158 +322,6 @@ pub fn init_logger_once() {
     {
         esp_idf_svc::log::EspLogger::initialize_default();
     }
-}
-
-/// Recentre `cand`'s own frequency out of the coarse DDC baseband
-/// down to the refine (`ds_rate`) baseband, trim the best-effort
-/// combined group delay, RMS-normalise (matching `engine::pipeline::
-/// refine_candidate_position_impl`'s own convention, so `process_
-/// candidate_precomputed`'s LLR scaling sees what it would from
-/// `downsample_cached`), then run the real `fst4_sync_search` refine.
-/// Same recipe `tests/fst4_ddc_sniper_full_decode.rs::ddc_refine_and_
-/// decode` verified against `downsample_cached` on host — see that
-/// test for the delay-trim derivation this mirrors.
-fn ddc_refine(
-    cand: &SyncCandidate,
-    coarse_i: &[f32],
-    coarse_q: &[f32],
-    coarse_delay_orig: usize,
-) -> Vec<Complex32> {
-    let mut refine = if WIDEBAND {
-        wideband_refine_recenter(cand.freq_hz, CENTER_HZ)
-    } else {
-        sniper_refine_recenter(cand.freq_hz, CENTER_HZ)
-    };
-    // Sized from the cascade's own fixed L/M ratio (plus a small margin
-    // for `flush`'s tail) rather than growing from empty via repeated
-    // reallocation — this runs up to ~90 times per bench invocation
-    // (Stage 2a + 2c), each on a buffer this module's own doc comment
-    // already sizes at up to ~266 KB. Both refine configs share L=9;
-    // only M differs (64 sniper / 256 wideband).
-    let cap = if WIDEBAND {
-        coarse_i.len() * 9 / 256 + 16
-    } else {
-        coarse_i.len() * 9 / 64 + 16
-    };
-    let mut cd0_i = Vec::with_capacity(cap);
-    let mut cd0_q = Vec::with_capacity(cap);
-    refine.push(coarse_i, coarse_q, &mut cd0_i, &mut cd0_q);
-    refine.flush(&mut cd0_i, &mut cd0_q);
-    let refine_delay_out = refine.group_delay_output_samples();
-
-    let total_delay_out = (coarse_delay_orig as f32 * REFINE_DS_RATE_HZ / 12_000.0).round()
-        as usize
-        + refine_delay_out;
-    let trim = total_delay_out.min(cd0_i.len());
-
-    let mut cd0: Vec<Complex32> = cd0_i[trim..]
-        .iter()
-        .zip(cd0_q[trim..].iter())
-        .map(|(&i, &q)| Complex32::new(i, q))
-        .collect();
-
-    let sum2: f32 = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len().max(1) as f32;
-    if sum2 > f32::EPSILON {
-        let inv = 1.0 / sum2.sqrt();
-        for c in cd0.iter_mut() {
-            *c *= inv;
-        }
-    }
-    cd0
-}
-
-/// The correlation matrix, as both cores see it while filling it.
-/// Rows are disjoint by construction — index `fi` owns
-/// `sync2d[fi * n_lag ..][.. n_lag]` and nothing else — which is why
-/// this loop needs no lock.
-struct Sync2dCtx {
-    s: *const Spectrogram,
-    shape: *const Sync2dShape,
-    sync2d: *mut f32,
-    n_lag: usize,
-}
-
-/// One row of the correlation matrix. Returns `Option<()>` rather than
-/// a result type because the output *is* the matrix; `Vec<()>` is a ZST
-/// vector, so `run_split`'s result collection allocates nothing.
-fn sync2d_row(ctx: &Sync2dCtx, fi: usize) -> Option<()> {
-    // SAFETY: `run_split`/`drain_single` block until both cores are
-    // done, so all three pointers outlive this call. The write is to
-    // row `fi` alone, and `NEXT_IDX` hands out each `fi` exactly once,
-    // so no two cores ever hold overlapping slices.
-    let s = unsafe { &*ctx.s };
-    let shape = unsafe { &*ctx.shape };
-    let row = unsafe { core::slice::from_raw_parts_mut(ctx.sync2d.add(fi * ctx.n_lag), ctx.n_lag) };
-    fill_sync2d_row::<Fst4s60>(s, shape, fi, row);
-    Some(())
-}
-
-/// `coarse_sync_from_spectra` with its correlation fill spread across
-/// both cores (issue #327).
-///
-/// The fill is the largest post-slot item left in the wideband monitor
-/// — 4039 ms of the 5207 ms first-decode path, once #336 moved the
-/// spectrogram build into the capture window — and every row of it is a
-/// pure function of the finished spectrogram (the host already fills
-/// them through rayon). So it splits exactly the way the candidate loop
-/// does, over the same worker, and the results are **bit-identical**
-/// either way: the split decides only which core writes which row, and
-/// the ranking stage still sees the whole matrix.
-///
-/// Reports the fill/rank split too, which the single-call form cannot.
-/// Only the fill parallelises, so the rank half is the floor this can
-/// approach.
-fn coarse_search(s: &Spectrogram, rx_grid: RxGrid) -> Vec<SyncCandidate> {
-    let Some(shape) = sync2d_shape::<Fst4s60>(
-        CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
-        CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
-        rx_grid,
-    ) else {
-        return Vec::new();
-    };
-
-    let t_fill0 = now_us();
-    let mut sync2d = alloc::vec![0.0f32; shape.len()];
-    {
-        let ctx = Sync2dCtx {
-            s: s as *const Spectrogram,
-            shape: &shape as *const Sync2dShape,
-            sync2d: sync2d.as_mut_ptr(),
-            n_lag: shape.n_lag,
-        };
-        // No deadline: unlike a candidate, a row is not optional — a
-        // row left unfilled is a hole in the search band, not merely a
-        // decode not attempted.
-        if DUAL_CORE {
-            fst4_dual_core::run_split(&ctx, shape.n_freq, i64::MAX, sync2d_row);
-        } else {
-            fst4_dual_core::drain_single(&ctx, shape.n_freq, i64::MAX, sync2d_row);
-        }
-    }
-    let t_fill = now_us() - t_fill0;
-
-    let t_rank0 = now_us();
-    let cands = coarse_sync_from_sync2d::<Fst4s60>(
-        s,
-        &sync2d,
-        &shape,
-        SYNC_MIN,
-        None,
-        MAX_CAND,
-        rx_grid,
-    );
-    let t_rank = now_us() - t_rank0;
-
-    log::info!(
-        "fst4_ddc_bench: [diag] coarse search split — fill {} ms ({} rows x {} lags, {}), \
-         rank {} ms",
-        t_fill / 1000,
-        shape.n_freq,
-        shape.n_lag,
-        if DUAL_CORE { "dual-core" } else { "single-core" },
-        t_rank / 1000,
-    );
-    cands
 }
 
 /// `audio_bin` is the raw golden asset (`include_bytes!`,
@@ -564,61 +370,34 @@ pub fn run(audio_bin: &[u8]) {
     }
 
     // ---- Stage 1: DDC + coarse_sync ----
-    let t0 = now_us();
-    let coarse_cfg = if WIDEBAND {
-        wideband_cascade(CENTER_HZ)
-    } else {
-        sniper_cascade(CENTER_HZ)
-    };
-    let mut coarse = StreamingComplexDdc::new(&coarse_cfg);
-    let mut coarse_i = Vec::new();
-    let mut coarse_q = Vec::new();
+    //
+    // Both modes go through `SlotCapture`, the same front end a
+    // receiver runs; `STREAM_FRONTEND` decides only whether the
+    // spectrogram is built alongside the DDC (as an app does, during
+    // capture) or left for `compute_spectra` afterwards, and whether
+    // the audio arrives in blocks or one lump. Block size does not
+    // change the spectrogram — that is pinned by
+    // `fst4_spectrogram_builder` — so this is a pacing choice.
+    let cfg = monitor_config();
+    let rx_grid = cfg.rx_grid();
     let grid = grid_for(GRID_BANDWIDTH_HZ);
-    let rx_grid = RxGrid::complex(grid.fs_c, CENTER_HZ);
 
-    // In streaming mode the spectrogram is built alongside the DDC, one
-    // block at a time, so both finish with the capture rather than
-    // after it. `prebuilt` is what `coarse_sync_from_spectra` then
-    // consumes post-slot.
-    let mut prebuilt = None;
+    let t0 = now_us();
+    let mut capture = SlotCapture::new(cfg, STREAM_FRONTEND);
     if STREAM_FRONTEND {
-        let crop = spectra_crop_for::<Fst4s60>(
-            CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
-            CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
-            rx_grid,
-        );
-        let mut builder = crop.map(|(lo, hi)| SpectrogramBuilder::new::<Fst4s60>(lo, hi, rx_grid));
-        let mut blk_i = Vec::new();
-        let mut blk_q = Vec::new();
         for chunk in audio.chunks(STREAM_BLOCK) {
-            blk_i.clear();
-            blk_q.clear();
-            coarse.push_i16(chunk, &mut blk_i, &mut blk_q);
-            if let Some(b) = builder.as_mut() {
-                b.push(&blk_i, &blk_q);
-            }
-            coarse_i.extend_from_slice(&blk_i);
-            coarse_q.extend_from_slice(&blk_q);
+            capture.push_i16(chunk);
         }
-        blk_i.clear();
-        blk_q.clear();
-        coarse.flush(&mut blk_i, &mut blk_q);
-        if let Some(b) = builder.as_mut() {
-            b.push(&blk_i, &blk_q);
-        }
-        coarse_i.extend_from_slice(&blk_i);
-        coarse_q.extend_from_slice(&blk_q);
-        prebuilt = builder.map(|b| b.finish());
     } else {
-        coarse.push_i16(&audio, &mut coarse_i, &mut coarse_q);
-        coarse.flush(&mut coarse_i, &mut coarse_q);
+        capture.push_i16(&audio);
     }
-    let coarse_delay_orig = coarse.group_delay_input_samples();
+    let slot = capture.finish();
+    let coarse_delay_orig = slot.delay;
     let t_ddc = now_us() - t0;
     log::info!(
         "fst4_ddc_bench: DDC {} -> {} complex samples in {} ms",
         audio.len(),
-        coarse_i.len(),
+        slot.coarse_i.len(),
         t_ddc / 1000,
     );
     log_heap("post-ddc");
@@ -654,7 +433,7 @@ pub fn run(audio_bin: &[u8]) {
         if ib >= ia {
             let t_spec0 = now_us();
             let s = compute_spectra::<Fst4s60>(
-                AudioSource::Complex(&coarse_i, &coarse_q),
+                AudioSource::Complex(&slot.coarse_i, &slot.coarse_q),
                 ia,
                 (ib + headroom).min(usable.saturating_sub(1)),
                 rx_grid,
@@ -676,19 +455,28 @@ pub fn run(audio_bin: &[u8]) {
     log_heap("post-diag-spectra");
 
     let t1 = now_us();
-    let candidates = match &prebuilt {
+    let candidates = if slot.spectra.is_some() {
         // Streaming: the spectrogram was finished during capture, so
-        // only the correlation search is post-slot work.
-        Some(s) => coarse_search(s, rx_grid),
-        None => coarse_sync::<Fst4s60>(
-            AudioSource::Complex(&coarse_i, &coarse_q),
+        // only the correlation search is post-slot work — and its fill
+        // half runs on both cores.
+        let (cands, fill_us, rank_us) = fst4_monitor::coarse_search(&slot);
+        log::info!(
+            "fst4_ddc_bench: [diag] coarse search split — fill {} ms ({}), rank {} ms",
+            fill_us / 1000,
+            if DUAL_CORE { "dual-core" } else { "single-core" },
+            rank_us / 1000,
+        );
+        cands
+    } else {
+        coarse_sync::<Fst4s60>(
+            AudioSource::Complex(&slot.coarse_i, &slot.coarse_q),
             CENTER_HZ - SEARCH_HALF_WIDTH_HZ,
             CENTER_HZ + SEARCH_HALF_WIDTH_HZ,
             SYNC_MIN,
             None,
             MAX_CAND,
             rx_grid,
-        ),
+        )
     };
     let t_coarse_sync = now_us() - t1;
     log::info!(
@@ -709,15 +497,7 @@ pub fn run(audio_bin: &[u8]) {
     log_heap("post-coarse-sync");
 
     if MONITOR {
-        run_monitor_loop(
-            &candidates,
-            &coarse_i,
-            &coarse_q,
-            coarse_delay_orig,
-            t_ddc,
-            t_spectra_us,
-            t_coarse_sync,
-        );
+        run_monitor_loop(&slot, &candidates, t_ddc, t_spectra_us, t_coarse_sync);
         return;
     }
 
@@ -759,7 +539,7 @@ pub fn run(audio_bin: &[u8]) {
         .iter()
         .enumerate()
         .map(|(i, cand)| {
-            let cd0 = ddc_refine(cand, &coarse_i, &coarse_q, coarse_delay_orig);
+            let cd0 = fst4_monitor::ddc_refine(&cfg, cand, &slot.coarse_i, &slot.coarse_q, coarse_delay_orig);
             let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
             log::info!(
                 "fst4_ddc_bench: refine-all {}/{} done ({:.1} Hz)",
@@ -843,7 +623,7 @@ pub fn run(audio_bin: &[u8]) {
             cand.dt_sec,
         );
         let t_r = now_us();
-        let cd0 = ddc_refine(cand, &coarse_i, &coarse_q, coarse_delay_orig);
+        let cd0 = fst4_monitor::ddc_refine(&cfg, cand, &slot.coarse_i, &slot.coarse_q, coarse_delay_orig);
         let refine_us = now_us() - t_r;
         let m = &refine_meta[idx];
 
@@ -917,6 +697,26 @@ pub fn run(audio_bin: &[u8]) {
     log::info!("=== fst4_ddc_bench complete ===");
 }
 
+/// What this bench's build-time switches add up to, as the runtime
+/// config [`fst4_monitor`] takes. Every field is one `option_env!`
+/// constant above, so the bench keeps its "change a value, rebuild,
+/// re-measure" shape while the pipeline itself carries no build
+/// switches at all.
+fn monitor_config() -> MonitorConfig {
+    MonitorConfig {
+        band: if WIDEBAND { Band::Wide } else { Band::Sniper },
+        center_hz: CENTER_HZ,
+        half_width_hz: SEARCH_HALF_WIDTH_HZ,
+        grid_bandwidth_hz: GRID_BANDWIDTH_HZ,
+        sync_min: SYNC_MIN,
+        max_cand: MAX_CAND,
+        cap_ms: MONITOR_CAP_MS,
+        full_depth_ranks: FULL_DEPTH_RANKS,
+        deadline_ms: MONITOR_DEADLINE_MS,
+        dual_core: DUAL_CORE,
+    }
+}
+
 /// `MFSK_FST4_DDC_BENCH_MODE=monitor` — see [`MONITOR`] for why this
 /// exists and what it measures. Streaming, coarse-score-ordered,
 /// deadline-bounded; reports **time-to-first-decode** rather than a
@@ -952,10 +752,6 @@ pub fn run(audio_bin: &[u8]) {
 /// Spending the full ladder on the first few candidates and capping the
 /// tail therefore buys threshold sensitivity exactly where the signal
 /// is, and band coverage everywhere else.
-fn full_depth_for_rank(rank: usize) -> bool {
-    rank < FULL_DEPTH_RANKS
-}
-
 /// How many top-ranked candidates get the full, uncapped decode path
 /// (which brings OSD *and* production's automatic `i0 +/- 1` retry).
 /// `MFSK_FST4_DDC_BENCH_FULL_RANKS=<n>`; `0` restores a uniform cap.
@@ -987,115 +783,6 @@ const FULL_DEPTH_RANKS: usize = {
     }
 };
 
-/// One candidate's full work: refine, sync-search, decode. A plain
-/// `fn` item so [`fst4_dual_core::run_split`] can hand it to the worker
-/// task — a closure's captures cannot cross that boundary, which is why
-/// every input arrives through [`Ctx`].
-fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
-    // SAFETY: `run_split` blocks until both cores are done, so these
-    // outlive the call. Shared read-only across cores.
-    let candidates: &[SyncCandidate] =
-        unsafe { core::slice::from_raw_parts(ctx.candidates as *const SyncCandidate, ctx.n) };
-    let coarse_i: &[f32] = unsafe { core::slice::from_raw_parts(ctx.coarse_i, ctx.coarse_len) };
-    let coarse_q: &[f32] = unsafe { core::slice::from_raw_parts(ctx.coarse_q, ctx.coarse_len) };
-    let cand = &candidates[i];
-
-    let t_r = now_us();
-    let cd0 = ddc_refine(cand, coarse_i, coarse_q, ctx.coarse_delay_orig);
-    let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
-    let refine_us = now_us() - t_r;
-
-    let t_d = now_us();
-    let result = if MONITOR_CAP_MS > 0 && !full_depth_for_rank(i) {
-        // Per-candidate cap. The deadline cell is **per core** — with
-        // both cores in this function at once on different candidates,
-        // a single shared cell would have one core's arming truncate
-        // the other's ladder.
-        set_deadline(now_us() + MONITOR_CAP_MS * 1000);
-        let inputs = [RungMajorCandidate {
-            cand: cand.clone(),
-            cd0,
-            refined_freq_hz: s2.freq_hz,
-            i0: s2.i0,
-        }];
-        let (mut out, _) = decode_phase_split_timed::<Fst4s60>(
-            &inputs,
-            false,
-            false,
-            &[0],
-            None,
-            Some(budget_ok),
-            12_000.0,
-        );
-        set_deadline(i64::MAX);
-        out.pop().flatten()
-    } else {
-        let precomputed = (cd0, s2.freq_hz, s2.i0, s2.score);
-        process_candidate_precomputed::<Fst4s60>(
-            cand,
-            &[],
-            &mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE,
-            DecodeDepth::FULL,
-            DecodeStrictness::Normal,
-            &[],
-            EqMode::Off,
-            SYNC_Q_MIN,
-            precomputed,
-            true,
-            false,
-        )
-    };
-    let decode_us = now_us() - t_d;
-
-    let msg = result.and_then(|r| {
-        let m: &[u8; 77] = r.message77().try_into().ok()?;
-        unpack77(m)
-    });
-
-    Some(MonitorHit {
-        rank: i,
-        freq_hz: cand.freq_hz,
-        refined_hz: s2.freq_hz,
-        cscore: cand.score,
-        refine_us,
-        decode_us,
-        t_ms: (now_us() - ctx.t0_us) / 1000,
-        msg,
-    })
-}
-
-/// Everything one candidate needs that does not vary across the batch,
-/// shared read-only by both cores. Raw pointers rather than slices
-/// because this crosses a FreeRTOS task boundary; `run_split`'s
-/// send → work → blocking-recv discipline is what makes them valid for
-/// the whole batch.
-struct MonitorCtx {
-    candidates: *const core::ffi::c_void,
-    n: usize,
-    coarse_i: *const f32,
-    coarse_q: *const f32,
-    coarse_len: usize,
-    coarse_delay_orig: usize,
-    /// When the batch started, so per-candidate results can report a
-    /// loop-relative timestamp that means the same thing on both cores.
-    t0_us: i64,
-}
-
-/// One candidate's outcome. Carries `rank` because [`run_split`] does
-/// not preserve order — two cores complete interleaved.
-///
-/// [`run_split`]: fst4_dual_core::run_split
-struct MonitorHit {
-    rank: usize,
-    freq_hz: f32,
-    refined_hz: f32,
-    cscore: f32,
-    refine_us: i64,
-    decode_us: i64,
-    t_ms: i64,
-    msg: Option<String>,
-}
-
 /// `MFSK_FST4_DDC_BENCH_MODE=monitor` — see [`MONITOR`] for why this
 /// exists and what it measures. Streaming, coarse-score-ordered,
 /// deadline-bounded; reports **time-to-first-decode** rather than a
@@ -1108,10 +795,8 @@ struct MonitorHit {
 /// differs — so the two are directly comparable on one build pair.
 #[allow(clippy::too_many_arguments)]
 fn run_monitor_loop(
+    slot: &CapturedSlot,
     candidates: &[SyncCandidate],
-    coarse_i: &[f32],
-    coarse_q: &[f32],
-    coarse_delay_orig: usize,
     t_ddc_us: i64,
     t_spectra_us: i64,
     t_coarse_sync_us: i64,
@@ -1141,25 +826,7 @@ fn run_monitor_loop(
     // correlation fill can use it too.
 
     let t_loop0 = now_us();
-    let n = candidates.len();
-    let deadline_us = t_loop0 + MONITOR_DEADLINE_MS * 1000;
-    let ctx = MonitorCtx {
-        candidates: candidates.as_ptr() as *const core::ffi::c_void,
-        n,
-        coarse_i: coarse_i.as_ptr(),
-        coarse_q: coarse_q.as_ptr(),
-        coarse_len: coarse_i.len(),
-        coarse_delay_orig,
-        t0_us: t_loop0,
-    };
-
-    let mut hits = if DUAL_CORE {
-        fst4_dual_core::run_split(&ctx, n, deadline_us, monitor_candidate)
-    } else {
-        fst4_dual_core::drain_single(&ctx, n, deadline_us, monitor_candidate)
-    };
-    hits.sort_by_key(|h| h.rank);
-
+    let hits = fst4_monitor::run_candidate_loop(slot, candidates);
     let t_loop_ms = (now_us() - t_loop0) / 1000;
     let n_tried = hits.len();
 

--- a/embedded-poc/embedded-shared/src/fst4_monitor.rs
+++ b/embedded-poc/embedded-shared/src/fst4_monitor.rs
@@ -1,0 +1,578 @@
+//! The FST4 wideband monitor pipeline — issue #307/#327.
+//!
+//! Everything a receiver does to one slot of audio, in the order it
+//! does it, with no bench or application policy mixed in:
+//!
+//! | stage | when | cost (real CoreS3, FST4-60 wideband) |
+//! |---|---|---|
+//! | [`SlotCapture`] — DDC + spectrogram, block by block | during capture | 5839 ms, 9% duty of a 60 s slot |
+//! | [`coarse_search`] — correlation fill (dual-core) + ranking | post-slot | 1009 ms |
+//! | [`run_candidate_loop`] — refine + decode, rank-tiered, dual-core | post-slot | first decode +1174 ms, all 50 in 33.1 s |
+//!
+//! Extracted from `apps::fst4_ddc_bench`, which measured every one of
+//! those numbers and remains the thing that re-measures them. The
+//! extraction exists because a receiver application needs the same
+//! pipeline and the repo has already paid once for the alternative:
+//! the code-sharing audit (#290-298) found "80% shared" to be 31.8% in
+//! practice, mostly through copies like this one would have been.
+//!
+//! ## What is policy and what is not
+//!
+//! [`MonitorConfig`] carries every number a caller might legitimately
+//! choose differently — band, cap, tier depth, deadline. What it does
+//! *not* carry is anything that changes the answer rather than the
+//! schedule: `sync_min` defaults to the production 0.8 and raising it
+//! is a bench-only trick that disables issue #146's stage-1 OR-gate
+//! (see `apps::fst4_ddc_bench`'s own constant for the full warning).
+//!
+//! ## Monitor semantics
+//!
+//! The loop is **breadth-first over coarse score, not depth-first over
+//! the ladder**, because the number a monitoring receiver is judged on
+//! is time-to-first-decode, not total. Two measurements put the real
+//! signal at median coarse rank 1 at every SNR and on both AWGN and
+//! CCIR-moderate fading (#337/#343), which is what makes that ordering
+//! pay and what [`MonitorConfig::full_depth_ranks`] exploits: the top
+//! ranks get the full production ladder — OSD *and* production's
+//! automatic `i0 ± 1` timing retry — while the tail is capped. Under
+//! fading that tiering lands within 1-2 trials per 100 of the full
+//! production decoder (#345).
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use num_complex::Complex32;
+
+use mfsk_core::engine::dsp::ddc::StreamingComplexDdc;
+use mfsk_core::engine::equalize::EqMode;
+use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_precomputed};
+use mfsk_core::engine::sync::{
+    RxGrid, Spectrogram, SpectrogramBuilder, Sync2dShape, SyncCandidate, coarse_sync_from_sync2d,
+    fill_sync2d_row, spectra_crop_for, sync2d_shape,
+};
+use mfsk_core::engine::sync2d::fst4_sync_search;
+use mfsk_core::fst4::Fst4s60;
+use mfsk_core::fst4::ddc::{
+    REFINE_DS_RATE_HZ, grid_for, sniper_cascade, sniper_refine_recenter, wideband_cascade,
+    wideband_refine_recenter,
+};
+use mfsk_core::fst4::rung_major::{RungMajorCandidate, decode_phase_split_timed};
+use mfsk_core::msg::wsjt77::unpack77;
+
+use crate::fst4_dual_core;
+
+/// Matches `fst4::decode`'s own (private) `SYNC_Q_MIN`.
+const SYNC_Q_MIN: u32 = 16;
+
+/// Which DDC cascade the front end runs, and therefore which analysis
+/// grid everything downstream sits on.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Band {
+    /// L/M 64/243, no integer stage; K=1024, nfft1=2048. The
+    /// production 100-3000 Hz search.
+    Wide,
+    /// 49-tap /3 + L/M 16/81; K=256, nfft1=512. A known-target window,
+    /// used by the bench to answer "does the chain work end to end".
+    Sniper,
+}
+
+/// Everything about a slot's decode that a caller may choose.
+#[derive(Copy, Clone, Debug)]
+pub struct MonitorConfig {
+    pub band: Band,
+    /// DDC centre. The cascade's passband is built around it.
+    pub center_hz: f32,
+    /// Search half-width around [`Self::center_hz`].
+    pub half_width_hz: f32,
+    /// Bandwidth handed to `grid_for` — drives `K` and `nfft1`.
+    pub grid_bandwidth_hz: f32,
+    /// **Leave at the production 0.8** unless you have read
+    /// `apps::fst4_ddc_bench`'s constant of the same name: this value
+    /// doubles as issue #146's stage-1 gate, where a high value
+    /// disables ~3 dB of FST4 sensitivity rather than merely tightening
+    /// a score filter.
+    pub sync_min: f32,
+    pub max_cand: usize,
+    /// Per-candidate wall-clock decode cap for candidates outside the
+    /// tier, in ms; `0` disables it.
+    ///
+    /// Bounding wall-clock cannot separate an expensive noise candidate
+    /// from a weak signal that needs OSD — they are the same work — so
+    /// this is a schedule knob, not a quality one, and #343 measured
+    /// that under fading a uniform cap removes threshold recall
+    /// outright (0/100 without OSD at -26 dB). It is survivable only
+    /// because of [`Self::full_depth_ranks`].
+    pub cap_ms: i64,
+    /// How many top-ranked candidates skip the cap and take the full
+    /// production ladder — which is what carries OSD *and* production's
+    /// automatic `i0 ± 1` retry. `0` makes the cap uniform.
+    pub full_depth_ranks: usize,
+    /// Wall-clock bound on the whole candidate loop; a core that
+    /// reaches it stops claiming candidates.
+    pub deadline_ms: i64,
+    /// Spread the correlation fill and the candidate loop across both
+    /// cores ([`fst4_dual_core`], which must have been `init()`ed —
+    /// before WiFi, per its own ordering constraint).
+    pub dual_core: bool,
+}
+
+impl MonitorConfig {
+    /// The shipped FST4-60 wideband monitor: 100-3000 Hz at production
+    /// `sync_min`, 150 ms cap beyond rank 8, dual-core, 45 s deadline.
+    /// Every default here is a measured choice — see the module doc and
+    /// #337/#341/#343 for which measurement bought which number.
+    pub const FST4_60_WIDEBAND: Self = Self {
+        band: Band::Wide,
+        center_hz: 1550.0,
+        half_width_hz: 1450.0,
+        grid_bandwidth_hz: 2900.0,
+        sync_min: 0.8,
+        max_cand: 50,
+        cap_ms: 150,
+        full_depth_ranks: 8,
+        deadline_ms: 45_000,
+        dual_core: true,
+    };
+
+    fn freq_lo(&self) -> f32 {
+        self.center_hz - self.half_width_hz
+    }
+    fn freq_hi(&self) -> f32 {
+        self.center_hz + self.half_width_hz
+    }
+
+    /// The analysis grid the DDC output sits on.
+    pub fn rx_grid(&self) -> RxGrid {
+        RxGrid::complex(grid_for(self.grid_bandwidth_hz).fs_c, self.center_hz)
+    }
+}
+
+pub fn now_us() -> i64 {
+    unsafe { esp_idf_svc::sys::esp_timer_get_time() }
+}
+
+/// Absolute `esp_timer` deadline (µs) the [`budget_ok`] `fn` item reads.
+///
+/// `decode_phase_split_timed` takes `Option<fn() -> bool>` — a plain
+/// function pointer, not a closure — so the deadline cannot be captured
+/// and has to travel through a global. Xtensa's `max_atomic_width` is
+/// 32, so there is no `AtomicI64` to use; this mirrors
+/// `wspr_dual_core`'s `DeadlineCell` exactly, including why it is an
+/// `UnsafeCell` rather than an atomic.
+///
+/// **Per core**, not one shared cell: under [`MonitorConfig::dual_core`]
+/// both cores sit inside [`monitor_candidate`] on *different*
+/// candidates at once, so a single cell would let one core's arming
+/// truncate the other's ladder. Indexed by `xTaskGetCoreID`.
+struct DeadlineCells(core::cell::UnsafeCell<[i64; 2]>);
+// SAFETY: each core writes and reads only its own slot, and only
+// between its own candidates. No slot is ever touched by two cores.
+unsafe impl Sync for DeadlineCells {}
+static DEADLINE_US: DeadlineCells = DeadlineCells(core::cell::UnsafeCell::new([i64::MAX; 2]));
+
+fn core_slot() -> usize {
+    (unsafe { esp_idf_svc::sys::xTaskGetCoreID(core::ptr::null_mut()) } as usize) & 1
+}
+
+fn set_deadline(abs_us: i64) {
+    unsafe { (*DEADLINE_US.0.get())[core_slot()] = abs_us };
+}
+
+fn budget_ok() -> bool {
+    now_us() < unsafe { (*DEADLINE_US.0.get())[core_slot()] }
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Capture-time front end
+
+/// The DDC and the spectrogram, fed block by block as audio arrives.
+///
+/// This does not make the front end cheaper; it moves it. A receiver
+/// has the whole slot to do this work, so what it costs against is a
+/// *duty cycle*, not the post-slot guard budget — 5839 ms of a 60 s
+/// slot, 9%. WSPR already ships this shape (`wspr_app`'s `ddc_loop` ->
+/// `DDC_READY_IDX` -> `scan_loop`).
+///
+/// The spectrogram is bit-identical at any block size (pinned by
+/// `fst4_spectrogram_builder`), so how a caller chunks its audio is a
+/// pacing choice, not a numerical one.
+pub struct SlotCapture {
+    cfg: MonitorConfig,
+    ddc: StreamingComplexDdc,
+    builder: Option<SpectrogramBuilder>,
+    coarse_i: Vec<f32>,
+    coarse_q: Vec<f32>,
+}
+
+impl SlotCapture {
+    /// `with_spectrogram = false` skips the capture-time spectrogram,
+    /// leaving [`CapturedSlot::spectra`] empty for a caller that means
+    /// to build it after the slot (which is what the bench's batch mode
+    /// measures against).
+    pub fn new(cfg: MonitorConfig, with_spectrogram: bool) -> Self {
+        let cascade = match cfg.band {
+            Band::Wide => wideband_cascade(cfg.center_hz),
+            Band::Sniper => sniper_cascade(cfg.center_hz),
+        };
+        let builder = if with_spectrogram {
+            spectra_crop_for::<Fst4s60>(cfg.freq_lo(), cfg.freq_hi(), cfg.rx_grid())
+                .map(|(lo, hi)| SpectrogramBuilder::new::<Fst4s60>(lo, hi, cfg.rx_grid()))
+        } else {
+            None
+        };
+        Self {
+            cfg,
+            ddc: StreamingComplexDdc::new(&cascade),
+            builder,
+            coarse_i: Vec::new(),
+            coarse_q: Vec::new(),
+        }
+    }
+
+    /// Feed the next block of 12 kHz mono audio. Block boundaries do
+    /// not affect the result.
+    ///
+    /// The cascade appends straight into the slot buffer and the
+    /// builder is handed the tail that just appeared, rather than both
+    /// reading a separate block buffer that is then copied in. That
+    /// copy is not free at this size: it cost 80 ms of a 1300 ms DDC
+    /// on real hardware when the whole slot arrives as one push.
+    pub fn push_i16(&mut self, audio: &[i16]) {
+        let from = self.coarse_i.len();
+        self.ddc
+            .push_i16(audio, &mut self.coarse_i, &mut self.coarse_q);
+        if let Some(b) = self.builder.as_mut() {
+            b.push(&self.coarse_i[from..], &self.coarse_q[from..]);
+        }
+    }
+
+    /// End the slot: flush the cascade's tail and finish the
+    /// spectrogram.
+    pub fn finish(mut self) -> CapturedSlot {
+        let from = self.coarse_i.len();
+        self.ddc.flush(&mut self.coarse_i, &mut self.coarse_q);
+        if let Some(b) = self.builder.as_mut() {
+            b.push(&self.coarse_i[from..], &self.coarse_q[from..]);
+        }
+        CapturedSlot {
+            cfg: self.cfg,
+            delay: self.ddc.group_delay_input_samples(),
+            spectra: self.builder.map(|b| b.finish()),
+            coarse_i: self.coarse_i,
+            coarse_q: self.coarse_q,
+        }
+    }
+}
+
+/// One slot's baseband, and the spectrogram built alongside it.
+pub struct CapturedSlot {
+    pub cfg: MonitorConfig,
+    pub coarse_i: Vec<f32>,
+    pub coarse_q: Vec<f32>,
+    /// `None` when the caller asked for no capture-time spectrogram.
+    pub spectra: Option<Spectrogram>,
+    /// The cascade's group delay, in input samples.
+    pub delay: usize,
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Coarse search
+
+/// The correlation matrix, as both cores see it while filling it.
+/// Rows are disjoint by construction — index `fi` owns
+/// `sync2d[fi * n_lag ..][.. n_lag]` and nothing else — which is why
+/// this loop needs no lock.
+struct Sync2dCtx {
+    s: *const Spectrogram,
+    shape: *const Sync2dShape,
+    sync2d: *mut f32,
+    n_lag: usize,
+}
+
+/// One row of the correlation matrix. Returns `Option<()>` rather than
+/// a result type because the output *is* the matrix; `Vec<()>` is a ZST
+/// vector, so `run_split`'s result collection allocates nothing.
+fn sync2d_row(ctx: &Sync2dCtx, fi: usize) -> Option<()> {
+    // SAFETY: `run_split`/`drain_single` block until both cores are
+    // done, so all three pointers outlive this call. The write is to
+    // row `fi` alone, and `NEXT_IDX` hands out each `fi` exactly once,
+    // so no two cores ever hold overlapping slices.
+    let s = unsafe { &*ctx.s };
+    let shape = unsafe { &*ctx.shape };
+    let row = unsafe { core::slice::from_raw_parts_mut(ctx.sync2d.add(fi * ctx.n_lag), ctx.n_lag) };
+    fill_sync2d_row::<Fst4s60>(s, shape, fi, row);
+    Some(())
+}
+
+/// `coarse_sync_from_spectra` with its correlation fill spread across
+/// both cores (issue #327).
+///
+/// Every row of the fill is a pure function of the finished
+/// spectrogram, so the split decides only which core writes which row
+/// and the results are **bit-identical** either way; the ranking stage
+/// still sees the whole matrix.
+///
+/// Returns `(candidates, fill_us, rank_us)`. The two costs are worth
+/// reporting apart: only the fill parallelises, so the rank half is the
+/// floor this can approach — and it was the fill/rank split that found
+/// the ranking stage to be 72% of a search everyone had assumed was
+/// correlation-bound.
+pub fn coarse_search(slot: &CapturedSlot) -> (Vec<SyncCandidate>, i64, i64) {
+    let cfg = &slot.cfg;
+    let Some(s) = slot.spectra.as_ref() else {
+        return (Vec::new(), 0, 0);
+    };
+    let Some(shape) = sync2d_shape::<Fst4s60>(cfg.freq_lo(), cfg.freq_hi(), cfg.rx_grid()) else {
+        return (Vec::new(), 0, 0);
+    };
+
+    let t_fill0 = now_us();
+    let mut sync2d = alloc::vec![0.0f32; shape.len()];
+    {
+        let ctx = Sync2dCtx {
+            s: s as *const Spectrogram,
+            shape: &shape as *const Sync2dShape,
+            sync2d: sync2d.as_mut_ptr(),
+            n_lag: shape.n_lag,
+        };
+        // No deadline: unlike a candidate, a row is not optional — a
+        // row left unfilled is a hole in the search band, not merely a
+        // decode not attempted.
+        if cfg.dual_core {
+            fst4_dual_core::run_split(&ctx, shape.n_freq, i64::MAX, sync2d_row);
+        } else {
+            fst4_dual_core::drain_single(&ctx, shape.n_freq, i64::MAX, sync2d_row);
+        }
+    }
+    let fill_us = now_us() - t_fill0;
+
+    let t_rank0 = now_us();
+    let cands = coarse_sync_from_sync2d::<Fst4s60>(
+        s,
+        &sync2d,
+        &shape,
+        cfg.sync_min,
+        None,
+        cfg.max_cand,
+        cfg.rx_grid(),
+    );
+    (cands, fill_us, now_us() - t_rank0)
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Candidate loop
+
+/// Recentre `cand`'s own frequency out of the coarse DDC baseband down
+/// to the refine (`ds_rate`) baseband, trim the best-effort combined
+/// group delay, RMS-normalise (matching
+/// `engine::pipeline::refine_candidate_position_impl`'s own convention,
+/// so `process_candidate_precomputed`'s LLR scaling sees what it would
+/// from `downsample_cached`). Same recipe
+/// `tests/fst4_ddc_sniper_full_decode.rs::ddc_refine_and_decode`
+/// verified against `downsample_cached` on host — see that test for the
+/// delay-trim derivation this mirrors.
+pub fn ddc_refine(
+    cfg: &MonitorConfig,
+    cand: &SyncCandidate,
+    coarse_i: &[f32],
+    coarse_q: &[f32],
+    coarse_delay_orig: usize,
+) -> Vec<Complex32> {
+    let mut refine = match cfg.band {
+        Band::Wide => wideband_refine_recenter(cand.freq_hz, cfg.center_hz),
+        Band::Sniper => sniper_refine_recenter(cand.freq_hz, cfg.center_hz),
+    };
+    // Sized from the cascade's own fixed L/M ratio (plus a small margin
+    // for `flush`'s tail) rather than growing from empty via repeated
+    // reallocation — this runs once per candidate, each on a buffer up
+    // to ~266 KB. Both refine configs share L=9; only M differs
+    // (64 sniper / 256 wideband).
+    let cap = match cfg.band {
+        Band::Wide => coarse_i.len() * 9 / 256 + 16,
+        Band::Sniper => coarse_i.len() * 9 / 64 + 16,
+    };
+    let mut cd0_i = Vec::with_capacity(cap);
+    let mut cd0_q = Vec::with_capacity(cap);
+    refine.push(coarse_i, coarse_q, &mut cd0_i, &mut cd0_q);
+    refine.flush(&mut cd0_i, &mut cd0_q);
+
+    let total_delay_out = (coarse_delay_orig as f32 * REFINE_DS_RATE_HZ / 12_000.0).round()
+        as usize
+        + refine.group_delay_output_samples();
+    let trim = total_delay_out.min(cd0_i.len());
+
+    let mut cd0: Vec<Complex32> = cd0_i[trim..]
+        .iter()
+        .zip(cd0_q[trim..].iter())
+        .map(|(&i, &q)| Complex32::new(i, q))
+        .collect();
+
+    let sum2: f32 = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len().max(1) as f32;
+    if sum2 > f32::EPSILON {
+        let inv = 1.0 / sum2.sqrt();
+        for c in cd0.iter_mut() {
+            *c *= inv;
+        }
+    }
+    cd0
+}
+
+/// One candidate's outcome. Carries `rank` because the dual-core split
+/// does not preserve order — two cores complete interleaved.
+pub struct MonitorHit {
+    /// Position in the coarse-score ordering, 0-based.
+    pub rank: usize,
+    pub freq_hz: f32,
+    pub refined_hz: f32,
+    pub cscore: f32,
+    pub refine_us: i64,
+    pub decode_us: i64,
+    /// Milliseconds after the loop started — the same clock on both
+    /// cores, which is the number a monitor is judged on.
+    pub t_ms: i64,
+    pub msg: Option<String>,
+}
+
+/// Everything one candidate needs that does not vary across the batch,
+/// shared read-only by both cores. Raw pointers rather than slices
+/// because this crosses a FreeRTOS task boundary; `run_split`'s
+/// send → work → blocking-recv discipline is what makes them valid for
+/// the whole batch.
+struct MonitorCtx {
+    cfg: MonitorConfig,
+    candidates: *const core::ffi::c_void,
+    n: usize,
+    coarse_i: *const f32,
+    coarse_q: *const f32,
+    coarse_len: usize,
+    coarse_delay_orig: usize,
+    t0_us: i64,
+}
+
+/// One candidate's full work: refine, sync-search, decode. A plain `fn`
+/// item so [`fst4_dual_core::run_split`] can hand it to the worker task
+/// — a closure's captures cannot cross that boundary, which is why
+/// every input arrives through [`MonitorCtx`].
+fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
+    // SAFETY: `run_split` blocks until both cores are done, so these
+    // outlive the call. Shared read-only across cores.
+    let candidates: &[SyncCandidate] =
+        unsafe { core::slice::from_raw_parts(ctx.candidates as *const SyncCandidate, ctx.n) };
+    let coarse_i: &[f32] = unsafe { core::slice::from_raw_parts(ctx.coarse_i, ctx.coarse_len) };
+    let coarse_q: &[f32] = unsafe { core::slice::from_raw_parts(ctx.coarse_q, ctx.coarse_len) };
+    let cand = &candidates[i];
+
+    let t_r = now_us();
+    let cd0 = ddc_refine(&ctx.cfg, cand, coarse_i, coarse_q, ctx.coarse_delay_orig);
+    let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
+    let refine_us = now_us() - t_r;
+
+    let t_d = now_us();
+    let result = if ctx.cfg.cap_ms > 0 && i >= ctx.cfg.full_depth_ranks {
+        set_deadline(now_us() + ctx.cfg.cap_ms * 1000);
+        let inputs = [RungMajorCandidate {
+            cand: cand.clone(),
+            cd0,
+            refined_freq_hz: s2.freq_hz,
+            i0: s2.i0,
+        }];
+        let (mut out, _) = decode_phase_split_timed::<Fst4s60>(
+            &inputs,
+            false,
+            false,
+            &[0],
+            None,
+            Some(budget_ok),
+            12_000.0,
+        );
+        set_deadline(i64::MAX);
+        out.pop().flatten()
+    } else {
+        // The full production ladder — which is what brings OSD *and*
+        // production's automatic `i0 ± 1` retry (`pipeline.rs:1236`,
+        // #308). That retry is the whole of the monitor's measured
+        // fading gap, so which candidates land in this arm is the
+        // single most consequential line in the loop (#344/#345).
+        let precomputed = (cd0, s2.freq_hz, s2.i0, s2.score);
+        process_candidate_precomputed::<Fst4s60>(
+            cand,
+            &[],
+            &mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE,
+            DecodeDepth::FULL,
+            DecodeStrictness::Normal,
+            &[],
+            EqMode::Off,
+            SYNC_Q_MIN,
+            precomputed,
+            true,
+            false,
+        )
+    };
+    let decode_us = now_us() - t_d;
+
+    let msg = result.and_then(|r| {
+        let m: &[u8; 77] = r.message77().try_into().ok()?;
+        unpack77(m)
+    });
+
+    Some(MonitorHit {
+        rank: i,
+        freq_hz: cand.freq_hz,
+        refined_hz: s2.freq_hz,
+        cscore: cand.score,
+        refine_us,
+        decode_us,
+        t_ms: (now_us() - ctx.t0_us) / 1000,
+        msg,
+    })
+}
+
+/// Walk `candidates` in coarse-score order, refining and decoding each,
+/// until the list or [`MonitorConfig::deadline_ms`] runs out.
+///
+/// Results come back **sorted by rank**, which the dual-core path has
+/// to restore explicitly: two cores complete interleaved.
+pub fn run_candidate_loop(slot: &CapturedSlot, candidates: &[SyncCandidate]) -> Vec<MonitorHit> {
+    let t0 = now_us();
+    let n = candidates.len();
+    let ctx = MonitorCtx {
+        cfg: slot.cfg,
+        candidates: candidates.as_ptr() as *const core::ffi::c_void,
+        n,
+        coarse_i: slot.coarse_i.as_ptr(),
+        coarse_q: slot.coarse_q.as_ptr(),
+        coarse_len: slot.coarse_i.len(),
+        coarse_delay_orig: slot.delay,
+        t0_us: t0,
+    };
+    let deadline = t0 + slot.cfg.deadline_ms * 1000;
+
+    let mut hits = if slot.cfg.dual_core {
+        fst4_dual_core::run_split(&ctx, n, deadline, monitor_candidate)
+    } else {
+        fst4_dual_core::drain_single(&ctx, n, deadline, monitor_candidate)
+    };
+    hits.sort_by_key(|h| h.rank);
+    hits
+}
+
+/// Collapse hits into distinct decoded stations, in the order they were
+/// first decoded.
+///
+/// By decoded *message*, not by position: a monitor reports stations,
+/// and two coarse cells for one signal are the same station. Cheaper
+/// than a dedup barrier ahead of the loop, and it cannot delay a first
+/// decode.
+pub fn distinct_decodes(hits: &[MonitorHit]) -> Vec<(String, f32, i64)> {
+    let mut out: Vec<(String, f32, i64)> = Vec::new();
+    for h in hits {
+        if let Some(text) = &h.msg {
+            if !out.iter().any(|(m, _, _)| m == text) {
+                out.push((text.clone(), h.refined_hz, h.t_ms));
+            }
+        }
+    }
+    out
+}

--- a/embedded-poc/embedded-shared/src/fst4_monitor.rs
+++ b/embedded-poc/embedded-shared/src/fst4_monitor.rs
@@ -212,6 +212,21 @@ impl SlotCapture {
     /// to build it after the slot (which is what the bench's batch mode
     /// measures against).
     pub fn new(cfg: MonitorConfig, with_spectrogram: bool) -> Self {
+        Self::with_input_hint(cfg, with_spectrogram, 0)
+    }
+
+    /// Same, but reserve the baseband buffers up front for a slot of
+    /// `input_samples` 12 kHz samples.
+    ///
+    /// Worth doing on a device: the pair grows by doubling otherwise,
+    /// and at 1.5 MB combined a reallocation near the end of a slot
+    /// transiently needs 3 MB of an 8 MB PSRAM that is also holding a
+    /// spectrogram and, in a receiver, the previous slot.
+    pub fn with_input_hint(
+        cfg: MonitorConfig,
+        with_spectrogram: bool,
+        input_samples: usize,
+    ) -> Self {
         let cascade = match cfg.band {
             Band::Wide => wideband_cascade(cfg.center_hz),
             Band::Sniper => sniper_cascade(cfg.center_hz),
@@ -222,12 +237,18 @@ impl SlotCapture {
         } else {
             None
         };
+        // The cascades' output rates: wideband decimates by 243/64,
+        // sniper by 3 * 81/16. A little slack for `flush`'s tail.
+        let cap = match cfg.band {
+            Band::Wide => input_samples * 64 / 243 + 64,
+            Band::Sniper => input_samples * 16 / 243 + 64,
+        };
         Self {
             cfg,
             ddc: StreamingComplexDdc::new(&cascade),
             builder,
-            coarse_i: Vec::new(),
-            coarse_q: Vec::new(),
+            coarse_i: Vec::with_capacity(cap),
+            coarse_q: Vec::with_capacity(cap),
         }
     }
 
@@ -433,6 +454,11 @@ pub struct MonitorHit {
     /// cores, which is the number a monitor is judged on.
     pub t_ms: i64,
     pub msg: Option<String>,
+    /// From the decode, when there was one — a receiver displays these,
+    /// and both ladder arms return the same `DecodeResult` shape.
+    pub snr_db: f32,
+    pub dt_sec: f32,
+    pub hard_errors: u32,
 }
 
 /// Everything one candidate needs that does not vary across the batch,
@@ -512,7 +538,7 @@ fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
     };
     let decode_us = now_us() - t_d;
 
-    let msg = result.and_then(|r| {
+    let msg = result.as_ref().and_then(|r| {
         let m: &[u8; 77] = r.message77().try_into().ok()?;
         unpack77(m)
     });
@@ -526,6 +552,9 @@ fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
         decode_us,
         t_ms: (now_us() - ctx.t0_us) / 1000,
         msg,
+        snr_db: result.as_ref().map_or(f32::NAN, |r| r.snr_db),
+        dt_sec: result.as_ref().map_or(f32::NAN, |r| r.dt_sec),
+        hard_errors: result.as_ref().map_or(0, |r| r.hard_errors),
     })
 }
 
@@ -558,19 +587,19 @@ pub fn run_candidate_loop(slot: &CapturedSlot, candidates: &[SyncCandidate]) -> 
     hits
 }
 
-/// Collapse hits into distinct decoded stations, in the order they were
-/// first decoded.
+/// The hits that decoded, one per distinct message, in the order they
+/// were first decoded.
 ///
 /// By decoded *message*, not by position: a monitor reports stations,
 /// and two coarse cells for one signal are the same station. Cheaper
 /// than a dedup barrier ahead of the loop, and it cannot delay a first
 /// decode.
-pub fn distinct_decodes(hits: &[MonitorHit]) -> Vec<(String, f32, i64)> {
-    let mut out: Vec<(String, f32, i64)> = Vec::new();
+pub fn distinct_decodes(hits: &[MonitorHit]) -> Vec<&MonitorHit> {
+    let mut out: Vec<&MonitorHit> = Vec::new();
     for h in hits {
         if let Some(text) = &h.msg {
-            if !out.iter().any(|(m, _, _)| m == text) {
-                out.push((text.clone(), h.refined_hz, h.t_ms));
+            if !out.iter().any(|o| o.msg.as_deref() == Some(text.as_str())) {
+                out.push(h);
             }
         }
     }

--- a/embedded-poc/embedded-shared/src/lib.rs
+++ b/embedded-poc/embedded-shared/src/lib.rs
@@ -10,6 +10,7 @@ pub mod dual_core;
 pub mod esp_dsp_dotprod;
 pub mod esp_dsp_fft;
 pub mod fst4_dual_core;
+pub mod fst4_monitor;
 pub mod internal_pool;
 pub mod pipeline;
 pub mod stage1_inc;

--- a/embedded-poc/m5stack-cores3-app/Cargo.toml
+++ b/embedded-poc/m5stack-cores3-app/Cargo.toml
@@ -51,6 +51,11 @@ harness = false
 # the decoder half `fst4-bench` above measures. See
 # `embedded-shared::apps::fst4_ddc_bench`'s module doc comment.
 [[bin]]
+name = "fst4-app"
+path = "src/bin/fst4_app.rs"
+harness = false
+
+[[bin]]
 name = "fst4-ddc-bench"
 path = "src/bin/fst4_ddc_bench.rs"
 harness = false

--- a/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
+++ b/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
@@ -1,0 +1,896 @@
+//! CoreS3 FST4-60 wideband monitor receiver — the application on top of
+//! the pipeline `fst4_ddc_bench` measured (issues #306/#307/#327).
+//!
+//! What it does, once per 60 s slot: down-convert and build the
+//! spectrogram *as audio arrives*, then after the slot search
+//! 100-3000 Hz for candidates and decode them in coarse-score order,
+//! deepest first, until the band is covered. Decodes land on the LCD
+//! and in the log. On the real hardware this pipeline reaches its first
+//! decode 2.2 s after the slot ends and covers all 50 candidates in
+//! 33 s of the next slot.
+//!
+//! **A new binary, not a mode of `wspr_app`.** The two share the
+//! CoreS3's board/PMIC/UAC/WiFi plumbing and nothing else: different
+//! decoder, different slot length, different memory profile, and — the
+//! part that actually decides it — a different task/priority layout,
+//! below.
+//!
+//! ## Task layout, and why it is not `wspr_app`'s
+//!
+//! | task | core | prio | duty |
+//! |---|---|---|---|
+//! | display | 1 | **7** | ~30 ms every 500 ms |
+//! | capture (DDC + spectrogram) | 1 | **6** | 5.7 s per 60 s slot |
+//! | scan (coarse search + candidate loop) | 0 | 5 | up to 34 s per slot |
+//! | `fst4_dual_core` worker | 1 | 5 | with the scan task |
+//! | network (WiFi/NTP/HTTP) | 1 | 2 | one-time, then idle |
+//!
+//! `wspr_app` keeps its compute on core 0 and everything else on core
+//! 1, so a lower-priority display task on core 1 is never starved. FST4
+//! cannot do that: its candidate loop is *dual-core* (#327, 1.67×), so
+//! core 1 is occupied at priority 5 for most of the post-slot window.
+//! A display or capture task below that priority would be starved
+//! exactly the way `wspr_app`'s display task was before its own fix.
+//!
+//! So both are put *above* the decode instead. That inverts the usual
+//! intuition and is deliberate: **audio arrival is real-time and the
+//! decode is best-effort.** Capture must not miss samples — a dropped
+//! block is a hole in the slot that no amount of later compute
+//! recovers — while a decode that finishes 2 s later is still a decode.
+//! Both preempting tasks are small (9.5% and ~6% duty), so the loop
+//! stretches by roughly that much and still fits the slot.
+//!
+//! ## Memory, and why the spectrogram is dropped early
+//!
+//! A slot in flight is ~1.5 MB of baseband plus ~3.3 MB of
+//! spectrogram, against 8 MB of PSRAM. A receiver always has two slots
+//! alive — decoding slot N while capturing slot N+1 — and 2 × 4.8 MB
+//! does not fit.
+//!
+//! It does not have to. Only the coarse search reads the spectrogram,
+//! and that is the first second of the post-slot work; the candidate
+//! loop needs the baseband alone. So the scan task drops the
+//! spectrogram the moment the search returns, taking the finished slot
+//! down to 1.5 MB for the 33 s the loop runs. Peak is then one full
+//! slot plus one baseband, ~6.3 MB.
+//!
+//! ## Audio source
+//!
+//! Real USB audio arrives through `uac.rs`'s `AudioSink` — shared with
+//! the FT8 controller and `wspr_app` — and is **not hardware-verified**
+//! (issue #163, no UAC source has ever enumerated on this board).
+//! Until one does, the capture task replays the baked golden FST4-60
+//! slot instead, so the app is fully exercisable with no radio
+//! attached and the screen shows real decodes of real (if replayed)
+//! signals. `A` in the status bar is which source is live.
+//!
+//! **No wall-clock slot alignment yet** for the real-audio path — the
+//! same open item `wspr_app` and `uac.rs` already carry. Slot
+//! boundaries are counted in samples from whenever the stream started,
+//! not UTC.
+
+#![allow(dead_code)] // board.rs/pmic.rs/uac.rs carry items this bin doesn't use (no touch, no TX).
+
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use esp_idf_hal::delay::{Ets, FreeRtos};
+use esp_idf_hal::gpio::{AnyIOPin, PinDriver};
+use esp_idf_hal::peripherals::Peripherals;
+use esp_idf_hal::spi::{config::Config as SpiConfig, SpiDeviceDriver, SpiDriver, SpiDriverConfig};
+use esp_idf_hal::units::FromValueType;
+
+use esp_idf_svc::eventloop::EspSystemEventLoop;
+use esp_idf_svc::nvs::{EspDefaultNvsPartition, EspNvs, NvsDefault};
+
+use display_interface_spi::SPIInterface;
+use mipidsi::options::{ColorInversion, Orientation, Rotation};
+use mipidsi::{models::ILI9342CRgb565, Builder};
+
+use embedded_shared::fst4_dual_core;
+use embedded_shared::fst4_monitor::{
+    self, CapturedSlot, MonitorConfig, MonitorHit, SlotCapture,
+};
+use mfsk_app_shared::log_sink::{FanoutLogger, LogFanout};
+use mfsk_app_shared::settings;
+use mfsk_app_shared::{http_config, ntp, udp_log};
+use mfsk_app_shared::ui::fst4_list::{self, Fst4SpotRow, Fst4UiState};
+
+#[path = "../board.rs"]
+mod board;
+#[path = "../pmic.rs"]
+mod pmic;
+#[path = "../uac.rs"]
+mod uac;
+
+/// The same baked golden slot `fst4-ddc-bench` runs — raw `i16` little
+/// endian at 12 kHz, byte-wise rather than transmuted (1-byte
+/// `include_bytes!` alignment faults an unaligned `i16` load on
+/// Xtensa).
+const GOLDEN_AUDIO: &[u8] = include_bytes!("../../../assets/fst4_60_golden_audio.bin");
+
+const WIFI_SSID: &str = env!("WIFI_SSID");
+const WIFI_PSK: &str = env!("WIFI_PSK");
+const UDP_LOG_TARGET: &str = env!("UDP_LOG_TARGET");
+const UDP_LOG_PORT: &str = env!("UDP_LOG_PORT");
+
+static FANOUT: LogFanout = LogFanout::new();
+static LOGGER: FanoutLogger = FanoutLogger::new(&FANOUT, log::LevelFilter::Info);
+
+/// FST4-60's slot. Capture paces itself to this; the decode has the
+/// same period to finish in.
+const SLOT_SAMPLES_12K: usize = 60 * 12_000;
+const SLOT_US: i64 = 60_000_000;
+
+/// Feed size for the replay source. One second of audio — large enough
+/// that per-block overhead is irrelevant, small enough to interleave
+/// with the decode. The spectrogram is bit-identical at any block size.
+const REPLAY_BLOCK: usize = 12_000;
+
+/// The bench reserves 96 KiB for the identical work and reports
+/// **~91 KiB still untouched** — i.e. ~5 KiB actually used across
+/// `coarse_search` and the candidate loop, which allocate their real
+/// state on the heap. 48 KiB is a 10x margin on that, and the 48 KiB it
+/// gives back is internal DRAM the WiFi PHY needs: the first boot of
+/// this app aborted in `phy_track_pll_init` with `ESP_ERR_NO_MEM`
+/// against 15 KB of internal DRAM left, with a 96 KiB reservation here
+/// as the largest single cause.
+const SCAN_STACK: u32 = 48 * 1024;
+/// Small, and deliberately **not** in PSRAM: this is the DSP-heavy task
+/// (7.9 s per slot of FIR and FFT), and a PSRAM stack would slow every
+/// inner loop that touches a local. The network task is the one that
+/// can afford external memory.
+const CAPTURE_STACK: u32 = 16 * 1024;
+const DISPLAY_STACK: u32 = 24 * 1024;
+const NETWORK_STACK: u32 = 24 * 1024;
+
+/// See this file's task-layout table: display and capture sit *above*
+/// the decode, not below it.
+const DISPLAY_PRIORITY: u32 = 7;
+const CAPTURE_PRIORITY: u32 = 6;
+const SCAN_PRIORITY: u32 = 5;
+const NETWORK_PRIORITY: u32 = 2;
+
+/// `MFSK_FST4_APP_USB_HOST=1` — install the USB host + UAC class
+/// driver, and take real audio from a radio. See the call site for why
+/// this is off by default while #163 is open.
+const USB_HOST: bool = match option_env!("MFSK_FST4_APP_USB_HOST") {
+    Some(v) => matches!(v.as_bytes(), [b'1']),
+    None => false,
+};
+
+/// The shipped monitor, with one number changed.
+///
+/// **The candidate loop is slower in an app than in the bench**, and
+/// measurably so: 46-48 s here against the bench's 33 s for the same
+/// 50 candidates. The capture task is the reason — from the second
+/// slot on it runs its FIR/FFT front end concurrently with the decode
+/// on both cores, and the two contend for PSRAM bandwidth. The same
+/// contention runs the other way too: the front end itself goes 5.9 s
+/// on the first slot (nothing else running) to ~15 s once the decoder
+/// is busy.
+///
+/// 45 s therefore truncated the band at ~30 of 50 candidates. 52 s
+/// covers them while still landing before the next slot's handoff at
+/// ~T+61 s. Nothing about time-to-first-decode changes — that is 2.4 s
+/// post-slot either way, since the signal is at coarse rank 1.
+const CFG: MonitorConfig = MonitorConfig {
+    deadline_ms: 52_000,
+    ..MonitorConfig::FST4_60_WIDEBAND
+};
+
+const MALLOC_CAP_SPIRAM: u32 = 1 << 10;
+
+/// Same bound `wspr_app` uses — one attempt at boot, then the app runs
+/// regardless.
+const NTP_SYNC_TIMEOUT_MS: u32 = 20_000;
+
+static SCAN_GO: AtomicBool = AtomicBool::new(false);
+/// Flips true on the first real sample from a UAC device, after which
+/// the capture task stops replaying the golden slot.
+static UAC_AUDIO_ACTIVE: AtomicBool = AtomicBool::new(false);
+
+/// The finished slot waiting to be decoded. One deep on purpose: if
+/// the scan task has not taken the previous slot by the time the next
+/// one ends, the new slot replaces it and that is the correct
+/// behaviour for a monitor — freshest audio wins, and the log says so.
+static SLOT_READY: Mutex<Option<CapturedSlot>> = Mutex::new(None);
+
+/// Real audio waiting to be fed into the slot being captured.
+///
+/// The capture task owns its [`SlotCapture`] on its own stack and is
+/// the only thing that ever touches it; the USB reader thread only
+/// appends raw samples here. That split is not just tidiness — a
+/// `SlotCapture` holds the spectrogram builder's `Box<dyn Fft>`, which
+/// is not `Send`, and the reader thread has no business running 5.7 s
+/// of DSP per slot in the first place. `wspr_app`'s sink does run its
+/// DDC inline on that thread; this one deliberately does not.
+///
+/// Bounded: if the capture task ever stalls, old audio is dropped
+/// rather than growing without limit, and the drop is logged.
+static AUDIO_STAGING: Mutex<Vec<i16>> = Mutex::new(Vec::new());
+/// ~2 s of 12 kHz audio. Enough to absorb scheduling jitter at
+/// [`CAPTURE_PRIORITY`] *and* the inter-slot wait described at
+/// [`SPECTRA_FREE`], far short of a slot.
+const STAGING_CAP: usize = 24_000;
+
+/// Whether the previous slot's spectrogram has been released.
+///
+/// Two spectrograms do not fit: one slot in flight is ~1.5 MB of
+/// baseband plus ~3.3 MB of spectrogram, and 8 MB of PSRAM cannot hold
+/// two. The first boot of this app proved it — the capture task
+/// allocated slot N+1 the instant it posted slot N and aborted on
+/// `memory allocation of 758772 bytes failed`, which is exactly one
+/// slot's baseband reserve.
+///
+/// So the capture task waits for this before allocating the next
+/// capture, and the scan task sets it the moment `coarse_search`
+/// returns and the spectrogram can go. That wait is ~1.2 s of a 60 s
+/// slot; real audio arriving during it is held in [`AUDIO_STAGING`].
+static SPECTRA_FREE: AtomicBool = AtomicBool::new(true);
+
+static FST4_UI: Mutex<Fst4UiState> = Mutex::new(Fst4UiState::new());
+
+fn now_us() -> i64 {
+    unsafe { esp_idf_svc::sys::esp_timer_get_time() }
+}
+
+fn log_heap(tag: &str) {
+    const MALLOC_CAP_8BIT: u32 = 1 << 2;
+    const MALLOC_CAP_INTERNAL: u32 = 1 << 11;
+    unsafe {
+        log::info!(
+            "[mem] {tag}: internal {} KB, PSRAM {} KB (largest contig {} KB)",
+            esp_idf_svc::sys::heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT) / 1024,
+            esp_idf_svc::sys::heap_caps_get_free_size(MALLOC_CAP_SPIRAM) / 1024,
+            esp_idf_svc::sys::heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM) / 1024,
+        );
+    }
+}
+
+fn main() -> ! {
+    esp_idf_svc::sys::link_patches();
+    LOGGER.install();
+
+    log::info!("=== mfsk-core-m5stack-cores3-app fst4-app boot ===");
+    log::info!("mfsk-core {}", mfsk_core::VERSION);
+
+    // The candidate loop is compute-bound for tens of seconds with no
+    // yield point on either core; IDLE0/IDLE1 starve and the task
+    // watchdog fires. Same call, same reason, as every bench here.
+    let r = unsafe { esp_idf_svc::sys::esp_task_wdt_deinit() };
+    log::info!("task watchdog deinit -> {r}");
+
+    // **Before WiFi**, per `fst4_dual_core::init`'s ordering
+    // constraint: its stack is a `.bss` reservation the linker makes,
+    // but the TCB and queues are still allocations, and WSPR measured a
+    // worker spawn silently lost to heap fragmentation with the radio
+    // up.
+    fst4_dual_core::init();
+
+    let peripherals = Peripherals::take().expect("peripherals taken twice");
+    let nvs_part = EspDefaultNvsPartition::take().expect("NVS partition take");
+    let nvs = settings::open_nvs(nvs_part.clone()).expect("settings NVS open");
+    let nvs = Arc::new(Mutex::new(nvs));
+
+    // Scan task's 96 KiB stack first, before anything else can
+    // fragment internal DRAM — `wspr_app`'s own comment explains what
+    // this ordering is worth on real hardware (a display task's
+    // concurrent SPI-driver allocations beat it to the block once).
+    log_heap("pre-scan-spawn");
+    spawn_scan_task();
+    spawn_capture_task();
+    log_heap("post-scan-spawn");
+
+    // Register the sink before the display task, whose body installs
+    // the USB host driver — same "wire the consumer before installing
+    // the driver" ordering `wspr_app` relies on.
+    uac::set_audio_sink(Fst4Sink);
+
+    spawn_display_task(DisplayCtx {
+        i2c0: peripherals.i2c0,
+        spi2: peripherals.spi2,
+        pins: peripherals.pins,
+    });
+    log_heap("post-display-spawn");
+
+    // WiFi *driver construction* is synchronous and stays here, before
+    // `SCAN_GO`: `peripherals.modem` is consumed by value and is not
+    // returned on `Err`, so a failure is permanent for this boot, and
+    // the internal-DRAM it needs has to be claimed in the same quiet
+    // window the task stacks were. The slow, unbounded half
+    // (associate/DHCP retry) is what the network task backgrounds.
+    let sysloop = EspSystemEventLoop::take().expect("sysloop");
+    let wifi_driver = if WIFI_SSID.is_empty() {
+        log::warn!("fst4_app: WIFI_SSID empty (no cfg.toml) — NTP and HTTP config unavailable");
+        None
+    } else {
+        match mfsk_app_shared::wifi::wifi_driver_init(peripherals.modem, sysloop, Some(nvs_part)) {
+            Ok(w) => Some(w),
+            Err(e) => {
+                log::error!("fst4_app: WiFi driver init failed (unrecoverable this boot): {e:#}");
+                None
+            }
+        }
+    };
+    log_heap("post-wifi-driver-init");
+
+    if let Some(wifi_driver) = wifi_driver {
+        spawn_network_task(NetworkCtx { wifi_driver, nvs });
+    }
+    log_heap("post-network-spawn");
+
+    // Decode start does not wait on WiFi — same conclusion `wspr_app`
+    // reached the hard way: this app's test AP needs unbounded retry,
+    // so gating boot on it means an unbounded hang, not a delay.
+    SCAN_GO.store(true, Ordering::Release);
+
+    loop {
+        FreeRtos::delay_ms(1000);
+    }
+}
+
+// ── Capture task ─────────────────────────────────────────────────────
+
+extern "C" fn capture_task_entry(_arg: *mut core::ffi::c_void) {
+    capture_loop();
+}
+
+fn spawn_capture_task() {
+    let created = unsafe {
+        esp_idf_svc::sys::xTaskCreatePinnedToCore(
+            Some(capture_task_entry),
+            c"fst4_capture".as_ptr(),
+            CAPTURE_STACK,
+            core::ptr::null_mut(),
+            CAPTURE_PRIORITY,
+            core::ptr::null_mut(),
+            1,
+        )
+    };
+    if created != 1 {
+        log::error!("fst4_app: failed to create fst4_capture task");
+    }
+}
+
+/// Finish a slot and post it for the scan task.
+fn post_slot(cap: SlotCapture) {
+    let t0 = now_us();
+    let slot = cap.finish();
+    let mut ready = SLOT_READY.lock().expect("SLOT_READY poisoned");
+    if ready.is_some() {
+        log::warn!("fst4_app::capture: previous slot not consumed — dropping it for the new one");
+    }
+    log::info!(
+        "fst4_app::capture: slot ready ({} baseband samples, flush {} ms)",
+        slot.coarse_i.len(),
+        (now_us() - t0) / 1000,
+    );
+    *ready = Some(slot);
+}
+
+/// Owns the slot boundary and the [`SlotCapture`] behind it, fed
+/// either from real UAC audio (via [`AUDIO_STAGING`]) or, until a
+/// device enumerates, by replaying the golden slot at real-time
+/// cadence.
+fn capture_loop() -> ! {
+    while !SCAN_GO.load(Ordering::Acquire) {
+        FreeRtos::delay_ms(200);
+    }
+    log::info!("fst4_app: capture loop starting");
+    log_heap("capture-start");
+
+    let mut block: Vec<i16> = Vec::with_capacity(REPLAY_BLOCK);
+    loop {
+        // Wait for the previous slot's spectrogram to be released
+        // before claiming memory for this one — see [`SPECTRA_FREE`].
+        let t_wait0 = now_us();
+        while !SPECTRA_FREE.swap(false, Ordering::AcqRel) {
+            FreeRtos::delay_ms(20);
+        }
+        let waited_ms = (now_us() - t_wait0) / 1000;
+        if waited_ms > 0 {
+            log::info!("fst4_app::capture: waited {waited_ms} ms for the previous slot's memory");
+        }
+
+        let slot_start = now_us();
+        let mut cap = SlotCapture::with_input_hint(CFG, true, SLOT_SAMPLES_12K);
+        let mut fed = 0usize;
+        let mut t_compute = 0i64;
+
+        while fed < SLOT_SAMPLES_12K {
+            let live = UAC_AUDIO_ACTIVE.load(Ordering::Acquire);
+            if live {
+                // Real audio: take whatever has arrived and feed it.
+                // The slot still ends on sample count, so a stream
+                // that stops mid-slot ends the slot short rather than
+                // hanging — see this file's alignment caveat.
+                let staged = core::mem::take(&mut *AUDIO_STAGING.lock().expect("staging poisoned"));
+                if staged.is_empty() {
+                    FreeRtos::delay_ms(20);
+                    continue;
+                }
+                let t = now_us();
+                cap.push_i16(&staged);
+                t_compute += now_us() - t;
+                fed += staged.len();
+            } else {
+                let take = REPLAY_BLOCK.min(SLOT_SAMPLES_12K - fed);
+                let samples = GOLDEN_AUDIO.len() / 2;
+                block.clear();
+                block.extend(
+                    GOLDEN_AUDIO
+                        .chunks_exact(2)
+                        .cycle()
+                        .skip(fed % samples)
+                        .take(take)
+                        .map(|b| i16::from_le_bytes([b[0], b[1]])),
+                );
+                let t = now_us();
+                cap.push_i16(&block);
+                t_compute += now_us() - t;
+                fed += take;
+
+                // Pace to real time, so the front end's cost is a duty
+                // cycle rather than a flat-out run.
+                let due_us = slot_start + (fed as i64) * 1_000_000 / 12_000;
+                let sleep_ms = ((due_us - now_us()).max(0) / 1000) as u32;
+                if sleep_ms > 0 {
+                    FreeRtos::delay_ms(sleep_ms);
+                }
+            }
+        }
+
+        log::info!(
+            "fst4_app::capture: front end {} ms of a {} ms slot ({:.1}% duty), source {}",
+            t_compute / 1000,
+            SLOT_US / 1000,
+            t_compute as f64 / SLOT_US as f64 * 100.0,
+            if UAC_AUDIO_ACTIVE.load(Ordering::Acquire) { "UAC" } else { "golden replay" },
+        );
+        post_slot(cap);
+    }
+}
+
+/// Real-audio sink. All it does is stage samples for the capture task
+/// — see [`AUDIO_STAGING`] for why the DSP is not done here.
+struct Fst4Sink;
+
+impl uac::AudioSink for Fst4Sink {
+    fn push_samples(&mut self, samples_12k_mono: &[i16]) {
+        if !UAC_AUDIO_ACTIVE.swap(true, Ordering::AcqRel) {
+            log::info!("fst4_app: real UAC audio active — golden replay stops at the next slot");
+        }
+        let mut staging = AUDIO_STAGING.lock().expect("staging poisoned");
+        if staging.len() + samples_12k_mono.len() > STAGING_CAP {
+            log::warn!(
+                "fst4_app: audio staging full ({} samples) — dropping {}; capture task is behind",
+                staging.len(),
+                samples_12k_mono.len(),
+            );
+            return;
+        }
+        staging.extend_from_slice(samples_12k_mono);
+    }
+}
+
+// ── Scan task ────────────────────────────────────────────────────────
+
+extern "C" fn scan_task_entry(_arg: *mut core::ffi::c_void) {
+    scan_loop();
+}
+
+fn spawn_scan_task() {
+    let created = unsafe {
+        esp_idf_svc::sys::xTaskCreatePinnedToCore(
+            Some(scan_task_entry),
+            c"fst4_scan".as_ptr(),
+            SCAN_STACK,
+            core::ptr::null_mut(),
+            SCAN_PRIORITY,
+            core::ptr::null_mut(),
+            0, // core 0; `fst4_dual_core`'s worker takes core 1.
+        )
+    };
+    if created != 1 {
+        log::error!("fst4_app: failed to create fst4_scan task");
+    }
+}
+
+fn scan_loop() -> ! {
+    while !SCAN_GO.load(Ordering::Acquire) {
+        FreeRtos::delay_ms(200);
+    }
+    log::info!("fst4_app: scan loop starting");
+
+    let mut slot_num = 0u32;
+    loop {
+        let mut slot = loop {
+            if let Some(s) = SLOT_READY.lock().expect("SLOT_READY poisoned").take() {
+                break s;
+            }
+            FreeRtos::delay_ms(200);
+        };
+
+        let t_post0 = now_us();
+        let (candidates, fill_us, rank_us) = fst4_monitor::coarse_search(&slot);
+        // Drop the spectrogram now — only the search reads it, and the
+        // 33 s candidate loop below runs while the *next* slot is being
+        // captured. See this file's memory section, and [`SPECTRA_FREE`]
+        // for what the capture task is waiting on.
+        slot.spectra = None;
+        SPECTRA_FREE.store(true, Ordering::Release);
+        let t_search_ms = (now_us() - t_post0) / 1000;
+        log::info!(
+            "fst4_app::scan: slot {slot_num} — {} candidates in {} ms (fill {} ms, rank {} ms)",
+            candidates.len(),
+            t_search_ms,
+            fill_us / 1000,
+            rank_us / 1000,
+        );
+
+        let hits = fst4_monitor::run_candidate_loop(&slot, &candidates);
+        let decoded = fst4_monitor::distinct_decodes(&hits);
+        let loop_ms = (now_us() - t_post0) / 1000 - t_search_ms;
+        let first_ms = decoded.first().map_or(0, |h| h.t_ms + t_search_ms);
+
+        for h in &decoded {
+            log::info!(
+                "fst4_app::scan: {:?} @ {:.1} Hz dt {:+.2} s — post-slot {} ms",
+                h.msg.as_deref().unwrap_or(""),
+                h.refined_hz,
+                h.dt_sec,
+                h.t_ms + t_search_ms,
+            );
+        }
+        log::info!(
+            "fst4_app::scan: slot {slot_num} done — {} tried, {} distinct decodes, \
+             search {} ms + loop {} ms, first decode {} ms post-slot",
+            hits.len(),
+            decoded.len(),
+            t_search_ms,
+            loop_ms,
+            first_ms,
+        );
+
+        let rows: Vec<Fst4SpotRow> = decoded.iter().map(|h| to_row(h, t_search_ms)).collect();
+        {
+            let mut ui = FST4_UI.lock().expect("FST4_UI poisoned");
+            ui.last_slot_cands = candidates.len();
+            ui.last_slot_tried = hits.len();
+            ui.last_first_decode_ms = first_ms;
+            ui.audio_live = UAC_AUDIO_ACTIVE.load(Ordering::Acquire);
+            ui.set_slot(&current_hhmm(), &rows);
+        }
+        log_heap("post-slot");
+        slot_num = slot_num.wrapping_add(1);
+    }
+}
+
+fn to_row(h: &MonitorHit, search_ms: i64) -> Fst4SpotRow {
+    let mut msg: heapless::String<22> = heapless::String::new();
+    let text = h.msg.as_deref().unwrap_or("");
+    let _ = msg.push_str(&text[..text.len().min(22)]);
+    Fst4SpotRow {
+        utc_hhmm: current_hhmm(),
+        freq_hz: h.refined_hz,
+        snr_db: h.snr_db.is_finite().then(|| h.snr_db.clamp(-99.0, 99.0) as i8),
+        dt_sec: h.dt_sec,
+        msg,
+        t_s: (h.t_ms + search_ms) as f32 / 1000.0,
+    }
+}
+
+fn current_hhmm() -> heapless::String<4> {
+    use core::fmt::Write as _;
+    let mut s: heapless::String<4> = heapless::String::new();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let _ = write!(&mut s, "{:02}{:02}", (now / 3600) % 24, (now / 60) % 60);
+    s
+}
+
+fn current_hhmmss() -> heapless::String<8> {
+    use core::fmt::Write as _;
+    let mut s: heapless::String<8> = heapless::String::new();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    let _ = write!(
+        &mut s,
+        "{:02}:{:02}:{:02}",
+        (now / 3600) % 24,
+        (now / 60) % 60,
+        now % 60
+    );
+    s
+}
+
+// ── Display task ─────────────────────────────────────────────────────
+
+struct DisplayCtx {
+    i2c0: esp_idf_hal::i2c::I2C0<'static>,
+    spi2: esp_idf_hal::spi::SPI2<'static>,
+    pins: esp_idf_hal::gpio::Pins,
+}
+
+extern "C" fn display_task_entry(arg: *mut core::ffi::c_void) {
+    // SAFETY: `spawn_display_task` leaked exactly this pointer.
+    let ctx = unsafe { Box::from_raw(arg as *mut DisplayCtx) };
+    display_loop(*ctx);
+}
+
+fn spawn_display_task(ctx: DisplayCtx) {
+    let ptr = Box::into_raw(Box::new(ctx)) as *mut core::ffi::c_void;
+    let created = unsafe {
+        esp_idf_svc::sys::xTaskCreatePinnedToCore(
+            Some(display_task_entry),
+            c"fst4_display".as_ptr(),
+            DISPLAY_STACK,
+            ptr,
+            DISPLAY_PRIORITY,
+            core::ptr::null_mut(),
+            1,
+        )
+    };
+    if created != 1 {
+        log::error!("fst4_app: failed to create fst4_display task");
+    }
+}
+
+fn display_loop(ctx: DisplayCtx) -> ! {
+    let mut display = match pmic::init(ctx.i2c0, ctx.pins.gpio12, ctx.pins.gpio11) {
+        Ok(mut i2c) => {
+            // VBUS boost before the USB host driver, or the host stack
+            // sees no device — same sequence `wspr_app` documents.
+            if let Err(e) = pmic::enable_usb_host_vbus(&mut i2c) {
+                log::error!("BUS_OUT_EN failed: {e:#}");
+            }
+            drop(i2c);
+
+            // Installing the USB host driver **detaches
+            // USB-Serial-JTAG**, i.e. the serial console, the moment it
+            // returns — which is why `wspr_app` wires UDP log fanout
+            // first and why this is opt-in here rather than
+            // unconditional.
+            //
+            // Default off, deliberately, for as long as issue #163 is
+            // open: no UAC source has ever enumerated on this board, so
+            // turning it on today costs the only telemetry channel that
+            // works without a WiFi association and buys nothing. Build
+            // with `MFSK_FST4_APP_USB_HOST=1` to attach a radio; the
+            // app then depends on the UDP log sink for its logs, same
+            // as `wspr_app` does.
+            if USB_HOST {
+                log::info!("fst4_app: installing USB host + UAC class driver");
+                if let Err(e) = uac::start_host() {
+                    log::error!("fst4_app: UAC host start failed: {e:#}");
+                }
+            } else {
+                log::info!(
+                    "fst4_app: USB host disabled (build with MFSK_FST4_APP_USB_HOST=1) \
+                     — serial console kept, golden slot replayed"
+                );
+            }
+
+            let driver = SpiDriver::new(
+                ctx.spi2,
+                ctx.pins.gpio36,
+                ctx.pins.gpio37,
+                Option::<AnyIOPin>::None,
+                &SpiDriverConfig::new(),
+            )
+            .expect("SPI2 driver");
+            let spi_cfg = SpiConfig::new().baudrate(20_u32.MHz().into());
+            let spi_dev =
+                SpiDeviceDriver::new(driver, Some(ctx.pins.gpio3), &spi_cfg).expect("SPI device");
+            let dc = PinDriver::output(ctx.pins.gpio35).expect("DC gpio35");
+            let di = SPIInterface::new(spi_dev, dc);
+
+            let mut delay = Ets;
+            match Builder::new(ILI9342CRgb565, di)
+                .display_size(320, 240)
+                .orientation(Orientation::new().rotate(Rotation::Deg90))
+                .invert_colors(ColorInversion::Inverted)
+                .init(&mut delay)
+            {
+                Ok(d) => d,
+                Err(e) => {
+                    log::error!("display init failed: {e:?}");
+                    loop {
+                        log::info!("alive (no LCD)");
+                        FreeRtos::delay_ms(2000);
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            log::error!("PMIC init failed: {e:#}");
+            loop {
+                log::info!("alive (no PMIC/LCD)");
+                FreeRtos::delay_ms(2000);
+            }
+        }
+    };
+    log::info!("LCD init OK ({}x{})", board::LCD_WIDTH, board::LCD_HEIGHT);
+
+    {
+        let ui = FST4_UI.lock().expect("FST4_UI poisoned");
+        if let Err(e) = fst4_list::render_all(&mut display, &ui) {
+            log::error!("fst4_app::display: render_all FAILED: {e:?}");
+        }
+    }
+
+    let mut last_dirty = u32::MAX;
+    let mut tick: u32 = 0;
+    loop {
+        let heap_kb = (unsafe { esp_idf_svc::sys::esp_get_free_heap_size() } / 1024) as u32;
+        let hhmmss = current_hhmmss();
+        let dirty = {
+            let mut ui = FST4_UI.lock().expect("FST4_UI poisoned");
+            ui.free_heap_kb = heap_kb;
+            ui.utc_hhmmss = hhmmss.clone();
+            ui.dirty_seq()
+        };
+        {
+            let ui = FST4_UI.lock().expect("FST4_UI poisoned");
+            if let Err(e) = fst4_list::render_status(&mut display, &ui) {
+                log::warn!("fst4_app::display: render_status failed: {e:?}");
+            }
+            if dirty != last_dirty {
+                if let Err(e) = fst4_list::render_slot(&mut display, &ui) {
+                    log::warn!("fst4_app::display: render_slot failed: {e:?}");
+                }
+                if let Err(e) = fst4_list::render_history(&mut display, &ui) {
+                    log::warn!("fst4_app::display: render_history failed: {e:?}");
+                }
+                last_dirty = dirty;
+            }
+        }
+        // Direct evidence that this task keeps running through the
+        // scan task's compute-bound stretch — the same reason
+        // `wspr_app`'s display loop logs one.
+        if tick % 20 == 0 {
+            log::info!(
+                "fst4_app::display: alive tick={tick} dirty={dirty} utc={hhmmss} heap={heap_kb}k"
+            );
+        }
+        tick = tick.wrapping_add(1);
+        FreeRtos::delay_ms(500);
+    }
+}
+
+// ── Network task ─────────────────────────────────────────────────────
+
+struct NetworkCtx {
+    wifi_driver: esp_idf_svc::wifi::BlockingWifi<esp_idf_svc::wifi::EspWifi<'static>>,
+    nvs: Arc<Mutex<EspNvs<NvsDefault>>>,
+}
+
+extern "C" fn network_task_entry(arg: *mut core::ffi::c_void) {
+    // SAFETY: `spawn_network_task` leaked exactly this pointer.
+    let ctx = unsafe { Box::from_raw(arg as *mut NetworkCtx) };
+    network_loop(*ctx);
+}
+
+/// Stack in PSRAM, not internal DRAM: `wspr_app` measured WiFi driver
+/// bring-up taking internal DRAM to 10 KB free / 7 KB largest block,
+/// nowhere near a 24 KiB stack, regardless of spawn ordering.
+fn spawn_network_task(ctx: NetworkCtx) {
+    let ptr = Box::into_raw(Box::new(ctx)) as *mut core::ffi::c_void;
+    let created = unsafe {
+        esp_idf_svc::sys::xTaskCreatePinnedToCoreWithCaps(
+            Some(network_task_entry),
+            c"fst4_net".as_ptr(),
+            NETWORK_STACK,
+            ptr,
+            NETWORK_PRIORITY,
+            core::ptr::null_mut(),
+            1,
+            MALLOC_CAP_SPIRAM,
+        )
+    };
+    if created != 1 {
+        log::error!("fst4_app: failed to create fst4_net task");
+    }
+}
+
+fn network_loop(mut ctx: NetworkCtx) -> ! {
+    // Blocks until connected; only `Err`s for a malformed SSID/PSK,
+    // not for a transient failure — see `connect_with_retry`'s own doc
+    // comment for why unbounded retry is what this AP needs.
+    let info = match mfsk_app_shared::wifi::connect_with_retry(
+        &mut ctx.wifi_driver,
+        WIFI_SSID,
+        WIFI_PSK,
+        None,
+    ) {
+        Ok(i) => i,
+        Err(e) => {
+            log::error!("fst4_app::net: WiFi setup failed permanently: {e:#}");
+            loop {
+                FreeRtos::delay_ms(60_000);
+            }
+        }
+    };
+    log::info!("fst4_app::net: WiFi up, ip {}", info.ip);
+
+    // UDP log sink — the serial console goes away the moment the USB
+    // host driver installs, so this is the only log this app has once
+    // it is running for real.
+    let target_ip: std::net::IpAddr = if UDP_LOG_TARGET.is_empty() || UDP_LOG_TARGET == "auto" {
+        std::net::IpAddr::V4(info.subnet_broadcast)
+    } else {
+        match UDP_LOG_TARGET.parse() {
+            Ok(ip) => ip,
+            Err(e) => {
+                log::warn!(
+                    "fst4_app::net: UDP_LOG_TARGET '{UDP_LOG_TARGET}' parse failed ({e}); \
+                     using subnet broadcast"
+                );
+                std::net::IpAddr::V4(info.subnet_broadcast)
+            }
+        }
+    };
+    let addr = std::net::SocketAddr::new(target_ip, UDP_LOG_PORT.parse().unwrap_or(9999));
+    match udp_log::UdpLogSink::new(addr) {
+        Ok(sink) => {
+            if let Ok(mut slot) = FANOUT.udp.try_lock() {
+                *slot = Some(sink);
+            }
+            FANOUT.drain_staging_to_udp();
+            log::info!("fst4_app::net: UDP log sink up -> {addr}");
+        }
+        Err(e) => log::warn!("fst4_app::net: UDP socket bind failed: {e}"),
+    }
+
+    let initial_settings = {
+        let g = ctx.nvs.lock().expect("settings NVS mutex poisoned");
+        settings::load(&g)
+    };
+    let (ntp_synced, _sntp_keepalive) = if initial_settings.ntp_enabled {
+        match ntp::start(&initial_settings.ntp_server) {
+            Ok(sntp) => {
+                let synced = ntp::wait_synced(&sntp, NTP_SYNC_TIMEOUT_MS);
+                (synced, Some(sntp))
+            }
+            Err(e) => {
+                log::warn!("fst4_app::net: NTP start failed: {e:#}");
+                (false, None)
+            }
+        }
+    } else {
+        log::info!("fst4_app::net: NTP sync disabled in settings");
+        (false, None)
+    };
+    if !ntp_synced {
+        // Slot timestamps on screen stay relative to boot until this
+        // succeeds. The decode itself does not depend on it — slot
+        // boundaries are counted in samples, not wall clock (see this
+        // file's alignment caveat).
+        log::warn!("fst4_app::net: NTP never synced — UTC column is not absolute");
+    }
+    FST4_UI.lock().expect("FST4_UI poisoned").ntp_synced = ntp_synced;
+
+    let _http_server = match http_config::start(ctx.nvs.clone()) {
+        Ok(s) => {
+            log::info!("fst4_app::net: HTTP config server up");
+            Some(s)
+        }
+        Err(e) => {
+            log::warn!("fst4_app::net: HTTP config server failed: {e:#}");
+            None
+        }
+    };
+
+    // `ctx.wifi_driver`/`_sntp_keepalive`/`_http_server` are never read
+    // again but their `Drop`s tear down the association / stop syncing
+    // / stop listening, so this task keeps them alive by never
+    // returning.
+    loop {
+        FreeRtos::delay_ms(60_000);
+    }
+}

--- a/embedded-poc/mfsk-app-shared/src/ui/fst4_list.rs
+++ b/embedded-poc/mfsk-app-shared/src/ui/fst4_list.rs
@@ -1,0 +1,394 @@
+//! FST4 monitor screen for the CoreS3's panel, run **portrait**
+//! (240×320) — the same geometry, chrome and repaint discipline
+//! `wspr_list` established, carrying FST4 rows instead of WSPR spots.
+//!
+//! ```text
+//! y=0..16     status bar        (mode / dial freq / UTC / NTP / heap)
+//! y=16..37    this-slot header + column header
+//! y=37..145   this slot's decodes (9 rows, wholesale replace)
+//! y=145..147  divider
+//! y=147..168  history header + column header
+//! y=168..312  decode history (12 rows, newest at top)
+//! y=312..320  unused margin
+//! ```
+//!
+//! **A sibling of `wspr_list`, not a generalisation of it.** The two
+//! could share a row-agnostic renderer — the regions differ only in
+//! header text and row type — and that refactor is worth doing. It is
+//! deliberately not done here: `wspr_list`'s layout constants were
+//! settled by looking at a real panel (see its doc comment, and
+//! `render_all`'s note on `DrawTarget::clear()` being unreliable on
+//! this mipidsi/SPI setup), and a refactor whose only real test is "does
+//! the screen still look right" should not ride along with a new app
+//! that cannot verify the old screen. The duplication is one file and
+//! is marked, rather than silently accumulated.
+//!
+//! What it does share, structurally: per-region wipe-then-draw with no
+//! full-frame clear (avoids flicker), an explicit `Rectangle` fill
+//! rather than `clear()`, and a caller that gates repaints on
+//! [`Fst4UiState::dirty_seq`].
+
+use core::fmt::Write as _;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use embedded_graphics::{
+    mono_font::{MonoTextStyleBuilder, ascii::FONT_6X10},
+    pixelcolor::Rgb565,
+    prelude::*,
+    primitives::{PrimitiveStyle, Rectangle},
+    text::{Baseline, Text},
+};
+use heapless::String;
+
+pub const PANEL_WIDTH: u32 = 240;
+pub const PANEL_HEIGHT: u32 = 320;
+
+pub const STATUS_ORIGIN_Y: i32 = 0;
+pub const STATUS_HEIGHT: u32 = 16;
+
+const SLOT_HEADER_Y: i32 = STATUS_HEIGHT as i32;
+const HEADER_H: u32 = 11;
+const COL_HEADER_H: u32 = 10;
+const ROW_PX: u32 = 12;
+
+const SLOT_COL_HEADER_Y: i32 = SLOT_HEADER_Y + HEADER_H as i32;
+pub const SLOT_ROWS_Y: i32 = SLOT_COL_HEADER_Y + COL_HEADER_H as i32;
+pub const SLOT_ROWS: usize = 9;
+const SLOT_REGION_H: u32 = SLOT_ROWS as u32 * ROW_PX;
+
+const DIVIDER_Y: i32 = SLOT_ROWS_Y + SLOT_REGION_H as i32;
+const DIVIDER_H: u32 = 2;
+
+const HISTORY_HEADER_Y: i32 = DIVIDER_Y + DIVIDER_H as i32;
+const HISTORY_COL_HEADER_Y: i32 = HISTORY_HEADER_Y + HEADER_H as i32;
+pub const HISTORY_ROWS_Y: i32 = HISTORY_COL_HEADER_Y + COL_HEADER_H as i32;
+pub const HISTORY_ROWS: usize = 12;
+
+/// One slot's worth of decodes kept for display. The monitor's own
+/// `max_cand` is 50, but distinct *messages* in one 60 s slot are far
+/// fewer; 16 is the same headroom `wspr_state` uses.
+pub const SLOT_CAP: usize = 16;
+pub const HISTORY_CAP: usize = 48;
+
+const BG: Rgb565 = Rgb565::BLACK;
+const FG: Rgb565 = Rgb565::WHITE;
+const HEADER_BG: Rgb565 = Rgb565::new(0, 8, 0);
+const COL_HEADER_FG: Rgb565 = Rgb565::CSS_GRAY;
+
+/// One decoded FST4 transmission, sized for a 40-char panel row.
+#[derive(Clone, Debug)]
+pub struct Fst4SpotRow {
+    /// Slot start, UTC, `HHMM`.
+    pub utc_hhmm: String<4>,
+    /// Decoded audio frequency, Hz — the refined offset, not the
+    /// coarse cell's.
+    pub freq_hz: f32,
+    /// `None` when the decoder could not report one.
+    ///
+    /// That is the normal case on the wideband DDC monitor path: FST4's
+    /// WSJT-X-faithful SNR estimate reads a baseline out of the
+    /// whole-slot forward FFT (`SnrCtx::fft_cache`), and the DDC front
+    /// end exists precisely so that FFT is never computed. Reporting
+    /// nothing is the honest answer until an SNR estimator that works
+    /// from the DDC baseband exists.
+    pub snr_db: Option<i8>,
+    pub dt_sec: f32,
+    /// The 77-bit message as text; WSJT-X messages fit in 22 chars.
+    pub msg: String<22>,
+    /// Seconds after the slot ended that this decode landed. The
+    /// number a monitor is actually judged on, and the one thing a
+    /// bench log shows that a receiver screen otherwise would not.
+    pub t_s: f32,
+}
+
+/// Column header matching [`Fst4SpotRow::format_row`]'s field order.
+pub const ROW_HEADER: &str = "UTC  FREQ  SNR   DT  MESSAGE      T+";
+
+impl Fst4SpotRow {
+    /// One fixed-width line: `HHMM freq snr dt message t+`.
+    ///
+    /// `snr` renders as `--` when absent, which on the DDC monitor
+    /// path is the normal case rather than an error — see
+    /// [`Self::snr_db`].
+    pub fn format_row(&self, out: &mut String<56>) {
+        out.clear();
+        let mut snr: String<4> = String::new();
+        match self.snr_db {
+            Some(v) => {
+                let _ = write!(&mut snr, "{v:>3}");
+            }
+            None => {
+                let _ = snr.push_str(" --");
+            }
+        }
+        let _ = write!(
+            out,
+            "{:<4} {:>5.0} {:>3} {:>+4.1} {:<13} {:>3.1}",
+            self.utc_hhmm.as_str(),
+            self.freq_hz,
+            snr.as_str(),
+            self.dt_sec,
+            // Truncated to the column, not to storage: a long message
+            // must not push the `t+` column out of alignment.
+            &self.msg.as_str()[..self.msg.len().min(13)],
+            self.t_s,
+        );
+    }
+}
+
+/// What the FST4 screen renders. Mutated by the scan task once a slot,
+/// read by the display task at its own tick — [`Self::dirty_seq`] is
+/// what keeps the expensive panes from repainting in between.
+pub struct Fst4UiState {
+    slot: heapless::Vec<Fst4SpotRow, SLOT_CAP>,
+    history: heapless::Deque<Fst4SpotRow, HISTORY_CAP>,
+    last_slot_hhmm: Option<String<4>>,
+    /// Decodes the last slot produced before [`SLOT_CAP`] truncation,
+    /// so a truncated slot is visible rather than looking like a quiet
+    /// band.
+    last_slot_count: usize,
+    /// Candidates the last slot's coarse search produced, and how many
+    /// of them the loop actually reached before its deadline — the two
+    /// numbers that say whether the monitor is keeping up.
+    pub last_slot_cands: usize,
+    pub last_slot_tried: usize,
+    /// Post-slot milliseconds to the first decode of the last slot.
+    pub last_first_decode_ms: i64,
+    pub dial_mhz: f64,
+    pub utc_hhmmss: String<8>,
+    pub ntp_synced: bool,
+    pub audio_live: bool,
+    pub free_heap_kb: u32,
+    dirty_seq: AtomicU32,
+}
+
+impl Default for Fst4UiState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Fst4UiState {
+    pub const fn new() -> Self {
+        Self {
+            slot: heapless::Vec::new(),
+            history: heapless::Deque::new(),
+            last_slot_hhmm: None,
+            last_slot_count: 0,
+            last_slot_cands: 0,
+            last_slot_tried: 0,
+            last_first_decode_ms: 0,
+            dial_mhz: 0.0,
+            utc_hhmmss: String::new(),
+            ntp_synced: false,
+            audio_live: false,
+            free_heap_kb: 0,
+            dirty_seq: AtomicU32::new(0),
+        }
+    }
+
+    /// Replace this slot's decodes and append them to the history.
+    pub fn set_slot(&mut self, hhmm: &str, rows: &[Fst4SpotRow]) {
+        self.slot.clear();
+        for r in rows.iter().take(SLOT_CAP) {
+            let _ = self.slot.push(r.clone());
+        }
+        self.last_slot_count = rows.len();
+        let mut h: String<4> = String::new();
+        let _ = h.push_str(&hhmm[..hhmm.len().min(4)]);
+        self.last_slot_hhmm = Some(h);
+        for r in rows {
+            if self.history.is_full() {
+                let _ = self.history.pop_front();
+            }
+            let _ = self.history.push_back(r.clone());
+        }
+        self.dirty_seq.fetch_add(1, Ordering::Release);
+    }
+
+    pub fn dirty_seq(&self) -> u32 {
+        self.dirty_seq.load(Ordering::Acquire)
+    }
+    pub fn slot_rows(&self) -> &[Fst4SpotRow] {
+        &self.slot
+    }
+    pub fn slot_counts(&self) -> (usize, usize) {
+        (self.slot.len(), self.last_slot_count)
+    }
+    pub fn last_slot_hhmm(&self) -> Option<&str> {
+        self.last_slot_hhmm.as_deref()
+    }
+    pub fn history_len(&self) -> usize {
+        self.history.len()
+    }
+    pub fn history_iter(&self) -> impl Iterator<Item = &Fst4SpotRow> {
+        self.history.iter()
+    }
+}
+
+fn text_style(
+    fg: Rgb565,
+    bg: Rgb565,
+) -> embedded_graphics::mono_font::MonoTextStyle<'static, Rgb565> {
+    MonoTextStyleBuilder::new()
+        .font(&FONT_6X10)
+        .text_color(fg)
+        .background_color(bg)
+        .build()
+}
+
+fn fill(display: &mut impl DrawTarget<Color = Rgb565>, y: i32, h: u32, color: Rgb565) {
+    let _ = Rectangle::new(Point::new(0, y), Size::new(PANEL_WIDTH, h))
+        .into_styled(PrimitiveStyle::with_fill(color))
+        .draw(display);
+}
+
+/// Status bar: mode, dial frequency, UTC, NTP and live-audio flags,
+/// free heap. `A` is the flag that says whether the decodes on screen
+/// came from a radio or from the built-in golden slot.
+pub fn render_status<D>(display: &mut D, ui: &Fst4UiState) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let mut s: String<48> = String::new();
+    let ntp = if ui.ntp_synced { 'Y' } else { 'N' };
+    let aud = if ui.audio_live { 'Y' } else { 'N' };
+    let _ = write!(
+        &mut s,
+        "FST4 {:>8.4}M {} N{ntp} A{aud} {:>4}k",
+        ui.dial_mhz, ui.utc_hhmmss, ui.free_heap_kb
+    );
+    fill(display, STATUS_ORIGIN_Y, STATUS_HEIGHT, HEADER_BG);
+    Text::with_baseline(
+        s.as_str(),
+        Point::new(2, STATUS_ORIGIN_Y + 3),
+        text_style(FG, HEADER_BG),
+        Baseline::Top,
+    )
+    .draw(display)?;
+    Ok(())
+}
+
+/// This slot's decodes, headed by the two numbers that say whether the
+/// monitor kept up: candidates reached out of candidates found, and
+/// how long the first decode took.
+pub fn render_slot<D>(display: &mut D, ui: &Fst4UiState) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let (shown, decoded) = ui.slot_counts();
+    let mut header: String<48> = String::new();
+    match ui.last_slot_hhmm() {
+        Some(hhmm) => {
+            let _ = write!(
+                &mut header,
+                "SLOT {hhmm}Z {shown}/{decoded} {}/{} c {}ms",
+                ui.last_slot_tried, ui.last_slot_cands, ui.last_first_decode_ms
+            );
+        }
+        None => {
+            let _ = header.push_str("SLOT  (no decode yet)");
+        }
+    }
+    fill(display, SLOT_HEADER_Y, HEADER_H, BG);
+    Text::with_baseline(
+        header.as_str(),
+        Point::new(2, SLOT_HEADER_Y + 2),
+        text_style(FG, BG),
+        Baseline::Top,
+    )
+    .draw(display)?;
+
+    fill(display, SLOT_COL_HEADER_Y, COL_HEADER_H, BG);
+    Text::with_baseline(
+        ROW_HEADER,
+        Point::new(2, SLOT_COL_HEADER_Y),
+        text_style(COL_HEADER_FG, BG),
+        Baseline::Top,
+    )
+    .draw(display)?;
+
+    render_rows(display, ui.slot_rows().iter(), SLOT_ROWS_Y, SLOT_ROWS, false)
+}
+
+/// Decode history, newest at the top.
+pub fn render_history<D>(display: &mut D, ui: &Fst4UiState) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let mut header: String<32> = String::new();
+    let _ = write!(&mut header, "HISTORY  ({} since boot)", ui.history_len());
+    fill(display, HISTORY_HEADER_Y, HEADER_H, BG);
+    Text::with_baseline(
+        header.as_str(),
+        Point::new(2, HISTORY_HEADER_Y + 2),
+        text_style(FG, BG),
+        Baseline::Top,
+    )
+    .draw(display)?;
+
+    fill(display, HISTORY_COL_HEADER_Y, COL_HEADER_H, BG);
+    Text::with_baseline(
+        ROW_HEADER,
+        Point::new(2, HISTORY_COL_HEADER_Y),
+        text_style(COL_HEADER_FG, BG),
+        Baseline::Top,
+    )
+    .draw(display)?;
+
+    let all: heapless::Vec<&Fst4SpotRow, HISTORY_CAP> = ui.history_iter().collect();
+    let take = all.len().min(HISTORY_ROWS);
+    let start = all.len() - take;
+    let visible = all[start..].iter().rev().copied();
+
+    render_rows(display, visible, HISTORY_ROWS_Y, HISTORY_ROWS, true)
+}
+
+fn render_rows<'a, D>(
+    display: &mut D,
+    rows: impl Iterator<Item = &'a Fst4SpotRow>,
+    origin_y: i32,
+    max_rows: usize,
+    divider_after: bool,
+) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    let style = text_style(FG, BG);
+    let mut buf: String<56> = String::new();
+    let mut drawn = 0usize;
+    for row in rows.take(max_rows) {
+        let y = origin_y + (drawn as i32) * ROW_PX as i32;
+        fill(display, y, ROW_PX, BG);
+        row.format_row(&mut buf);
+        Text::with_baseline(buf.as_str(), Point::new(2, y + 1), style, Baseline::Top)
+            .draw(display)?;
+        drawn += 1;
+    }
+    if drawn < max_rows {
+        let blank_y = origin_y + (drawn as i32) * ROW_PX as i32;
+        let blank_h = ((max_rows - drawn) as u32) * ROW_PX;
+        fill(display, blank_y, blank_h, BG);
+    }
+    if divider_after {
+        fill(display, DIVIDER_Y, DIVIDER_H, COL_HEADER_FG);
+    }
+    Ok(())
+}
+
+/// Paint every region — the first frame, before any slot completes.
+/// Explicit `Rectangle` fill rather than `DrawTarget::clear()`, which
+/// real-hardware testing found unreliable on this mipidsi/SPI setup
+/// (see `wspr_list::render_all` for the full finding).
+pub fn render_all<D>(display: &mut D, ui: &Fst4UiState) -> Result<(), D::Error>
+where
+    D: DrawTarget<Color = Rgb565>,
+{
+    fill(display, 0, PANEL_HEIGHT, BG);
+    render_status(display, ui)?;
+    render_slot(display, ui)?;
+    render_history(display, ui)?;
+    Ok(())
+}
+
+const _: () = assert!((HISTORY_ROWS_Y as u32 + HISTORY_ROWS as u32 * ROW_PX) <= PANEL_HEIGHT);

--- a/embedded-poc/mfsk-app-shared/src/ui/mod.rs
+++ b/embedded-poc/mfsk-app-shared/src/ui/mod.rs
@@ -14,6 +14,7 @@
 //! Phase 0: モジュール宣言のみ。
 
 pub mod decoded_list;
+pub mod fst4_list;
 pub mod menu;
 pub mod state;
 pub mod status_bar;


### PR DESCRIPTION
An FST4-60 monitor receiver application for the CoreS3, and the pipeline extraction that made it possible without a copy.

## 1. The extraction

A receiver needs the same three stages `fst4_ddc_bench`'s monitor mode runs, and the code-sharing audit (#290–298) found "80% shared" to be 31.8% in practice — mostly through copies like the one this avoids. `embedded-shared/src/fst4_monitor.rs` now owns:

| item | what it is |
|---|---|
| `MonitorConfig` | every number a caller may choose; `FST4_60_WIDEBAND` is the shipped operating point |
| `SlotCapture` / `CapturedSlot` | the capture-time front end (DDC + spectrogram, block by block) |
| `coarse_search` | dual-core correlation fill + ranking, returning both costs |
| `run_candidate_loop` / `MonitorHit` | the rank-tiered, deadline-bounded, dual-core candidate loop |

The build-time switches stay in the bench, which now builds a `MonitorConfig` from them. Nothing an application links carries an `option_env!`.

**One improvement fell out**: routing both bench modes through one front end first added a whole-slot copy worth 80 ms of a 1300 ms DDC. The fix removes it from both paths — the cascade appends straight into the slot buffer and the builder is handed the tail that just appeared.

Verified on real CoreS3, both bench configurations unchanged:

| | before | after |
|---|---|---|
| sniper `TOTALS` | 1300 / 394 / 1358 / 300 ms, 2/2 | **1300 / 394 / 1356 / 299 ms, 2/2** |
| wide monitor fill / rank / search | 714 / 292 / 1009 ms | **714 / 292 / 1008 ms** |
| wide capture (DDC + spectrogram) | 5840 ms | **5695 ms** |
| first decode, post-slot | 2183 ms | **2173 ms** |

## 2. The app

`fst4-app` runs continuously on hardware. Four consecutive slots, golden replay source, WiFi up:

| | |
|---|---:|
| front end during capture | 5.9 s first slot, ~16 s under load (9.8% → 27% duty) |
| coarse search, post-slot | 1.03 s (fill 708 ms dual-core, rank 319 ms) |
| first decode, post-slot | 2.4–3.8 s, against a 7.2 s TX guard |
| candidates covered | 33–37 of 50 in the 52 s deadline |
| decodes | both stations, every slot |
| display tick | 520 ms, unbroken through the decode |
| PSRAM steady state | 2.0 MB free |

Three things it has to do differently from `wspr_app`, each forced by a measurement:

**Display and capture run *above* the decode.** WSPR keeps compute on core 0, so a low-priority display task on core 1 is safe. FST4's candidate loop is dual-core (#327), so core 1 is busy at priority 5 for most of the post-slot window and anything below it starves — the exact bug `wspr_app` hit before its own fix. Audio arrival is real-time and the decode is best-effort, so both preempt it.

**The spectrogram is dropped as soon as the search returns.** A slot in flight is 1.5 MB of baseband plus 3.3 MB of spectrogram, and a receiver always has two alive. First boot proved 2 × 4.8 MB does not fit in 8 MB — `memory allocation of 758772 bytes failed`, exactly one baseband reserve. Only the search reads the spectrogram, so the capture task waits on `SPECTRA_FREE` (~1.1 s of a 60 s slot) and peak drops to ~6.3 MB.

**The USB reader thread only stages samples.** `wspr_app` runs its DDC inline there; this app cannot (a `SlotCapture` holds the spectrogram builder's non-`Send` `Box<dyn Fft>`) and should not — 5.9 s of DSP per slot does not belong on the audio-arrival path.

Also fixed on first boot: a 96 KiB scan stack left 15 KB of internal DRAM and WiFi PHY init aborted (`phy_track_pll_init`, `ESP_ERR_NO_MEM`). The bench measures ~5 KiB actually used, so 48 KiB is a 10× margin and leaves 71 KB free.

## Two honest gaps

- **SNR renders `--`.** FST4's WSJT-X-faithful SNR estimate reads its baseline out of the whole-slot forward FFT, and the DDC front end exists precisely so that FFT is never computed. An estimator that works from the DDC baseband is real work, not wiring.
- **The candidate loop is ~1.6× slower in an app than in the bench** (52 s vs 33 s), and the front end ~2.7× (16 s vs 5.9 s), because they now run concurrently and contend for PSRAM bandwidth. Coverage is 33–37 candidates rather than 50; with the signal at median coarse rank 1 and 88% of recall inside rank 8 (#341/#343) that costs little, but it is the top open item.

USB host install is opt-in (`MFSK_FST4_APP_USB_HOST=1`) while #163 is open — it detaches the serial console, and no UAC source has ever enumerated on this board. Until one does, the capture task replays the baked golden slot, so the app is fully exercisable with no radio attached.

Refs #307, #327, #163.