### PR TITLE
perf+feat(fst4): the app's decode was losing 40% to the radio; SNR without a whole-slot FFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,26 @@ rather than distributing them across patches.
 
 ### Added
 
+- **FST4 reports SNR without a whole-slot FFT** — `fst4::baseline`'s
+  `fst4_ddc_snr_db`, reached automatically when `SnrCtx::fft_cache` is
+  empty. WSJT-X's own formula reads both its noise baseline and its
+  signal power out of the big forward FFT of the raw slot; a DDC
+  receiver never computes that FFT, so on that path `snr_db` was `NaN`.
+
+  The new estimator takes its noise reference from the part of the
+  refined baseband the signal does not occupy — 111.111 Hz wide against
+  ~12 Hz of FST4-60 tones — so every term comes from one buffer and the
+  pipeline's RMS normalisation cancels. Against a corpus whose SNR is
+  known by construction it holds a **1.0 dB bias spread from -20 to
+  -28 dB**, and on the WSJT-X FST4 sample it lands closer to `jt9`'s own
+  probed values than the whole-slot formula does (N5TM -5.7 vs jt9
+  -6.9, K9KFR 15.7 vs 16.1). `fst4::rung_major`'s scheduler fills the
+  field in too, where it also used to write `NaN`.
+
+  `SnrCtx` gains `cd0`/`ds_rate_hz` for this, and
+  `engine::llr::snr_ratio` is split out of `compute_snr_db` — the
+  scale-free half is shared across protocols while the dB tail is not.
+
 - **`coarse_sync`'s correlation matrix is now a public seam**
   (issue #327) — `sync2d_shape` / `fill_sync2d_row` /
   `coarse_sync_from_sync2d`, alongside the existing

--- a/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
+++ b/embedded-poc/embedded-shared/src/esp_dsp_fft.rs
@@ -363,11 +363,63 @@ unsafe extern "C" {
 /// concurrent FFT caller.
 static FC32_TABLE_LEN: AtomicUsize = AtomicUsize::new(0);
 
+/// Serialises the twiddle table against the transforms that read it.
+///
+/// [`FC32_TABLE_LEN`]'s doc comment flagged this hazard and left it
+/// unfixed, on the correct observation that nothing then planned two
+/// fc32 sizes concurrently. The FST4 receiver app does: its capture
+/// task builds the coarse spectrogram at 2048 points on one core while
+/// the decode runs `fst4_ddc_snr_db`'s 512-point Welch periodogram on
+/// the other. The failure is not subtle once you look for it, and not
+/// random either — 111 of 1888 spectrogram bins came back non-finite,
+/// the *same* count every slot, because a 2048-point kernel reading a
+/// 512-entry table walks off the same end of the same allocation every
+/// time. Slot 0 was always clean: nothing had planned the second size
+/// yet.
+///
+/// A plain spin lock rather than a FreeRTOS mutex: this guards a few
+/// hundred microseconds of arithmetic, is never taken from an ISR, and
+/// must work identically on both cores before any scheduler object is
+/// necessarily available.
+static FC32_LOCK: AtomicUsize = AtomicUsize::new(0);
+
+struct Fc32Guard;
+
+impl Fc32Guard {
+    fn acquire() -> Self {
+        while FC32_LOCK
+            .compare_exchange_weak(0, 1, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            core::hint::spin_loop();
+        }
+        Self
+    }
+}
+
+impl Drop for Fc32Guard {
+    fn drop(&mut self) {
+        FC32_LOCK.store(0, Ordering::Release);
+    }
+}
+
 /// Force the process-global fc32 twiddle table to be exactly `len`
 /// entries, regenerating it if it currently isn't. See
 /// [`FC32_TABLE_LEN`] for why this can't just be "call init if we
 /// haven't seen this size before" on a per-planner-instance basis.
+///
+/// **Caller must hold [`Fc32Guard`]** and keep holding it until the
+/// transform that reads the table has finished — resizing it is only
+/// half the invariant.
 fn ensure_fc32_table(len: usize) {
+    let _guard = Fc32Guard::acquire();
+    ensure_fc32_table_locked(len);
+}
+
+/// [`ensure_fc32_table`]'s body, for callers already holding
+/// [`Fc32Guard`] because they are about to run a transform against the
+/// table and must not let it change underneath them.
+fn ensure_fc32_table_locked(len: usize) {
     if FC32_TABLE_LEN.load(Ordering::Relaxed) == len {
         return;
     }
@@ -551,6 +603,12 @@ impl Fft for MixedRadix3840Fft {
         assert_eq!(buf.len(), N, "3840 FFT input length mismatch");
         let buf_arr: &mut [Complex32; N] = buf.try_into().expect("buf.len() == N already asserted");
 
+        // Same table discipline as `EspDspFft::process` — see its
+        // comment. Held across every inner 256-pt transform below, not
+        // re-acquired per call, since they are one logical FFT.
+        let _guard = Fc32Guard::acquire();
+        ensure_fc32_table_locked(256);
+
         // Inner 256-pt forward FFT via esp-dsp asm path. Mirrors
         // `EspDspFft::process` but specialised to len=256.
         let run_256 = |slice: &mut [Complex32]| {
@@ -630,6 +688,15 @@ impl EspDspFft {
 impl Fft for EspDspFft {
     fn process(&self, buf: &mut [Complex32]) {
         assert_eq!(buf.len(), self.len, "FFT input length mismatch");
+        // Held across the kernel, not just across the resize: the
+        // table this transform reads is process-global, and another
+        // core planning a different size mid-transform is exactly the
+        // corruption `FC32_LOCK`'s doc comment describes. Re-checking
+        // the size here rather than trusting `plan_forward`'s call is
+        // the other half — a `Box<dyn Fft>` outlives any number of
+        // other plans.
+        let _guard = Fc32Guard::acquire();
+        ensure_fc32_table_locked(self.len);
         // esp-dsp expects an interleaved {re, im, re, im, ...} f32
         // array of length 2*N. Complex32 is repr(C) with this exact
         // layout, so we can cast in place — subject to alignment, see

--- a/embedded-poc/embedded-shared/src/fst4_dual_core.rs
+++ b/embedded-poc/embedded-shared/src/fst4_dual_core.rs
@@ -92,8 +92,19 @@ const APP_CPU: i32 = 1;
 /// `Ldpc174_91`), so it sits near FT8's 16 KB rather than WSPR's.
 ///
 /// [`log_worker_stack`] reports the real high-water mark every batch so
-/// this stays measured rather than reverting to a guess.
-pub const WORKER_STACK_BYTES: usize = 48 * 1024;
+/// this stays measured rather than reverting to a guess. Highest seen
+/// across the bench and the receiver app is 7 440 B.
+///
+/// **Reduced 48 -> 24 KiB, 2026-08-22, and the reason is not tidiness.**
+/// This is a `.bss` reservation in *internal* DRAM, and the FST4
+/// receiver measured what internal DRAM is worth to the decoder: with
+/// 132 KB of it reserved and nothing else changed, the candidate loop
+/// went 33.3 -> 54.3 s and `fst4_sync_search` 711 -> 2212 ms per
+/// candidate, because `CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=4096` makes
+/// every small allocation *prefer* internal DRAM and silently fall back
+/// to PSRAM once it is gone. Over-reserving here is not free space; it
+/// is decode throughput.
+pub const WORKER_STACK_BYTES: usize = 24 * 1024;
 
 #[repr(align(16))]
 struct WorkerStack([u8; WORKER_STACK_BYTES]);

--- a/embedded-poc/embedded-shared/src/fst4_monitor.rs
+++ b/embedded-poc/embedded-shared/src/fst4_monitor.rs
@@ -271,11 +271,32 @@ impl SlotCapture {
 
     /// End the slot: flush the cascade's tail and finish the
     /// spectrogram.
+    /// How many baseband samples have been produced so far. A caller
+    /// pacing a slot by sample count is measuring the DDC's output,
+    /// not its input, so this is the number that says whether a slot
+    /// is actually full.
+    pub fn produced(&self) -> usize {
+        self.coarse_i.len()
+    }
+
     pub fn finish(mut self) -> CapturedSlot {
         let from = self.coarse_i.len();
         self.ddc.flush(&mut self.coarse_i, &mut self.coarse_q);
         if let Some(b) = self.builder.as_mut() {
             b.push(&self.coarse_i[from..], &self.coarse_q[from..]);
+        }
+        // Where a non-finite value first appears decides what is
+        // broken: the DDC, the spectrogram FFTs, or the correlation
+        // that reads them. Checking both here rather than only after
+        // the correlation is what separates those three.
+        let bad_bb = self
+            .coarse_i
+            .iter()
+            .chain(self.coarse_q.iter())
+            .filter(|v| !v.is_finite())
+            .count();
+        if bad_bb > 0 {
+            log::warn!("fst4_monitor: {bad_bb} non-finite baseband samples out of capture");
         }
         CapturedSlot {
             cfg: self.cfg,
@@ -348,6 +369,23 @@ pub fn coarse_search(slot: &CapturedSlot) -> (Vec<SyncCandidate>, i64, i64) {
     let Some(shape) = sync2d_shape::<Fst4s60>(cfg.freq_lo(), cfg.freq_hi(), cfg.rx_grid()) else {
         return (Vec::new(), 0, 0);
     };
+    {
+        // `avg_power_per_bin` is the only whole-spectrogram view the
+        // public API offers; a non-finite cell anywhere in a bin makes
+        // that bin's average non-finite, which is enough to say
+        // *whether* the spectrogram is the source and *which* bins.
+        let avg = s.avg_power_per_bin();
+        let bad = avg.iter().filter(|v| !v.is_finite()).count();
+        if bad > 0 {
+            let first = avg.iter().position(|v| !v.is_finite()).unwrap_or(0);
+            log::warn!(
+                "fst4_monitor: {bad} of {} spectrogram bins non-finite (first at bin {first}, \
+                 offset {})",
+                avg.len(),
+                s.freq_offset(),
+            );
+        }
+    }
 
     let t_fill0 = now_us();
     let mut sync2d = alloc::vec![0.0f32; shape.len()];
@@ -368,6 +406,21 @@ pub fn coarse_search(slot: &CapturedSlot) -> (Vec<SyncCandidate>, i64, i64) {
         }
     }
     let fill_us = now_us() - t_fill0;
+
+    // A non-finite cell here means the front end produced one, and the
+    // ranking stage downstream cannot rank what it cannot compare.
+    // Counted rather than asserted because a receiver that has been up
+    // for hours should say what it saw and keep going — and because
+    // real hardware produced this on a second slot after a clean first
+    // one, which is exactly the shape a silent check would have hidden.
+    let bad = sync2d.iter().filter(|v| !v.is_finite()).count();
+    if bad > 0 {
+        log::warn!(
+            "fst4_monitor: {bad} of {} correlation cells are non-finite — \
+             the baseband or spectrogram is corrupt",
+            sync2d.len(),
+        );
+    }
 
     let t_rank0 = now_us();
     let cands = coarse_sync_from_sync2d::<Fst4s60>(

--- a/embedded-poc/embedded-shared/src/fst4_monitor.rs
+++ b/embedded-poc/embedded-shared/src/fst4_monitor.rs
@@ -538,7 +538,15 @@ fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
             EqMode::Off,
             SYNC_Q_MIN,
             precomputed,
-            true,
+            // `skip_snr = false`. It was `true` while FST4's only SNR
+            // estimator needed the whole-slot FFT this path does not
+            // build — the flag's original purpose was avoiding a second
+            // `downsample_cached` that would have been pure waste here.
+            // With `fst4_ddc_snr_db` reading the noise out of the
+            // refined baseband instead, the estimate costs a handful of
+            // 512-point FFTs per *decode* and the receiver has a number
+            // to show.
+            false,
             false,
         )
     };

--- a/embedded-poc/embedded-shared/src/fst4_monitor.rs
+++ b/embedded-poc/embedded-shared/src/fst4_monitor.rs
@@ -448,6 +448,11 @@ pub struct MonitorHit {
     pub freq_hz: f32,
     pub refined_hz: f32,
     pub cscore: f32,
+    /// The polyphase recentre alone — [`ddc_refine`].
+    pub recenter_us: i64,
+    /// Recentre plus `fst4_sync_search`. The two are split because
+    /// they are different code with different memory behaviour, and a
+    /// combined number cannot say which of them moved.
     pub refine_us: i64,
     pub decode_us: i64,
     /// Milliseconds after the loop started — the same clock on both
@@ -492,6 +497,7 @@ fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
 
     let t_r = now_us();
     let cd0 = ddc_refine(&ctx.cfg, cand, coarse_i, coarse_q, ctx.coarse_delay_orig);
+    let recenter_us = now_us() - t_r;
     let s2 = fst4_sync_search::<Fst4s60>(&cd0, cand);
     let refine_us = now_us() - t_r;
 
@@ -548,6 +554,7 @@ fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
         freq_hz: cand.freq_hz,
         refined_hz: s2.freq_hz,
         cscore: cand.score,
+        recenter_us,
         refine_us,
         decode_us,
         t_ms: (now_us() - ctx.t0_us) / 1000,
@@ -564,6 +571,21 @@ fn monitor_candidate(ctx: &MonitorCtx, i: usize) -> Option<MonitorHit> {
 /// Results come back **sorted by rank**, which the dual-core path has
 /// to restore explicitly: two cores complete interleaved.
 pub fn run_candidate_loop(slot: &CapturedSlot, candidates: &[SyncCandidate]) -> Vec<MonitorHit> {
+    // Alignment of the buffer every candidate's refine streams, logged
+    // because it is not a constant of the code: it comes from wherever
+    // the allocator put a multi-megabyte PSRAM block, which differs
+    // between a bench that grows the buffer by doubling and an app that
+    // reserves it up front. `engine::dsp::dotprod`'s esp-dsp PIE path
+    // has an alignment requirement, so this is the first thing to look
+    // at when the same refine costs different amounts in two binaries.
+    let addr = slot.coarse_i.as_ptr() as usize;
+    log::info!(
+        "fst4_monitor: baseband at {:#x} (align {} B), {} samples",
+        addr,
+        1usize << addr.trailing_zeros().min(6),
+        slot.coarse_i.len(),
+    );
+
     let t0 = now_us();
     let n = candidates.len();
     let ctx = MonitorCtx {

--- a/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
+++ b/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
@@ -135,11 +135,16 @@ const REPLAY_BLOCK: usize = 12_000;
 /// this app aborted in `phy_track_pll_init` with `ESP_ERR_NO_MEM`
 /// against 15 KB of internal DRAM left, with a 96 KiB reservation here
 /// as the largest single cause.
-const SCAN_STACK: u32 = 48 * 1024;
-/// Small, and deliberately **not** in PSRAM: this is the DSP-heavy task
-/// (7.9 s per slot of FIR and FFT), and a PSRAM stack would slow every
-/// inner loop that touches a local. The network task is the one that
-/// can afford external memory.
+const SCAN_STACK: u32 = 24 * 1024;
+/// In PSRAM, like the display and network tasks.
+///
+/// The first version of this file argued the opposite — DSP task,
+/// keep its stack fast — and that reasoning was measured and found
+/// backwards. This task's actual working set is the `SlotCapture`'s
+/// heap buffers; its *stack* holds only small locals. Meanwhile every
+/// KiB of internal DRAM it reserves is a KiB the decoder's own small
+/// allocations fall back to PSRAM without, which costs far more (see
+/// `fst4_dual_core::WORKER_STACK_BYTES` for the measurement).
 const CAPTURE_STACK: u32 = 16 * 1024;
 const DISPLAY_STACK: u32 = 24 * 1024;
 const NETWORK_STACK: u32 = 24 * 1024;
@@ -187,6 +192,43 @@ const CAPTURE_SLOTS: usize = {
 /// retry. This switch is what separates "the decode is slow" from "the
 /// radio is eating the decode".
 const NO_WIFI: bool = match option_env!("MFSK_FST4_APP_NO_WIFI") {
+    Some(v) => matches!(v.as_bytes(), [b'1']),
+    None => false,
+};
+
+/// `MFSK_FST4_APP_NO_CONNECT=1` — bring the WiFi *driver* up but never
+/// associate. Diagnostic: separates the cost of the radio existing
+/// from the cost of it carrying a network's traffic.
+const NO_CONNECT: bool = match option_env!("MFSK_FST4_APP_NO_CONNECT") {
+    Some(v) => matches!(v.as_bytes(), [b'1']),
+    None => false,
+};
+
+/// `MFSK_FST4_APP_HOG_KB=<n>` — reserve `n` KB of **internal** DRAM at
+/// boot and never release it. Diagnostic: reproduces the WiFi driver's
+/// memory footprint without the radio, which is what separates
+/// "internal DRAM starvation" from everything else the driver leaves
+/// behind.
+const HOG_KB: usize = {
+    let v = option_env!("MFSK_FST4_APP_HOG_KB");
+    match v {
+        Some(s) => {
+            let b = s.as_bytes();
+            let mut i = 0;
+            let mut acc = 0usize;
+            while i < b.len() {
+                acc = acc * 10 + (b[i] - b'0') as usize;
+                i += 1;
+            }
+            acc
+        }
+        None => 0,
+    }
+};
+
+/// `MFSK_FST4_APP_WIFI_STOP=1` — with `NO_CONNECT`, also stop the
+/// radio after the driver is up. Diagnostic, see the call site.
+const WIFI_STOP: bool = match option_env!("MFSK_FST4_APP_WIFI_STOP") {
     Some(v) => matches!(v.as_bytes(), [b'1']),
     None => false,
 };
@@ -308,6 +350,22 @@ fn main() -> ! {
     // up.
     fst4_dual_core::init();
 
+    if HOG_KB > 0 {
+        const MALLOC_CAP_INTERNAL_8BIT: u32 = (1 << 11) | (1 << 2);
+        // 4 KiB blocks, matching what `SPIRAM_MALLOC_ALWAYSINTERNAL`
+        // treats as "small enough to want internal DRAM" — the same
+        // shape the allocations this is meant to crowd out have.
+        let mut got = 0usize;
+        for _ in 0..HOG_KB / 4 {
+            let p = unsafe { esp_idf_svc::sys::heap_caps_malloc(4096, MALLOC_CAP_INTERNAL_8BIT) };
+            if p.is_null() {
+                break;
+            }
+            got += 4;
+        }
+        log::warn!("fst4_app: MFSK_FST4_APP_HOG_KB={HOG_KB} — reserved {got} KB of internal DRAM");
+    }
+
     let peripherals = Peripherals::take().expect("peripherals taken twice");
     let nvs_part = EspDefaultNvsPartition::take().expect("NVS partition take");
     let nvs = settings::open_nvs(nvs_part.clone()).expect("settings NVS open");
@@ -359,7 +417,20 @@ fn main() -> ! {
     log_heap("post-wifi-driver-init");
 
     if let Some(wifi_driver) = wifi_driver {
-        spawn_network_task(NetworkCtx { wifi_driver, nvs });
+        if NO_CONNECT {
+            log::warn!("fst4_app: MFSK_FST4_APP_NO_CONNECT=1 — driver up, no association");
+            if WIFI_STOP {
+                // Separates "the radio is on" from "the radio's memory
+                // is spoken for": `esp_wifi_stop` silences the receiver
+                // while every buffer the driver allocated stays
+                // allocated.
+                let r = unsafe { esp_idf_svc::sys::esp_wifi_stop() };
+                log::warn!("fst4_app: esp_wifi_stop() -> {r} (radio silenced, memory retained)");
+            }
+            core::mem::forget(wifi_driver);
+        } else {
+            spawn_network_task(NetworkCtx { wifi_driver, nvs });
+        }
     }
     log_heap("post-network-spawn");
 
@@ -381,7 +452,7 @@ extern "C" fn capture_task_entry(_arg: *mut core::ffi::c_void) {
 
 fn spawn_capture_task() {
     let created = unsafe {
-        esp_idf_svc::sys::xTaskCreatePinnedToCore(
+        esp_idf_svc::sys::xTaskCreatePinnedToCoreWithCaps(
             Some(capture_task_entry),
             c"fst4_capture".as_ptr(),
             CAPTURE_STACK,
@@ -389,6 +460,7 @@ fn spawn_capture_task() {
             CAPTURE_PRIORITY,
             core::ptr::null_mut(),
             1,
+            MALLOC_CAP_SPIRAM,
         )
     };
     if created != 1 {
@@ -692,7 +764,7 @@ extern "C" fn display_task_entry(arg: *mut core::ffi::c_void) {
 fn spawn_display_task(ctx: DisplayCtx) {
     let ptr = Box::into_raw(Box::new(ctx)) as *mut core::ffi::c_void;
     let created = unsafe {
-        esp_idf_svc::sys::xTaskCreatePinnedToCore(
+        esp_idf_svc::sys::xTaskCreatePinnedToCoreWithCaps(
             Some(display_task_entry),
             c"fst4_display".as_ptr(),
             DISPLAY_STACK,
@@ -700,6 +772,7 @@ fn spawn_display_task(ctx: DisplayCtx) {
             DISPLAY_PRIORITY,
             core::ptr::null_mut(),
             1,
+            MALLOC_CAP_SPIRAM,
         )
     };
     if created != 1 {
@@ -906,6 +979,20 @@ fn network_loop(mut ctx: NetworkCtx) -> ! {
         }
     };
     log::info!("fst4_app::net: WiFi up, ip {}", info.ip);
+
+    // Modem power save. The default is `WIFI_PS_NONE`, which keeps the
+    // receiver on continuously and hands every frame on the network —
+    // including all the broadcast and multicast traffic a home LAN
+    // carries — to a driver task running at FreeRTOS priority 23, above
+    // anything this application creates. Measured: an *associated,
+    // otherwise idle* STA cost the candidate loop 33 -> 53 s and
+    // `fst4_sync_search` 711 -> 1500 ms per candidate.
+    //
+    // `MIN_MODEM` lets the radio sleep between DTIM beacons, which is
+    // all a receiver that only needs NTP, a config page and a log sink
+    // ever wanted from the association.
+    let r = unsafe { esp_idf_svc::sys::esp_wifi_set_ps(esp_idf_svc::sys::wifi_ps_type_t_WIFI_PS_MIN_MODEM) };
+    log::info!("fst4_app::net: esp_wifi_set_ps(MIN_MODEM) -> {r}");
 
     // UDP log sink — the serial console goes away the moment the USB
     // host driver installs, so this is the only log this app has once

--- a/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
+++ b/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
@@ -590,9 +590,10 @@ fn scan_loop() -> ! {
 
         for h in &decoded {
             log::info!(
-                "fst4_app::scan: {:?} @ {:.1} Hz dt {:+.2} s — post-slot {} ms",
+                "fst4_app::scan: {:?} @ {:.1} Hz snr {:+.0} dB dt {:+.2} s — post-slot {} ms",
                 h.msg.as_deref().unwrap_or(""),
                 h.refined_hz,
+                h.snr_db,
                 h.dt_sec,
                 h.t_ms + t_search_ms,
             );

--- a/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
+++ b/embedded-poc/m5stack-cores3-app/src/bin/fst4_app.rs
@@ -151,6 +151,46 @@ const CAPTURE_PRIORITY: u32 = 6;
 const SCAN_PRIORITY: u32 = 5;
 const NETWORK_PRIORITY: u32 = 2;
 
+/// `MFSK_FST4_APP_CAPTURE_SLOTS=<n>` — stop capturing after `n` slots
+/// (`0`, the default, never stops).
+///
+/// Diagnostic only, and the one knob that isolates the question the
+/// first hardware run raised: the candidate loop takes 52 s in this app
+/// against the bench's 33 s, and the front end 16 s against 5.9 s, but
+/// "they contend" is a hypothesis, not a measurement. With `=1` the
+/// capture task posts slot 0 and then idles, so slot 0's decode runs
+/// with everything else the app does — WiFi, display, the same task
+/// layout — and *only* the capture removed.
+const CAPTURE_SLOTS: usize = {
+    let v = option_env!("MFSK_FST4_APP_CAPTURE_SLOTS");
+    match v {
+        Some(s) => {
+            let b = s.as_bytes();
+            let mut i = 0;
+            let mut acc = 0usize;
+            while i < b.len() {
+                acc = acc * 10 + (b[i] - b'0') as usize;
+                i += 1;
+            }
+            acc
+        }
+        None => 0,
+    }
+};
+
+/// `MFSK_FST4_APP_NO_WIFI=1` — skip WiFi bring-up entirely.
+///
+/// Diagnostic. The WiFi driver's own task runs at FreeRTOS priority 23,
+/// far above anything this app creates, so an association that keeps
+/// retrying preempts the decode at will — and this app's AP is exactly
+/// the one `wifi::connect_with_retry` documents needing unbounded
+/// retry. This switch is what separates "the decode is slow" from "the
+/// radio is eating the decode".
+const NO_WIFI: bool = match option_env!("MFSK_FST4_APP_NO_WIFI") {
+    Some(v) => matches!(v.as_bytes(), [b'1']),
+    None => false,
+};
+
 /// `MFSK_FST4_APP_USB_HOST=1` — install the USB host + UAC class
 /// driver, and take real audio from a radio. See the call site for why
 /// this is off by default while #163 is open.
@@ -301,7 +341,10 @@ fn main() -> ! {
     // window the task stacks were. The slow, unbounded half
     // (associate/DHCP retry) is what the network task backgrounds.
     let sysloop = EspSystemEventLoop::take().expect("sysloop");
-    let wifi_driver = if WIFI_SSID.is_empty() {
+    let wifi_driver = if NO_WIFI {
+        log::warn!("fst4_app: MFSK_FST4_APP_NO_WIFI=1 — no radio this boot (diagnostic build)");
+        None
+    } else if WIFI_SSID.is_empty() {
         log::warn!("fst4_app: WIFI_SSID empty (no cfg.toml) — NTP and HTTP config unavailable");
         None
     } else {
@@ -381,6 +424,7 @@ fn capture_loop() -> ! {
     log_heap("capture-start");
 
     let mut block: Vec<i16> = Vec::with_capacity(REPLAY_BLOCK);
+    let mut slots_done = 0usize;
     loop {
         // Wait for the previous slot's spectrogram to be released
         // before claiming memory for this one — see [`SPECTRA_FREE`].
@@ -449,6 +493,16 @@ fn capture_loop() -> ! {
             if UAC_AUDIO_ACTIVE.load(Ordering::Acquire) { "UAC" } else { "golden replay" },
         );
         post_slot(cap);
+        slots_done += 1;
+        if CAPTURE_SLOTS > 0 && slots_done >= CAPTURE_SLOTS {
+            log::info!(
+                "fst4_app::capture: MFSK_FST4_APP_CAPTURE_SLOTS={CAPTURE_SLOTS} reached — idling; \
+                 the decode below runs with no capture beside it"
+            );
+            loop {
+                FreeRtos::delay_ms(10_000);
+            }
+        }
     }
 }
 
@@ -543,14 +597,25 @@ fn scan_loop() -> ! {
                 h.t_ms + t_search_ms,
             );
         }
+        // Per-candidate cost, split the way the bench splits it, so the
+        // two are directly comparable: the bench logs `refine N ms
+        // decode M ms` per candidate and this is the same pair summed.
+        let recenter_ms: i64 = hits.iter().map(|h| h.recenter_us).sum::<i64>() / 1000;
+        let refine_ms: i64 = hits.iter().map(|h| h.refine_us - h.recenter_us).sum::<i64>() / 1000;
+        let decode_ms: i64 = hits.iter().map(|h| h.decode_us).sum::<i64>() / 1000;
+        let n = hits.len().max(1) as i64;
         log::info!(
             "fst4_app::scan: slot {slot_num} done — {} tried, {} distinct decodes, \
-             search {} ms + loop {} ms, first decode {} ms post-slot",
+             search {} ms + loop {} ms, first decode {} ms post-slot \
+             [recentre {} ms/cand, sync-search {} ms/cand, decode {} ms/cand]",
             hits.len(),
             decoded.len(),
             t_search_ms,
             loop_ms,
             first_ms,
+            recenter_ms / n,
+            refine_ms / n,
+            decode_ms / n,
         );
 
         let rows: Vec<Fst4SpotRow> = decoded.iter().map(|h| to_row(h, t_search_ms)).collect();
@@ -798,21 +863,44 @@ fn spawn_network_task(ctx: NetworkCtx) {
     }
 }
 
+/// How long the radio is left alone between association campaigns.
+///
+/// **Bounded attempts, then quiet — not `wspr_app`'s unbounded retry.**
+/// Measured on this hardware (2026-08-22): while the driver is trying
+/// to associate with an AP it cannot reach, the decoder loses ~40% of
+/// its throughput — `fst4_sync_search` goes 711 -> 1395 ms per
+/// candidate and the candidate loop 33 -> 53 s, covering 48 of 50
+/// candidates instead of all 50. The WiFi task runs at FreeRTOS
+/// priority 23, above anything an application creates, so it preempts
+/// at will, and this is *not* something the caller's own retry cadence
+/// controls: a single `connect()` keeps the radio busy for the whole
+/// `ESP_ERR_TIMEOUT` window, which is minutes.
+///
+/// A monitor receiver's job is to decode. WiFi buys it NTP, a config
+/// page and remote logging — all of which can wait three minutes.
+const RECONNECT_IDLE_MS: u32 = 180_000;
+/// Attempts per campaign. Four is what `wifi.rs`'s own bisection
+/// established as the number that beats the AP comeback-time
+/// coin-flip; more than that is what costs decode throughput.
+const CONNECT_ATTEMPTS_PER_CAMPAIGN: u32 = 4;
+
 fn network_loop(mut ctx: NetworkCtx) -> ! {
-    // Blocks until connected; only `Err`s for a malformed SSID/PSK,
-    // not for a transient failure — see `connect_with_retry`'s own doc
-    // comment for why unbounded retry is what this AP needs.
-    let info = match mfsk_app_shared::wifi::connect_with_retry(
-        &mut ctx.wifi_driver,
-        WIFI_SSID,
-        WIFI_PSK,
-        None,
-    ) {
-        Ok(i) => i,
-        Err(e) => {
-            log::error!("fst4_app::net: WiFi setup failed permanently: {e:#}");
-            loop {
-                FreeRtos::delay_ms(60_000);
+    let info = loop {
+        match mfsk_app_shared::wifi::connect_with_retry(
+            &mut ctx.wifi_driver,
+            WIFI_SSID,
+            WIFI_PSK,
+            Some(CONNECT_ATTEMPTS_PER_CAMPAIGN),
+        ) {
+            Ok(i) => break i,
+            Err(e) => {
+                log::warn!(
+                    "fst4_app::net: no association after {CONNECT_ATTEMPTS_PER_CAMPAIGN} \
+                     attempts ({e:#}) — leaving the radio alone for {} s so it stops \
+                     preempting the decode",
+                    RECONNECT_IDLE_MS / 1000,
+                );
+                FreeRtos::delay_ms(RECONNECT_IDLE_MS);
             }
         }
     };

--- a/embedded-poc/mfsk-app-shared/src/wifi.rs
+++ b/embedded-poc/mfsk-app-shared/src/wifi.rs
@@ -68,6 +68,16 @@ const CONNECT_MAX_ATTEMPTS: u32 = 4;
 /// file's previous, narrower 2000 ms, now that the retry itself also
 /// matches that implementation's shape.
 const CONNECT_RETRY_DELAY_MS: u32 = 3_000;
+/// Ceiling once the retry loop has backed off — see
+/// [`connect_with_retry`]'s doc comment for what the backoff is
+/// protecting.
+const CONNECT_RETRY_MAX_DELAY_MS: u32 = 60_000;
+/// Attempts to make at the fast [`CONNECT_RETRY_DELAY_MS`] cadence
+/// before backing off. Deliberately the same count as
+/// [`CONNECT_MAX_ATTEMPTS`]: that is the window the bisection above
+/// established as what actually fixes the AP's comeback-time
+/// coin-flip, and nothing here should shorten it.
+const CONNECT_FAST_ATTEMPTS: u32 = CONNECT_MAX_ATTEMPTS;
 
 /// Live WiFi STA handle. Drop ends the WiFi association (and any sockets
 /// bound on top stop receiving), so callers must keep this alive.
@@ -256,6 +266,34 @@ where
 /// being pulled in at two different (structurally identical but
 /// nominally distinct) versions via `embedded_svc` vs. this crate's
 /// own direct dependency.
+/// Delay before the next attempt: the established fast cadence for the
+/// first [`CONNECT_FAST_ATTEMPTS`], then doubling to
+/// [`CONNECT_RETRY_MAX_DELAY_MS`].
+///
+/// **Why back off at all, when the whole point of the unbounded mode is
+/// to keep trying**: a retry loop is not free to the rest of the
+/// device. Measured on the CoreS3 FST4 receiver (2026-08-22) against an
+/// AP that never associates, this loop at its fixed 3 s cadence cost
+/// the decoder **40% of its throughput** — `fst4_sync_search` went 711
+/// -> 1380 ms per candidate and the candidate loop 33 -> 54 s, covering
+/// 42 of 50 candidates instead of all 50. The WiFi driver's own task
+/// runs at FreeRTOS priority 23, above anything an application creates,
+/// so it preempts at will; the fix is to ask for the radio less often,
+/// not to ask for a different priority.
+///
+/// Backing off does not change what the unbounded mode promises — it
+/// still retries forever — only how often it interrupts the work the
+/// device exists to do.
+fn retry_delay_ms(attempt: u32) -> u32 {
+    if attempt <= CONNECT_FAST_ATTEMPTS {
+        return CONNECT_RETRY_DELAY_MS;
+    }
+    let steps = (attempt - CONNECT_FAST_ATTEMPTS).min(5);
+    CONNECT_RETRY_DELAY_MS
+        .saturating_mul(1u32 << steps)
+        .min(CONNECT_RETRY_MAX_DELAY_MS)
+}
+
 pub fn connect_with_retry(
     wifi: &mut BlockingWifi<EspWifi<'static>>,
     ssid: &str,
@@ -274,13 +312,22 @@ pub fn connect_with_retry(
     loop {
         attempt += 1;
         let outcome = (|| -> Result<()> {
-            let ap_infos = wifi.scan()?;
-            channel = ap_infos
-                .iter()
-                .find(|ap| ap.ssid.as_str() == ssid)
-                .map(|ap| ap.channel);
-            if channel.is_none() {
-                log::warn!("WiFi: SSID '{ssid}' not seen in scan; trying anyway");
+            // Re-scan only when there is something to learn: with the
+            // channel already known, a scan is pure cost — and an
+            // active scan is the most expensive thing in this loop,
+            // sweeping every channel with the radio and the driver
+            // task (FreeRTOS priority 23) preempting everything the
+            // application is doing. Every fifth attempt anyway, in
+            // case the AP moved.
+            if channel.is_none() || attempt % 5 == 0 {
+                let ap_infos = wifi.scan()?;
+                channel = ap_infos
+                    .iter()
+                    .find(|ap| ap.ssid.as_str() == ssid)
+                    .map(|ap| ap.channel);
+                if channel.is_none() {
+                    log::warn!("WiFi: SSID '{ssid}' not seen in scan; trying anyway");
+                }
             }
             wifi.set_configuration(&Configuration::Client(ClientConfiguration {
                 ssid: ssid
@@ -320,7 +367,7 @@ pub fn connect_with_retry(
                     None => true,
                 };
                 if keep_going {
-                    FreeRtos::delay_ms(CONNECT_RETRY_DELAY_MS);
+                    FreeRtos::delay_ms(retry_delay_ms(attempt));
                 } else {
                     break;
                 }

--- a/mfsk-core/src/engine/llr.rs
+++ b/mfsk-core/src/engine/llr.rs
@@ -536,6 +536,27 @@ pub fn compute_snr_db<P: Protocol>(cs: &[Cmplx<f32>], itone: &[u8]) -> f32 {
 /// to f32 at the boundary, so a `Cmplx<Q14i16>` cs gives a sane SNR
 /// without intermediate f32 quantisation.
 pub fn compute_snr_db_generic<P: Protocol, S: SpecScalar>(cs: &[Cmplx<S>], itone: &[u8]) -> f32 {
+    match snr_ratio::<P, S>(cs, itone) {
+        Some(ratio) => (10.0 * ratio.log10() - 27.0_f32).max(-24.0),
+        None => -24.0,
+    }
+}
+
+/// The scale-free half of [`compute_snr_db`]: `Σ|cs[k][itone[k]]|² /
+/// Σ|cs[k][opposite]|² − 1`, i.e. an estimate of S/N per tone bin.
+/// `None` when the noise reference is empty or the ratio is
+/// degenerate.
+///
+/// Split out because the dB tail is **not** shared across protocols
+/// while this part is: [`compute_snr_db`]'s `−27` is calibrated for
+/// FT8's per-tone bandwidth against WSJT-X's 2500 Hz reference, and
+/// FST4 has its own tail (see `fst4::baseline`). Both want the same
+/// ratio.
+///
+/// Being scale-free is the property that matters for a receiver
+/// without a whole-slot FFT: every term comes from the same `cs`, so
+/// any normalisation applied to the baseband upstream cancels.
+pub fn snr_ratio<P: Protocol, S: SpecScalar>(cs: &[Cmplx<S>], itone: &[u8]) -> Option<f32> {
     let ntones = P::NTONES as usize;
     let n_sym = P::N_SYMBOLS as usize;
     let mut xsig = 0.0f32;
@@ -547,13 +568,10 @@ pub fn compute_snr_db_generic<P: Protocol, S: SpecScalar>(cs: &[Cmplx<S>], itone
         xnoi += cs[k * ntones + (t + offset) % ntones].norm_sqr_f32();
     }
     if xnoi < f32::EPSILON {
-        return -24.0;
+        return None;
     }
     let ratio = xsig / xnoi - 1.0;
-    if ratio <= 0.001 {
-        return -24.0;
-    }
-    (10.0 * ratio.log10() - 27.0_f32).max(-24.0)
+    (ratio > 0.001).then_some(ratio)
 }
 
 /// Hard-decision sync quality — count sync symbols whose dominant tone

--- a/mfsk-core/src/engine/pipeline.rs
+++ b/mfsk-core/src/engine/pipeline.rs
@@ -436,6 +436,17 @@ pub struct SnrCtx<'a> {
     pub cs: &'a [Complex<f32>],
     /// [`encode_tones_for_snr`]`::<P>` output.
     pub itone: &'a [u8],
+    /// The refined baseband the symbol spectra were built from, and
+    /// its sample rate.
+    ///
+    /// FST4's DDC path is this pair's only reader: with no whole-slot
+    /// FFT to take a noise baseline from, it measures the noise in the
+    /// part of *this* buffer the signal does not occupy. Dead in any
+    /// build without `fst4`, like the two fields below.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
+    pub cd0: &'a [Complex<f32>],
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
+    pub ds_rate_hz: f32,
     /// Coarse-sync candidate score (`SyncCandidate::score`) — FT4's
     /// `candidate(2,icand)` equivalent.
     // FT4's `snr_db` override is this field's only reader, so a build
@@ -486,6 +497,17 @@ pub(crate) struct SnrCtx<'a> {
     pub cs: &'a [Complex<f32>],
     /// [`encode_tones_for_snr`]`::<P>` output.
     pub itone: &'a [u8],
+    /// The refined baseband the symbol spectra were built from, and
+    /// its sample rate.
+    ///
+    /// FST4's DDC path is this pair's only reader: with no whole-slot
+    /// FFT to take a noise baseline from, it measures the noise in the
+    /// part of *this* buffer the signal does not occupy. Dead in any
+    /// build without `fst4`, like the two fields below.
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
+    pub cd0: &'a [Complex<f32>],
+    #[cfg_attr(not(feature = "fst4"), allow(dead_code))]
+    pub ds_rate_hz: f32,
     /// Coarse-sync candidate score (`SyncCandidate::score`) — FT4's
     /// `candidate(2,icand)` equivalent.
     // FT4's `snr_db` override is this field's only reader, so a build
@@ -925,6 +947,8 @@ where
                     P::snr_db(SnrCtx {
                         cs,
                         itone: &itone,
+                        cd0: &cd0,
+                        ds_rate_hz: ds_rate,
                         cand_score: cand.score,
                         cand_freq_hz: cand.freq_hz,
                         fft_cache,
@@ -1068,6 +1092,8 @@ where
                             let snr_db = P::snr_db(SnrCtx {
                                 cs,
                                 itone: &itone,
+                                cd0: &cd0,
+                                ds_rate_hz: ds_rate,
                                 cand_score: cand.score,
                                 cand_freq_hz: cand.freq_hz,
                                 fft_cache,
@@ -1108,6 +1134,8 @@ where
                                 let snr_db = P::snr_db(SnrCtx {
                                     cs,
                                     itone: &itone,
+                                    cd0: &cd0,
+                                    ds_rate_hz: ds_rate,
                                     cand_score: cand.score,
                                     cand_freq_hz: cand.freq_hz,
                                     fft_cache,

--- a/mfsk-core/src/engine/sync.rs
+++ b/mfsk-core/src/engine/sync.rs
@@ -1035,7 +1035,13 @@ pub fn coarse_sync_from_sync2d<P: Protocol>(
 
     let pct = |xs: &[f32]| {
         let mut sorted = xs.to_vec();
-        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // `total_cmp`, not `partial_cmp().unwrap()`. A NaN reaching
+        // here is a bug upstream, but aborting the whole decoder is
+        // the wrong response to one: real hardware hit exactly this
+        // (CoreS3 FST4 receiver, 2026-08-22, second slot) and the
+        // process died. `total_cmp` sorts NaNs to one end and the
+        // percentile below carries on.
+        sorted.sort_by(f32::total_cmp);
         let pct_idx = (0.40 * n_freq as f32) as usize;
         sorted[pct_idx.min(n_freq - 1)].max(f32::EPSILON)
     };

--- a/mfsk-core/src/fst4/baseline.rs
+++ b/mfsk-core/src/fst4/baseline.rs
@@ -371,3 +371,147 @@ pub(crate) fn fst4_snr_db<P: crate::engine::Protocol>(
         WSJTX_INVALID_SENTINEL
     }
 }
+
+/// Welch segment length for [`fst4_ddc_snr_db`]. 512 bins across the
+/// refine baseband's 111.111 Hz gives 0.217 Hz resolution, and a
+/// 60 s FST4-60 baseband (6667 samples) yields 13 segments to average
+/// — enough that the noise percentile below is stable rather than
+/// reading one realisation's luck.
+const WELCH_N: usize = 512;
+
+/// SNR from the refined baseband alone — no whole-slot FFT, no symbol
+/// spectra, no decode (issue #307/#346).
+///
+/// **Why this exists when `fst4_snr_db_from_cs` already does not need
+/// the big FFT**: that one takes its noise reference from the
+/// non-signal tones of the signal's own comb, and a strong tone leaks
+/// into its neighbours. Measured on the FST4-60 golden, whose two
+/// signals are 25.4 dB apart, it reproduced only 11-14 dB of that
+/// separation regardless of which quantile of the off-tone bins was
+/// used as the reference (tried 1/4, 1/8, 1/16 — the quantile moved
+/// the offset and left the compression). A noise reference inside the
+/// signal's own comb cannot work.
+///
+/// This one takes it from **outside the signal's spectrum but inside
+/// the same buffer**. `wideband_refine_recenter` produces a 111.111 Hz
+/// baseband centred on the candidate, of which FST4-60's four tones
+/// occupy ~12 Hz — so ~90% of the band is signal-free and is measured
+/// in exactly the units the signal is measured in. Nothing has to be
+/// calibrated between two transforms, which is the trap the whole-slot
+/// formula's port fell into twice (see this module's own doc comment).
+///
+/// The arithmetic, with the baseband RMS-normalised upstream so its
+/// mean power is 1:
+///
+/// - `n0` = a low quantile of the Welch periodogram over the
+///   signal-free bins, i.e. noise power per bin;
+/// - `n0 * WELCH_N` = noise power across the whole refine band, so
+///   `1 / (n0 * WELCH_N) - 1` = S/N in that band;
+/// - referring to WSJT-X's 2500 Hz convention costs
+///   `10*log10(111.111 / 2500)`.
+///
+/// Returns `None` when the band looks like noise alone.
+pub(crate) fn fst4_ddc_snr_db<P: crate::engine::Protocol>(
+    cd0: &[Complex<f32>],
+    ds_rate_hz: f32,
+) -> Option<f32> {
+    if cd0.len() < WELCH_N {
+        return None;
+    }
+    let mut planner = crate::engine::fft::default_planner();
+    let fft = planner.plan_forward(WELCH_N);
+
+    // Blackman-Harris, not the rectangular window a plain slice
+    // implies. A rectangular window's sidelobes fall off as 1/f² from
+    // -13 dB,
+    // which on this measurement means a strong signal's own spectrum
+    // sitting on top of the noise floor being measured beside it —
+    // observed directly: with no window the FST4-60 golden's +16.8 dB
+    // signal read 10.3 dB, its floor overestimated ~4.5x, while the
+    // -8.6 dB one was already within 1 dB.
+    let window: Vec<f32> = (0..WELCH_N)
+        .map(|n| {
+            let x = core::f32::consts::TAU * n as f32 / WELCH_N as f32;
+            0.35875 - 0.48829 * x.cos() + 0.14128 * (2.0 * x).cos() - 0.01168 * (3.0 * x).cos()
+        })
+        .collect();
+    // The window's mean square, so the periodogram still reads noise
+    // *power* per bin rather than a windowed fraction of it.
+    let win_power = 0.258_0_f32;
+
+    let mut acc = vec![0.0f32; WELCH_N];
+    let mut buf = vec![Complex::new(0.0f32, 0.0); WELCH_N];
+    let nseg = cd0.len() / WELCH_N;
+    for seg in 0..nseg {
+        for (b, (c, w)) in buf
+            .iter_mut()
+            .zip(cd0[seg * WELCH_N..(seg + 1) * WELCH_N].iter().zip(&window))
+        {
+            *b = c * *w;
+        }
+        fft.process(&mut buf);
+        for (a, c) in acc.iter_mut().zip(buf.iter()) {
+            *a += c.norm_sqr();
+        }
+    }
+    // Normalise so the mean over bins equals the baseband's own mean
+    // power — that is what makes `n0 * WELCH_N` a share of the total
+    // and lets the caller's RMS normalisation cancel out.
+    let norm = 1.0 / (nseg as f32 * WELCH_N as f32 * WELCH_N as f32 * win_power);
+    for a in acc.iter_mut() {
+        *a *= norm;
+    }
+
+    // Exclude the signal. The tones run from the candidate frequency
+    // (bin 0 after recentring) upward, so the occupied span is
+    // `NTONES * TONE_SPACING_HZ`; the guard either side covers GFSK
+    // shaping and the fine-frequency offset the sync search has not
+    // applied here.
+    let hz_per_bin = ds_rate_hz / WELCH_N as f32;
+    let guard_hz = P::TONE_SPACING_HZ * 2.0;
+    let hi_bin = ((P::TONE_SPACING_HZ * P::NTONES as f32 + guard_hz) / hz_per_bin) as usize;
+    let lo_bin = WELCH_N - (guard_hz / hz_per_bin) as usize;
+
+    let mut noise: Vec<f32> = acc
+        .iter()
+        .enumerate()
+        .filter(|(k, _)| *k > hi_bin && *k < lo_bin)
+        .map(|(_, &p)| p)
+        .collect();
+    if noise.len() < WELCH_N / 4 {
+        return None;
+    }
+    noise.sort_by(|a, b| a.partial_cmp(b).unwrap_or(core::cmp::Ordering::Equal));
+    // Median, not a mean: this reference is outside the signal, but
+    // "outside" is not "clean" — another station inside the same
+    // 111 Hz refine band would land in these bins, and a median
+    // ignores it where a mean would not.
+    //
+    // The median of a Welch periodogram is **not** the noise power,
+    // and the correction depends on how many segments were averaged:
+    // each bin is chi-squared with `2 * nseg` degrees of freedom, whose
+    // median/mean ratio is `(1 - 1/(9 * nseg))³` (Wilson-Hilferty).
+    // Getting this wrong is not subtle — using the single-periodogram
+    // factor `ln 2` here inflated the floor by 1.4x, which is more than
+    // the entire signal-to-noise ratio of a threshold FST4 signal in
+    // this band (-13.5 dB in 111 Hz at -27 dB in 2500 Hz), so every
+    // corpus trial came back "no signal" while the two strong signals
+    // of the golden still looked fine.
+    let median_over_mean = {
+        let c = 1.0 - 1.0 / (9.0 * nseg as f32);
+        c * c * c
+    };
+    let n0 = noise[noise.len() / 2] / median_over_mean;
+    // NaN-safe: a floor that is not a positive number means the band
+    // held nothing measurable.
+    if n0.partial_cmp(&0.0) != Some(core::cmp::Ordering::Greater) {
+        return None;
+    }
+
+    let mean_power = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len() as f32;
+    let snr_band = mean_power / (n0 * WELCH_N as f32) - 1.0;
+    if snr_band <= 0.0 {
+        return None;
+    }
+    Some(10.0 * snr_band.log10() + 10.0 * (ds_rate_hz / 2500.0).log10())
+}

--- a/mfsk-core/src/fst4/decode.rs
+++ b/mfsk-core/src/fst4/decode.rs
@@ -143,6 +143,20 @@ macro_rules! impl_frame_decodable {
             /// scale-convention mismatch) it took to land within ~1-2
             /// dB of jt9's own reported SNR (issue #255).
             fn snr_db(ctx: pipeline::SnrCtx<'_>) -> f32 {
+                if ctx.fft_cache.is_empty() {
+                    // A DDC receiver: no whole-slot FFT exists, by
+                    // design (`fst4::ddc`), so WSJT-X's own formula has
+                    // no inputs. Measure the noise outside the signal's
+                    // own spectrum in the refined baseband instead —
+                    // see `fst4_ddc_snr_db`, and its doc comment for
+                    // why the symbol spectra cannot supply that
+                    // reference themselves.
+                    return crate::fst4::baseline::fst4_ddc_snr_db::<$proto>(
+                        ctx.cd0,
+                        ctx.ds_rate_hz,
+                    )
+                    .unwrap_or(-99.9);
+                }
                 crate::fst4::baseline::fst4_snr_db::<$proto>(
                     ctx.itone,
                     ctx.cand_freq_hz,

--- a/mfsk-core/src/fst4/mod.rs
+++ b/mfsk-core/src/fst4/mod.rs
@@ -153,6 +153,7 @@ macro_rules! fst4_submode {
             /// from anything else — see the `fst4_submode!` invocation
             /// below for this sub-mode's literal.
             pub(crate) const SNR_CALFAC: f32 = $snr_calfac;
+
         }
 
         impl ModulationParams for $name {

--- a/mfsk-core/src/fst4/rung_major.rs
+++ b/mfsk-core/src/fst4/rung_major.rs
@@ -198,12 +198,12 @@ pub enum Schedule {
 /// list.
 ///
 /// Returns one slot per input candidate, `Some` for the ones that
-/// decoded. `DecodeResult::snr_db`/`sync_cv` are not computed here (NaN
-/// / 0.0 placeholders) — same convention `process_candidate_precomputed`
-/// establishes for its own `skip_snr` flag: this function answers the
-/// wall-clock/scheduling question, not the SNR-reporting one. Callers
-/// that need real SNR should re-derive it from the returned candidate
-/// positions the way `process_candidate_basic` already does.
+/// decoded. `DecodeResult::sync_cv` is left at `0.0` — this function
+/// answers the wall-clock/scheduling question, and no caller of it has
+/// wanted that field. `snr_db` *is* filled in, from the refined
+/// baseband alone (`fst4::baseline::fst4_ddc_snr_db`); it used to be
+/// `NaN` here only because the estimator that existed needed a
+/// whole-slot FFT no caller of this function has.
 pub fn decode_rung_major<P>(
     candidates: &[RungMajorCandidate],
     skip_llrc: bool,
@@ -400,7 +400,15 @@ where
             sync_score: input.cand.score,
             pass,
             sync_cv: 0.0,
-            snr_db: f32::NAN,
+            // Measurable here after all, and cheap: the refined
+            // baseband this candidate already holds is 111 Hz wide
+            // where the signal occupies ~12, so the noise can be read
+            // straight out of the rest of it — see
+            // `fst4::baseline::fst4_ddc_snr_db`. Was `NaN` because the
+            // only estimator that existed needed a whole-slot FFT this
+            // path never has.
+            snr_db: crate::fst4::baseline::fst4_ddc_snr_db::<P>(&input.cd0, ds_rate)
+                .unwrap_or(f32::NAN),
         }
     }
 

--- a/mfsk-core/src/ft4/decode.rs
+++ b/mfsk-core/src/ft4/decode.rs
@@ -243,6 +243,8 @@ mod tests {
             let via_trait = <Ft4 as pipeline::GenericPipelineProtocol>::snr_db(pipeline::SnrCtx {
                 cs: &cs,
                 itone: &itone,
+                cd0: &[],
+                ds_rate_hz: 0.0,
                 cand_score,
                 cand_freq_hz: 1000.0,
                 fft_cache: &fft_cache,

--- a/mfsk-core/src/msg/pipeline_ap.rs
+++ b/mfsk-core/src/msg/pipeline_ap.rs
@@ -215,7 +215,7 @@ where
                 if let Some(r) = fec.decode_soft($llr, &bp_opts)
                     && let Some(res) = finalise_result::<P>(
                         &r, cand, &refined, sync_cv, $pass_id, cs_ref, None, &fec, fft_cache,
-                        ds_cfg, i_start,
+                        ds_cfg, i_start, &cd0, ds_rate,
                     )
                 {
                     return Some(res);
@@ -272,6 +272,8 @@ where
                             fft_cache,
                             ds_cfg,
                             i_start,
+                            &cd0,
+                            ds_rate,
                         )
                     {
                         return Some(res);
@@ -304,6 +306,8 @@ where
                                     fft_cache,
                                     ds_cfg,
                                     i_start,
+                                    &cd0,
+                                    ds_rate,
                                 )
                             {
                                 return Some(res);
@@ -330,6 +334,8 @@ fn finalise_result<P: GenericPipelineProtocol>(
     fft_cache: &[Complex<f32>],
     ds_cfg: &DownsampleCfg,
     i_start: i32,
+    cd0: &[Complex<f32>],
+    ds_rate: f32,
 ) -> Option<DecodeResult>
 where
     P::Fec: crate::engine::protocol::BpPooledFec,
@@ -375,6 +381,8 @@ where
     let snr_db = P::snr_db(SnrCtx {
         cs,
         itone: &itone,
+        cd0,
+        ds_rate_hz: ds_rate,
         cand_score: cand.score,
         cand_freq_hz: cand.freq_hz,
         fft_cache,

--- a/mfsk-core/tests/fst4_ddc_snr_calibration.rs
+++ b/mfsk-core/tests/fst4_ddc_snr_calibration.rs
@@ -1,0 +1,320 @@
+//! What SNR can a DDC receiver report, and how close is it to the one
+//! WSJT-X's own formula gives? — issue #307/#346.
+//!
+//! FST4's shipped SNR estimate (`fst4::baseline::fst4_snr_db`) reads
+//! its noise baseline and its unnormalised signal power out of the
+//! whole-slot forward FFT. A DDC front end never computes that FFT —
+//! not computing it is the entire reason the front end exists — so on
+//! the wideband monitor path the field came back `NaN` and the receiver
+//! app had nothing to show.
+//!
+//! `fst4_snr_db_from_cs` estimates it from the symbol spectra the
+//! decoder already built instead. This test is what says whether that
+//! estimate is worth showing: it decodes the same recording twice, once
+//! through each path, and compares them signal by signal.
+//!
+//! Two tests, and the second is the one that carries the weight: the
+//! golden has two signals, while `fst4_ddc_snr_vs_nominal` runs the
+//! estimator against a corpus whose SNR is **known by construction**
+//! across the range a weak-signal monitor operates in.
+//!
+//! Measured (2026-08-22). Against `fst4sim`'s nominal, AWGN:
+//!
+//! | nominal | n | mean | bias | sd |
+//! |---:|---:|---:|---:|---:|
+//! | -20 | 20 | -20.0 | +0.0 | 0.44 |
+//! | -22 | 20 | -21.9 | +0.1 | 0.66 |
+//! | -24 | 20 | -23.7 | +0.3 | 0.94 |
+//! | -26 | 20 | -25.4 | +0.6 | 1.41 |
+//! | -27 | 17 | -26.0 | +1.0 | 1.70 |
+//! | -28 |  7 | -27.9 | +0.1 | 2.41 |
+//!
+//! The small positive bias at the weakest cells is selection: only
+//! decoded trials can be measured, and a lucky-high realisation decodes
+//! more often than a lucky-low one.
+//!
+//! And against the real recording, where `jt9` itself is the ground
+//! truth (probed values from issue #255, recorded in
+//! `fst4::baseline`'s own doc comment):
+//!
+//! | signal | jt9 | production (whole-slot FFT) | DDC |
+//! |---|---:|---:|---:|
+//! | N5TM | -6.90 | -8.61 | **-5.7** |
+//! | K9KFR | 16.14 | 16.82 | **15.7** |
+//!
+//! On both signals the DDC estimate is *closer to jt9* than the
+//! shipped whole-slot formula is. That is not a claim that it is
+//! better in general — two signals — but it does say the DDC path is
+//! not the poor relation here.
+
+#![cfg(all(feature = "fst4", any(feature = "fft-rustfft", feature = "fft-extern")))]
+
+use std::path::PathBuf;
+
+use num_complex::Complex;
+
+#[allow(dead_code)]
+mod common;
+use common::load_wav_i16_opt;
+
+use mfsk_core::engine::dsp::ddc::StreamingComplexDdc;
+use mfsk_core::engine::equalize::EqMode;
+use mfsk_core::engine::pipeline::{DecodeDepth, DecodeStrictness, process_candidate_precomputed};
+use mfsk_core::engine::sync::{AudioSource, RxGrid, SyncCandidate, coarse_sync};
+use mfsk_core::engine::sync2d::fst4_sync_search;
+use mfsk_core::fst4::Fst4s60;
+use mfsk_core::fst4::ddc::{
+    REFINE_DS_RATE_HZ, grid_for, wideband_cascade, wideband_refine_recenter,
+};
+use mfsk_core::fst4::decode::FST4_60A_DOWNSAMPLE;
+use mfsk_core::msg::decode_request::DecodeRequest;
+use mfsk_core::msg::wsjt77::unpack77;
+
+const CENTER_HZ: f32 = 1550.0;
+const HALF: f32 = 1450.0;
+const SYNC_MIN: f32 = 0.8;
+const MAX_CAND: usize = 50;
+const SYNC_Q_MIN: u32 = 16;
+
+fn sample_path() -> Option<PathBuf> {
+    common::corpus::golden_path_or_upstream(
+        "fst4/210115_0058.wav",
+        Some("FST4+FST4W/210115_0058.wav"),
+    )
+}
+
+fn msg_of(m: &[u8]) -> Option<String> {
+    m.try_into().ok().and_then(|a: &[u8; 77]| unpack77(a))
+}
+
+/// Mirrors `embedded_shared::fst4_monitor::ddc_refine`.
+fn ddc_refine(c: &SyncCandidate, ci: &[f32], cq: &[f32], d: usize) -> Vec<Complex<f32>> {
+    let mut r = wideband_refine_recenter(c.freq_hz, CENTER_HZ);
+    let (mut a, mut b) = (Vec::new(), Vec::new());
+    r.push(ci, cq, &mut a, &mut b);
+    r.flush(&mut a, &mut b);
+    let t = ((d as f32 * REFINE_DS_RATE_HZ / 12_000.0).round() as usize
+        + r.group_delay_output_samples())
+    .min(a.len());
+    let mut cd0: Vec<Complex<f32>> = a[t..]
+        .iter()
+        .zip(b[t..].iter())
+        .map(|(&i, &q)| Complex::new(i, q))
+        .collect();
+    let s2: f32 = cd0.iter().map(|c| c.norm_sqr()).sum::<f32>() / cd0.len().max(1) as f32;
+    if s2 > f32::EPSILON {
+        let inv = 1.0 / s2.sqrt();
+        for c in cd0.iter_mut() {
+            *c *= inv;
+        }
+    }
+    cd0
+}
+
+/// Every distinct message the wideband DDC monitor path decodes, with
+/// the SNR it reports for it.
+fn ddc_decodes(audio: &[i16]) -> Vec<(String, f32)> {
+    let cfg = wideband_cascade(CENTER_HZ);
+    let mut ddc = StreamingComplexDdc::new(&cfg);
+    let (mut ci, mut cq) = (Vec::new(), Vec::new());
+    ddc.push_i16(audio, &mut ci, &mut cq);
+    ddc.flush(&mut ci, &mut cq);
+    let delay = ddc.group_delay_input_samples();
+    let grid = grid_for(2900.0);
+    let cands = coarse_sync::<Fst4s60>(
+        AudioSource::Complex(&ci, &cq),
+        CENTER_HZ - HALF,
+        CENTER_HZ + HALF,
+        SYNC_MIN,
+        None,
+        MAX_CAND,
+        RxGrid::complex(grid.fs_c, CENTER_HZ),
+    );
+
+    let mut out: Vec<(String, f32)> = Vec::new();
+    for c in &cands {
+        let cd0 = ddc_refine(c, &ci, &cq, delay);
+        let s2 = fst4_sync_search::<Fst4s60>(&cd0, c);
+        let pre = (cd0, s2.freq_hz, s2.i0, s2.score);
+        // `fft_cache = &[]` and `skip_snr = false`: exactly what the
+        // embedded monitor now passes, which is what routes FST4's
+        // `snr_db` override to the no-whole-slot-FFT estimator.
+        let Some(r) = process_candidate_precomputed::<Fst4s60>(
+            c,
+            &[],
+            &FST4_60A_DOWNSAMPLE,
+            DecodeDepth::FULL,
+            DecodeStrictness::Normal,
+            &[],
+            EqMode::Off,
+            SYNC_Q_MIN,
+            pre,
+            false,
+            false,
+        ) else {
+            continue;
+        };
+        let Some(text) = msg_of(r.message77()) else {
+            continue;
+        };
+        if !out.iter().any(|(m, _)| m == &text) {
+            out.push((text, r.snr_db));
+        }
+    }
+    out
+}
+
+#[test]
+fn fst4_ddc_snr_calibration() {
+    let Some(path) = sample_path() else {
+        if std::env::var("MFSK_REQUIRE_CORPUS").is_ok() {
+            panic!("MFSK_REQUIRE_CORPUS set but fst4/210115_0058.wav is absent");
+        }
+        eprintln!("fst4/210115_0058.wav absent — skipping");
+        return;
+    };
+    let audio = load_wav_i16_opt(&path).expect("golden WAV readable");
+
+    let production: Vec<(String, f32)> =
+        DecodeRequest::<Fst4s60>::new(&audio, 100.0, 3000.0, SYNC_MIN, MAX_CAND)
+            .decode()
+            .results
+            .iter()
+            .filter_map(|r| msg_of(r.message77()).map(|m| (m, r.snr_db)))
+            .collect();
+    let ddc = ddc_decodes(&audio);
+
+    eprintln!("\nFST4-60 golden — SNR by path");
+    eprintln!(
+        "  {:<24} {:>12} {:>12} {:>8}",
+        "message", "production", "DDC", "delta"
+    );
+    let mut deltas: Vec<f32> = Vec::new();
+    for (msg, prod_snr) in &production {
+        let Some((_, ddc_snr)) = ddc.iter().find(|(m, _)| m == msg) else {
+            eprintln!("  {msg:<24} {prod_snr:>12.1} {:>12}", "(not decoded)");
+            continue;
+        };
+        eprintln!(
+            "  {msg:<24} {prod_snr:>12.1} {ddc_snr:>12.1} {:>8.1}",
+            ddc_snr - prod_snr
+        );
+        assert!(
+            ddc_snr.is_finite(),
+            "{msg}: DDC path reported a non-finite SNR — the whole point of \
+             `fst4_snr_db_from_cs` is that this path has a number to report"
+        );
+        deltas.push(ddc_snr - prod_snr);
+    }
+    assert!(
+        deltas.len() >= 2,
+        "need at least two signals to say anything about the estimator's slope; got {}",
+        deltas.len()
+    );
+
+    let mean = deltas.iter().sum::<f32>() / deltas.len() as f32;
+    let spread = deltas.iter().cloned().fold(f32::MIN, f32::max)
+        - deltas.iter().cloned().fold(f32::MAX, f32::min);
+    eprintln!("  mean delta {mean:+.2} dB, spread {spread:.2} dB");
+    eprintln!(
+        "  (mean is what `SNR_CS_OFFSET_DB` absorbs; spread is what says the estimator tracks)"
+    );
+
+    assert!(
+        spread <= 4.0,
+        "DDC SNR does not track the production estimate: {spread:.1} dB of spread across \
+         signals means no constant offset can line the two up"
+    );
+    assert!(
+        mean.abs() <= 2.0,
+        "DDC SNR is offset from the production estimate by {mean:+.1} dB"
+    );
+
+    // `jt9` itself, on this recording — the values issue #255 probed a
+    // real WSJT-X build for. The production estimator sits 0.7-1.7 dB
+    // from these; anything in that neighbourhood is doing as well as
+    // the thing it stands in for.
+    for (msg, jt9) in [("CQ N5TM EL29", -6.90f32), ("CQ K9KFR EN71", 16.14)] {
+        let Some((_, ddc_snr)) = ddc.iter().find(|(m, _)| m == msg) else {
+            panic!("{msg} did not decode on the DDC path");
+        };
+        let err = ddc_snr - jt9;
+        eprintln!("  vs jt9: {msg:<24} {jt9:>+6.2} -> {ddc_snr:>+6.2} ({err:+.2} dB)");
+        assert!(
+            err.abs() <= 3.0,
+            "{msg}: DDC SNR {ddc_snr:+.1} is {err:+.1} dB from jt9's own {jt9:+.1}"
+        );
+    }
+}
+
+/// The golden above is two signals. This is the same estimator against
+/// a corpus whose SNR is **known by construction** — `fst4sim`'s own
+/// nominal dB, in the same 2500 Hz reference the estimator reports in —
+/// across the range a weak-signal monitor actually operates in.
+///
+/// Tier C, needs the generated corpus:
+///
+/// ```sh
+/// scripts/build_fst4sim.sh && scripts/gen_fst4_sweep_wavs.sh
+/// cargo test -p mfsk-core --features full,internal-testing --release \
+///   --test fst4_ddc_snr_calibration fst4_ddc_snr_vs_nominal -- --ignored --nocapture
+/// ```
+#[test]
+#[ignore = "tier C — needs the fst4_60_awgn_* sweep corpus; run with --ignored --nocapture"]
+fn fst4_ddc_snr_vs_nominal() {
+    const GOLDEN_MSG: &str = "CQ JL1NIE PM95";
+    const TRIALS: usize = 20;
+
+    let manifest = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_default();
+    let dir = std::path::Path::new(&manifest).join("../embedded-poc/assets/fst4_sweep");
+
+    eprintln!("\nFST4-60 AWGN — DDC SNR estimate vs fst4sim's nominal");
+    eprintln!(
+        "  {:>8} {:>5} {:>10} {:>8} {:>8}",
+        "nominal", "n", "mean", "bias", "sd"
+    );
+    let mut all_bias: Vec<f32> = Vec::new();
+    for nominal in [-20i32, -22, -24, -26, -27, -28] {
+        let mut snrs: Vec<f32> = Vec::new();
+        for trial in 1..=TRIALS {
+            let path = dir.join(format!("fst4_60_awgn_m{:02}_{trial:02}.wav", -nominal));
+            let Some(audio) = load_wav_i16_opt(&path) else {
+                continue;
+            };
+            if let Some((_, snr)) = ddc_decodes(&audio)
+                .into_iter()
+                .find(|(m, _)| m == GOLDEN_MSG)
+                && snr.is_finite()
+            {
+                snrs.push(snr);
+            }
+        }
+        if snrs.is_empty() {
+            eprintln!("  {nominal:>8} {:>5} {:>10}", 0, "(no decode)");
+            continue;
+        }
+        let n = snrs.len() as f32;
+        let mean = snrs.iter().sum::<f32>() / n;
+        let sd = (snrs.iter().map(|s| (s - mean).powi(2)).sum::<f32>() / n).sqrt();
+        let bias = mean - nominal as f32;
+        eprintln!(
+            "  {nominal:>8} {:>5} {mean:>10.1} {bias:>+8.1} {sd:>8.2}",
+            snrs.len()
+        );
+        all_bias.push(bias);
+    }
+
+    assert!(
+        all_bias.len() >= 3,
+        "corpus too sparse to say anything: {} cells produced decodes",
+        all_bias.len()
+    );
+    let spread = all_bias.iter().cloned().fold(f32::MIN, f32::max)
+        - all_bias.iter().cloned().fold(f32::MAX, f32::min);
+    let mean_bias = all_bias.iter().sum::<f32>() / all_bias.len() as f32;
+    eprintln!("  mean bias {mean_bias:+.2} dB, bias spread {spread:.2} dB across cells");
+    assert!(
+        spread <= 3.0,
+        "the estimate does not track nominal SNR: bias varies {spread:.1} dB across cells"
+    );
+}


### PR DESCRIPTION
Two things the FST4 receiver app needed, in the order they were asked for.

## 1. The decode was losing 40% — to the radio, not to its own capture

The app runs the candidate loop in 52 s where the bench runs it in 33 s, and the front end in 16 s where the bench takes 5.9 s. The obvious reading — they now run concurrently and contend for PSRAM bandwidth — was mine, and it is wrong.

Eliminated, in order:

- **Capture concurrency.** With the capture task idled after one slot (`MFSK_FST4_APP_CAPTURE_SLOTS=1`), the loop is *still* 52 s.
- **A general slowdown.** The dual-core split is perfectly balanced (21/42 from the worker) and the coarse-search fill runs at exactly bench speed (714 ms vs 714 ms).
- **Baseband alignment.** It differs between the two binaries (4 B vs 8 B) and is unchanged in the fast case below.

Splitting per-candidate cost localised it to `fst4_sync_search` — 1380 ms/candidate against the bench's ~430. Then, with the radio off (`MFSK_FST4_APP_NO_WIFI=1`):

| | WiFi churning | radio off |
|---|---:|---:|
| candidate loop | 53.7 s | **33.3 s** |
| candidates covered | 48/50 | **50/50** |
| `fst4_sync_search` | 1395 ms/cand | **711 ms/cand** |
| polyphase recentre | 596 ms/cand | **353 ms/cand** |
| first decode, post-slot | 2759 ms | **2154 ms** |

The WiFi driver's task runs at FreeRTOS priority 23, above anything an application creates, so while it is trying to associate it preempts the decode at will. The AP was unreachable for these runs — the pathological case, and not one the caller's retry cadence controls: a single `connect()` holds the radio for the whole `ESP_ERR_TIMEOUT` window.

Two mitigations, **neither yet verified on hardware** (the board dropped off USB mid-measurement and needs re-attaching):

- `wifi::connect_with_retry` backs off after its established four fast attempts, doubling to a 60 s ceiling, and stops re-scanning once it knows the channel. The four fast attempts are untouched — that window is what `wifi.rs`'s own bisection established as the fix for the AP comeback-time coin-flip.
- The FST4 app runs *bounded* association campaigns instead of unbounded retry, leaving the radio alone for three minutes between them.

Plus the telemetry this needed: per-candidate cost split into recentre / sync-search / decode, and the baseband's address and alignment logged.

## 2. SNR, where there is no whole-slot FFT to take it from

FST4's shipped estimate reads its noise baseline *and* its signal power out of the big forward FFT of the raw slot. A DDC receiver never computes that FFT — not computing it is the entire reason the front end exists — so `snr_db` was `NaN` and the app showed `--`.

`fst4_ddc_snr_db` measures the noise **outside the signal's spectrum but inside the same buffer**: the refined baseband is 111.111 Hz wide and FST4-60's four tones occupy ~12 Hz of it. Welch periodogram, Blackman-Harris windowed, median of the signal-free bins as the floor. Every term comes from one buffer, so the pipeline's RMS normalisation cancels and nothing needs calibrating between two transforms — the trap the whole-slot formula's port fell into twice (#255). It needs no decode, so the capped rung-major arm gets a number too.

Against a corpus whose SNR is **known by construction**:

| nominal | n | mean | bias | sd |
|---:|---:|---:|---:|---:|
| −20 | 20 | −20.0 | +0.0 | 0.44 |
| −22 | 20 | −21.9 | +0.1 | 0.66 |
| −24 | 20 | −23.7 | +0.3 | 0.94 |
| −26 | 20 | −25.4 | +0.6 | 1.41 |
| −27 | 17 | −26.0 | +1.0 | 1.70 |
| −28 |  7 | −27.9 | +0.1 | 2.41 |

**1.0 dB of bias spread across the whole threshold range.** The positive bias at the weakest cells is selection — only decoded trials can be measured.

On the real recording, against `jt9`'s own probed values:

| signal | jt9 | production (whole-slot FFT) | DDC |
|---|---:|---:|---:|
| N5TM | −6.90 | −8.61 | **−5.71** |
| K9KFR | 16.14 | 16.82 | **15.74** |

Closer to jt9 than the whole-slot formula on both.

### Two things measured and discarded

Recorded because they look reasonable and are not:

- **A noise reference inside the signal's own comb cannot work.** The obvious estimator — signal tones against the other tones of the same symbol, which is what `compute_snr_db` does for FT8, scale-free and free — reproduced only 11–14 dB of the golden's 25.4 dB separation: a strong tone leaks into its comb neighbours and inflates the very quantity used as noise. Tried the 1/4, 1/8 and 1/16 quantiles; the quantile moved the offset and left the compression.
- **The median of a Welch periodogram is not the noise power**, and the correction depends on the segment count — chi-squared with `2·nseg` dof, median/mean `(1 − 1/(9·nseg))³`. Using the single-periodogram factor `ln 2` inflated the floor by 1.4×, more than a threshold FST4 signal's entire ratio in this band, so every corpus trial came back "no signal" **while the golden's two strong signals still looked fine**. A test on strong signals alone would have shipped it.

## Host

670 tests pass, including with `-C debug-assertions=on`.

Refs #307, #327, #255, #163.