### PR TITLE
docs(ft8): correct the decode_block module doc and the Goertzel phase claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,44 @@ cadence".
 
 ### Changed
 
+- **`ft8::decode_block`'s module doc described a decoder that no
+  longer exists.** It claimed an 8192-pt spectrogram FFT with a
+  `≈ 1.465 Hz` bin width, Costas tone positions "computed at
+  fractional bins and rounded to the nearest integer", and a
+  resulting `≤ 0.7 Hz` alignment jitter. All of that predates the
+  move to `NFFT_SPEC = 3840 = 2 × NSPS` (WSJT-X `sync8.f90`'s own
+  `NFFT1`), where `tone_step_bins` is **2.0 exactly** and there is no
+  fractional-bin rounding or Hann window left to compensate. Rewritten
+  to say what the module actually does, and to state why the embedded
+  path runs two different frequency analyses rather than reusing one:
+  the 3840-pt spectrogram is the *search* grid (`coarse_sync` wants
+  every bin, so an FFT is the right shape), while
+  `fill_symbol_spectra_goertzel` is the *extraction* step at each
+  candidate's own continuous `(freq_hz, dt_sec)`, where only 8 of 1920
+  bins are wanted. The spectrogram cannot stand in for the second:
+  its time grid is quantised to `NSTEP`, its frequency grid to
+  `3.125 Hz`, and under `fixed-point` it stores `u16` magnitude-squared
+  with the phase already gone.
+
+- **The generalised-Goertzel phase rotation is documented as measured,
+  not as "irrelevant".** 0.6.4's CHANGELOG entry justified the
+  rotation with "FT8 downstream consumes `|cs|²`", which is true of
+  the shipping embedded configuration and not of the decoder as a
+  whole — `engine::llr::build_group_amplitudes` sums complex cells
+  across a symbol group and only then takes a magnitude, so the
+  `nsym ≥ 2` LLRs (llrb / llrc) do see phase.
+  `fill_symbol_spectra_goertzel` now carries a "Phase convention"
+  section with the measurement: the factor is `exp(jω(N-1))`,
+  magnitudes agree to `7.3e-5`, and since `NSPS × 6.25 / 12000 = 1`
+  exactly, the `exp(jωN)` half is common to every tone, leaving a
+  `-0.1875°`-per-tone-step tilt (`1.3°` across the tone axis) as the
+  only tone-dependent term. Below the channel's own phase error and
+  never observed to move a golden test, but not zero — and
+  `DecodeDepth::EMBEDDED` (`LlrEffort::Minimal`) stops at `nsym = 1`,
+  so it does not reach that path at all. The 0.6.4 entry in
+  `docs/historical/CHANGELOG-0.6-0.7.md` gains a correction note
+  rather than a rewrite.
+
 - **`CLAUDE.md` describes the codebase, not just the workflow.** The
   agent notes had accumulated procedure — how to run the tests, how to
   cut a release — without ever saying what the repository *is*: the

--- a/docs/historical/CHANGELOG-0.6-0.7.md
+++ b/docs/historical/CHANGELOG-0.6-0.7.md
@@ -578,6 +578,23 @@ consumes `|cs|²` so the rotation is irrelevant. **Zero caller-
 provided scratch**, +0.16..+0.63 dB SNR improvement (f32 Goertzel
 has more precision than the pre-existing Q15 BASIS dot product).
 
+> **Correction (2026-08-28).** "FT8 downstream consumes `|cs|²` so
+> the rotation is irrelevant" describes the shipping embedded
+> configuration, not the whole decoder. It holds exactly for
+> `sync_quality`, the `xsnr2` / `snr_ratio` estimators and the
+> `nsym = 1` LLRs (llra / llrd) — which is everything
+> `DecodeDepth::EMBEDDED` (`LlrEffort::Minimal`) reaches. It does
+> not hold for the `nsym ≥ 2` LLRs (llrb / llrc): `engine::llr::
+> build_group_amplitudes` sums complex cells across a symbol group
+> and only then takes a magnitude, so a phase difference does reach
+> that path. Measured, the factor is `exp(jω(N-1))` — magnitudes
+> agree to `7.3e-5`, and because `NSPS × 6.25 / 12000 = 1` exactly
+> the `exp(jωN)` half is common to all eight tones, leaving a
+> `-0.1875°`-per-tone-step tilt (`1.3°` across the tone axis) as the
+> only tone-dependent term. Small enough that no golden test has
+> ever moved on it, but not zero. See
+> `fill_symbol_spectra_goertzel`'s "Phase convention" doc section.
+
 The 120 KB internal-DRAM win unblocks downstream embedded work that
 couldn't fit alongside BASIS — most immediately, M5StickS3 Qso-mode
 I2S bidirectional DMA descriptor allocation (`i2s_alloc_dma_desc:

--- a/mfsk-core/src/ft8/decode_block.rs
+++ b/mfsk-core/src/ft8/decode_block.rs
@@ -1,18 +1,46 @@
-//! Embedded-friendly FT8 decode (esp-dsp pow-of-2 FFT only).
+//! Embedded-friendly FT8 decode (no 192 k FFT cache, no cd0 chain).
 //!
-//! Mirrors the host `decode_frame` pipeline but skips the 192_000-pt
-//! wide-band FFT cache and the 3_840-pt per-symbol FFT — both of
-//! which are non-power-of-two. Uses an 8192-pt per-symbol FFT for
-//! the spectrogram (1920-sample input zero-padded) and a brute-force
-//! per-tone DFT for the per-candidate LLR pass. Calls `bp_decode_kind`
-//! with `BpKind::NormalizedMinSum` so the BP step skips the
-//! `tanh`/`atanh` cache.
+//! Mirrors the host `decode_frame` pipeline but skips the whole
+//! `ft8b.f90:154-161` route the host takes to build a candidate's
+//! symbol spectra — 192_000-pt wide-band FFT → tapered LPF →
+//! 3_200-pt inverse FFT to a 200 sps `cd0` baseband → per-symbol
+//! 32-pt FFT. Neither 192_000 nor 3_200 is a power of two, so
+//! neither fits esp-dsp's radix-2 kernels, and a 192 k complex FFT
+//! does not fit the memory budget either.
 //!
-//! Because the FFT bin width (≈ 1.465 Hz at 8192-pt) does not divide
-//! the 6.25 Hz tone spacing evenly, Costas tone positions are computed
-//! at fractional bins and rounded to the nearest integer. The
-//! resulting bin-alignment jitter (≤ 0.7 Hz) is below FT8's
-//! frequency-search tolerance.
+//! Two frequency analyses replace it, and they are not redundant:
+//!
+//! 1. **Spectrogram** ([`compute_spectrogram`]) —
+//!    `NFFT_SPEC = 3840 = 2 × NSPS`, matching WSJT-X `sync8.f90`'s
+//!    `NFFT1`, over 1920-sample slices zero-padded to 3840. This is
+//!    the *search* grid: `coarse_sync` needs every bin, so an FFT is
+//!    the right shape. 3840 is not a power of two either — it goes
+//!    through the 256 × 15 mixed-radix wrapper
+//!    (`embedded-shared::esp_dsp_fft::MixedRadix3840Fft`, with the
+//!    15-pt PFA factor in `engine::dsp::fft_15`). Keeping WSJT-X's
+//!    own NFFT is what makes `savg` / `sbase` / `xsig` / `xsnr2`
+//!    comparable bin-for-bin against reference output.
+//! 2. **Per-symbol DFT** ([`fill_symbol_spectra_goertzel`]) — the
+//!    *extraction* step, run at each surviving candidate's own
+//!    `(freq_hz, dt_sec)` rather than on the shared grid. Only 8 of
+//!    1920 bins are wanted per symbol, which is exactly the regime
+//!    where a Goertzel recursion beats an FFT, and it needs no
+//!    caller scratch.
+//!
+//! The spectrogram cannot serve as the second stage: its time grid
+//! is quantised to `NSTEP`, its frequency grid to `df = 3.125 Hz`
+//! (a candidate's carrier is a continuous value between bins), and
+//! under `fixed-point` it stores `u16` magnitude-squared with the
+//! phase already discarded.
+//!
+//! `tone_step_bins = TONE_SPACING_HZ / df = 6.25 / (12000/3840)` is
+//! **2.0 exactly**, so each FT8 tone falls on a single bin and the
+//! rectangular window's sidelobes do not leak onto adjacent tones —
+//! no fractional-bin rounding, and no Hann window (see
+//! [`NFFT_SPEC`] for the history of both).
+//!
+//! Calls `bp_decode_kind` with `BpKind::NormalizedMinSum` so the BP
+//! step skips the `tanh`/`atanh` cache.
 //!
 //! Same FFT trait, same compute path on host (rustfft) and on target
 //! (esp-dsp) — sensitivity sweeps run on host and the result transfers

--- a/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
+++ b/mfsk-core/src/ft8/decode_block/fill_symbol_spectra.rs
@@ -426,10 +426,11 @@ pub fn fill_symbol_spectra_generic<Sc: crate::engine::scalar::SpecScalar, S: Aud
 /// been the sole production path on every embedded target for
 /// several releases.
 ///
-/// Same output (`Σ x[n] exp(-jωn)` for each tone at `ω = 2π·f/Fs`
-/// across NSPS=1920 samples), produced via a 2-tap IIR recursion
-/// instead of a sin/cos dot-product. Needs no basis scratch at all —
-/// the whole point of Phase 1.7.7-Stick.
+/// Same **magnitude** as `Σ x[n] exp(-jωn)` for each tone at
+/// `ω = 2π·f/Fs` across NSPS=1920 samples (see "Phase convention"
+/// below for the complex-value caveat), produced via a 2-tap IIR
+/// recursion instead of a sin/cos dot-product. Needs no basis
+/// scratch at all — the whole point of Phase 1.7.7-Stick.
 ///
 /// Algorithm (per `(sym, tone)`):
 /// ```text
@@ -454,6 +455,36 @@ pub fn fill_symbol_spectra_generic<Sc: crate::engine::scalar::SpecScalar, S: Aud
 /// per-tone-outer layout. The sample fetch is also done once per
 /// `n` instead of `NTONES × NSPS` times — 8× less audio-buffer
 /// traffic, friendlier to the LX7 L1.
+///
+/// **Phase convention.** The generalised-Goertzel extraction does
+/// not return the DFT bin itself but `X_goertzel = exp(jω(N-1)) ·
+/// X_dft`. Measured against [`fill_symbol_spectra_generic`] (the
+/// rotator-based direct DFT) on a tone-plus-noise buffer, at
+/// `f0 = 1000 Hz` and `f0 = 1003 Hz`:
+///
+/// - `|X_goertzel / X_dft| = 1.0000` — max deviation `7.3e-5` across
+///   every filled cell, i.e. the magnitudes are the same number.
+/// - `arg(X_goertzel / X_dft)` is constant across symbols and tilts
+///   by exactly `-ω` per tone step: `-0.1875°` per tone, `1.3°`
+///   across all eight. `NSPS × TONE_SPACING_HZ / Fs = 1` exactly
+///   (the MFSK orthogonality condition), so the `exp(jωN)` half of
+///   the factor is common to every tone and only `exp(-jω_tone)`
+///   survives as a tone-dependent term.
+///
+/// Consequence, by consumer: [`sync_quality`](crate::ft8::llr::sync_quality),
+/// the `xsnr2` / [`snr_ratio`](crate::engine::llr::snr_ratio)
+/// estimators, and the `nsym = 1` LLRs (llra / llrd) read magnitudes
+/// only, so the rotation is exactly irrelevant to them — and
+/// `DecodeDepth::EMBEDDED` (`LlrEffort::Minimal`) stops there, which
+/// is why this is the ship configuration's whole story. The
+/// `nsym ≥ 2` LLRs (llrb / llrc) do **not**: `engine::llr::
+/// build_group_amplitudes` sums complex cells across a symbol group
+/// and takes `|a + b|`, so the `1.3°` tilt across the tone axis is
+/// carried into that coherent sum. It is far below the phase error
+/// the channel itself contributes, and no golden test has ever moved
+/// on it, but it is not zero — earlier notes (0.6.4's CHANGELOG
+/// entry) that called the rotation irrelevant because "downstream
+/// consumes `|cs|²`" were describing the `Minimal` path only.
 ///
 /// **Numerics**: f32 internal arithmetic. Host validation on
 /// qso3_busy.wav (pre-0.8.0, against the now-removed BASIS Q15 path)


### PR DESCRIPTION
Two stale/imprecise statements found while explaining why the embedded
FT8 path runs two separate frequency analyses.

`decode_block.rs`'s module doc still described an 8192-pt spectrogram
FFT with a 1.465 Hz bin width, Costas tone positions "computed at
fractional bins and rounded", and a 0.7 Hz alignment jitter. That
predates NFFT_SPEC = 3840 = 2*NSPS (WSJT-X sync8.f90's own NFFT1),
where tone_step_bins is 2.0 exactly and neither the fractional-bin
rounding nor the Hann compensation survives. Rewritten to describe the
current shape, and to say why the spectrogram FFT and the per-symbol
Goertzel are not redundant: the first is the search grid (coarse_sync
wants every bin), the second the extraction at a candidate's own
continuous (freq_hz, dt_sec), where 8 of 1920 bins are wanted. The
spectrogram cannot stand in — NSTEP-quantised time, 3.125 Hz frequency
grid, and u16 magnitude-squared with the phase discarded under
fixed-point.

0.6.4 justified the generalised-Goertzel phase rotation with "FT8
downstream consumes |cs|^2 so the rotation is irrelevant". That holds
for sync_quality, the xsnr2/snr_ratio estimators and the nsym=1 LLRs,
i.e. everything DecodeDepth::EMBEDDED (LlrEffort::Minimal) reaches, but
not for llrb/llrc: engine::llr::build_group_amplitudes sums complex
cells across a symbol group and only then takes a magnitude.
fill_symbol_spectra_goertzel gains a "Phase convention" section with
the measurement against fill_symbol_spectra_generic — factor
exp(jw(N-1)), magnitudes agreeing to 7.3e-5, and since
NSPS*6.25/12000 = 1 exactly the exp(jwN) half is common to all eight
tones, leaving a -0.1875 deg per-tone-step tilt (1.3 deg across the
tone axis) as the only tone-dependent term. Small, never observed to
move a golden test, but not zero. The historical 0.6.4 entry gets a
correction note rather than a rewrite.

Docs only — no code change. Merge gate green (670 passed, 0 failed,
MFSK_REQUIRE_CORPUS=1), fmt/clippy/rustdoc clean.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01P3pUywdYnS9dRZSCNTSBCv