### PR TITLE
fix(ft4): the slot grid was steered from the wrong reference frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,49 @@
 
 ## 0.10.2 — the M5StickS3 USB-host claim said more than the measurement did
 
-**Why a patch bump.** Documentation and release tooling. No public API
-change, no decoder behaviour change, no measured sensitivity movement.
+**Why a patch bump.** Additive public API, an embedded-only fix,
+documentation and release tooling. No host decoder behaviour change and
+no measured sensitivity movement.
 This section accumulates until the next tag — see `CLAUDE.md`'s
 "Release cadence".
+
+### Fixed
+
+- **FT4's slot grid was steered from the wrong reference frame, and now
+  has tests (#354).** `apps/ft4.rs` read "samples to the next UTC
+  boundary" from the clock and handed it straight to
+  `SlotAccum::anchor_or_reanchor`, which counts from where the
+  *accumulator* sits in the sample stream. The two are the staged-but-
+  not-yet-fed backlog apart. During capture that is one UAC read
+  (~21 ms) and would not matter; once a slot it is the decode — the
+  ~1.4 s that piles up while `decode_slot` runs — which is past
+  `REANCHOR_THRESH_SAMPLES` and comparable to the whole ±1.0 s Δt
+  search. A grid that was not drifting therefore read as off by exactly
+  the backlog, in the same direction, every slot. The caller now
+  converts before it asks.
+
+  Found by reading, not by running: this path is inside `if live`, so
+  the baked-golden replay never reaches it and nothing had exercised it
+  yet.
+
+- **`embedded_shared::apps::ft4_grid::SlotGrid`** — the slot grid's
+  arithmetic, split out of `SlotAccum` with no DSP and no ESP-IDF in
+  it, so `hosttest/mfsk-app-shared` compiles it and its cases run in
+  CI. `ft4_rx` pulls in `esp_idf_svc` and spawns a second core, so it
+  only builds for Xtensa, and `embedded-poc` sits outside the host
+  workspace with neither CI lint nor CI test reaching it — what was
+  left checking this was a live run against a radio, which is the most
+  expensive instrument available and the last one to be pointed at an
+  off-by-one.
+
+  Behaviour is unchanged: the same skip/fill/carry the accumulator
+  already ran, moved where it can be tested. Seven cases, including the
+  reference-frame bug above, the trim landing at the next window close
+  rather than on a gap already set, the wrap that keeps a boundary just
+  behind the grid reading as a small negative error, and a correction
+  too large for one 0.725 s gap being carried rather than truncated.
+  `SlotAccum::phase_error` exposes the same number for the receiver to
+  log.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,17 @@ This section accumulates until the next tag — see `CLAUDE.md`'s
   expensive instrument available and the last one to be pointed at an
   off-by-one.
 
+  It also corrects a claim in three places — `capture_window.rs`'s
+  module doc, `ROADMAP.md`, and this file's own #313 entry below — that
+  FT8 and FT4 both capture a *contiguous* grid and so have no
+  inter-slot gap to manage. That is true of FT8 only. FT4 closes its
+  capture at 6.775 s of a 7.5 s slot and discards the 8 700 samples
+  between, which is the same skip `CaptureWindow` exists for; what is
+  actually different is that FT4's grid carries a phase correction
+  across window closes and `CaptureWindow` has no state of that kind.
+  Both remain consolidation candidates rather than one covering the
+  other, and neither is changed.
+
   Behaviour is unchanged: the same skip/fill/carry the accumulator
   already ran, moved where it can be tested. Seven cases, including the
   reference-frame bug above, the trim landing at the next window close
@@ -215,9 +226,10 @@ This section accumulates until the next tag — see `CLAUDE.md`'s
   by `hosttest/mfsk-app-shared` rather than trusted: the app crate
   builds only for Xtensa, and this is the third slot grid in it. The
   other two — FT8's `Ft8ChunkSink` in `uac.rs`, FT4's
-  `ft4_rx::SlotAccum` (#354, shipped in 0.10.1) — capture a contiguous
-  grid where every sample belongs to some slot, so neither needed the
-  gap this type manages, and neither is changed here. `civil_time
+  `ft4_rx::SlotAccum` (#354, shipped in 0.10.1) — keep their own, and
+  neither is changed here. (This entry said both capture a contiguous
+  grid and so had no gap to manage. That is true of FT8 only; see the
+  correction in this section's own FT4 entry above.) `civil_time
   ::slot_start_unix` rounds a clock read to the nearest slot boundary
   rather than flooring, since the read that opens a window lands a few
   milliseconds either side of the boundary it aimed at and flooring

--- a/docs/notes/ROADMAP.md
+++ b/docs/notes/ROADMAP.md
@@ -424,9 +424,15 @@ version if you're picking up work.
   with no plausible clock it idles the fixed 6 s tail instead and says
   so. The batch-splitting and gap arithmetic moved to
   `mfsk_app_shared::capture_window`, which `hosttest/mfsk-app-shared`
-  compiles and tests. FT8 (`uac.rs`) and FT4 (`ft4_rx::SlotAccum`,
-  #354) keep their own bookkeeping: both capture a contiguous grid, so
-  neither needs the inter-slot gap this type manages.
+  compiles and tests. FT8 (`uac.rs`) and FT4 (`ft4_grid::SlotGrid`,
+  #354) keep their own bookkeeping. **Only FT8 captures a contiguous
+  grid** and so genuinely has no gap to manage; this paragraph said
+  the same of FT4 until 2026-09-09 and was wrong — FT4 closes at
+  6.775 s of a 7.5 s slot and discards the 8 700 samples between. What
+  is different about FT4 is that its grid also carries a phase
+  correction across window closes, which `CaptureWindow` has no state
+  for. Both are consolidation candidates, not cases this type already
+  covers.
 
   What is left needs things a host cannot supply: the wsprnet sink is
   blocked on a live third-party endpoint (and carries a cost the

--- a/embedded-poc/embedded-shared/src/apps/ft4_grid.rs
+++ b/embedded-poc/embedded-shared/src/apps/ft4_grid.rs
@@ -1,0 +1,373 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//! The FT4 capture window's place on the slot grid — the arithmetic
+//! half of [`SlotAccum`](super::ft4_rx::SlotAccum), with no DSP and no
+//! ESP-IDF in it.
+//!
+//! Split out so it can be tested. `ft4_rx` pulls in `esp_idf_svc` for
+//! `esp_timer_get_time` and spawns a second core, so it only compiles
+//! for Xtensa, and `embedded-poc` is outside the host workspace with
+//! neither CI lint nor CI test reaching it (`embedded-poc/CLAUDE.md`
+//! opens on exactly that). What was left checking this was a live run
+//! against a radio, which is the most expensive instrument available
+//! and the last one to be pointed at an off-by-one.
+//!
+//! Everything here is `usize`/`i32` over sample counts, so
+//! `hosttest/mfsk-app-shared` compiles it and the cases below run in
+//! CI. The window length, the grid period and the re-anchor threshold
+//! are constructor arguments rather than constants: their values and
+//! the measurements behind them stay in `ft4_rx`, and a test can use
+//! small round numbers.
+//!
+//! # Against `mfsk_app_shared::capture_window::CaptureWindow`
+//!
+//! The two overlap and are not the same. `CaptureWindow` decides what
+//! to do with a batch given a phase reading and is re-armed by its
+//! caller each window; this carries the phase itself — a pending
+//! correction across window closes, and a threshold below which the
+//! clock is ignored in favour of the DT-median trim. Its doc records
+//! the position that folding FT4 onto it would be a consolidation
+//! rather than a fix, and nothing here changes that: this is the same
+//! arithmetic `SlotAccum` already ran, moved where it can be tested.
+//!
+//! One claim there is worth checking against the code before it is
+//! relied on: FT4 does not capture a contiguous grid. `SlotAccum`
+//! discards `SLOT_SAMPLES - CAPTURE_CLOSE_SAMPLES` — 8 700 samples,
+//! 0.725 s — between windows, because the capture closes at 6.775 s of
+//! a 7.5 s slot. FT8 is the contiguous one.
+//!
+//! # The two reference frames
+//!
+//! Every phase figure here is counted **from where the accumulator
+//! sits in the sample stream**, never from the wall clock. The two are
+//! not the same point: audio arrives while the decoder is busy, so the
+//! accumulator is normally behind real time by whatever is staged and
+//! not yet fed. On FT4 that gap is ~1.4 s once per slot — the decode
+//! budget — which is larger than the whole re-anchor threshold and
+//! comparable to the Δt search itself.
+//!
+//! [`SlotGrid::anchor_or_reanchor`] therefore takes
+//! `samples_to_boundary_from_here`, and it is the caller's job to
+//! convert: a clock that says the boundary is `remain` samples away
+//! from *now* puts it `remain + staged_not_yet_fed` samples away from
+//! the accumulator.
+
+/// Where the capture window sits on the slot grid, and what is pending
+/// against it.
+#[derive(Clone, Copy, Debug)]
+pub struct SlotGrid {
+    window: usize,
+    period: usize,
+    reanchor_thresh: i32,
+    /// Samples of the current window already filled.
+    filled: usize,
+    /// Samples still to be discarded before the next window opens.
+    skip: usize,
+    /// Signed correction folded into `skip` the next time a window
+    /// closes — from the UTC drift check and from the DT-median trim
+    /// alike.
+    pending_shift: i32,
+    aligned: bool,
+}
+
+impl SlotGrid {
+    /// `window` is the capture window in samples, `period` the slot
+    /// grid's period (window plus the inter-window gap), and
+    /// `reanchor_thresh` the phase error past which
+    /// [`anchor_or_reanchor`](Self::anchor_or_reanchor) moves the grid
+    /// rather than leaving the wobble to the DT trim.
+    pub fn new(window: usize, period: usize, reanchor_thresh: i32) -> Self {
+        Self {
+            window,
+            period,
+            reanchor_thresh,
+            filled: 0,
+            skip: 0,
+            pending_shift: 0,
+            aligned: false,
+        }
+    }
+
+    /// Whether an external clock has set the grid's phase at least
+    /// once. Until it has, the grid free-runs from the first sample the
+    /// accumulator ever saw — which is what a receiver replaying a
+    /// recording, or one with no clock at all, is left with.
+    pub fn is_aligned(&self) -> bool {
+        self.aligned
+    }
+
+    /// Samples from the accumulator's position to the next window
+    /// opening, given where it sits in its skip / fill / skip cycle.
+    /// The phase [`anchor_or_reanchor`](Self::anchor_or_reanchor)
+    /// compares against the clock's.
+    pub fn samples_to_next_window_open(&self) -> i32 {
+        if self.skip > 0 {
+            self.skip as i32
+        } else {
+            // Mid-window (or opening now): finish filling it, then the
+            // inter-window skip.
+            (self.window - self.filled) as i32 + (self.period - self.window) as i32
+        }
+    }
+
+    /// Set — or, once set, trim — the grid's phase from an external
+    /// clock.
+    ///
+    /// `samples_to_boundary_from_here` is counted from the
+    /// **accumulator's** position, not from now; see the module doc for
+    /// why the distinction is load-bearing rather than pedantic.
+    ///
+    /// The first call anchors the grid outright: the next window opens
+    /// on that boundary. Later calls move it only when the phase has
+    /// drifted past the re-anchor threshold, which is what absorbs the
+    /// clock stepping when NTP first disciplines an RTC-seeded clock —
+    /// that step can be seconds, well past what the Δt search could
+    /// pull back. Jitter below the threshold is left for
+    /// [`shift_next_window`](Self::shift_next_window).
+    pub fn anchor_or_reanchor(&mut self, samples_to_boundary_from_here: usize) {
+        if !self.aligned {
+            // Exactly on a boundary reads as a whole period; that means
+            // "open now", not "skip a slot".
+            self.skip = samples_to_boundary_from_here % self.period;
+            self.filled = 0;
+            self.pending_shift = 0;
+            self.aligned = true;
+            return;
+        }
+        if let Some(delta) = self.phase_error(samples_to_boundary_from_here) {
+            self.pending_shift += delta;
+        }
+    }
+
+    /// The signed phase error the next [`anchor_or_reanchor`] would act
+    /// on, or `None` when it is inside the threshold. Positive means
+    /// the clock's boundary is later than the grid's — the grid is
+    /// running early.
+    ///
+    /// Public because it is the number worth logging: it is the
+    /// disagreement between the clock and the grid, which with a
+    /// disciplined clock is the band's offset and with an RTC-seeded
+    /// one is that chip's drift accumulating in view.
+    pub fn phase_error(&self, samples_to_boundary_from_here: usize) -> Option<i32> {
+        let period = self.period as i32;
+        let want = (samples_to_boundary_from_here % self.period) as i32;
+        let have = self.samples_to_next_window_open();
+        // Normalised to (−½ period, +½ period]: the sign says which way
+        // the grid is off, not how many slots.
+        let mut delta = (want - have) % period;
+        if delta > period / 2 {
+            delta -= period;
+        } else if delta <= -period / 2 {
+            delta += period;
+        }
+        (delta.abs() > self.reanchor_thresh).then_some(delta)
+    }
+
+    /// Fold a signed correction into the next inter-window gap — the
+    /// DT-median trim. Positive delays the next window: the slot opened
+    /// early, so the decoded signals sat late in it (WSJT-X's DT sign).
+    pub fn shift_next_window(&mut self, delta_samples: i32) {
+        self.pending_shift += delta_samples;
+    }
+
+    /// How many of `avail` samples to discard before the next window
+    /// opens. Consumes them.
+    pub fn take_skip(&mut self, avail: usize) -> usize {
+        let take = self.skip.min(avail);
+        self.skip -= take;
+        take
+    }
+
+    /// Room left in the current window.
+    pub fn room(&self) -> usize {
+        self.window - self.filled
+    }
+
+    /// Advance the window by `n` filled samples. Returns `true` on the
+    /// call that closes it, having already set the next gap.
+    ///
+    /// `n` must not exceed [`room`](Self::room) — the caller splits a
+    /// block on the boundary, which is what keeps its block size from
+    /// shifting the grid.
+    pub fn fill(&mut self, n: usize) -> bool {
+        self.filled += n;
+        debug_assert!(self.filled <= self.window);
+        if self.filled < self.window {
+            return false;
+        }
+        self.filled = 0;
+        // The inter-window gap, plus whatever correction the clock
+        // check and the DT trim asked for. A correction too big for one
+        // gap to hold is clamped and the remainder carried into the
+        // next, so a shift larger than the gap takes two boundaries
+        // instead of being silently truncated.
+        let want_skip =
+            (self.period - self.window) as i32 + core::mem::take(&mut self.pending_shift);
+        self.skip = want_skip.clamp(0, self.period as i32) as usize;
+        self.pending_shift = want_skip - self.skip as i32;
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Round numbers in the same proportions as FT4's own: a window
+    // that is most of the period, and a threshold well under the gap.
+    const WINDOW: usize = 800;
+    const PERIOD: usize = 1_000;
+    const THRESH: i32 = 20;
+
+    fn aligned_grid() -> SlotGrid {
+        let mut g = SlotGrid::new(WINDOW, PERIOD, THRESH);
+        // Anchor with the boundary right here: the window opens now.
+        g.anchor_or_reanchor(0);
+        assert!(g.is_aligned());
+        assert_eq!(
+            g.take_skip(PERIOD),
+            0,
+            "an anchor at 0 must not skip a slot"
+        );
+        g
+    }
+
+    /// Finish whatever window is open, then discard the gap that
+    /// follows it. Returns the samples that gap actually consumed —
+    /// which is where a pending trim becomes visible, since a trim is
+    /// folded in when a window *closes*, not onto a gap already set.
+    fn one_cycle(g: &mut SlotGrid) -> usize {
+        g.take_skip(PERIOD);
+        let room = g.room();
+        assert!(g.fill(room), "filling the room must close the window");
+        g.take_skip(PERIOD)
+    }
+
+    #[test]
+    fn an_anchored_grid_holds_its_period() {
+        let mut g = aligned_grid();
+        for _ in 0..4 {
+            assert_eq!(one_cycle(&mut g), PERIOD - WINDOW);
+        }
+    }
+
+    /// The case a live run would otherwise be the first thing to check:
+    /// a clock figure that was measured at "now" while the accumulator
+    /// is a decode's worth of audio behind it.
+    #[test]
+    fn a_boundary_counted_from_now_is_not_a_boundary_counted_from_here() {
+        // A decode's backlog, in the same proportion FT4 has: the
+        // window is 800 of a 1 000 period and the decode holds ~1.4 s
+        // of a 7.5 s slot, so ~190 here.
+        const BACKLOG: usize = 190;
+
+        let mut g = aligned_grid();
+        one_cycle(&mut g);
+        // Re-open and close one more window so the grid is sitting in
+        // its gap, which is where the caller checks the clock.
+        let room = g.room();
+        g.fill(room);
+        let here = g.samples_to_next_window_open();
+        assert_eq!(here, (PERIOD - WINDOW) as i32);
+
+        // The clock is right and the grid is right, but the clock was
+        // read `BACKLOG` samples further down the stream than the
+        // accumulator has reached.
+        let remain_from_now = (here as usize + PERIOD - BACKLOG) % PERIOD;
+
+        // Passed as-is, it reads as a phase error of exactly the
+        // backlog — every slot, in the same direction, on a grid that
+        // was not drifting.
+        let mut naive = g;
+        assert_eq!(naive.phase_error(remain_from_now), Some(-(BACKLOG as i32)));
+        naive.anchor_or_reanchor(remain_from_now);
+        // A trim lands at the *next* window close, not on the gap
+        // already set, so run one cycle to see it.
+        assert_eq!(
+            one_cycle(&mut naive),
+            (PERIOD - WINDOW) - BACKLOG,
+            "the grid walks by the backlog, and would again next slot"
+        );
+
+        // Converted to this frame first, it reads as no error.
+        let mut correct = g;
+        assert_eq!(correct.phase_error(remain_from_now + BACKLOG), None);
+        correct.anchor_or_reanchor(remain_from_now + BACKLOG);
+        assert_eq!(one_cycle(&mut correct), PERIOD - WINDOW);
+    }
+
+    /// The same conversion at the *first* anchor, where getting it
+    /// wrong is worse: nothing bounds it, the grid simply opens in the
+    /// wrong place.
+    #[test]
+    fn the_first_anchor_is_counted_from_here_too() {
+        const BACKLOG: usize = 190;
+        let mut g = SlotGrid::new(WINDOW, PERIOD, THRESH);
+        // The boundary is 300 samples ahead of *now*, and the
+        // accumulator is BACKLOG behind now.
+        g.anchor_or_reanchor(300 + BACKLOG);
+        assert_eq!(g.take_skip(PERIOD), 300 + BACKLOG);
+    }
+
+    #[test]
+    fn a_step_larger_than_the_threshold_moves_the_grid_and_jitter_does_not() {
+        let mut g = aligned_grid();
+        one_cycle(&mut g);
+        let room = g.room();
+        g.fill(room);
+        let here = g.samples_to_next_window_open() as usize;
+
+        // Inside the threshold: left to the DT trim.
+        let mut jitter = g;
+        jitter.anchor_or_reanchor(here + (THRESH as usize));
+        assert_eq!(one_cycle(&mut jitter), PERIOD - WINDOW);
+
+        // Past it: the next gap moves by exactly the error.
+        let mut step = g;
+        step.anchor_or_reanchor(here + 100);
+        assert_eq!(one_cycle(&mut step), (PERIOD - WINDOW) + 100);
+    }
+
+    /// The wrap is the point: a boundary just *behind* the grid must
+    /// read as a small negative error, not as nearly a whole period.
+    #[test]
+    fn phase_error_takes_the_short_way_round() {
+        let mut g = aligned_grid();
+        one_cycle(&mut g);
+        let room = g.room();
+        g.fill(room);
+        let here = g.samples_to_next_window_open() as usize;
+
+        assert_eq!(g.phase_error(here + PERIOD - 100), Some(-100));
+        assert_eq!(g.phase_error(here + 100), Some(100));
+        // And the far side of the period is the same point.
+        assert_eq!(g.phase_error(here + PERIOD), None);
+    }
+
+    /// A correction bigger than one gap can hold is carried, not lost.
+    #[test]
+    fn an_oversized_shift_is_carried_to_the_next_boundary() {
+        let mut g = aligned_grid();
+        let gap = (PERIOD - WINDOW) as i32;
+        // Ask to pull the next window in by more than the whole gap.
+        g.shift_next_window(-gap - 50);
+        assert_eq!(one_cycle(&mut g), 0, "the gap cannot go negative");
+        // The remainder lands on the following boundary.
+        assert_eq!(one_cycle(&mut g), (gap - 50) as usize);
+        // And then it is spent.
+        assert_eq!(one_cycle(&mut g), gap as usize);
+    }
+
+    /// A block straddling the boundary must not shift the grid, which
+    /// is why the caller splits it.
+    #[test]
+    fn filling_in_pieces_is_filling_in_one_go() {
+        let mut whole = aligned_grid();
+        let mut pieces = aligned_grid();
+        assert!(whole.fill(WINDOW));
+        for _ in 0..(WINDOW / 8) {
+            assert!(!pieces.fill(8) || pieces.room() == WINDOW);
+        }
+        assert_eq!(whole.room(), pieces.room());
+        assert_eq!(whole.take_skip(PERIOD), pieces.take_skip(PERIOD));
+    }
+}

--- a/embedded-poc/embedded-shared/src/apps/ft4_rx.rs
+++ b/embedded-poc/embedded-shared/src/apps/ft4_rx.rs
@@ -49,6 +49,7 @@ use mfsk_core::ft4::Ft4;
 use mfsk_core::msg::wsjt77::unpack77;
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicUsize, Ordering};
+use super::ft4_grid::SlotGrid;
 use mfsk_core::engine::sync::SyncCandidate;
 use num_complex::Complex;
 
@@ -143,10 +144,6 @@ const MAX_CAND: usize = 100;
 /// not a curve, and every station past the edge is lost outright.
 const WSJTX_WINDOW: (i32, i32) = (-344, 1012);
 
-/// The slot grid's period — one FT4 slot. [`SlotAccum::anchor_or_reanchor`]
-/// works modulo this.
-const GRID_PERIOD: i32 = SLOT_SAMPLES as i32;
-
 /// Phase error past which [`SlotAccum::anchor_or_reanchor`] moves the
 /// grid rather than leaving the wobble to the DT-median trim. 100 ms — a
 /// tenth of the ±1.0 s [`WSJTX_WINDOW`], the same ratio `uac.rs`'s
@@ -196,26 +193,18 @@ pub struct SlotAccum {
     savg: Ft4SavgBuilder,
     decim: SlotDecimator,
     half: Vec<f32>,
-    /// Samples still to be discarded before the next slot's window
-    /// opens: the slot grid is 7.5 s and the window is 6.25 s, so the
-    /// tail no candidate can reach is dropped rather than accumulated.
-    /// This is what keeps the grid a *slot* grid after the early
-    /// close — without it each window would start 1.25 s earlier than
-    /// the last and walk off the transmissions entirely.
-    skip: usize,
-    /// Signed sample correction folded into `skip` the next time a
-    /// window closes. Both the UTC drift check
-    /// ([`anchor_or_reanchor`](Self::anchor_or_reanchor)) and the
-    /// DT-median trim ([`shift_next_window`](Self::shift_next_window))
-    /// land here. The board crate owns the clock and the DT tracker
+    /// Where the window sits on the slot grid: the inter-window skip
+    /// that keeps this a *slot* grid after the early close (without it
+    /// each window would start 1.25 s earlier than the last and walk
+    /// off the transmissions entirely), the pending phase correction,
+    /// and whether an external clock has set the phase at all.
+    ///
+    /// Its own module, because it is integer arithmetic and this one
+    /// cannot be compiled off-target — see [`SlotGrid`]'s doc. The
+    /// board crate owns the clock and the DT tracker
     /// (`mfsk-app-shared`'s `time_sync`); this crate only moves the grid
     /// when told, the same shared/board split the module doc describes.
-    pending_shift: i32,
-    /// Whether an external clock has set the grid phase at least once.
-    /// Until it has, the grid free-runs from the first sample the
-    /// accumulator ever saw — which is what a receiver replaying a
-    /// recording, or one with no clock at all, is left with.
-    aligned: bool,
+    grid: SlotGrid,
 }
 
 impl Default for SlotAccum {
@@ -233,30 +222,24 @@ impl SlotAccum {
             // Half the window; the stage's group delay is what makes
             // it a little short of exactly half.
             half: Vec::with_capacity(CAPTURE_CLOSE_SAMPLES / 2),
-            skip: 0,
-            pending_shift: 0,
-            aligned: false,
+            grid: SlotGrid::new(CAPTURE_CLOSE_SAMPLES, SLOT_SAMPLES, REANCHOR_THRESH_SAMPLES),
         }
     }
 
     /// Whether the grid has been anchored to an external clock.
     pub fn is_aligned(&self) -> bool {
-        self.aligned
+        self.grid.is_aligned()
     }
 
-    /// Samples from now until the next capture window opens, given where
-    /// the accumulator currently sits in its skip / fill / skip cycle.
-    /// The phase reference [`anchor_or_reanchor`](Self::anchor_or_reanchor)
-    /// compares against UTC.
-    fn samples_to_next_window_open(&self) -> i32 {
-        if self.skip > 0 {
-            self.skip as i32
-        } else {
-            // Mid-window (or opening now): finish filling it, then the
-            // inter-window skip.
-            (CAPTURE_CLOSE_SAMPLES - self.audio.len()) as i32
-                + (SLOT_SAMPLES - CAPTURE_CLOSE_SAMPLES) as i32
-        }
+    /// The signed disagreement between the clock's boundary and the
+    /// grid's, in samples, or `None` when it is inside the re-anchor
+    /// threshold. Positive means the grid is running early.
+    ///
+    /// Same frame as [`anchor_or_reanchor`](Self::anchor_or_reanchor) —
+    /// counted from the accumulator, not from now. Exposed so a
+    /// receiver can log the number it is steering on.
+    pub fn phase_error(&self, samples_to_boundary_from_here: usize) -> Option<i32> {
+        self.grid.phase_error(samples_to_boundary_from_here)
     }
 
     /// Set — or, once set, trim — the slot grid's phase from an external
@@ -275,27 +258,8 @@ impl SlotAccum {
     /// step can be seconds, well past what the DT search could pull
     /// back. Jitter below the threshold is left for
     /// [`shift_next_window`](Self::shift_next_window).
-    pub fn anchor_or_reanchor(&mut self, samples_to_boundary: usize) {
-        if !self.aligned {
-            // Exactly on a boundary reads as a whole period; that means
-            // "open now", not "skip a slot".
-            self.skip = samples_to_boundary % GRID_PERIOD as usize;
-            self.aligned = true;
-            return;
-        }
-        // Phase error, normalised to (−½ slot, +½ slot]: the sign says
-        // which way the grid is off, not how many slots.
-        let want = samples_to_boundary as i32;
-        let have = self.samples_to_next_window_open();
-        let mut delta = (want - have) % GRID_PERIOD;
-        if delta > GRID_PERIOD / 2 {
-            delta -= GRID_PERIOD;
-        } else if delta <= -GRID_PERIOD / 2 {
-            delta += GRID_PERIOD;
-        }
-        if delta.abs() > REANCHOR_THRESH_SAMPLES {
-            self.pending_shift += delta;
-        }
+    pub fn anchor_or_reanchor(&mut self, samples_to_boundary_from_here: usize) {
+        self.grid.anchor_or_reanchor(samples_to_boundary_from_here);
     }
 
     /// Fold a signed correction into the next inter-window skip — the
@@ -305,7 +269,7 @@ impl SlotAccum {
     /// [`anchor_or_reanchor`](Self::anchor_or_reanchor) has the grid
     /// within ~100 ms of UTC before this ever runs.
     pub fn shift_next_window(&mut self, delta_samples: i32) {
-        self.pending_shift += delta_samples;
+        self.grid.shift_next_window(delta_samples);
     }
 
     /// Feed the next block. Returns the finished slot on the block that
@@ -335,30 +299,22 @@ impl SlotAccum {
         let mut rest = samples;
         let mut done = None;
         while !rest.is_empty() {
-            if self.skip > 0 {
-                let take = self.skip.min(rest.len());
-                self.skip -= take;
-                rest = &rest[take..];
+            let dropped = self.grid.take_skip(rest.len());
+            if dropped > 0 {
+                rest = &rest[dropped..];
                 continue;
             }
-            let room = CAPTURE_CLOSE_SAMPLES - self.audio.len();
-            let take = room.min(rest.len());
+            let take = self.grid.room().min(rest.len());
             self.audio.extend_from_slice(&rest[..take]);
             self.savg.push_with_rows(&rest[..take], on_row);
             self.decim.push_i16(&rest[..take], &mut self.half);
             rest = &rest[take..];
-            if self.audio.len() == CAPTURE_CLOSE_SAMPLES {
-                let carry_shift = core::mem::take(&mut self.pending_shift);
-                let carry_aligned = self.aligned;
+            if self.grid.fill(take) {
+                // `fill` has already set the next gap; carry the grid
+                // across the reset that moves the buffers out.
+                let grid = self.grid;
                 let prev = core::mem::replace(self, Self::new());
-                // The inter-window skip, plus whatever correction the
-                // clock check and the DT trim asked for. A correction
-                // too big for one gap to hold is clamped and the
-                // remainder carried into the next.
-                let want_skip = (SLOT_SAMPLES - CAPTURE_CLOSE_SAMPLES) as i32 + carry_shift;
-                self.skip = want_skip.clamp(0, GRID_PERIOD) as usize;
-                self.pending_shift = want_skip - self.skip as i32;
-                self.aligned = carry_aligned;
+                self.grid = grid;
                 done = Some(CapturedSlot {
                     audio: prev.audio,
                     savg: prev.savg.finish(),

--- a/embedded-poc/embedded-shared/src/apps/mod.rs
+++ b/embedded-poc/embedded-shared/src/apps/mod.rs
@@ -12,6 +12,10 @@ pub mod fst4_bench;
 pub mod fst4_ddc_bench;
 #[cfg(feature = "ft4-bench")]
 pub mod ft4_bench;
+/// The FT4 slot grid's arithmetic, with no DSP and no ESP-IDF in it —
+/// gated on nothing, so `hosttest/mfsk-app-shared` can compile it and
+/// its cases run in CI. See its module doc for why that mattered.
+pub mod ft4_grid;
 #[cfg(feature = "ft4")]
 pub mod ft4_rx;
 pub mod rx_wavsim;

--- a/embedded-poc/m5stack-cores3-app/src/apps/ft4.rs
+++ b/embedded-poc/m5stack-cores3-app/src/apps/ft4.rs
@@ -409,6 +409,20 @@ fn slot_loop() -> ! {
             if let Some(mut remain) =
                 mfsk_app_shared::time_sync::samples_to_next_slot_12k_ms(FT4_SLOT_MS)
             {
+                // Into the accumulator's frame before anything else.
+                //
+                // The clock answers "how far to the boundary from
+                // *now*"; `SlotAccum` needs "from where the
+                // accumulator is", and the two are `block` apart —
+                // audio that has arrived and not yet been fed. During
+                // capture that is one UAC read (~21 ms) and would not
+                // matter. Once a slot, it is the decode: `block` holds
+                // the ~1.4 s that piled up while `decode_slot` ran, and
+                // 1.4 s is past `REANCHOR_THRESH_SAMPLES` and
+                // comparable to the whole Δt search. Unconverted, a
+                // grid that is not drifting reads as off by exactly the
+                // backlog, in the same direction, every slot.
+                remain += block.len();
                 let was_aligned = accum.is_aligned();
                 // Fold in the persisted FT8 acquisition fix (#356b) on
                 // the first anchor only — after that the DT-median trim
@@ -419,12 +433,22 @@ fn slot_loop() -> ! {
                     let shifted = remain as i64 + (fix_us as i64 * 12 / 1000);
                     remain = shifted.rem_euclid(period) as usize;
                 }
+                let err = accum.phase_error(remain);
                 accum.anchor_or_reanchor(remain);
                 if !was_aligned && accum.is_aligned() {
                     log::info!(
                         "ft4_app: slot grid anchored to {} — {} ms to the next boundary",
                         if seeded_from_air { "the FT8 air fix" } else { "UTC" },
                         remain / 12,
+                    );
+                } else if let Some(delta) = err {
+                    // Past the threshold, so the grid just moved. Worth
+                    // a line: with a disciplined clock this is the
+                    // band's own offset, and with an RTC-seeded one it
+                    // is that chip's drift, accumulating in view.
+                    log::info!(
+                        "ft4_app: slot grid {:+} ms off the clock — trimmed",
+                        delta / 12
                     );
                 }
                 // Grid lock state (#356b). FT4's coarse stage has no DT

--- a/embedded-poc/mfsk-app-shared/src/capture_window.rs
+++ b/embedded-poc/mfsk-app-shared/src/capture_window.rs
@@ -14,12 +14,23 @@
 //! Written for `wspr_app`'s DDC sink (#313 item 1). All three
 //! receivers anchor to UTC now, each with its own bookkeeping: FT8's
 //! is in `m5stack-cores3-app`'s `uac.rs` (`Ft8ChunkSink`), FT4's in
-//! `embedded_shared::apps::ft4_rx::SlotAccum` (`anchor_or_reanchor`,
-//! #354). Both of those capture a *contiguous* grid — every sample
-//! belongs to some slot — which is why neither needed the gap this
-//! type exists to manage. Folding them onto it would be a
-//! consolidation, not a fix, and `uac.rs`'s version is
-//! hardware-verified, so neither is changed here.
+//! `embedded_shared::apps::ft4_grid::SlotGrid` (#354).
+//!
+//! **Only FT8 captures a contiguous grid**, where every sample belongs
+//! to some slot, and it is the one that genuinely has no gap to
+//! manage. This doc said the same of FT4 until 2026-09-09 and was
+//! wrong: FT4's capture closes at 6.775 s of a 7.5 s slot and it
+//! discards the 8 700 samples between, which is the same skip this
+//! type exists for. What is actually different about FT4 is that its
+//! grid also carries a phase correction across window closes — the
+//! DT-median trim, with a threshold below which the clock is ignored —
+//! and `CaptureWindow` has no state of that kind: it is re-armed by
+//! its caller each window.
+//!
+//! So the two are consolidation candidates rather than one covering
+//! the other, and `SlotGrid` is now the same shape of tested
+//! arithmetic. Neither is changed here, and `uac.rs`'s version is
+//! hardware-verified.
 //!
 //! The phase itself comes from [`crate::time_sync`]; this type only
 //! decides what to do with a batch given a phase reading, which is

--- a/hosttest/mfsk-app-shared/src/lib.rs
+++ b/hosttest/mfsk-app-shared/src/lib.rs
@@ -50,6 +50,16 @@ pub mod spot_state;
 #[path = "../../../embedded-poc/mfsk-app-shared/src/parity.rs"]
 pub mod parity;
 
+/// The FT4 capture window's place on the slot grid — from
+/// `embedded-shared`, not `mfsk-app-shared`, and here rather than in a
+/// hosttest crate of its own because this one is what CI runs. It is
+/// integer arithmetic over sample counts with no dependency at all;
+/// the module it was split out of pulls in `esp_idf_svc` and so cannot
+/// be compiled off-target, which left a live run against a radio as
+/// the only thing checking it.
+#[path = "../../../embedded-poc/embedded-shared/src/apps/ft4_grid.rs"]
+pub mod ft4_grid;
+
 /// Slot-boundary time sync. Pulled in for `ClockSource`: the rule that
 /// only an NTP-disciplined clock may be written back to the RTC is the
 /// kind of thing that was wrong for months without anything failing


### PR DESCRIPTION
FT4's slot grid alignment shipped in 0.10.1 (#354). This is a defect in it that the replay path cannot reach, plus the split that makes it testable.

## The bug

`apps/ft4.rs` asked the clock how far the next UTC boundary was **from now** and handed that straight to `SlotAccum::anchor_or_reanchor`, which counts **from where the accumulator sits in the sample stream**. The two are the staged-but-not-yet-fed backlog apart.

During capture that gap is one UAC read — ~21 ms, under `REANCHOR_THRESH_SAMPLES`, invisible. Once a slot it is the decode. On the first loop iteration after `decode_slot` returns, `block` holds the ~1.4 s that piled up while it ran:

```
want  =  81_900   from the clock, measured 1.4 s downstream
have  =   8_700   the gap the accumulator is actually sitting in
delta = −16_800   after the half-period fold
```

16 800 samples is fourteen times the re-anchor threshold and 1.4 s against a ±1.0 s Δt search. A grid that was not drifting read as off by exactly the backlog, in the same direction, every slot, and the trim walked it there.

The caller now converts into the accumulator's frame before it asks, and the parameter is named for the frame it is in. `SlotAccum::phase_error` exposes the same number the trim acts on, so the receiver logs the clock-vs-grid disagreement rather than leaving it to be inferred.

**Found by reading, not by running.** This path is inside `if live`, so the baked golden never reaches it and FT4 has not been in front of a radio yet. It would have been the first thing the live run tripped over, and it would have presented as a decoder or antenna problem.

## Why it was readable but not testable

The arithmetic was interleaved with the DSP inside `push_with_rows`, in a module that pulls in `esp_idf_svc` and spawns a second core — Xtensa-only, and `embedded-poc` sits outside the host workspace where neither the pre-commit clippy nor any CI job reaches it. What was left checking a sample-count off-by-one was a live run against a radio.

`embedded_shared::apps::ft4_grid::SlotGrid` is that arithmetic and nothing else, over `usize`/`i32`: no DSP, no ESP-IDF, no feature gate. `hosttest/mfsk-app-shared` compiles it with a `#[path]` and its cases run in CI. **Behaviour is unchanged** — the same state machine, moved. Window length, period and threshold became constructor arguments, so the values and their justifications stay in `ft4_rx` and tests can use round numbers.

Seven cases, each previously true only by argument: the reference-frame bug stated both ways; the same conversion at the *first* anchor, where nothing bounds the error; a trim landing at the next window *close* rather than on a gap already set; the half-period fold; an oversized correction carried rather than truncated; a split block giving the same grid as a whole one.

## Second commit: a doc claim corrected

`capture_window.rs`, `ROADMAP.md` and the 0.10.2 #313 CHANGELOG entry said FT8 **and FT4** capture a contiguous grid and so have no inter-slot gap to manage. True of FT8 only — FT4 closes at 6.775 s of a 7.5 s slot and discards the 8 700 samples between, which is the same skip `CaptureWindow` exists for. The claim read as "already covered" when the case is precisely the one that type handles. What is actually different is that FT4's grid carries a phase correction across window closes and `CaptureWindow` has no state of that kind. Both remain consolidation candidates; neither is changed.

## Verification

- host tier A+B green (`MFSK_REQUIRE_CORPUS=1`, `--features full,internal-testing --release`)
- `hosttest/mfsk-app-shared` 56 passed, including the 7 new cases
- built for `xtensa-esp32s3-espidf` under `--features ft4,ft4-replay`; no new clippy warnings
- **not flashed.** #354's remaining items are measurements that need a radio: the DT median's convergence, and the spread that sets the trim deadband.

Refs #354, #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ezgLpNw9oU9Tqmho796kd