### PR TITLE
perf(ft4): the shared decimate-by-2, wired — 12 of 12 candidates, 11 decodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,38 @@ streaming coarse stage below.)
 
 ### Added
 
+- **FT4's candidate loop stopped being truncated: 12 of 12 candidates
+  and 11 decodes, where it had been 11 and 10.** `ft4::ddc` gained a
+  slot-wide decimate-by-2 (`SharedFrontEnd`, `shared_baseband`) ahead
+  of the per-candidate chain, and `CandidateDdc::new_predecimated` /
+  `candidate_baseband_shared` are that chain at 6 kHz — stage A drops
+  from 199 taps and decimate-by-18 to 101 and 9. Every candidate had
+  been filtering the same audio at full rate: 61 ms of a candidate's
+  96.
+
+  The shared leg is **streamed from the capture side**, beside
+  `Ft4SavgBuilder`, so it costs the post-slot budget nothing at all —
+  `ft4_rx::CapturedSlot` now carries the 6 kHz stream instead of the
+  12 kHz audio (45 000 `f32` against 90 000 `i16`, the same 180 KB;
+  nothing below the candidate loop wanted 12 kHz). On a CoreS3, A/B on
+  the same baked golden slot: **192.5 → 165.6 ms per candidate**, and
+  the whole 12-candidate list now finishes in 1 987 ms where 11 of them
+  took 2 118. The decode that appears is `W7BOB KJ7G RR73` at −17 dB,
+  the weakest signal on the recording and the one the deadline had been
+  giving up.
+
+  A third filter stage is not bit-identical to two, so the equivalence
+  is measured rather than asserted: noise bandwidth **+0.021 dB**
+  against `downsample_cached`'s band — the same figure as the direct
+  DDC path, to four digits — the same 11 golden decodes at both
+  `EMBEDDED` and `FULL` with refined frequencies matching the direct
+  DDC to 0.00 Hz, >50 dB rejection of the 3 200 Hz+ content the
+  decimation would otherwise fold onto the search band, and
+  block-size-independent output across seven chunk sizes. The tier-C
+  560-file recall comparison has not been re-run (no `ft4_sweep` corpus
+  on this machine), so this is golden-neutral, not yet
+  sensitivity-neutral. `docs/notes/FT4_BENCHMARK.md` §39.
+
 - **FT4's embedded decode fits its slot at realistic band occupancy.**
   A day of hardware measurement on a CoreS3 took the FT4 ship
   configuration from **2.33× over its 1 960 ms post-slot budget to

--- a/docs/notes/FT4_BENCHMARK.md
+++ b/docs/notes/FT4_BENCHMARK.md
@@ -2811,3 +2811,99 @@ the streamed coarse into the receiver.
 `push_block_real` and its equivalence test are the only new code so
 far — `ft4::ddc`'s `CandidateDdc` itself is unchanged, so this is a
 measurement, not yet a shipped optimization.
+
+## 39. The shared decimation, wired — and the cut stopped firing (2026-09-01)
+
+§37.2 left the shared front end as a measurement: `push_block_real`
+existed, `CandidateDdc` did not use it. This wires it, and the wiring
+turns out to be worth more than the arithmetic in §37.1 predicted —
+not because the filters are faster than measured, but because the
+shared leg does not have to be paid **after** the slot.
+
+`ft4::ddc` grew three pieces:
+
+- `SharedFrontEnd` — the 165-tap decimate-by-2 over the slot's real
+  audio, fed a block at a time (`push_i16`) and flushed to exactly
+  `SLOT_SAMPLES / 2`;
+- `CandidateDdc::new_predecimated` / `push_f32` — the same chain with
+  stage A cut to 101 taps and decimate-by-9 at 6 kHz, stage B and the
+  derotation untouched;
+- `shared_baseband` / `candidate_baseband_shared` — the block helpers,
+  matching `candidate_baseband`'s contract exactly (`CD0_LEN` samples,
+  un-normalised, `f0` at DC).
+
+**The shared leg streams, the way the coarse stage already does.**
+`ft4_rx::SlotAccum` runs `SharedFrontEnd` beside `Ft4SavgBuilder` on
+the capture side, and `CapturedSlot` carries the 6 kHz stream *instead
+of* the 12 kHz audio — 45 000 `f32` against 90 000 `i16`, the same
+180 KB, and nothing downstream of the candidate loop ever wanted
+12 kHz. So §37.2's 108 ms shared leg lands on the capture thread at
+~0.3 ms per 256-sample block (against §33's 21.3 ms budget for that
+block) rather than on the 1 960 ms that decides how many candidates
+get tried.
+
+### 39.1 A/B on the board, same day, same baked slot
+
+`ft4-demo` on a CoreS3, eleven slots each, `main` at `dec61dfa`
+against the same tree with the wiring:
+
+```
+before   slot N — 11 of 12 candidates tried, 10 decodes in 2 067-2 118 ms — cut 1 at score 1.55
+after    slot N — 12 of 12 candidates tried, 11 decodes in 1 932-1 987 ms
+```
+
+| | before | after |
+|---|---:|---:|
+| candidates tried | 11 of 12 | **12 of 12** |
+| decodes | 10 | **11** |
+| post-slot | 2 118 ms | **1 987 ms** |
+| per candidate | 192.5 ms | **165.6 ms** |
+
+**26.9 ms per candidate**, against the 30.2 ms §37.2's leg measurement
+projected (61.0 → 30.8 for stage A) — the rest of the chain is
+unchanged, so the shortfall is the shared stage's own effect on cache
+and the per-block bookkeeping the projection ignored. And one whole
+candidate more inside a budget that is 131 ms *shorter* than before:
+§34's cut, which had fired on every slot since it was built, does not
+fire at all.
+
+The eleventh decode is `W7BOB KJ7G RR73` at −17 dB — the weakest
+signal on the golden, and precisely the one the cut was giving up.
+This is §37's claim ("milliseconds convert to stations") arriving as a
+station.
+
+### 39.2 What says it is the same decoder
+
+A third filter stage is a different filter, so none of this is
+bit-identical to §20's chain and it cannot be:
+
+- **Noise bandwidth**: the measurement the RMS normalisation actually
+  sees. `noise_bandwidth_matches_the_reference_band` now measures all
+  three paths against `downsample_cached`'s band — direct DDC
+  2.1610e-3, shared 2.1608e-3, reference 2.1503e-3. Both DDC paths sit
+  at **+0.021 dB**, i.e. the shared front end changes the band by less
+  than the four digits printed.
+- **Decodes**: `ft4_ddc_equivalence` grew a third arm. On the golden,
+  at both `EMBEDDED` and `FULL`, the shared path decodes the same 11
+  messages as the FFT path, and its refined frequency matches the
+  direct DDC's to **0.00 Hz** on every candidate.
+- **Aliasing**: the one failure mode the decimate-by-2 introduces is
+  content above 3 200 Hz folding onto the search band.
+  `shared_stage_stops_what_would_fold_onto_the_band` fires a tone at
+  3 400 Hz (which would land on 2 600 Hz, a legal candidate) and holds
+  the rejection past 50 dB. This is what the 165 taps buy, and why
+  §37.1's first estimate of 111 was wrong.
+- **Block independence**: the stage runs from a capture callback, so
+  `shared_front_end_is_block_size_independent` pins one-shot output
+  against seven chunk sizes, including ones that do not divide the
+  decimation.
+
+Not closed: the tier-C 560-file recall test
+(`ft4_ddc_recall_matches_the_fft_path_across_the_crossing`) has **not**
+been re-run — the `ft4_sweep` corpus is not present on this machine.
+§37.1 called for it, and it is still owed before this can be called
+sensitivity-neutral rather than golden-neutral.
+
+Cost: 8.9 KB of internal heap (`free_heap` 8 124 400 → 8 115 476,
+`internal` 216 107 → 207 183) for the front end's history buffers and
+scratch. The slot buffer itself is a wash.

--- a/docs/reference/EMBEDDED.ja.md
+++ b/docs/reference/EMBEDDED.ja.md
@@ -984,6 +984,38 @@ DDC と合わせた投影は `(2 492 + 1 943) × 12/31 ≈ 1 717 ms` で
 焼いた候補リストを読んでおり実機では一度も動かしていない。`fst4::ddc` と同様、呼び出し側が使う部品で
 あって、ホストのフロントエンドを差し替える feature flag ではない。
 
+### 共有フロントエンドと、受信機が実際に動かしている形 (2026-09-01)
+
+上の 2 節はどれも実機で走らせる前に書かれたもの。その後実機で走って
+おり（経過は `docs/notes/FT4_BENCHMARK.md` §25-39）、出荷される形は上の
+図とは少し違う。
+
+音声と候補ごとのチェーンの間に 2 つの段が入り、どちらも
+**スロット終了後ではなくキャプチャ側でストリーム処理**される:
+
+```text
+12 kHz real i16、UAC read 単位
+  ├─ Ft4SavgBuilder                       -> savg, 粗候補 (スロット後 6 ms)
+  └─ ft4::ddc::SharedFrontEnd             -> 6 kHz real, 165 taps, /2
+        (候補ごと、スロット後)
+        -> Mixer(f0 + 31.25 Hz)           complex @ 6 kHz
+        -> FirStage A: 101 taps, /9       complex @ 666.667 Hz
+        -> FirStage B: 263 taps, /1       complex @ 666.667 Hz
+        -> Mixer(-31.25 Hz)               cd0, f0 が DC
+```
+
+`CandidateDdc::new` と `candidate_baseband` は従来どおり 12 kHz の
+2 段チェーンのまま。`new_predecimated` / `candidate_baseband_shared`
+が 6 kHz 版で、`shared_baseband` が共有する脚。受信機が欲しいのは
+後者——そうしないと候補ごとに同じ音声をフルレートで filter し直す
+ことになり、それが候補 96 ms のうち 61 ms だった。
+
+配線の参照実装は `embedded_shared::apps::ft4_rx`:
+`SlotAccum` が音声コールバックから両方の accumulator を回し、
+`CapturedSlot` は 12 kHz 音声ではなく 6 kHz ストリームを持つ。CoreS3
+実測で候補あたり 192.5 ms → 165.6 ms、12 候補すべてが 1 960 ms の
+スロット後予算に収まる。
+
 ## 次に読むべきもの
 
 読者の意図別:

--- a/docs/reference/EMBEDDED.md
+++ b/docs/reference/EMBEDDED.md
@@ -1805,6 +1805,39 @@ exercised it.
 Like `fst4::ddc`, this is a building block callers reach for, not a
 feature flag that swaps the host's front end.
 
+### The shared front end, and what the receiver actually runs (2026-09-01)
+
+Both paragraphs above were written before any of this ran on a board.
+It has since run: `docs/notes/FT4_BENCHMARK.md` §25-39 is the hardware
+sequence, and the shape that ships is not quite the diagram above.
+
+Two stages were added between the audio and the per-candidate chain,
+and both are **streamed from the capture side** rather than paid after
+the slot closes:
+
+```text
+12 kHz real i16, a UAC read at a time
+  ├─ Ft4SavgBuilder                       -> savg, coarse candidates (6 ms post-slot)
+  └─ ft4::ddc::SharedFrontEnd             -> 6 kHz real, 165 taps, /2
+        (per candidate, post-slot)
+        -> Mixer(f0 + 31.25 Hz)           complex @ 6 kHz
+        -> FirStage A: 101 taps, /9       complex @ 666.667 Hz
+        -> FirStage B: 263 taps, /1       complex @ 666.667 Hz
+        -> Mixer(-31.25 Hz)               cd0, f0 at DC
+```
+
+`CandidateDdc::new` and `candidate_baseband` still build the two-stage
+12 kHz chain, unchanged; `new_predecimated` / `candidate_baseband_shared`
+are the 6 kHz one, and `shared_baseband` is the leg they share. A
+receiver wants the second pair: every candidate was otherwise
+re-filtering the same audio at full rate, 61 ms of a candidate's 96.
+
+`embedded_shared::apps::ft4_rx` is the reference wiring —
+`SlotAccum` feeds both accumulators from the audio callback and
+`CapturedSlot` carries the 6 kHz stream, not the 12 kHz audio. On a
+CoreS3 that is 165.6 ms per candidate against 192.5, and the whole
+12-candidate list inside the 1 960 ms post-slot budget.
+
 ## Live UAC bring-up — what to check, in what order (issue #163)
 
 **This procedure did its job on 2026-08-23 and #163 is closed** — an

--- a/embedded-poc/embedded-shared/src/apps/ft4_rx.rs
+++ b/embedded-poc/embedded-shared/src/apps/ft4_rx.rs
@@ -43,7 +43,7 @@ use mfsk_core::engine::equalize::EqMode;
 use mfsk_core::engine::ft4_coarse::{ft4_coarse_sync_from_savg, Ft4SavgBuilder};
 use mfsk_core::engine::pipeline::{process_candidate_precomputed, DecodeDepth, DecodeStrictness};
 use mfsk_core::engine::sync2d::ft4_sync_search_window;
-use mfsk_core::ft4::ddc::candidate_baseband;
+use mfsk_core::ft4::ddc::{SharedFrontEnd, candidate_baseband_shared};
 use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
 use mfsk_core::ft4::Ft4;
 use mfsk_core::msg::wsjt77::unpack77;
@@ -51,6 +51,13 @@ use num_complex::Complex;
 
 /// One FT4 slot at 12 kHz: 7.5 s.
 pub const SLOT_SAMPLES: usize = 90_000;
+
+/// The same slot after the shared decimate-by-2, at 6 kHz.
+///
+/// This is what a captured slot actually carries — see
+/// [`CapturedSlot::pre`]. Same 180 KB the raw `i16` audio occupied
+/// (45 000 `f32` against 90 000 `i16`), so the buffer swap is free.
+pub const PRE_SAMPLES: usize = SLOT_SAMPLES / 2;
 
 /// `ft4::decode`'s own private `SYNC_Q_MIN` — 16 sync symbols
 /// (4 × Costas-4), at least half correct. Mirrored the same way
@@ -75,10 +82,21 @@ const MAX_CAND: usize = 100;
 /// (§18-19): what it gives up is reach, not sensitivity.
 const NARROW_WINDOW: (i32, i32) = (0, 667);
 
-/// A finished slot: its audio, and the periodogram accumulated while
-/// that audio was arriving.
+/// A finished slot: its audio at 6 kHz, and the periodogram
+/// accumulated while that audio was arriving.
 pub struct CapturedSlot {
-    pub audio: Vec<i16>,
+    /// The slot's audio, already through `ft4::ddc`'s shared
+    /// decimate-by-2 — the *only* copy kept, because nothing
+    /// downstream of the candidate loop wants 12 kHz.
+    ///
+    /// `ft4::ddc`'s per-candidate stage A was 61 ms of a candidate's
+    /// 96 and every candidate ran it over the same audio
+    /// (`FT4_BENCHMARK.md` §37). Halving the rate once first makes each
+    /// candidate's stage A a 101-tap decimate-by-9 at ~30 ms; the
+    /// shared leg is 108 ms — and, run a block at a time from the
+    /// capture side the way [`Ft4SavgBuilder`] already is, it is 108 ms
+    /// that never lands on the post-slot budget at all.
+    pub pre: Vec<f32>,
     /// Already averaged — [`Ft4SavgBuilder::finish`] has run.
     pub savg: Vec<f32>,
     /// `esp_timer` microseconds at the moment the slot closed, so the
@@ -97,8 +115,16 @@ fn now_us() -> i64 {
 /// needs the rows, so the builder cannot simply be run over the buffer
 /// afterwards — that is the 758 ms this receiver exists to avoid.
 pub struct SlotAccum {
-    audio: Vec<i16>,
+    /// The shared decimate-by-2's output, accumulated as the audio
+    /// arrives — see [`CapturedSlot::pre`].
+    pre: Vec<f32>,
+    front: SharedFrontEnd,
     savg: Ft4SavgBuilder,
+    /// 12 kHz samples taken so far. `pre.len()` cannot stand in for
+    /// this: the front end's own group delay means it trails the input
+    /// by half a filter, so the slot boundary has to be counted on the
+    /// input side.
+    n_in: usize,
 }
 
 impl Default for SlotAccum {
@@ -110,8 +136,10 @@ impl Default for SlotAccum {
 impl SlotAccum {
     pub fn new() -> Self {
         Self {
-            audio: Vec::with_capacity(SLOT_SAMPLES),
+            pre: Vec::with_capacity(PRE_SAMPLES),
+            front: SharedFrontEnd::new(),
             savg: Ft4SavgBuilder::new(SLOT_SAMPLES),
+            n_in: 0,
         }
     }
 
@@ -137,15 +165,21 @@ impl SlotAccum {
         let mut rest = samples;
         let mut done = None;
         while !rest.is_empty() {
-            let room = SLOT_SAMPLES - self.audio.len();
+            let room = SLOT_SAMPLES - self.n_in;
             let take = room.min(rest.len());
-            self.audio.extend_from_slice(&rest[..take]);
+            self.front.push_i16(&rest[..take], &mut self.pre);
             self.savg.push_with_rows(&rest[..take], on_row);
+            self.n_in += take;
             rest = &rest[take..];
-            if self.audio.len() == SLOT_SAMPLES {
-                let prev = core::mem::replace(self, Self::new());
+            if self.n_in == SLOT_SAMPLES {
+                let mut prev = core::mem::replace(self, Self::new());
+                // The tail the front end's group delay still holds,
+                // and the zero padding the reference's `fft1_size`
+                // buffer carries — the same flush `shared_baseband`
+                // does in one call.
+                prev.front.flush_to(PRE_SAMPLES, &mut prev.pre);
                 done = Some(CapturedSlot {
-                    audio: prev.audio,
+                    pre: prev.pre,
                     savg: prev.savg.finish(),
                     closed_us: now_us(),
                 });
@@ -251,7 +285,7 @@ pub fn decode_slot(slot: &CapturedSlot, budget_ms: i64) -> SlotOutcome {
             break;
         }
         tried += 1;
-        let mut cd0 = candidate_baseband(&slot.audio, cand.freq_hz);
+        let mut cd0 = candidate_baseband_shared(&slot.pre, cand.freq_hz);
         rms_normalise(&mut cd0);
         let s2 = ft4_sync_search_window::<Ft4>(&cd0, cand, NARROW_WINDOW.0, NARROW_WINDOW.1);
         let Some(r) = process_candidate_precomputed::<Ft4>(
@@ -412,7 +446,7 @@ pub fn wf_row(spectrum: &[f32]) -> [u8; crate::pipeline::WF_ROW_LEN] {
 /// Unit-power normalisation, matching what
 /// `process_candidate_basic_impl` applies to its own
 /// `downsample_cached` output (WSJT-X `ft4_decode.f90:231-232`).
-/// `candidate_baseband` deliberately does not do it, so every caller
+/// `candidate_baseband_shared` deliberately does not do it, so every caller
 /// must — `compute_llr`'s `LLR_SCALE` is calibrated against unit-RMS
 /// input.
 fn rms_normalise(cd0: &mut [Complex<f32>]) {

--- a/mfsk-core/src/ft4/ddc.rs
+++ b/mfsk-core/src/ft4/ddc.rs
@@ -180,6 +180,36 @@ const MIX_CHUNK: usize = 1_024;
 /// `FirStage`'s compaction well amortised.
 const HIST_MARGIN: usize = 512;
 
+/// Shared front end — one decimate-by-2 over the slot's real audio,
+/// ahead of every candidate's own mixer (`FT4_BENCHMARK.md` §37.1-37.2).
+///
+/// The per-candidate chain above pays stage A's 199 taps at 12 kHz
+/// *per candidate*, 61 ms each, and every candidate filters the same
+/// audio. Halving the rate once first makes each candidate's stage A a
+/// 101-tap decimate-by-9 over 45 000 samples — 30 ms — for one shared
+/// 108 ms leg (measured on a CoreS3, §37.2). Break-even is ~2.7
+/// candidates; §23's occupancy table never sits below 5.
+///
+/// `2 800 Hz` pass / `3 200 Hz` stop is not a round number. Decimating
+/// to 6 kHz folds everything above 3 000 Hz down; the search band tops
+/// out at 2 700 Hz and a candidate's own band reaches `f0 + 93.75`, so
+/// content between 3 000 and 3 200 Hz folds to 2 800-3 000 Hz, which is
+/// outside every candidate's band and which stage A' rejects anyway.
+/// What has to be stopped is above 3 200 Hz — a 400 Hz transition at
+/// 12 kHz, which a Blackman window buys at 165 taps.
+const SHARED_DECIM: usize = 2;
+const SHARED_NTAPS: usize = 165;
+const SHARED_FC_HZ: f32 = 2_800.0;
+
+/// Rate the shared front end hands the per-candidate chain: 6 kHz.
+pub const PRE_RATE_HZ: f32 = INPUT_RATE_HZ / SHARED_DECIM as f32;
+
+/// Stage A when the input is already decimated — same transition width
+/// in Hz as [`STAGE_A_NTAPS`]/[`STAGE_A_FC_HZ`] at half the rate, so
+/// half the taps, and the remaining decimation is `NDOWN / 2 = 9`.
+const STAGE_A_PRE_NTAPS: usize = 101;
+const STAGE_A_PRE_DECIM: usize = Ft4::NDOWN as usize / SHARED_DECIM;
+
 /// Streaming per-candidate down-converter — one instance per candidate
 /// frequency, fed the slot's 12 kHz PCM.
 ///
@@ -194,6 +224,10 @@ pub struct CandidateDdc {
     stage_a: FirStage,
     stage_b: FirStage,
     derotate: Mixer,
+    /// Stage A's decimation — 18 fed 12 kHz audio, 9 fed the shared
+    /// front end's 6 kHz. Read by the block and flush paths, which size
+    /// their scratch and their zero budget from it.
+    stage_a_decim: usize,
 }
 
 impl CandidateDdc {
@@ -214,6 +248,31 @@ impl CandidateDdc {
             // this stage has to undo the `+BAND_CENTER_OFFSET_HZ` the
             // input mixer applied, moving `f0` from `-31.25 Hz` to DC.
             derotate: Mixer::new(-BAND_CENTER_OFFSET_HZ, DS_RATE_HZ),
+            stage_a_decim: Ft4::NDOWN as usize,
+        }
+    }
+
+    /// The same converter, fed the shared front end's 6 kHz real
+    /// stream instead of the raw 12 kHz audio.
+    ///
+    /// Everything downstream of stage A is unchanged — same 263-tap
+    /// stage B at the same 666.667 Hz, same derotation — and stage A
+    /// keeps its transition width in Hz at half the rate with half the
+    /// taps. Feed this one [`push_f32`](Self::push_f32) (whose mixer
+    /// runs at [`PRE_RATE_HZ`]), never [`push_i16`](Self::push_i16);
+    /// the rate is baked into the phasor at construction.
+    pub fn new_predecimated(f0_hz: f32) -> Self {
+        Self {
+            mixer: Mixer::new(f0_hz + BAND_CENTER_OFFSET_HZ, PRE_RATE_HZ),
+            stage_a: FirStage::new(
+                STAGE_A_PRE_NTAPS,
+                STAGE_A_PRE_DECIM,
+                STAGE_A_FC_HZ / PRE_RATE_HZ,
+                HIST_MARGIN,
+            ),
+            stage_b: FirStage::new(STAGE_B_NTAPS, 1, STAGE_B_FC_HZ / DS_RATE_HZ, HIST_MARGIN),
+            derotate: Mixer::new(-BAND_CENTER_OFFSET_HZ, DS_RATE_HZ),
+            stage_a_decim: STAGE_A_PRE_DECIM,
         }
     }
 
@@ -248,21 +307,39 @@ impl CandidateDdc {
     /// (`docs/notes/FT4_BENCHMARK.md` §30.1). The block entry point had
     /// existed since `wspr::ddc` needed it and nothing here called it.
     pub fn push_i16(&mut self, audio: &[i16], out: &mut Vec<Complex<f32>>) {
+        self.push_blocks(audio, out);
+    }
+
+    /// Push a block of the shared front end's 6 kHz real stream — the
+    /// [`new_predecimated`](Self::new_predecimated) entry point.
+    ///
+    /// Same arithmetic as [`push_i16`](Self::push_i16) with a different
+    /// stage A and a mixer at [`PRE_RATE_HZ`]; the sample type differs
+    /// only because [`SharedFrontEnd`] has already left the integer
+    /// domain.
+    pub fn push_f32(&mut self, pre: &[f32], out: &mut Vec<Complex<f32>>) {
+        self.push_blocks(pre, out);
+    }
+
+    /// The block loop both entry points share: mix `n` samples in
+    /// `MIX_CHUNK`-sized pieces, hand each stage a block, derotate.
+    fn push_blocks<T: Copy + Into<f32>>(&mut self, input: &[T], out: &mut Vec<Complex<f32>>) {
         let mut mi: Vec<f32> = Vec::with_capacity(MIX_CHUNK);
         let mut mq: Vec<f32> = Vec::with_capacity(MIX_CHUNK);
-        // Stage A decimates by 18, so a chunk yields at most
-        // `MIX_CHUNK / 18 + 1` samples; stage B passes those through.
-        let inner = MIX_CHUNK / Ft4::NDOWN as usize + 2;
+        // Stage A decimates by 18 (or 9 behind the shared front end),
+        // so a chunk yields at most `MIX_CHUNK / decim + 1` samples;
+        // stage B passes those through.
+        let inner = MIX_CHUNK / self.stage_a_decim + 2;
         let mut ai: Vec<f32> = Vec::with_capacity(inner);
         let mut aq: Vec<f32> = Vec::with_capacity(inner);
         let mut bi: Vec<f32> = Vec::with_capacity(inner);
         let mut bq: Vec<f32> = Vec::with_capacity(inner);
 
-        for chunk in audio.chunks(MIX_CHUNK) {
+        for chunk in input.chunks(MIX_CHUNK) {
             mi.clear();
             mq.clear();
             for &s in chunk {
-                let (i, q) = self.mixer.mix(s as f32);
+                let (i, q) = self.mixer.mix(s.into());
                 mi.push(i);
                 mq.push(q);
             }
@@ -288,7 +365,7 @@ impl CandidateDdc {
     /// rather than a hard stop, and so does this one.
     pub fn flush_to(&mut self, want: usize, out: &mut Vec<Complex<f32>>) {
         let max_zeros =
-            (want + 1) * Ft4::NDOWN as usize + STAGE_A_NTAPS + STAGE_B_NTAPS * Ft4::NDOWN as usize;
+            (want + 1) * self.stage_a_decim + STAGE_A_NTAPS + STAGE_B_NTAPS * self.stage_a_decim;
         let mut pushed = 0usize;
         while out.len() < want && pushed < max_zeros {
             self.push_one(0.0, out);
@@ -315,6 +392,95 @@ pub fn candidate_baseband(audio: &[i16], f0_hz: f32) -> Vec<Complex<f32>> {
     let mut ddc = CandidateDdc::new(f0_hz);
     let mut out = Vec::with_capacity(CD0_LEN);
     ddc.push_i16(audio, &mut out);
+    ddc.flush_to(CD0_LEN, &mut out);
+    out.resize(CD0_LEN, Complex::new(0.0, 0.0));
+    out
+}
+
+/// The slot's decimate-by-2, paid once and read by every candidate.
+///
+/// Real in, real out: [`FirStage::push_block_real`] is one dot product
+/// per output rather than two, which is the difference between 108 ms
+/// and 202 ms for this stage on a CoreS3 (§37.2). The stage is
+/// otherwise an ordinary [`FirStage`], so its output 0 is centred on
+/// its input 0 and the cascade below it keeps `cd0[0]` aligned with
+/// `audio[0]` exactly as the direct path does.
+pub struct SharedFrontEnd {
+    stage: FirStage,
+}
+
+impl Default for SharedFrontEnd {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SharedFrontEnd {
+    pub fn new() -> Self {
+        Self {
+            stage: FirStage::new(
+                SHARED_NTAPS,
+                SHARED_DECIM,
+                SHARED_FC_HZ / INPUT_RATE_HZ,
+                HIST_MARGIN,
+            ),
+        }
+    }
+
+    /// Push a block of 12 kHz PCM, appending the 6 kHz samples it
+    /// completes.
+    pub fn push_i16(&mut self, audio: &[i16], out: &mut Vec<f32>) {
+        let mut mi: Vec<f32> = Vec::with_capacity(MIX_CHUNK);
+        for chunk in audio.chunks(MIX_CHUNK) {
+            mi.clear();
+            mi.extend(chunk.iter().map(|&s| s as f32));
+            self.stage.push_block_real(&mi, out);
+        }
+    }
+
+    /// Feed zeros until `out` holds `want` samples — the filter flush,
+    /// and the front half of the reference's zero-padding.
+    pub fn flush_to(&mut self, want: usize, out: &mut Vec<f32>) {
+        let zeros = [0.0f32; 64];
+        let mut budget = (want + 1) * SHARED_DECIM + SHARED_NTAPS;
+        while out.len() < want && budget > 0 {
+            let n = zeros.len().min(budget);
+            self.stage.push_block_real(&zeros[..n], out);
+            budget -= n;
+        }
+        out.truncate(want);
+    }
+}
+
+/// Block helper: the slot in at 12 kHz, the shared 6 kHz stream out —
+/// exactly `audio.len() / 2` samples, the slot as the reference sees
+/// it (real audio, then the zero padding its `fft1_size` buffer
+/// carries), so what each candidate's chain reads is the same signal
+/// [`candidate_baseband`] reads, at half the rate.
+pub fn shared_baseband(audio: &[i16]) -> Vec<f32> {
+    let want = audio.len() / SHARED_DECIM;
+    let mut front = SharedFrontEnd::new();
+    let mut out = Vec::with_capacity(want);
+    front.push_i16(audio, &mut out);
+    front.flush_to(want, &mut out);
+    out
+}
+
+/// [`candidate_baseband`] behind the shared front end: same `cd0`
+/// contract — [`CD0_LEN`] samples, un-normalised, `f0` at DC — from a
+/// stream [`shared_baseband`] produced once for the whole slot.
+///
+/// Not bit-identical to [`candidate_baseband`]: three filter stages
+/// are not two, so the passband shape and the rounding both move a
+/// little. What is held is the band, and therefore the noise power the
+/// RMS normalisation divides by — `shared_path_noise_bandwidth_matches`
+/// pins that against the reference, the same way
+/// `noise_bandwidth_matches_the_reference_band` does for the direct
+/// path.
+pub fn candidate_baseband_shared(pre: &[f32], f0_hz: f32) -> Vec<Complex<f32>> {
+    let mut ddc = CandidateDdc::new_predecimated(f0_hz);
+    let mut out = Vec::with_capacity(CD0_LEN);
+    ddc.push_f32(pre, &mut out);
     ddc.flush_to(CD0_LEN, &mut out);
     out.resize(CD0_LEN, Complex::new(0.0, 0.0));
     out
@@ -363,6 +529,85 @@ mod tests {
         assert!((BAND_CENTER_OFFSET_HZ - 31.2495).abs() < 1e-3);
         assert!((BAND_HALF_WIDTH_HZ - 62.499).abs() < 1e-3);
         assert!((BAND_CENTER_OFFSET_HZ - BAND_HALF_WIDTH_HZ + 31.2495).abs() < 1e-2);
+    }
+
+    /// Same three properties for the shared front end, since a third
+    /// stage is a different filter: full length, flat tones, and the
+    /// band edges rejected.
+    #[test]
+    fn shared_path_holds_the_band() {
+        let f0 = 1500.0f32;
+        let cd0 = |audio: &[i16]| candidate_baseband_shared(&shared_baseband(audio), f0);
+
+        assert_eq!(cd0(&tone(f0, 8000.0, 90_000)).len(), CD0_LEN);
+
+        let mut powers = vec![];
+        for k in 0..Ft4::NTONES {
+            let audio = tone(f0 + k as f32 * Ft4::TONE_SPACING_HZ, 8000.0, 90_000);
+            powers.push(mean_power(&cd0(&audio)[1000..4000]));
+        }
+        let max = powers.iter().cloned().fold(f32::MIN, f32::max);
+        let min = powers.iter().cloned().fold(f32::MAX, f32::min);
+        let ripple_db = 10.0 * (max / min).log10();
+        assert!(
+            ripple_db < 1.0,
+            "passband ripple {ripple_db} dB: {powers:?}"
+        );
+
+        let in_band = mean_power(&cd0(&tone(f0, 8000.0, 90_000))[1000..4000]);
+        for offset in [-125.0f32, -100.0, 160.0, 200.0, 400.0, 700.0] {
+            let p = mean_power(&cd0(&tone(f0 + offset, 8000.0, 90_000))[1000..4000]);
+            let rej_db = 10.0 * (in_band / p).log10();
+            assert!(
+                rej_db > 50.0,
+                "tone at f0{offset:+} Hz only {rej_db:.1} dB down"
+            );
+        }
+    }
+
+    /// The shared stage runs from a capture callback, a UAC read at a
+    /// time, so its output must not depend on how the audio is cut up.
+    /// [`FirStage::push_block_real`] carries that property; this is the
+    /// statement at the level a receiver uses it, across block sizes
+    /// that do and do not divide the decimation.
+    #[test]
+    fn shared_front_end_is_block_size_independent() {
+        let audio = tone(1500.0, 8000.0, 90_000);
+        let one_shot = shared_baseband(&audio);
+        for chunk in [1usize, 2, 3, 128, 256, 333, 1024] {
+            let mut front = SharedFrontEnd::new();
+            let mut out = Vec::with_capacity(one_shot.len());
+            for block in audio.chunks(chunk) {
+                front.push_i16(block, &mut out);
+            }
+            front.flush_to(one_shot.len(), &mut out);
+            assert_eq!(out.len(), one_shot.len(), "chunk {chunk}: length");
+            assert_eq!(out, one_shot, "chunk {chunk}: samples differ");
+        }
+    }
+
+    /// The decimate-by-2's own job: content above 3 200 Hz folds onto
+    /// the search band and nothing else does. A 3 400 Hz tone would
+    /// alias to 2 600 Hz — a legal candidate frequency — so this is the
+    /// one failure mode the shared stage introduces and the reason it
+    /// carries 165 taps rather than the 111 first assumed.
+    #[test]
+    fn shared_stage_stops_what_would_fold_onto_the_band() {
+        let f0 = 2600.0f32;
+        let in_band = mean_power(
+            &candidate_baseband_shared(&shared_baseband(&tone(f0, 8000.0, 90_000)), f0)[1000..4000],
+        );
+        for f in [3400.0f32, 3600.0, 4000.0, 5000.0] {
+            let aliased = mean_power(
+                &candidate_baseband_shared(&shared_baseband(&tone(f, 8000.0, 90_000)), f0)
+                    [1000..4000],
+            );
+            let rej_db = 10.0 * (in_band / aliased).log10();
+            assert!(
+                rej_db > 50.0,
+                "{f} Hz folds onto {f0} Hz only {rej_db:.1} dB down"
+            );
+        }
     }
 
     #[test]
@@ -471,11 +716,27 @@ mod tests {
         // Tone at the band centre, where both paths are flat.
         let probe = tone(f0 + BAND_CENTER_OFFSET_HZ, 8000.0, 90_000);
 
-        let path_ratio = |audio_n: &[i16], audio_t: &[i16], ddc_path: bool| -> f32 {
-            let (pn, pt) = if ddc_path {
+        /// Which front end the ratio is measured through.
+        enum Path {
+            Ddc,
+            Reference,
+            Shared,
+        }
+
+        let path_ratio = |audio_n: &[i16], audio_t: &[i16], path: Path| -> f32 {
+            let (pn, pt) = if let Path::Ddc = path {
                 (
                     mean_power(&candidate_baseband(audio_n, f0)[1000..4000]),
                     mean_power(&candidate_baseband(audio_t, f0)[1000..4000]),
+                )
+            } else if let Path::Shared = path {
+                (
+                    mean_power(
+                        &candidate_baseband_shared(&shared_baseband(audio_n), f0)[1000..4000],
+                    ),
+                    mean_power(
+                        &candidate_baseband_shared(&shared_baseband(audio_t), f0)[1000..4000],
+                    ),
                 )
             } else {
                 let cn = build_fft_cache(audio_n, &FT4_DOWNSAMPLE);
@@ -488,10 +749,16 @@ mod tests {
             pn / pt
         };
 
-        let ddc_enbw = path_ratio(&noise, &probe, true);
-        let ref_enbw = path_ratio(&noise, &probe, false);
+        let ddc_enbw = path_ratio(&noise, &probe, Path::Ddc);
+        let ref_enbw = path_ratio(&noise, &probe, Path::Reference);
+        let shared_enbw = path_ratio(&noise, &probe, Path::Shared);
         let ratio = ddc_enbw / ref_enbw;
         let db = 10.0 * ratio.log10();
+        let shared_db = 10.0 * (shared_enbw / ref_enbw).log10();
+        std::eprintln!(
+            "ENBW: ddc {ddc_enbw:.4e} ({db:+.3} dB)  shared {shared_enbw:.4e} \
+             ({shared_db:+.3} dB)  ref {ref_enbw:.4e}"
+        );
         // Measured **+0.021 dB** (DDC 2.161e-3, reference 2.150e-3) at
         // the tap counts above — the two bands integrate to the same
         // noise power to within half a percent, which is the whole
@@ -504,6 +771,15 @@ mod tests {
             db.abs() < 1.0,
             "DDC noise bandwidth is {db:+.2} dB against the reference band \
              (ddc {ddc_enbw:.4e}, ref {ref_enbw:.4e})"
+        );
+        // The shared front end is the same claim for the three-stage
+        // chain: a decimate-by-2 flat to 2 800 Hz changes nothing
+        // inside a ±62.5 Hz band at 1 500 Hz, and the measurement is
+        // what says so rather than the intent.
+        assert!(
+            shared_db.abs() < 1.0,
+            "shared-front-end noise bandwidth is {shared_db:+.2} dB against the \
+             reference band (shared {shared_enbw:.4e}, ref {ref_enbw:.4e})"
         );
     }
 }

--- a/mfsk-core/tests/ft4_ddc_equivalence.rs
+++ b/mfsk-core/tests/ft4_ddc_equivalence.rs
@@ -55,7 +55,7 @@ use mfsk_core::engine::pipeline::{
 use mfsk_core::engine::sync::SyncCandidate;
 use mfsk_core::engine::sync2d::ft4_sync_search;
 use mfsk_core::ft4::Ft4;
-use mfsk_core::ft4::ddc::candidate_baseband;
+use mfsk_core::ft4::ddc::{candidate_baseband, candidate_baseband_shared, shared_baseband};
 use mfsk_core::ft4::decode::FT4_DOWNSAMPLE;
 use mfsk_core::msg::wsjt77::unpack77;
 
@@ -101,18 +101,23 @@ fn rms_normalise(cd0: &mut [Complex<f32>]) {
     }
 }
 
-/// Arm B: DDC baseband → refined position → decode.
+/// Arm B/C: a DDC baseband → refined position → decode.
+///
+/// `cd0` is whichever front end is under test — [`candidate_baseband`]
+/// for the direct two-stage chain, or
+/// [`candidate_baseband_shared`] behind the slot-wide decimate-by-2.
+/// Everything after it is identical, which is what makes the two arms
+/// comparable to each other as well as to the FFT path.
 ///
 /// Returns the refined `(freq_hz, i0)` alongside the result so a
 /// divergence can be attributed to the sync search rather than to the
 /// decoder.
 fn ddc_arm(
     cand: &SyncCandidate,
-    audio: &[i16],
+    mut cd0: Vec<Complex<f32>>,
     fft_cache: &[Complex<f32>],
     depth: DecodeDepth,
 ) -> (Option<DecodeResult>, f32, i32) {
-    let mut cd0 = candidate_baseband(audio, cand.freq_hz);
     rms_normalise(&mut cd0);
     let s2 = ft4_sync_search::<Ft4>(&cd0, cand);
     let (freq_hz, i0) = (s2.freq_hz, s2.i0);
@@ -166,6 +171,9 @@ fn ft4_ddc_baseband_decodes_the_golden_like_the_fft_path() {
     let cands = ft4_coarse_sync(&audio, FREQ_MIN_HZ, FREQ_MAX_HZ, SYNC_MIN, None, MAX_CAND);
     assert!(!cands.is_empty(), "coarse stage found nothing");
     let fft_cache = build_fft_cache(&audio, &FT4_DOWNSAMPLE);
+    // Arm C's shared leg: computed once for the slot, exactly as a
+    // receiver would (`FT4_BENCHMARK.md` §37.2).
+    let pre = shared_baseband(&audio);
 
     for (depth_name, depth) in [
         ("EMBEDDED", DecodeDepth::EMBEDDED),
@@ -173,6 +181,8 @@ fn ft4_ddc_baseband_decodes_the_golden_like_the_fft_path() {
     ] {
         let mut fft_results: Vec<DecodeResult> = Vec::new();
         let mut ddc_results: Vec<DecodeResult> = Vec::new();
+        let mut shared_results: Vec<DecodeResult> = Vec::new();
+        let mut max_shared_dfreq = 0.0f32;
         // Refined-position disagreement, over candidates *both* arms
         // decode — the diagnostic that separates "the filter moved the
         // sync peak" from "the decoder gave up".
@@ -192,7 +202,20 @@ fn ft4_ddc_baseband_decodes_the_golden_like_the_fft_path() {
                 EqMode::Off,
                 SYNC_Q_MIN,
             );
-            let (ddc_r, ddc_freq, ddc_i0) = ddc_arm(c, &audio, &fft_cache, depth);
+            let (ddc_r, ddc_freq, ddc_i0) =
+                ddc_arm(c, candidate_baseband(&audio, c.freq_hz), &fft_cache, depth);
+            let (shared_r, shared_freq, _) = ddc_arm(
+                c,
+                candidate_baseband_shared(&pre, c.freq_hz),
+                &fft_cache,
+                depth,
+            );
+            if ddc_r.is_some() && shared_r.is_some() {
+                max_shared_dfreq = max_shared_dfreq.max((ddc_freq - shared_freq).abs());
+            }
+            if let Some(r) = shared_r {
+                shared_results.push(r);
+            }
 
             if let (Some(a), Some(_)) = (&fft_r, &ddc_r) {
                 both += 1;
@@ -218,14 +241,17 @@ fn ft4_ddc_baseband_decodes_the_golden_like_the_fft_path() {
 
         let fft_msgs = sorted_messages(&fft_results);
         let ddc_msgs = sorted_messages(&ddc_results);
+        let shared_msgs = sorted_messages(&shared_results);
 
         eprintln!(
             "[{depth_name}] {} candidates | FFT path {} distinct | DDC path {} distinct | \
-             max Δfreq {max_dfreq:.2} Hz ({freq_steps_off}/{both} candidates one step off), \
-             max Δi0 {max_di0}",
+             shared path {} distinct | max Δfreq {max_dfreq:.2} Hz \
+             ({freq_steps_off}/{both} candidates one step off), max Δi0 {max_di0}, \
+             max Δfreq DDC-vs-shared {max_shared_dfreq:.2} Hz",
             cands.len(),
             fft_msgs.len(),
-            ddc_msgs.len()
+            ddc_msgs.len(),
+            shared_msgs.len()
         );
         for m in &fft_msgs {
             let mark = if ddc_msgs.contains(m) { "  " } else { "!!" };
@@ -248,6 +274,23 @@ fn ft4_ddc_baseband_decodes_the_golden_like_the_fft_path() {
         assert_eq!(
             ddc_msgs, fft_msgs,
             "[{depth_name}] DDC front end decoded a different set than the FFT front end"
+        );
+        // Arm C is the same front end with a slot-wide decimate-by-2
+        // ahead of it (`ft4::ddc::shared_baseband`). It is a third
+        // filter stage, so it is not bit-identical to arm B — but it
+        // reproduces the same band to +0.021 dB of noise bandwidth
+        // (`ft4::ddc::tests::noise_bandwidth_matches_the_reference_band`),
+        // and the decodes are what say whether that is enough.
+        assert_eq!(
+            shared_msgs, fft_msgs,
+            "[{depth_name}] the shared decimate-by-2 front end decoded a different \
+             set than the FFT front end"
+        );
+        assert!(
+            max_shared_dfreq <= 1.0,
+            "[{depth_name}] the shared front end moved the refined frequency \
+             {max_shared_dfreq:.2} Hz against the direct DDC — more than \
+             ft4_sync_search's own 1 Hz grid step"
         );
         // The two front ends are different filters, so the refined
         // position may land one search cell away — but only one.
@@ -397,10 +440,15 @@ fn ft4_ddc_recall_matches_the_fft_path_across_the_crossing() {
                     .is_some_and(is_golden);
                 }
                 if !ddc_hit {
-                    ddc_hit = ddc_arm(c, &audio, &fft_cache, DecodeDepth::FULL)
-                        .0
-                        .as_ref()
-                        .is_some_and(is_golden);
+                    ddc_hit = ddc_arm(
+                        c,
+                        candidate_baseband(&audio, c.freq_hz),
+                        &fft_cache,
+                        DecodeDepth::FULL,
+                    )
+                    .0
+                    .as_ref()
+                    .is_some_and(is_golden);
                 }
                 if fft_hit && ddc_hit {
                     break;
@@ -506,10 +554,14 @@ fn ft4_ddc_arm_never_reads_the_wideband_cache() {
         let mut with_cache: Vec<DecodeResult> = Vec::new();
         let mut without_cache: Vec<DecodeResult> = Vec::new();
         for c in &cands {
-            if let (Some(r), _, _) = ddc_arm(c, &audio, &fft_cache, depth) {
+            if let (Some(r), _, _) =
+                ddc_arm(c, candidate_baseband(&audio, c.freq_hz), &fft_cache, depth)
+            {
                 with_cache.push(r);
             }
-            if let (Some(r), _, _) = ddc_arm(c, &audio, &empty, depth) {
+            if let (Some(r), _, _) =
+                ddc_arm(c, candidate_baseband(&audio, c.freq_hz), &empty, depth)
+            {
                 without_cache.push(r);
             }
         }


### PR DESCRIPTION
`FT4_BENCHMARK.md` §37.2 left the shared front end as a measurement — `FirStage::push_block_real` existed and `ft4::ddc` did not call it. This wires it.

## What changed

`ft4::ddc` gains:

- `SharedFrontEnd` — the 165-tap decimate-by-2 over the slot's real audio, fed a block at a time;
- `CandidateDdc::new_predecimated` / `push_f32` — the same chain with stage A cut to 101 taps and decimate-by-9 at 6 kHz (stage B and the derotation untouched);
- `shared_baseband` / `candidate_baseband_shared` — block helpers matching `candidate_baseband`'s contract exactly.

`candidate_baseband`'s two-stage 12 kHz chain is unchanged.

**The shared leg streams from the capture side**, the way the coarse stage already does: `ft4_rx::SlotAccum` runs it beside `Ft4SavgBuilder`, and `CapturedSlot` carries the 6 kHz stream *instead of* the 12 kHz audio — 45 000 `f32` against 90 000 `i16`, the same 180 KB, and nothing below the candidate loop wanted 12 kHz. So §37.2's 108 ms lands on the capture thread at ~0.3 ms per 256-sample block (§33's budget for that block is 21.3 ms) rather than on the 1 960 ms that decides how many candidates get tried.

## Measured — CoreS3, `ft4-demo`, eleven slots each, same baked golden

```
before  11 of 12 candidates, 10 decodes in 2067-2118 ms — cut 1 at score 1.55
after   12 of 12 candidates, 11 decodes in 1932-1987 ms
```

| | before | after |
|---|---:|---:|
| candidates tried | 11 of 12 | **12 of 12** |
| decodes | 10 | **11** |
| post-slot | 2 118 ms | **1 987 ms** |
| per candidate | 192.5 ms | **165.6 ms** |

26.9 ms per candidate against the 30.2 the leg measurement projected, and §34's cut — which had fired on every slot since it was built — does not fire. The eleventh decode is `W7BOB KJ7G RR73` at −17 dB, the weakest signal on the recording and exactly what the deadline had been giving up. Cost: 8.9 KB internal heap.

## Equivalence (three stages are not two, so it is measured)

- noise bandwidth **+0.021 dB** against `downsample_cached`'s band — the direct DDC's own figure, to four digits;
- `ft4_ddc_equivalence` grows a third arm: same 11 golden messages at both `EMBEDDED` and `FULL`, refined frequencies matching the direct DDC to **0.00 Hz**;
- \>50 dB rejection of the 3 200 Hz+ content the decimation would otherwise fold onto the search band (this is what 165 taps buys, and why §37.1's 111 was wrong);
- block-size independence across seven chunk sizes, since the stage runs from a capture callback.

## Not closed

The tier-C 560-file recall comparison has **not** been re-run — no `ft4_sweep` corpus on the measuring machine. This is golden-neutral, not yet sensitivity-neutral.

Docs: `docs/notes/FT4_BENCHMARK.md` §39, `docs/reference/EMBEDDED.md` + `.ja.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UcazZPoiKAtMBQxdaTSq5i